### PR TITLE
Add blog cards and article page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,10 @@ import Work from "./pages/Work";
 import About from "./pages/About";
 import Contact from "./pages/Contact";
 import UnderDevelopment from "./pages/UnderDevelopment";
+import Blog from "./pages/Blog";
+import Designing2025 from "./pages/Designing2025";
+import WorkflowTips from "./pages/WorkflowTips";
+import DigitalCraftsmanship from "./pages/DigitalCraftsmanship";
 
 function App() {
   return (
@@ -17,6 +21,10 @@ function App() {
             <Route path="/work" element={<Work />} />
             <Route path="/about" element={<About />} />
             <Route path="/contact" element={<Contact />} />
+            <Route path="/blog" element={<Blog />} />
+            <Route path="/blog/designing-in-2025" element={<Designing2025 />} />
+            <Route path="/blog/workflow-tips" element={<WorkflowTips />} />
+            <Route path="/blog/digital-craftsmanship" element={<DigitalCraftsmanship />} />
           </Routes>
         </Layout>
       </div>

--- a/src/pages/Article.module.css
+++ b/src/pages/Article.module.css
@@ -1,0 +1,74 @@
+@import "../styles/variables.css";
+@import "../styles/fonts.css";
+
+.article {
+  max-width: 60rem;
+  margin: 0 auto;
+  padding: 2rem;
+  font-family: var(--primary-body-font, sans-serif);
+  line-height: 1.6;
+}
+
+.article h1 {
+  font-family: var(--primary-heading-font, serif);
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.author {
+  font-size: 0.875rem;
+  color: var(--color-muted);
+  margin-bottom: 2rem;
+}
+
+.article h2 {
+  font-family: var(--secondary-heading-font, sans-serif);
+  font-size: 1.75rem;
+  margin-top: 2rem;
+}
+
+.article blockquote {
+  margin: 1.5rem 0;
+  padding-left: 1rem;
+  border-left: 4px solid var(--color-gray);
+  font-style: italic;
+}
+
+.article img {
+  max-width: 100%;
+  display: block;
+  margin: 2rem 0;
+}
+
+.video {
+  width: 100%;
+  margin: 2rem 0;
+}
+
+.similar {
+  margin-top: 3rem;
+}
+
+.similarList {
+  display: grid;
+  gap: 1rem;
+}
+
+.similarCard {
+  display: block;
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  color: inherit;
+  transition: background-color 0.3s;
+}
+
+.similarCard:hover,
+.similarCard:focus {
+  background-color: #fff7e3;
+  outline: 3px solid var(--color-dark);
+}
+
+.pink { background-color: var(--accent-pink); }
+.teal { background-color: var(--accent-teal); }
+.purple { background-color: var(--accent-purple); }

--- a/src/pages/Blog.module.css
+++ b/src/pages/Blog.module.css
@@ -1,0 +1,55 @@
+@import "../styles/variables.css";
+@import "../styles/fonts.css";
+
+.blog {
+  padding: 2rem;
+}
+
+.list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  gap: 2rem;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  color: inherit;
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  transition: background-color 0.3s;
+}
+
+.card:hover,
+.card:focus {
+  background-color: #fff7e3;
+  outline: 3px solid var(--color-dark);
+}
+
+.title {
+  font-family: var(--primary-heading-font, serif);
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem 0;
+}
+
+.lead {
+  font-family: var(--primary-body-font, sans-serif);
+  font-size: 1rem;
+  margin: 0 0 1rem 0;
+}
+
+.meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.875rem;
+}
+
+.readMore {
+  text-decoration: underline;
+}
+
+.pink { background-color: var(--accent-pink); }
+.teal { background-color: var(--accent-teal); }
+.purple { background-color: var(--accent-purple); }

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,0 +1,55 @@
+import styles from "./Blog.module.css";
+
+interface Post {
+  title: string;
+  lead: string;
+  link: string;
+  readTime: string;
+  color: string;
+}
+
+const posts: Post[] = [
+  {
+    title: "Designing in 2025: Navigating the AI-Assisted Creative Landscape",
+    lead: "After more than two decades in the design field, we’re exploring how AI partners with creativity.",
+    link: "/blog/designing-in-2025",
+    readTime: "5 min read",
+    color: styles.pink,
+  },
+  {
+    title: "Workflow Tips",
+    lead: "A behind-the-scenes look at how we keep projects moving.",
+    link: "/blog/workflow-tips",
+    readTime: "3 min read",
+    color: styles.teal,
+  },
+  {
+    title: "Digital Craftsmanship",
+    lead: "Thoughts on maintaining quality in a hurry-up culture.",
+    link: "/blog/digital-craftsmanship",
+    readTime: "4 min read",
+    color: styles.purple,
+  },
+];
+
+const Blog = () => {
+  return (
+    <div className={styles.blog}>
+      <h1>Blog</h1>
+      <div className={styles.list}>
+        {posts.map((post) => (
+          <a key={post.link} href={post.link} className={`${styles.card} ${post.color}`}> 
+            <h2 className={styles.title}>{post.title}</h2>
+            <p className={styles.lead}>{post.lead}</p>
+            <div className={styles.meta}>
+              <span className={styles.readTime}>{post.readTime}</span>
+              <span className={styles.readMore}>Read more</span>
+            </div>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Blog;

--- a/src/pages/Designing2025.tsx
+++ b/src/pages/Designing2025.tsx
@@ -1,0 +1,68 @@
+import styles from "./Article.module.css";
+import image from "../assets/images/abduction.webp";
+
+const Designing2025 = () => (
+  <article className={styles.article}>
+    <header>
+      <h1>Designing in 2025: Navigating the AI-Assisted Creative Landscape</h1>
+      <p className={styles.author}>By Digitaltableteur</p>
+    </header>
+    <p>After more than two decades in the design field, I’ve had the pleasure and privilege of witnessing the practice evolve—from sketchbooks and static wireframes to collaborative, cloud-based systems that update in real-time. And now, in 2025, we’re at the cusp of what may be the most profound shift yet: the rise of AI as a deeply embedded partner in the design process.</p>
+    <p>Artificial Intelligence is no longer a novelty. It’s embedded in the very tools we use—from generative ideation and layout prediction to code generation and automated testing. But despite this acceleration, one truth endures: design is still a deeply human act.</p>
+    <blockquote>At its best, design is how we care for people at scale.</blockquote>
+    <p>Our challenge now is not about keeping up with the speed of machines—it’s about preserving the purpose of design in an age of abundance.</p>
+
+    <h2>Beyond Automation: Reclaiming the Core of Creative Work</h2>
+    <p>We no longer face a blinking cursor on a blank canvas. AI can instantly generate layouts, suggest type pairings, or convert sketches into code. It’s impressive. But speed can’t replace soul.</p>
+    <p>AI, in my experience, isn’t here to replace creativity—it’s here to amplify it.</p>
+    <p>This means shifting our mindset. Not toward competing with machines, but toward outthinking them. Toward asking sharper questions. Challenging assumptions. Understanding people, behaviors, and contexts more deeply.</p>
+    <p>Because in a world where any prompt can output a hundred variations, our craft becomes less about creation and more about curation. Less about what we can generate, and more about what we choose to keep.</p>
+    <p>This is a return to judgment. To narrative. To human insight as the foundation of meaningful work.</p>
+
+    <h2>AI as a Partner, Not a Proxy</h2>
+    <p>There’s a myth that AI reduces the need for thinking. In practice, it does the opposite.</p>
+    <p>Great AI tools remove friction, not responsibility. They clear the repetitive and procedural, allowing us to focus on higher-order challenges: behavior, structure, intention, emotion.</p>
+    <p>That’s where modern creative leadership lives.</p>
+    <p>When mentoring younger designers, I often say: Your job isn’t to outpace the machine. It’s to know what matters and why. To hold the line when an output is technically correct but emotionally hollow.</p>
+    <p>AI can optimize. Only humans can care.</p>
+    <p>To succeed in 2025, designers must become bilingual—fluent in both human needs and machine capabilities. Because AI isn’t replacing our language. It’s becoming part of it.</p>
+
+    <h2>Design as Strategic Communication</h2>
+    <p>With infinite content at our fingertips, the temptation is to flood the space with more. But “more” isn’t the answer. “Better” is.</p>
+    <p>Paradoxically, making is easier—but mattering is harder.</p>
+    <p>Design must move from aesthetic polishing to strategic storytelling. In 2025, brands don’t compete solely on product—they compete on clarity, relevance, and emotional resonance. These are design problems.</p>
+    <p>A great visual system is no longer just about a logo or a palette. It’s a behavioral signal: it tells people what you stand for. It creates trust. It builds consistency in a fragmented landscape.</p>
+    <p>Done right, visual communication becomes a strategic layer—one that simplifies, clarifies, and connects.</p>
+
+    <h2>From Stylist to Steward</h2>
+    <p>One of the most significant shifts in the past decade is the evolution of our role.</p>
+    <p>We’re no longer just stylists brought in at the end to "make it pretty." We’re stewards of systems. Authors of intent. Designers of participation.</p>
+    <p>With AI in the mix, our responsibilities expand even further. We must now act as ethical gatekeepers:</p>
+    <p>What data trained this model?</p>
+    <p>Who benefits from this feature—and who’s left out?</p>
+    <p>Are we reinforcing bias, or challenging it?</p>
+    <p>These aren’t edge cases. They are the new core of responsible design.</p>
+
+    <h2>A Return to Purpose</h2>
+    <p>Yes, tools will continue to evolve. But our greatest assets remain unchanged: empathy, curiosity, judgment, courage.</p>
+    <p>These qualities don’t show up in any plugin. They’re not automatable. They’re earned—in practice, in conversation, in critique.</p>
+    <p>As AI shifts how we design, it’s up to us to preserve why we design.</p>
+    <p>Because the goal isn’t just to make things—it’s to make things matter.</p>
+    <p>And in 2025, that principle has never been more vital.</p>
+
+    <img src={image} alt="abstract background" />
+    <video className={styles.video} controls>
+      <source src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm" type="video/webm" />
+    </video>
+
+    <div className={styles.similar}>
+      <h2>Similar reads</h2>
+      <div className={styles.similarList}>
+        <a href="/blog/workflow-tips" className={`${styles.similarCard} ${styles.teal}`}>Workflow Tips</a>
+        <a href="/blog/digital-craftsmanship" className={`${styles.similarCard} ${styles.purple}`}>Digital Craftsmanship</a>
+      </div>
+    </div>
+  </article>
+);
+
+export default Designing2025;

--- a/src/pages/DigitalCraftsmanship.tsx
+++ b/src/pages/DigitalCraftsmanship.tsx
@@ -1,0 +1,13 @@
+import styles from "./Article.module.css";
+
+const DigitalCraftsmanship = () => (
+  <article className={styles.article}>
+    <header>
+      <h1>Digital Craftsmanship</h1>
+      <p className={styles.author}>By Digitaltableteur</p>
+    </header>
+    <p>This story is coming soon. It will dive into how we maintain quality while moving fast.</p>
+  </article>
+);
+
+export default DigitalCraftsmanship;

--- a/src/pages/WorkflowTips.tsx
+++ b/src/pages/WorkflowTips.tsx
@@ -1,0 +1,13 @@
+import styles from "./Article.module.css";
+
+const WorkflowTips = () => (
+  <article className={styles.article}>
+    <header>
+      <h1>Workflow Tips</h1>
+      <p className={styles.author}>By Digitaltableteur</p>
+    </header>
+    <p>We are preparing this article. Check back soon for insights into our day-to-day process.</p>
+  </article>
+);
+
+export default WorkflowTips;

--- a/src/patterns/Header/Header.tsx
+++ b/src/patterns/Header/Header.tsx
@@ -12,6 +12,7 @@ const Header = () => {
           <li><a href="/">Home</a></li>
           <li><a href="/work">Work</a></li>
           <li><a href="/about">About</a></li>
+          <li><a href="/blog">Blog</a></li>
           <li><a href="/contact">Contact</a></li>
         </ul>
       </nav>


### PR DESCRIPTION
## Summary
- add new Blog page listing articles with colorful cards
- create reusable styles for articles and blog cards
- implement first article "Designing in 2025" plus placeholders
- wire up blog routes and update navigation

## Testing
- `npm test -- --watchAll=false`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6843d3900c0c832ea2017c2420160ef2