### PR TITLE
Add analytics ID support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 REACT_APP_EMAIL_SERVICE_ID=your_service_id
 REACT_APP_EMAIL_TEMPLATE_ID=your_template_id
 REACT_APP_EMAIL_PUBLIC_KEY=your_public_key
+REACT_APP_GA_ID=your_ga_measurement_id

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ Install dependencies with:
 npm ci
 ```
 
-Copy `.env.example` to `.env` and fill in your EmailJS credentials if you want the contact form to work locally:
+Copy `.env.example` to `.env` and fill in your EmailJS credentials if you want the contact form to work locally. The file also includes `REACT_APP_GA_ID` for configuring Google Analytics:
 
 ```bash
 cp .env.example .env
 ```
+
+Set `REACT_APP_GA_ID` to your Google Analytics measurement ID if you want to collect usage statistics.
 
 ### Run the development server
 

--- a/public/index.html
+++ b/public/index.html
@@ -1,15 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-09HMKEXGPX"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-09HMKEXGPX');
-    </script>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,23 @@ import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 
+const gaId = process.env.REACT_APP_GA_ID;
+if (gaId) {
+  const gtagScript = document.createElement("script");
+  gtagScript.async = true;
+  gtagScript.src = `https://www.googletagmanager.com/gtag/js?id=${gaId}`;
+  document.head.appendChild(gtagScript);
+
+  const inlineScript = document.createElement("script");
+  inlineScript.innerHTML = `
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', '${gaId}');
+  `;
+  document.head.appendChild(inlineScript);
+}
+
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement,
 );


### PR DESCRIPTION
## Summary
- add `REACT_APP_GA_ID` to env example
- document analytics env variable
- inject analytics script dynamically in `index.tsx`
- remove hardcoded GA script from template

## Testing
- `CI=true npm test --silent`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854f2c812c8832e91fb1eba30d07e2c