### PR TITLE
Add toast component for SocialShare

### DIFF
--- a/src/components/SocialShare/SocialShare.tsx
+++ b/src/components/SocialShare/SocialShare.tsx
@@ -1,5 +1,5 @@
 // components/SocialShare.tsx
-import React from "react";
+import React, { useState } from "react";
 import styles from "./SocialShare.module.css";
 import {
   FaTwitter,
@@ -10,6 +10,7 @@ import {
   FaLink,
 } from "react-icons/fa";
 import Button from "../Button/Button";
+import Toast from "../Toast/Toast";
 
 interface SocialShareProps {
   url: string;
@@ -19,10 +20,15 @@ interface SocialShareProps {
 export const SocialShare = ({ url, title }: SocialShareProps) => {
   const encodedUrl = encodeURIComponent(url);
   const encodedTitle = encodeURIComponent(title);
+  const [toastOpen, setToastOpen] = useState(false);
 
   const handleCopy = async () => {
     await navigator.clipboard.writeText(url);
-    alert("Link copied!");
+    setToastOpen(true);
+  };
+
+  const handleToastClose = () => {
+    setToastOpen(false);
   };
 
   return (
@@ -70,12 +76,17 @@ export const SocialShare = ({ url, title }: SocialShareProps) => {
       <Button
         variant="secondary"
         icon={FaLink({})}
-        className={styles["copy-button"]}
+        className={styles.copyButton}
         onClick={handleCopy}
         aria-label="Copy link to clipboard"
       >
         Copy link to clipboard
       </Button>
+      <Toast
+        message="Link copied!"
+        open={toastOpen}
+        onClose={handleToastClose}
+      />
     </div>
   );
 };

--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -1,0 +1,15 @@
+@import url("../../styles/variables.css");
+
+.toast {
+  position: fixed;
+  bottom: var(--space-layout-24);
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: var(--color-dark);
+  color: var(--color-white);
+  padding: var(--space-internal-12) var(--space-internal-16);
+  border-radius: var(--radius-md);
+  box-shadow: 0 2px 6px rgb(0 0 0 / 20%);
+  z-index: 1000;
+  font-family: var(--primary-body-font);
+}

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect } from "react";
+import styles from "./Toast.module.css";
+
+export interface ToastProps {
+  message: string;
+  open: boolean;
+  duration?: number;
+  onClose?: () => void;
+}
+
+const Toast: React.FC<ToastProps> = ({
+  message,
+  open,
+  duration = 3000,
+  onClose,
+}) => {
+  useEffect(() => {
+    if (!open) return;
+    const timer = setTimeout(() => {
+      onClose?.();
+    }, duration);
+    return () => clearTimeout(timer);
+  }, [open, duration, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className={styles.toast} role="status" aria-live="polite">
+      {message}
+    </div>
+  );
+};
+
+export default Toast;


### PR DESCRIPTION
## Summary
- add a lightweight toast/snackbar component
- use the toast when copying the SocialShare link

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run lint` *(fails: ESLint import attribute error)*

------
https://chatgpt.com/codex/tasks/task_e_6854f2bc62bc832ea8d6e8eb412f8b08