### PR TITLE
Add work sections from figma

### DIFF
--- a/scripts/extractWorkData.js
+++ b/scripts/extractWorkData.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const figma = JSON.parse(fs.readFileSync('figma.json', 'utf8'));
+const texts = [];
+function walk(node){
+  if(node.characters && typeof node.characters === 'string') {
+    texts.push(node.characters);
+  }
+  if(node.children) node.children.forEach(walk);
+}
+walk(figma.document);
+const projects = [];
+const titles = new Set();
+texts.forEach(t => {
+  const yearMatch = t.match(/(19|20)\d{2}/);
+  if(yearMatch){
+    const title = t.split(/[\.\n]/)[0].trim();
+    if(!titles.has(title) && title.length > 3 && title.length < 100){
+      titles.add(title);
+      projects.push({title, description: t.trim(), year: yearMatch[0]});
+    }
+  }
+});
+fs.writeFileSync('src/data/workData.json', JSON.stringify(projects, null, 2));
+console.log('extracted', projects.length, 'projects');

--- a/src/data/workData.json
+++ b/src/data/workData.json
@@ -1,0 +1,472 @@
+[
+  {
+    "title": "Polygon Lady",
+    "description": "Polygon Lady\nA vector mesh rendering of a lady with diamond earrings. A study done for SC5 illustration style. Illustrator. 2014.",
+    "year": "2014"
+  },
+  {
+    "title": "IF I’m not 3d, ICE CREAM",
+    "description": "IF I’m not 3d, ICE CREAM\nA vector rendering of an ice lolly. Illustrator. 2012.",
+    "year": "2012"
+  },
+  {
+    "title": "Character design",
+    "description": "Character design\nA cartoon Cosa Nostra character turnaround sketch for 3D. Photoshop/Wacom. 2013.",
+    "year": "2013"
+  },
+  {
+    "title": "senile general",
+    "description": "senile general\nA cartoon General character rendering. Photoshop/Wacom. 2013.",
+    "year": "2013"
+  },
+  {
+    "title": "THE ESSENCE OF FINNISH GUTS",
+    "description": "THE ESSENCE OF FINNISH GUTS\nAn illustration of my favorite finnish candy,  Super Salmiakki. Illustrator. 2013.",
+    "year": "2013"
+  },
+  {
+    "title": "VECTOR MEDIUM",
+    "description": "VECTOR MEDIUM\nA cartoon vector rendering of a female medium character. Self initiated illustration study.\nIllustrator. 2012.",
+    "year": "2012"
+  },
+  {
+    "title": "new Things co logotype",
+    "description": "new Things co logotype\nNew Things Co official logotype. Illustrator. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "external link",
+    "description": "external link\nMedium article by Kimmo Kuisma. 2018.",
+    "year": "2018"
+  },
+  {
+    "title": "new Things co SECONDARY LOGOTYPE",
+    "description": "new Things co SECONDARY LOGOTYPE\nNew Things Co secondary logotype for mobile use. Illustrator. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "illustrative photo",
+    "description": "illustrative photo\nPhoto from the Printmotor stock collection. Courtesy of Printmotor. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "pre kick-off mini workshop",
+    "description": "pre kick-off mini workshop\nPositioning, values and tone excercise for the client to gain project insight. \nSketch. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "printmotor user testing",
+    "description": "printmotor user testing\nQuestions for user testing to validate project success with real users. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "screens from the storefront",
+    "description": "screens from the storefront\nPrintmotor storefront and order confirmation views.  Sketch. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "store creation mobile screen",
+    "description": "store creation mobile screen\nAn example of the mobile version of the admin storefront creation flow. \nSketch. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "examples of components",
+    "description": "examples of components\nExtensive atomic Design System for Alma Medias Autotalli.  Sketch/Figma. 2018.",
+    "year": "2018"
+  },
+  {
+    "title": "example of the style guide",
+    "description": "example of the style guide\nAutotalli Style Guide / Typography documentation. \nSketch/Figma. 2018.",
+    "year": "2018"
+  },
+  {
+    "title": "layout for car comparison",
+    "description": "layout for car comparison\nAll Autotalli screens were designed mobile first. Sketch/Figma. 2018.",
+    "year": "2018"
+  },
+  {
+    "title": "components on the front page",
+    "description": "components on the front page\nAn example of a few of the components on the front page. Sketch/Figma. 2018.",
+    "year": "2018"
+  },
+  {
+    "title": "the futures cone  Illustration and slides for the Futures of Work -workshop",
+    "description": "the futures cone  Illustration and slides for the Futures of Work -workshop.   \nIllustrator. 2018.",
+    "year": "2018"
+  },
+  {
+    "title": "modular components and variants",
+    "description": "modular components and variants\nExamples from the New Things Co Design System.  Figma Team Library / Figma. 2018.",
+    "year": "2018"
+  },
+  {
+    "title": "new things co responsive web",
+    "description": "new things co responsive web\nExamples of sections in the New Things Co Web- and mobile layouts. \nFigma. 2018.",
+    "year": "2018"
+  },
+  {
+    "title": "peeps and profit mobile apps",
+    "description": "peeps and profit mobile apps\nApp ideas brainstormed at Design Sprints and Lab time events for New Things Co.  Sketch. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "“newer things co”",
+    "description": "“newer things co”\nA tongue-in-cheek Stranger Things TV-series inspired illustration for an Instagram post. \nPhotoshop. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "office info displays",
+    "description": "office info displays\nThe New Things Co dev team put together an idea for our modular info system at the office.  Illustrator. 2018.",
+    "year": "2018"
+  },
+  {
+    "title": "RECRUITMENT AD",
+    "description": "RECRUITMENT AD\nA tongue-in-cheek recruitment ad illustration to help promote New Things Co.  Illustrator. 2018.",
+    "year": "2018"
+  },
+  {
+    "title": "swag",
+    "description": "swag\nA few apparel designs for New Things Co. Illustrator/Photoshop. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "Business cards",
+    "description": "Business cards\nBusiness cards with personalized greetings. Printed on recycled card stock. \nIndesign/Photoshop. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "vinyl stickers",
+    "description": "vinyl stickers\nA collection of New Things Co stickers. Illustrator/Photoshop. 2017–2018.",
+    "year": "2017"
+  },
+  {
+    "title": "brochure for trip to dubrovnik",
+    "description": "brochure for trip to dubrovnik \nAn informative trip brochure with common Croatian expressions, itinerary, team contact info and meal times.  Indesign. 2018.",
+    "year": "2018"
+  },
+  {
+    "title": "ai art background images",
+    "description": "ai art background images \nA series of AI or script generated backgrounds. \nIllustrator/Processing. 2018.",
+    "year": "2018"
+  },
+  {
+    "title": "layout for filter selection",
+    "description": "layout for filter selection\nAll Autotalli screens were designed mobile first. Sketch/Figma. 2018.",
+    "year": "2018"
+  },
+  {
+    "title": "alma tunnus hero background",
+    "description": "alma tunnus hero background\nExample of the Alma-Tunnus hero background suggestions. Sketch/Figma. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "about page Example",
+    "description": "about page Example\nInformative about page with hero image suggestion. Sketch/Figma. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "variations for sso-switch",
+    "description": "variations for sso-switch\nExample of the various strategies covered for switching to Alma-Tunnus. Sketch/Figma. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "sso-login modal examples",
+    "description": "sso-login modal examples\nLogin pages were also designed as modals. Sketch/Figma. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "example of THE old ui and build",
+    "description": "example of THE old ui and build\nThe starting point for the project. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "example of personas and journeys",
+    "description": "example of personas and journeys\nThe observations and interviews were documented and categorized as compact persona/journeys. Sketch/Figma. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "example layouts for compass app",
+    "description": "example layouts for compass app\nExamples of the case handling and keyboard shortcuts screens. Sketch/Figma. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "tulli workshop slide bg",
+    "description": "tulli workshop slide bg \nBackground image for the NAKKI-project workshop and various presentations. Illustrator. 2016.",
+    "year": "2016"
+  },
+  {
+    "title": "agile explained to tulli",
+    "description": "agile explained to tulli\nThe agile design and development process the NAKKI-team used. Sketch. 2016.",
+    "year": "2016"
+  },
+  {
+    "title": "example 1 of the style guide",
+    "description": "example 1 of the style guide\nAs a part of the NAKKI-project I also documented all the components used in the layouts.  Sketch. 2016.",
+    "year": "2016"
+  },
+  {
+    "title": "example 2 of the style guide",
+    "description": "example 2 of the style guide\nAs a part of the NAKKI-project I documented all the components used in the layouts. Sketch. 2016.",
+    "year": "2016"
+  },
+  {
+    "title": "example 3 of the style guide",
+    "description": "example 3 of the style guide\nAs a part of the NAKKI-project I documented all the components used in the layouts. Sketch. 2016.",
+    "year": "2016"
+  },
+  {
+    "title": "example 4 of the style guide",
+    "description": "example 4 of the style guide\nAs a part of the NAKKI-project I documented all the components used in the layouts. Sketch. 2016.",
+    "year": "2016"
+  },
+  {
+    "title": "example 5 of the style guide",
+    "description": "example 5 of the style guide\nAs a part of the NAKKI-project I documented all the components used in the layouts. Sketch. 2016.",
+    "year": "2016"
+  },
+  {
+    "title": "tulli e-services and intrastat",
+    "description": "tulli e-services and intrastat\nExamples of the e-services frontpage and INTRASTAT e-service. Sketch. 2016.",
+    "year": "2016"
+  },
+  {
+    "title": "issue #2 fin and eng covers",
+    "description": "issue #2 fin and eng covers\nCover designs printed on high quality card stock. Indesign/Photoshop. 2014.",
+    "year": "2014"
+  },
+  {
+    "title": "issue #3 spine",
+    "description": "issue #3 spine\nSpine and cover designs printed on high quality card stock. Indesign/Photoshop. 2014.",
+    "year": "2014"
+  },
+  {
+    "title": "issue #1 editorial design",
+    "description": "issue #1 editorial design\nI designed all the content twice a year from 2014–2017. Indesign/Photoshop. 2014.",
+    "year": "2014"
+  },
+  {
+    "title": "the blue arrow awards logo",
+    "description": "the blue arrow awards logo\nLogo original I designed for the first Blue Arrow Awards. Illustrator. 2016",
+    "year": "2016"
+  },
+  {
+    "title": "examples layout",
+    "description": "examples layout\nExample page of a marketing mailer we sent to Finnair looking for sponsors. Illustrator. 2016.",
+    "year": "2016"
+  },
+  {
+    "title": "examples layout 2",
+    "description": "examples layout 2\nExample page of a marketing mailer we sent to Finnair looking for sponsors. Illustrator. 2016.",
+    "year": "2016"
+  },
+  {
+    "title": "layout for the website frontpage",
+    "description": "layout for the website frontpage\nHero section of the Blue Arrow Awards 2016 homepage. Illustrator/Sketch. 2016.",
+    "year": "2016"
+  },
+  {
+    "title": "examples of judges component",
+    "description": "examples of judges component\nComponent for web. Many renowned names in IT were involved. Illustrator/Sketch. 2016.",
+    "year": "2016"
+  },
+  {
+    "title": "photo from event",
+    "description": "photo from event\nThe identity was carried onto the event materials.  Used with permission from the Better Digital Services Finland. 2016.",
+    "year": "2016"
+  },
+  {
+    "title": "ROUND stickers",
+    "description": "ROUND stickers\nPromotional stickers for promotional use.  Illustrator. 2015.",
+    "year": "2015"
+  },
+  {
+    "title": "logo originals and safe areas",
+    "description": "logo originals and safe areas\nExtract from the Corporate Guidelines.  Illustrator. 2014.",
+    "year": "2014"
+  },
+  {
+    "title": "document creation guide",
+    "description": "document creation guide\nLetterhead and mobile document creation guidelines. Illustrator/Indesign. 2014.",
+    "year": "2014"
+  },
+  {
+    "title": "icons for various uses",
+    "description": "icons for various uses\nIcons designed for use both in print and online. Illustrator. 2014.",
+    "year": "2014"
+  },
+  {
+    "title": "repeating pattern",
+    "description": "repeating pattern\nPattern design featuring the diverse people working at SC5.\nIllustrator. 2014.",
+    "year": "2014"
+  },
+  {
+    "title": "backgrounds for social media",
+    "description": "backgrounds for social media\nWallpapers for social media. \nIllustrator. 2014.",
+    "year": "2014"
+  },
+  {
+    "title": "stationery",
+    "description": "stationery\nAs a part of the Corporate Guidelines, I also documented all the applications designed for SC5.  Illustrator/Indesign. 2014.",
+    "year": "2014"
+  },
+  {
+    "title": "sc5 website design",
+    "description": "sc5 website design\nExample of the Cases page. Illustrator. 2014.",
+    "year": "2014"
+  },
+  {
+    "title": "SC5 stylebook implementation",
+    "description": "SC5 stylebook implementation\nExample of process charts for the SC5 Living Styleguide. Illustrator. 2015.",
+    "year": "2015"
+  },
+  {
+    "title": "co-design workshop mini-swot",
+    "description": "co-design workshop mini-swot\nAn example of the topics covered in the Alma Media co-design workshops. Sketch/Figma. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "illustrative photo about the sso",
+    "description": "illustrative photo about the sso\nAn example of the photos shot to showcase the SSO-project. Photo by Kimmo Kuisma. 2018.",
+    "year": "2018"
+  },
+  {
+    "title": "example of the sso-signup flow",
+    "description": "example of the sso-signup flow\nBasic signup for Alma-Tunnus. Sketch/Figma. 2017.",
+    "year": "2017"
+  },
+  {
+    "title": "issue #4 fin and eng covers",
+    "description": "issue #4 fin and eng covers\nCover designs on high quality dust jackets over debossed card stock. Indesign/Photoshop. 2014.",
+    "year": "2014"
+  },
+  {
+    "title": "examples layout 3",
+    "description": "examples layout 3\nExample page of a marketing mailer we sent to Finnair looking for sponsors. Illustrator. 2016.",
+    "year": "2016"
+  },
+  {
+    "title": "2012–2014",
+    "description": "2012–2014",
+    "year": "2012"
+  },
+  {
+    "title": "2014–2015",
+    "description": "2014–2015",
+    "year": "2014"
+  },
+  {
+    "title": "2016",
+    "description": "2016",
+    "year": "2016"
+  },
+  {
+    "title": "Raw View was a magazine of documentary photography",
+    "description": "Raw View was a magazine of documentary photography. It ran for ten  years between 2007–2017 and it was launched under the name Photo Raw.\n\nIn 2014 I was approached by Hannamari directly as she had previously worked with a uni classmate who had recommended me. We discussed about the magazine’s ideology with Art Director at the time, Teun van der Heijden and the direction they wanted to go with it. We shared a common view and not long after I was hard at work. Raw View was born.\n\nWe began with the publication masthead ie. the cover, publication specs and master pages while simultaneosly negotiating with printhouses and working on the first issue with the editorial team from all over the globe. \n\nIn 2009 the magazine was awarded with the Quality Prize for Culture magazines by the Ministry of Culture in Finland and with The Cult Journalism award in 2016. The tenth and last issue was released in November 2017 and was dedicated to Finland.",
+    "year": "2007"
+  },
+  {
+    "title": "2014–2017",
+    "description": "2014–2017",
+    "year": "2014"
+  },
+  {
+    "title": "In 2016 The Finnish Customs launched several IT system projects to develop new electronic services",
+    "description": "In 2016 The Finnish Customs launched several IT system projects to develop new electronic services. Businesses and individuals can now submit (or lodge) declarations to the Finnish Customs conveniently via the e-services platform or the newly renewed message exchange platform.\n\nI was commissioned by The Customs IT-Department to help them research, define and design the new streamlined e-services (Nettiasiointi- käyttöliittymä, aka NAKKI). Another task was to collect all the necessary components into a library that Tulli could, in time, learn to uphold themselves. Back then agile methods in government organisations were commonplace but having introduced more lean there was also genuine interest in streamlining their processes. \n\nTogether with the team we managed to change the way Tulli approaches their development efforts and influenced them to adopt lean practises.  We held minor user experiments daily and more extensive user testing sessions once per quater and there was even discussion of going open source on some minor systems as a result.",
+    "year": "2016"
+  },
+  {
+    "title": "2016–2017",
+    "description": "2016–2017",
+    "year": "2016"
+  },
+  {
+    "title": "2017",
+    "description": "2017",
+    "year": "2017"
+  },
+  {
+    "title": "Alma Autotalli got in touch to further develop their current design and development processes",
+    "description": "Alma Autotalli got in touch to further develop their current design and development processes. Enabling the use of a Design System was key, while improving the services current customer experience would be a plus.\n\nThe project was started by mapping the needs of the users and by selecting a portion of the service for the Design System. For this, the user understanding was collected from existing customer surveys and analytics.\n\nAutotalli expressed that they were only able to carry out any design\nimprovements in small parts, so we began by mapping the current version thoroughly. Some UX-bloopers were corrected, the main features were re-designed to meet the needs of the user and the appearance of the service was refreshed. The customer representative was closely involved in the design process as he was also very keen to learn about Design Systems.\n\nThe resulting deliverable was a comprehensive Design System, which was incorporated as part in Autotalli’s service development process. The implementation is currently underway and set to be finished in spring 2019.",
+    "year": "2019"
+  },
+  {
+    "title": "2018",
+    "description": "2018",
+    "year": "2018"
+  },
+  {
+    "title": "2017–2018",
+    "description": "2017–2018",
+    "year": "2017"
+  },
+  {
+    "title": "Portfolio 2021",
+    "description": "Portfolio 2021",
+    "year": "2021"
+  },
+  {
+    "title": "Updated 11/2021",
+    "description": "Updated 11/2021",
+    "year": "2021"
+  },
+  {
+    "title": "MY TECHNO WEIGHS A TON",
+    "description": "MY TECHNO WEIGHS A TON\nIllustrations for apparel and event promotion. Illustrator. 2018.",
+    "year": "2018"
+  },
+  {
+    "title": "Intrastat tuonti-ilmoitus 2016-04",
+    "description": "Intrastat tuonti-ilmoitus 2016-04",
+    "year": "2016"
+  },
+  {
+    "title": "Intrastat vienti-ilmoitus 2016-04",
+    "description": "Intrastat vienti-ilmoitus 2016-04",
+    "year": "2016"
+  },
+  {
+    "title": "Intrastat tuonti-ilmoitus 2016-03",
+    "description": "Intrastat tuonti-ilmoitus 2016-03",
+    "year": "2016"
+  },
+  {
+    "title": "Intrastat vienti-ilmoitus 2016-03",
+    "description": "Intrastat vienti-ilmoitus 2016-03",
+    "year": "2016"
+  },
+  {
+    "title": "9202122",
+    "description": "9202122",
+    "year": "2021"
+  },
+  {
+    "title": "Intrastat tuonti-ilmoitus 2016-02",
+    "description": "Intrastat tuonti-ilmoitus 2016-02",
+    "year": "2016"
+  },
+  {
+    "title": "Intrastat vienti-ilmoitus 2016-02",
+    "description": "Intrastat vienti-ilmoitus 2016-02",
+    "year": "2016"
+  },
+  {
+    "title": "Intrastat tuonti-ilmoitus 2016-01",
+    "description": "Intrastat tuonti-ilmoitus 2016-01",
+    "year": "2016"
+  },
+  {
+    "title": "Intrastat vienti-ilmoitus 2016-01",
+    "description": "Intrastat vienti-ilmoitus 2016-01",
+    "year": "2016"
+  },
+  {
+    "title": "selected work 2019 – Petri Lahdelma",
+    "description": "selected work 2019 – Petri Lahdelma",
+    "year": "2019"
+  },
+  {
+    "title": "Selected work 2019",
+    "description": "Selected work 2019",
+    "year": "2019"
+  }
+]

