### PR TITLE
Convert camelCase classes to kebab-case

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,19 +1,19 @@
-.App {
+.app {
   text-align: center;
 }
 
-.App-logo {
+.app-logo {
   height: 40vmin;
   pointer-events: none;
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
+  .app-logo {
+    animation: app-logo-spin infinite 20s linear;
   }
 }
 
-.App-header {
+.app-header {
   background-color: var(--color-header-bg);
   min-height: 100vh;
   display: flex;
@@ -24,11 +24,11 @@
   color: white;
 }
 
-.App-link {
+.app-link {
   color: var(--color-react);
 }
 
-@keyframes App-logo-spin {
+@keyframes app-logo-spin {
   from {
     transform: rotate(0deg);
   }

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -56,7 +56,7 @@
   cursor: not-allowed;
 }
 
-.button.iconOnly {
+.button.icon-only {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -68,7 +68,7 @@
   line-height: 1;
 }
 
-.button.iconOnly .icon {
+.button.icon-only .icon {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -79,7 +79,7 @@
   margin-right: 0.5rem;
 }
 
-.endIcon {
+.end-icon {
   margin-left: 0.5rem;
 }
 
@@ -87,6 +87,6 @@
   margin-left: 0.5rem; /* Add padding between icon and text */
 }
 
-.button > .text + :is(svg, .endIcon) {
+.button > .text + :is(svg, .end-icon) {
   margin-left: 0.5rem; /* Add padding between text and icon when icon is on the right */
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -37,7 +37,7 @@ const Button: React.FC<ButtonProps> = ({
 
   return (
     <button
-      className={`${styles.button} ${styles[variant]} ${!children && normalizedIcon ? styles.iconOnly : ""}`}
+      className={`${styles.button} ${styles[variant]} ${!children && normalizedIcon ? styles["icon-only"] : ""}`}
       disabled={disabled}
       aria-describedby={accessibleDescription}
       aria-label={accessibleName}

--- a/src/components/Checkbox/Checkbox.module.css
+++ b/src/components/Checkbox/Checkbox.module.css
@@ -1,7 +1,7 @@
 @import "../../styles/variables.css";
 @import "../../styles/fonts.css";
 
-.checkboxContainer {
+.checkbox-container {
   display: flex;
   align-items: center;
   gap: 0.5rem;

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -29,7 +29,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     };
 
     return (
-      <div className={styles.checkboxContainer}>
+      <div className={styles["checkbox-container"]}>
         <input
           type="checkbox"
           ref={ref}

--- a/src/components/CheckboxGroup/CheckboxGroup.module.css
+++ b/src/components/CheckboxGroup/CheckboxGroup.module.css
@@ -1,7 +1,7 @@
 @import "../../styles/variables.css";
 @import "../../styles/fonts.css";
 
-.checkboxGroup {
+.checkbox-group {
   display: flex;
   flex-direction: column;
   gap: 1rem;

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -61,7 +61,7 @@ const CheckboxGroup: React.FC<CheckboxGroupProps> = ({ label, options, onChange 
   };
 
   return (
-    <div className={styles.checkboxGroup}>
+    <div className={styles["checkbox-group"]}>
       <GroupLabel htmlFor="master-checkbox">{label}</GroupLabel>
       <Checkbox
         ref={masterCheckboxRef}

--- a/src/components/Contact Form/ContactForm.module.css
+++ b/src/components/Contact Form/ContactForm.module.css
@@ -1,7 +1,7 @@
 @import "../../styles/variables.css";
 @import "../../styles/fonts.css";
 
-.contactForm {
+.contact-form {
   max-width: var(--size-width-form, 500px);
   margin: 0 auto;
   padding: 1.5rem;
@@ -10,22 +10,22 @@
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
-.formGroup {
+.form-group {
   margin-bottom: 1.5rem;
 }
 
-.privacyPolicy {
+.privacy-policy {
   font-size: 0.875rem;
   color: var(--color-gray-medium);
   text-align: center;
 }
 
-.privacyPolicy a {
+.privacy-policy a {
   color: var(--color-primary);
   text-decoration: none;
 }
 
-.privacyPolicy a:hover {
+.privacy-policy a:hover {
   text-decoration: underline;
 }
 

--- a/src/components/Contact Form/ContactForm.tsx
+++ b/src/components/Contact Form/ContactForm.tsx
@@ -43,9 +43,9 @@ const ContactForm = () => {
   };
 
   return (
-    <div className={styles.contactForm}>
+    <div className={styles["contact-form"]}>
       <form onSubmit={handleSubmit}>
-        <div className={styles.formGroup}>
+        <div className={styles["form-group"]}>
           <Inputs
             label="Full Name"
             type="text"
@@ -55,7 +55,7 @@ const ContactForm = () => {
           />
         </div>
 
-        <div className={styles.formGroup}>
+        <div className={styles["form-group"]}>
           <Inputs
             label="Email Address"
             type="email"
@@ -65,7 +65,7 @@ const ContactForm = () => {
           />
         </div>
 
-        <div className={styles.formGroup}>
+        <div className={styles["form-group"]}>
           <Inputs
             label="Phone Number"
             type="text"
@@ -75,7 +75,7 @@ const ContactForm = () => {
           />
         </div>
 
-        <div className={styles.formGroup}>
+        <div className={styles["form-group"]}>
           <CheckboxGroup
             label="Your Interest"
             options={[
@@ -88,7 +88,7 @@ const ContactForm = () => {
           />
         </div>
 
-        <div className={styles.formGroup}>
+        <div className={styles["form-group"]}>
           <Inputs
             label="Your Message"
             type="text"
@@ -98,13 +98,13 @@ const ContactForm = () => {
           />
         </div>
 
-        <div className={styles.formGroup}>
+        <div className={styles["form-group"]}>
           <Button type="submit" variant="primary">
             Submit
           </Button>
         </div>
 
-        <p className={styles.privacyPolicy}>
+        <p className={styles["privacy-policy"]}>
           By pressing submit you agree for your information to be processed according to our
           <a href="/privacy-policy"> privacy policy</a>.
         </p>

--- a/src/components/GroupLabel/GroupLabel.module.css
+++ b/src/components/GroupLabel/GroupLabel.module.css
@@ -1,7 +1,7 @@
 @import "../../styles/variables.css";
 @import "../../styles/fonts.css";
 
-.groupLabel {
+.group-label {
   font-size: 1rem;
   font-family: "Moderat", sans-serif;
   font-weight: 500;

--- a/src/components/GroupLabel/GroupLabel.tsx
+++ b/src/components/GroupLabel/GroupLabel.tsx
@@ -14,7 +14,7 @@ const GroupLabel: React.FC<GroupLabelProps> = ({ htmlFor, children, tooltipText,
   return (
     <label
       htmlFor={htmlFor}
-      className={`${styles.groupLabel} ${disabled ? styles.disabled : ""}`}
+      className={`${styles["group-label"]} ${disabled ? styles.disabled : ""}`}
       title={title || tooltipText} // Use title or fallback to tooltipText
     >
       {children}

--- a/src/components/Inputs/Inputs.module.css
+++ b/src/components/Inputs/Inputs.module.css
@@ -1,7 +1,7 @@
 @import "../../styles/variables.css";
 @import "../../styles/fonts.css";
 
-.inputContainer {
+.input-container {
   display: flex;
   flex-direction: column;
   margin-bottom: 1rem;
@@ -39,7 +39,7 @@
   background-color: var(--color-error-bg);
 }
 
-.errorMessage {
+.error-message {
   font-family: "Moderat", sans-serif;
   font-size: 0.875rem;
   color: var(--color-error-text);

--- a/src/components/Inputs/Inputs.tsx
+++ b/src/components/Inputs/Inputs.tsx
@@ -30,7 +30,7 @@ const Input: React.FC<InputProps> = ({
   };
 
   return (
-    <div className={styles.inputContainer}>
+    <div className={styles["input-container"]}>
       <Label
         htmlFor={label}
         required={!!error}
@@ -48,7 +48,7 @@ const Input: React.FC<InputProps> = ({
         onChange={handleChange}
         disabled={disabled} // Apply disabled prop
       />
-      {error && <span className={styles.errorMessage}>{error}</span>}
+      {error && <span className={styles["error-message"]}>{error}</span>}
     </div>
   );
 };

--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -1,7 +1,7 @@
 @import "../../styles/variables.css";
 @import "../../styles/fonts.css";
 
-.selectContainer {
+.select-container {
   display: flex;
   flex-direction: column;
   margin-bottom: 1rem;
@@ -41,13 +41,13 @@
   color: var(--color-muted);
 }
 
-.selectWrapper {
+.select-wrapper {
   position: relative;
   display: inline-block;
   width: var(--size-width-md);
 }
 
-.chevronIcon {
+.chevron-icon {
   position: absolute;
   right: 1rem;
   top: 50%;

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -25,9 +25,9 @@ const Select: React.FC<SelectProps> = ({
   };
 
   return (
-    <div className={styles.selectContainer}>
+    <div className={styles["select-container"]}>
       {label && <Label htmlFor={label}>{label}</Label>}
-      <div className={styles.selectWrapper}>
+      <div className={styles["select-wrapper"]}>
         <select
           className={styles.select}
           value={value}
@@ -40,7 +40,7 @@ const Select: React.FC<SelectProps> = ({
             </option>
           ))}
         </select>
-        {FaChevronDown({ className: styles.chevronIcon })}
+        {FaChevronDown({ className: styles["chevron-icon"] })}
       </div>
     </div>
   );

--- a/src/pages/Article.module.css
+++ b/src/pages/Article.module.css
@@ -49,12 +49,12 @@
   margin-top: 3rem;
 }
 
-.similarList {
+.similar-list {
   display: grid;
   gap: 1rem;
 }
 
-.similarCard {
+.similar-card {
   display: block;
   padding: 1rem;
   border-radius: var(--radius-md);
@@ -63,8 +63,8 @@
   transition: background-color 0.3s;
 }
 
-.similarCard:hover,
-.similarCard:focus {
+.similar-card:hover,
+.similar-card:focus {
   background-color: #fff7e3;
   outline: 3px solid var(--color-dark);
 }

--- a/src/pages/Blog.module.css
+++ b/src/pages/Blog.module.css
@@ -46,7 +46,7 @@
   font-size: 0.875rem;
 }
 
-.readMore {
+.read-more {
   text-decoration: underline;
 }
 

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -43,7 +43,7 @@ const Blog = () => {
             <p className={styles.lead}>{post.lead}</p>
             <div className={styles.meta}>
               <span className={styles.readTime}>{post.readTime}</span>
-              <span className={styles.readMore}>Read more</span>
+              <span className={styles["read-more"]}>Read more</span>
             </div>
           </a>
         ))}

--- a/src/pages/Contact.module.css
+++ b/src/pages/Contact.module.css
@@ -6,7 +6,7 @@
   padding: 20px;
 }
 
-.contactForm {
+.contact-form {
   max-width: var(--size-width-form);
   margin: 0 auto;
   padding: 1rem;
@@ -15,21 +15,21 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.formGroup {
+.form-group {
   margin-bottom: 1.5rem;
 }
 
-.privacyPolicy {
+.privacy-policy {
   font-size: 0.875rem;
   color: var(--color-gray-medium);
   text-align: center;
 }
 
-.privacyPolicy a {
+.privacy-policy a {
   color: var(--color-primary);
   text-decoration: none;
 }
 
-.privacyPolicy a:hover {
+.privacy-policy a:hover {
   text-decoration: underline;
 }

--- a/src/pages/Designing2025.tsx
+++ b/src/pages/Designing2025.tsx
@@ -57,9 +57,9 @@ const Designing2025 = () => (
 
     <div className={styles.similar}>
       <h2>Similar reads</h2>
-      <div className={styles.similarList}>
-        <a href="/blog/workflow-tips" className={`${styles.similarCard} ${styles.teal}`}>Workflow Tips</a>
-        <a href="/blog/digital-craftsmanship" className={`${styles.similarCard} ${styles.purple}`}>Digital Craftsmanship</a>
+      <div className={styles["similar-list"]}>
+        <a href="/blog/workflow-tips" className={`${styles["similar-card"]} ${styles.teal}`}>Workflow Tips</a>
+        <a href="/blog/digital-craftsmanship" className={`${styles["similar-card"]} ${styles.purple}`}>Digital Craftsmanship</a>
       </div>
     </div>
   </article>

--- a/src/pages/Work.module.css
+++ b/src/pages/Work.module.css
@@ -13,7 +13,7 @@
   line-height: 1.2;
 }
 
-.workPage {
+.work-page {
   scroll-snap-type: y mandatory;
   height: 100vh;
   overflow-y: scroll;
@@ -36,7 +36,7 @@ section {
   outline: none;
 }
 
-.workPage:focus-visible {
+.work-page:focus-visible {
   scroll-behavior: smooth;
 }
 

--- a/src/pages/Work.tsx
+++ b/src/pages/Work.tsx
@@ -3,7 +3,7 @@ import MoireBackground from "../components/MoireBackground";
 
 const Work = () => {
   return (
-    <div className={styles.workPage}>
+    <div className={styles["work-page"]}>
       <section className={styles.section1}>
         <ul>
           <li>Strategy</li>


### PR DESCRIPTION
## Summary
- rename CSS module class selectors from camelCase to kebab-case
- update React components to use new kebab-case class names

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843dbce73e0832eb2f8f950345711e2