### PR TITLE
Fix storybook dynamic import

### DIFF
--- a/src/stories/KitchenSink.stories.tsx
+++ b/src/stories/KitchenSink.stories.tsx
@@ -4,7 +4,12 @@ import Label from "../components/Label/Label";
 import Link from "../components/Link/Link";
 import { FaSearch, FaArrowLeft } from "react-icons/fa";
 
-const componentsContext = (require as any).context("../components", true, /\.tsx$/);
+// Use Webpack's `require.context` to load all component modules eagerly.
+const componentsContext: __WebpackModuleApi.RequireContext = require.context(
+  "../components",
+  true,
+  /\.tsx$/
+);
 
 function isReactComponent(component: any): component is React.ComponentType<any> {
   return typeof component === "function" || (typeof component === "object" && component !== null && "render" in component);


### PR DESCRIPTION
## Summary
- use typed `require.context` to load components in the Kitchen Sink story

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844537be520832e94e5eb7c9e947aeb