--- a/src/pages/Work.module.css
+++ b/src/pages/Work.module.css
@@ -112,3 +112,29 @@ section {
   align-items: center;
   justify-content: center;
 }
+
+.projectSection {
+  background-color: var(--color-secondary);
+  flex-direction: column;
+  padding: 2rem;
+  overflow-y: auto;
+}
+
+.project {
+  margin-bottom: 2rem;
+  max-width: 800px;
+  text-align: left;
+}
+.project h3 {
+  margin: 0 0 0.5rem;
+  font-size: 2rem;
+  font-family: "Moderat", sans-serif;
+}
+.project p {
+  margin: 0 0 0.5rem;
+  line-height: 1.3;
+}
+.project .year {
+  font-size: 1.2rem;
+  opacity: 0.8;
+}

--- a/src/pages/Work.tsx
+++ b/src/pages/Work.tsx
@@ -6,6 +6,7 @@ import Ufo from "../assets/images/ufo.webp";
 import sausage from "../assets/images/sausage.webp";
 import fur from "../assets/images/fur.webp";
 import blackletter from "../assets/images/blackletter.webp";
+import projectData from "../data/workData.json";
 
 const Work = () => {
   return (
@@ -60,6 +61,15 @@ const Work = () => {
               </div>
             </div>
           </div>
+        </section>
+        <section className={styles.projectSection}>
+          {projectData.slice(0, 6).map((project, idx) => (
+            <div key={idx} className={styles.project}>
+              <h3>{project.title}</h3>
+              <p>{project.description}</p>
+              <div className={styles.year}>{project.year}</div>
+            </div>
+          ))}
         </section>
         <section className={styles.section6}>Section 6</section>
         <section className={styles.section7}>Section 7</section>


### PR DESCRIPTION
## Summary
- parse `figma.json` for project text and export to `src/data/workData.json`
- display parsed projects on Work page
- style new project section

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run lint --silent` *(fails: import attribute missing)*


------
https://chatgpt.com/codex/tasks/task_e_684f348e8828832e8291c023fad8515a