### PR TITLE
Remove weight from heading font variables

### DIFF
--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -43,7 +43,7 @@
 h2 {
   font-family: var(--primary-heading-font, "Times New Roman"), serif;
   font-size: 8rem;
-  font-weight: 300;
+  font-weight: var(--primary-heading-weight, 300);
   line-height: 6rem;
   margin-block-start: -5.6rem;
 }

--- a/src/pages/Work.module.css
+++ b/src/pages/Work.module.css
@@ -6,7 +6,7 @@
 .work h1 {
   font-family: var(--primary-heading-font, "Times New Roman"), serif;
   font-size: 14rem;
-  font-weight: 300;
+  font-weight: var(--primary-heading-weight, 300);
   line-height: 1.2;
 }
 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -3,8 +3,10 @@
   --primary-body-font: "Moderat-Regular", sans-serif;
   --secondary-body-font: "TiemposHeadline-Regular", serif;
 
-  --primary-heading-font: "TiemposHeadline-Light", serif;
-  --secondary-heading-font: "Moderat-Regular", serif;
+  --primary-heading-font: "TiemposHeadline", serif;
+  --primary-heading-weight: 300;
+  --secondary-heading-font: "Moderat", serif;
+  --secondary-heading-weight: 400;
 
   /* Accent colors */
   --accent-pink: #f205c5;


### PR DESCRIPTION
## Summary
- decouple font weight from heading font families
- reference new weight variables in Home and Work styles

## Testing
- `npm run build`
- `npm test -- --watchAll=false` *(fails: cannot resolve module)*

------
https://chatgpt.com/codex/tasks/task_e_684215cf185c832ebe880bcbe5cdae5d