### PR TITLE
Add emailjs support to contact form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "digitaltableteur",
       "version": "0.1.0",
       "dependencies": {
+        "@emailjs/browser": "^4.4.1",
         "@emotion/is-prop-valid": "^1.3.1",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -2309,6 +2310,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@emailjs/browser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@emailjs/browser/-/browser-4.4.1.tgz",
+      "integrity": "sha512-DGSlP9sPvyFba3to2A50kDtZ+pXVp/0rhmqs2LmbMS3I5J8FSOgLwzY2Xb4qfKlOVHh29EAutLYwe5yuEZmEFg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@emotion/is-prop-valid": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@emailjs/browser": "^4.4.1",
     "@emotion/is-prop-valid": "^1.3.1",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/src/components/Contact Form/ContactForm.tsx
+++ b/src/components/Contact Form/ContactForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { send } from "@emailjs/browser";
 import styles from "./ContactForm.module.css";
 import Inputs from "../Inputs/Inputs";
 import Button from "../Button/Button";
@@ -35,13 +36,20 @@ const ContactForm = () => {
     setFormData({ ...formData, interest: selectedOptions.join(", ") });
   };
 
+  const SERVICE_ID = "service_ix55445";
+  const TEMPLATE_ID = "template_bfw826h";
+  const PUBLIC_KEY = "ockSR3pBVF7_k4-Tu";
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const mailtoLink = `mailto:mail@digitaltableteur.com?subject=Contact Form Submission&body=${encodeURIComponent(
-      `Full Name: ${formData.fullName}\nEmail: ${formData.email}\nPhone: ${formData.phone}\nInterest: ${formData.interest}\nMessage: ${formData.message}`,
-    )}`;
-    window.location.href = mailtoLink;
-    setIsModalOpen(true);
+    send(SERVICE_ID, TEMPLATE_ID, formData, PUBLIC_KEY)
+      .then(() => {
+        setIsModalOpen(true);
+      })
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error("Failed to send message", err);
+      });
   };
 
   return (


### PR DESCRIPTION
## Summary
- send messages through EmailJS instead of a mailto link
- install `@emailjs/browser` to talk to EmailJS

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844c298c4fc832eb073d7ad61e2c54b