### PR TITLE
Fix home page test

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import App from './App';
+import Home from './pages/Home';
+
 
 test('renders the home page title', () => {
-  render(<App />);
-  const titleElement = screen.getByText(/Welcome to Digitaltableteur/i);
+  render(<Home />);
+  const titleElement = screen.getByText(/Creative & Development/i);
   expect(titleElement).toBeInTheDocument();
 });
 
 test('renders the grid items', () => {
-  render(<App />);
-  const gridItems = screen.getAllByRole('gridcell');
+  const { container } = render(<Home />);
+  const gridItems = container.querySelectorAll('.grid > div');
   expect(gridItems.length).toBeGreaterThan(0);
 });


### PR DESCRIPTION
## Summary
- adjust unit tests to render the `Home` page directly
- verify the grid items using a CSS selector
- update the expected heading text

## Testing
- `npm test --silent --color=false`

------
https://chatgpt.com/codex/tasks/task_e_684215d8d8f4832e9e95a0b66d2ba54f