### PR TITLE
Add cookie consent modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,12 +11,15 @@ import Designing2025 from "./pages/Designing2025";
 import WorkflowTips from "./pages/WorkflowTips";
 import DigitalCraftsmanship from "./pages/DigitalCraftsmanship";
 import NotFound from "./pages/NotFound";
+import CookiePolicy from "./pages/CookiePolicy";
+import CookieConsent from "./components/CookieConsent/CookieConsent";
 
 function App() {
   return (
     <Router>
       <div>
         <UnderDevelopment />
+        <CookieConsent />
         <Layout>
           <Routes>
             <Route path="/" element={<Home />} />
@@ -30,6 +33,7 @@ function App() {
               path="/blog/digital-craftsmanship"
               element={<DigitalCraftsmanship />}
             />
+            <Route path="/cookie-policy" element={<CookiePolicy />} />
             <Route path="*" element={<NotFound />} />
           </Routes>
         </Layout>

--- a/src/components/CookieConsent/CookieConsent.tsx
+++ b/src/components/CookieConsent/CookieConsent.tsx
@@ -1,0 +1,52 @@
+import React, { useState, useEffect } from "react";
+import Modal from "../Modal/Modal";
+import Button from "../Button/Button";
+import Link from "../Link/Link";
+
+const CookieConsent = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    const consent = localStorage.getItem("cookie-consent");
+    if (!consent) {
+      setIsOpen(true);
+    }
+  }, []);
+
+  const handleAcceptAll = () => {
+    localStorage.setItem("cookie-consent", "accepted");
+    setIsOpen(false);
+  };
+
+  const handleEssentialOnly = () => {
+    localStorage.setItem("cookie-consent", "essential-only");
+    setIsOpen(false);
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      title="Cookie consent"
+      footer={
+        <>
+          <Button variant="secondary" onClick={handleEssentialOnly}>
+            Accept only essential
+          </Button>
+          <Button variant="primary" onClick={handleAcceptAll}>
+            Accept all
+          </Button>
+        </>
+      }
+    >
+      <p>
+        We use cookies to improve your experience. Choosing
+        <strong>Accept all</strong> enables optional analytics cookies.
+        Selecting <strong>Accept only essential</strong> stores only the cookies
+        required for the site to function. Read our
+        <Link href="/cookie-policy"> cookie policy</Link> to learn more.
+      </p>
+    </Modal>
+  );
+};
+
+export default CookieConsent;

--- a/src/pages/CookiePolicy.module.css
+++ b/src/pages/CookiePolicy.module.css
@@ -1,0 +1,17 @@
+@import "../styles/variables.css";
+@import "../styles/fonts.css";
+
+.policyPage {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  font-family: var(--primary-body-font, sans-serif);
+  line-height: 1.6;
+}
+
+.policyPage h1 {
+  font-family: var(--secondary-heading-font, sans-serif);
+  font-weight: var(--secondary-heading-weight, 400);
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}

--- a/src/pages/CookiePolicy.tsx
+++ b/src/pages/CookiePolicy.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import styles from "./CookiePolicy.module.css";
+
+const CookiePolicy = () => {
+  return (
+    <div className={styles.policyPage}>
+      <h1>Cookie Policy</h1>
+      <p>
+        We use cookies to remember your preferences and to analyze how our site
+        is used. Essential cookies are saved automatically because the site
+        cannot operate without them.
+      </p>
+      <p>
+        Analytics cookies are enabled only if you click{" "}
+        <strong>Accept all</strong> on the banner. Choosing{" "}
+        <strong>Accept only essential</strong> keeps these disabled. You can
+        change your preference at any time through your browser settings.
+      </p>
+      <p>
+        For details about how we handle personal data and your rights under
+        GDPR, please contact us.
+      </p>
+    </div>
+  );
+};
+
+export default CookiePolicy;


### PR DESCRIPTION
## Summary
- show cookie consent modal on initial visit
- link to GDPR cookie policy
- implement cookie policy page
- update button labels to "Accept all" and "Accept only essential"

## Testing
- `npm run lint` *(fails: code style issues found)*
- `npm test -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684789098ebc832ea5fb5899e2feae2c