### PR TITLE
Improve reusable modal component

### DIFF
--- a/src/components/Contact Form/ContactForm.tsx
+++ b/src/components/Contact Form/ContactForm.tsx
@@ -3,6 +3,7 @@ import styles from "./ContactForm.module.css";
 import Inputs from "../Inputs/Inputs";
 import Button from "../Button/Button";
 import CheckboxGroup from "../CheckboxGroup/CheckboxGroup";
+import Modal from "../Modal/Modal";
 
 const ContactForm = () => {
   const [formData, setFormData] = useState({
@@ -12,6 +13,7 @@ const ContactForm = () => {
     interest: "",
     message: "",
   });
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleFullNameChange = (value: string | number) => {
     setFormData({ ...formData, fullName: String(value) });
@@ -39,7 +41,7 @@ const ContactForm = () => {
       `Full Name: ${formData.fullName}\nEmail: ${formData.email}\nPhone: ${formData.phone}\nInterest: ${formData.interest}\nMessage: ${formData.message}`,
     )}`;
     window.location.href = mailtoLink;
-    alert("Email sent successfully!");
+    setIsModalOpen(true);
   };
 
   return (
@@ -113,6 +115,14 @@ const ContactForm = () => {
           <a href="/privacy-policy"> privacy policy</a>.
         </p>
       </form>
+      <Modal
+        isOpen={isModalOpen}
+        variant="success"
+        title="Success"
+        onClose={() => setIsModalOpen(false)}
+      >
+        Email successfully sent
+      </Modal>
     </div>
   );
 };

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -1,0 +1,98 @@
+@import "../../styles/variables.css";
+@import "../../styles/fonts.css";
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background-color: var(--color-white);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  width: 90%;
+  max-width: var(--size-width-md);
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem 0 1.5rem;
+}
+
+.title {
+  font-family: var(--secondary-heading-font, sans-serif);
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.menu {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.close-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-dark);
+  font-size: 1rem;
+  padding: 0;
+}
+
+.content {
+  padding: 0 1.5rem 1rem 1.5rem;
+  font-family: var(--primary-body-font, sans-serif);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.footer {
+  padding: 0 1.5rem 1.5rem 1.5rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.success {
+  border-top: 4px solid var(--color-success);
+}
+
+.error {
+  border-top: 4px solid var(--color-error);
+}
+
+.loading {
+  border-top: 4px solid var(--color-info);
+}
+
+.spinner {
+  border: 4px solid var(--color-border-light);
+  border-top: 4px solid var(--color-info);
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from "react";
+import { Meta, StoryFn } from "@storybook/react-webpack5";
+import Modal, { ModalProps } from "./Modal";
+import Button from "../Button/Button";
+
+export default {
+  title: "Components/Modal",
+  component: Modal,
+} as Meta<ModalProps>;
+
+const Template: StoryFn<ModalProps> = (args) => {
+  const [open, setOpen] = useState(true);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open modal</Button>
+      <Modal {...args} isOpen={open} onClose={() => setOpen(false)} />
+    </>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  title: "Default Modal",
+  children: <p>This is a regular modal dialog.</p>,
+};
+
+export const Success = Template.bind({});
+Success.args = {
+  variant: "success",
+  title: "Success",
+  children: <p>Action completed successfully!</p>,
+};
+
+export const Error = Template.bind({});
+Error.args = {
+  variant: "error",
+  title: "Error",
+  children: <p>Something went wrong.</p>,
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  variant: "loading",
+  title: "Loading",
+  children: <p>Please wait...</p>,
+};

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { FaTimes } from "react-icons/fa";
+import styles from "./Modal.module.css";
+import Button from "../Button/Button";
+
+export type ModalVariant = "default" | "success" | "error" | "loading";
+
+export interface ModalProps {
+  /** Controls visibility */
+  isOpen: boolean;
+  /** Title shown in header */
+  title?: string;
+  /** Dialog variant styling */
+  variant?: ModalVariant;
+  /** Optional contextual menu or extra controls */
+  menu?: React.ReactNode;
+  /** Modal content */
+  children?: React.ReactNode;
+  /** Footer content, e.g. actions */
+  footer?: React.ReactNode;
+  /** Close callback */
+  onClose?: () => void;
+}
+
+const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  title,
+  variant = "default",
+  menu,
+  children,
+  footer,
+  onClose,
+}) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  const renderFooter = () => {
+    if (footer !== undefined) {
+      return footer;
+    }
+    if (variant !== "loading") {
+      return (
+        <Button onClick={onClose} variant="primary">
+          OK
+        </Button>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <div className={styles.overlay} role="dialog" aria-modal="true">
+      <div className={`${styles.modal} ${styles[variant]}`}>
+        <div className={styles.header}>
+          {title && <h2 className={styles.title}>{title}</h2>}
+          <div className={styles.menu}>
+            {menu}
+            {onClose && (
+              <button
+                className={styles["close-button"]}
+                onClick={onClose}
+                aria-label="Close"
+              >
+                <FaTimes />
+              </button>
+            )}
+          </div>
+        </div>
+        <div className={styles.content}>
+          {variant === "loading" && <div className={styles.spinner} />}
+          {children}
+        </div>
+        {(footer !== undefined || variant !== "loading") && (
+          <div className={styles.footer}>{renderFooter()}</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;


### PR DESCRIPTION
## Summary
- redesign `Modal` with header, content, footer and variants
- add storybook stories for default, success, error and loading
- update contact form to use new modal structure

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run lint` *(fails: ESLint could not load .eslintrc.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844abf5e35c832e9caca1c1dfd7fe3d