### PR TITLE
Add Google Analytics tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-09HMKEXGPX"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-09HMKEXGPX');
+    </script>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
## Summary
- add Google Analytics script tag in `public/index.html`

## Testing
- `NODE_OPTIONS='--experimental-json-modules' npm run lint`
- `npm test -- -u --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_684815d349e0832ea5a61718e74384a2