### PR TITLE
Fix Storybook KitchenSink glob

### DIFF
--- a/src/stories/KitchenSink.stories.tsx
+++ b/src/stories/KitchenSink.stories.tsx
@@ -4,13 +4,36 @@ import Label from "../components/Label/Label";
 import Link from "../components/Link/Link";
 import { FaSearch, FaArrowLeft } from "react-icons/fa";
 
+declare const require: any;
+
 declare global {
   interface ImportMeta {
-    glob: (pattern: string, opts: { eager: boolean }) => Record<string, any>;
+    glob?: (pattern: string, opts: { eager: boolean }) => Record<string, any>;
   }
 }
 
-const modules = import.meta.glob("../components/**/*.tsx", { eager: true });
+let modules: Record<string, any> = {};
+
+if (
+  typeof import.meta !== "undefined" &&
+  typeof import.meta.glob === "function"
+) {
+  modules = import.meta.glob("../components/**/*.tsx", { eager: true });
+} else if (
+  typeof require !== "undefined" &&
+  typeof require.context === "function"
+) {
+  const req = require.context("../components", true, /\.tsx$/);
+  modules = req.keys().reduce(
+    (acc: Record<string, any>, key: string) => {
+      acc[`../components/${key.replace(/^\.\//, "")}`] = {
+        default: req(key).default || req(key),
+      };
+      return acc;
+    },
+    {} as Record<string, any>,
+  );
+}
 
 const isReactComponent = (
   component: any,


### PR DESCRIPTION
## Summary
- support Storybook webpack without `import.meta.glob`

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint` *(fails: ESLint config JSON import issue)*


------
https://chatgpt.com/codex/tasks/task_e_6844d37ff52c832e875166f20b088f96