### PR TITLE
Fix CSS font variable syntax and remove debug log

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,7 +3,6 @@ import styles from "./Home.module.css";
 import "../styles/variables.css";
 
 const Home = () => {
-  console.log(styles); // Debugging the styles object
 
   return (
     <div className={styles.home}>

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -3,8 +3,8 @@
   --primary-body-font: "Moderat-Regular", sans-serif;
   --secondary-body-font: "TiemposHeadline-Regular", serif;
 
-  --primary-heading-font: "TiemposHeadline-Light", serif font-weight: 500;
-  --secondary-heading-font: "Moderat-Regular", serif font-weight: 400;
+  --primary-heading-font: "TiemposHeadline-Light", serif;
+  --secondary-heading-font: "Moderat-Regular", serif;
 
   /* Accent colors */
   --accent-pink: #f205c5;


### PR DESCRIPTION
## Summary
- correct the font variable definitions in `variables.css`
- remove debugging log from the `Home` component

## Testing
- `npm install`
- `CI=true npm test --silent -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_684213352e08832ea1c4c2c38c844d0b