### PR TITLE
Improve Checkbox indeterminate handling

### DIFF
--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -28,5 +28,7 @@ Checked.args = {
 export const Indeterminate = Template.bind({});
 Indeterminate.args = {
   label: "Indeterminate Checkbox",
+  checked: false,
   indeterminate: true,
 };
+

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -12,12 +12,12 @@ export interface CheckboxProps {
 
 const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   (
-    { label, showLabel = true, checked, indeterminate, onChange },
+    { label, showLabel = true, checked, indeterminate = false, onChange },
     ref
   ) => {
     useEffect(() => {
       if (ref && "current" in ref && ref.current) {
-        ref.current.indeterminate = indeterminate || false;
+        ref.current.indeterminate = indeterminate;
       }
     }, [indeterminate, ref]);
 
@@ -26,12 +26,15 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
         <input
           type="checkbox"
           ref={ref}
-          className={`${styles.checkbox} ${indeterminate ? styles.indeterminate : ""}`}
-          checked={checked && !indeterminate}
+          className={styles.checkbox}
+          checked={checked}
+          aria-checked={indeterminate ? "mixed" : checked}
           onChange={(e) => {
-            const isChecked = e.target.checked;
+            if (ref && "current" in ref && ref.current) {
+              ref.current.indeterminate = false;
+            }
             if (onChange) {
-              onChange(isChecked);
+              onChange(e.target.checked);
             }
           }}
         />


### PR DESCRIPTION
## Summary
- remove TriState story
- reset indeterminate state on interaction
- simplify onChange logic and keep aria support

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421e551738832e8b37c86b6d228020