### PR TITLE
Fix storybook types and add ESLint config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,27 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:prettier/recommended',
+  ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['react', '@typescript-eslint', 'prettier'],
+  rules: {
+    quotes: ['error', 'double'],
+    'jsx-quotes': ['error', 'prefer-double'],
+    'prettier/prettier': ['error', { singleQuote: false, jsxSingleQuote: false }],
+    'no-undef': 'off',
+    'no-unused-vars': 'off',
+  },
+};

--- a/src/stories/KitchenSink.stories.tsx
+++ b/src/stories/KitchenSink.stories.tsx
@@ -4,7 +4,19 @@ import Label from "../components/Label/Label";
 import Link from "../components/Link/Link";
 import { FaSearch, FaArrowLeft } from "react-icons/fa";
 
+declare global {
+  interface ImportMeta {
+    glob: (pattern: string, opts: { eager: boolean }) => Record<string, any>;
+  }
+}
+
 const modules = import.meta.glob("../components/**/*.tsx", { eager: true });
+
+const isReactComponent = (
+  component: any,
+): component is React.ComponentType<any> =>
+  typeof component === "function" ||
+  (typeof component === "object" && component !== null);
 
 const components = Object.entries(modules).reduce(
   (
@@ -27,7 +39,7 @@ const components = Object.entries(modules).reduce(
 );
 
 // Add Label to the components list
-const allComponents = {
+const allComponents: Record<string, React.ComponentType<any>> = {
   ...components,
   Label,
   Link,


### PR DESCRIPTION
## Summary
- add `.eslintrc.cjs` for Node 22 compatibility
- update KitchenSink stories to handle `import.meta.glob` and type checks

## Testing
- `npx prettier "src/**/*.{ts,tsx,css}" --check`
- `npx eslint -c .eslintrc.cjs "src/**/*.tsx"`
- `npx stylelint "src/**/*.css"`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68449b623bf0832ea915eeb27df98341