### PR TITLE
Add Open Graph meta tags

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -13,6 +13,19 @@ const About = () => {
           name="description"
           content="Learn about Digitaltableteur's approach to design and development."
         />
+        <meta property="og:title" content="About | Digitaltableteur" />
+        <meta
+          property="og:description"
+          content="Learn about Digitaltableteur's approach to design and development."
+        />
+        <meta property="og:image" content="/logo512.png" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="About | Digitaltableteur" />
+        <meta
+          name="twitter:description"
+          content="Learn about Digitaltableteur's approach to design and development."
+        />
+        <meta name="twitter:image" content="/logo512.png" />
       </Helmet>
       <div className={styles.about}>
         <section className={styles.hero}>

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -31,6 +31,19 @@ const Blog = () => {
           name="description"
           content="Insights and articles from the Digitaltableteur team"
         />
+        <meta property="og:title" content="Blog | Digitaltableteur" />
+        <meta
+          property="og:description"
+          content="Insights and articles from the Digitaltableteur team"
+        />
+        <meta property="og:image" content="/logo512.png" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Blog | Digitaltableteur" />
+        <meta
+          name="twitter:description"
+          content="Insights and articles from the Digitaltableteur team"
+        />
+        <meta name="twitter:image" content="/logo512.png" />
       </Helmet>
       <div className={styles.blog}>
         <Title size="L">Articles</Title>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -14,6 +14,19 @@ const Contact = () => {
           name="description"
           content="Get in touch with Digitaltableteur to discuss your next project."
         />
+        <meta property="og:title" content="Contact | Digitaltableteur" />
+        <meta
+          property="og:description"
+          content="Get in touch with Digitaltableteur to discuss your next project."
+        />
+        <meta property="og:image" content="/logo512.png" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Contact | Digitaltableteur" />
+        <meta
+          name="twitter:description"
+          content="Get in touch with Digitaltableteur to discuss your next project."
+        />
+        <meta name="twitter:image" content="/logo512.png" />
       </Helmet>
       <div className={styles.contact}>
         <Title size="L">

--- a/src/pages/CookiePolicy.tsx
+++ b/src/pages/CookiePolicy.tsx
@@ -11,6 +11,19 @@ const CookiePolicy = () => {
           name="description"
           content="How Digitaltableteur uses cookies and your choices about them"
         />
+        <meta property="og:title" content="Cookie Policy | Digitaltableteur" />
+        <meta
+          property="og:description"
+          content="How Digitaltableteur uses cookies and your choices about them"
+        />
+        <meta property="og:image" content="/logo512.png" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Cookie Policy | Digitaltableteur" />
+        <meta
+          name="twitter:description"
+          content="How Digitaltableteur uses cookies and your choices about them"
+        />
+        <meta name="twitter:image" content="/logo512.png" />
       </Helmet>
       <div className={styles.policyPage}>
         <h1>Cookie Policy</h1>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -34,6 +34,25 @@ const Home = () => {
           name="description"
           content="Design-led digital studio delivering strategy, branding and development."
         />
+        <meta
+          property="og:title"
+          content="Digitaltableteur - Creative & Development"
+        />
+        <meta
+          property="og:description"
+          content="Design-led digital studio delivering strategy, branding and development."
+        />
+        <meta property="og:image" content="/logo512.png" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+          name="twitter:title"
+          content="Digitaltableteur - Creative & Development"
+        />
+        <meta
+          name="twitter:description"
+          content="Design-led digital studio delivering strategy, branding and development."
+        />
+        <meta name="twitter:image" content="/logo512.png" />
       </Helmet>
       <div className={styles.home}>
         <Grid columns={1} gap="1rem">

--- a/src/pages/Work.tsx
+++ b/src/pages/Work.tsx
@@ -17,6 +17,19 @@ const Work = () => {
           name="description"
           content="Selected projects and experiments by Digitaltableteur"
         />
+        <meta property="og:title" content="Work | Digitaltableteur" />
+        <meta
+          property="og:description"
+          content="Selected projects and experiments by Digitaltableteur"
+        />
+        <meta property="og:image" content="/logo512.png" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Work | Digitaltableteur" />
+        <meta
+          name="twitter:description"
+          content="Selected projects and experiments by Digitaltableteur"
+        />
+        <meta name="twitter:image" content="/logo512.png" />
       </Helmet>
       <div className={styles["work-page"]}>
         <section className={styles.section1}>

--- a/src/pages/posts/Designing2025.tsx
+++ b/src/pages/posts/Designing2025.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet";
 import styles from "../Article.module.css";
 import Author from "../../components/Author/Author";
 import VaultBoy from "../../assets/images/pete-vault-boy.jpg";
@@ -6,159 +7,193 @@ import Card from "../../components/Card/Card";
 import { SocialShare } from "../../components/SocialShare/SocialShare";
 
 const Designing2025 = () => (
-  <article className={styles.article}>
-    <header>
-      <h1>
-        Designing in 2025:
-        <br />
-        Navigating the AI-Assisted Creative Landscape
-      </h1>
-      <Author name="Petri Lahdelma" imageUrl={VaultBoy} size="32px" />
-    </header>
-    <p>
-      After more than two decades in the design field, I’ve had the pleasure and
-      privilege of witnessing the practice evolve—from sketchbooks and static
-      wireframes to collaborative, cloud-based systems that update in real-time.
-      And now, in 2025, we’re at the cusp of what may be the most profound shift
-      yet: the rise of AI as a deeply embedded partner in the design process.
-    </p>
-    <p>
-      Artificial Intelligence is no longer a novelty. It’s embedded in the very
-      tools we use—from generative ideation and layout prediction to code
-      generation and automated testing. But despite this acceleration, one truth
-      endures: design is still a deeply human act.
-    </p>
-    <blockquote>
-      At its best, design is how we care for people at scale.
-    </blockquote>
-    <p>
-      Our challenge now is not about keeping up with the speed of machines—it’s
-      about preserving the purpose of design in an age of abundance.
-    </p>
+  <>
+    <Helmet>
+      <title>Designing in 2025 | Digitaltableteur</title>
+      <meta
+        name="description"
+        content="Navigating the AI-assisted creative landscape."
+      />
+      <meta
+        property="og:title"
+        content="Designing in 2025 | Digitaltableteur"
+      />
+      <meta
+        property="og:description"
+        content="Navigating the AI-assisted creative landscape."
+      />
+      <meta property="og:image" content="/logo512.png" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta
+        name="twitter:title"
+        content="Designing in 2025 | Digitaltableteur"
+      />
+      <meta
+        name="twitter:description"
+        content="Navigating the AI-assisted creative landscape."
+      />
+      <meta name="twitter:image" content="/logo512.png" />
+    </Helmet>
+    <article className={styles.article}>
+      <header>
+        <h1>
+          Designing in 2025:
+          <br />
+          Navigating the AI-Assisted Creative Landscape
+        </h1>
+        <Author name="Petri Lahdelma" imageUrl={VaultBoy} size="32px" />
+      </header>
+      <p>
+        After more than two decades in the design field, I’ve had the pleasure
+        and privilege of witnessing the practice evolve—from sketchbooks and
+        static wireframes to collaborative, cloud-based systems that update in
+        real-time. And now, in 2025, we’re at the cusp of what may be the most
+        profound shift yet: the rise of AI as a deeply embedded partner in the
+        design process.
+      </p>
+      <p>
+        Artificial Intelligence is no longer a novelty. It’s embedded in the
+        very tools we use—from generative ideation and layout prediction to code
+        generation and automated testing. But despite this acceleration, one
+        truth endures: design is still a deeply human act.
+      </p>
+      <blockquote>
+        At its best, design is how we care for people at scale.
+      </blockquote>
+      <p>
+        Our challenge now is not about keeping up with the speed of
+        machines—it’s about preserving the purpose of design in an age of
+        abundance.
+      </p>
 
-    <h2>Beyond Automation: Reclaiming the Core of Creative Work</h2>
-    <p>
-      We no longer face a blinking cursor on a blank canvas. AI can instantly
-      generate layouts, suggest type pairings, or convert sketches into code.
-      It’s impressive. But speed can’t replace soul.
-    </p>
-    <p>
-      AI, in my experience, isn’t here to replace creativity—it’s here to
-      amplify it.
-    </p>
-    <p>
-      This means shifting our mindset. Not toward competing with machines, but
-      toward outthinking them. Toward asking sharper questions. Challenging
-      assumptions. Understanding people, behaviors, and contexts more deeply.
-    </p>
-    <p>
-      Because in a world where any prompt can output a hundred variations, our
-      craft becomes less about creation and more about curation. Less about what
-      we can generate, and more about what we choose to keep.
-    </p>
-    <p>
-      This is a return to judgment. To narrative. To human insight as the
-      foundation of meaningful work.
-    </p>
+      <h2>Beyond Automation: Reclaiming the Core of Creative Work</h2>
+      <p>
+        We no longer face a blinking cursor on a blank canvas. AI can instantly
+        generate layouts, suggest type pairings, or convert sketches into code.
+        It’s impressive. But speed can’t replace soul.
+      </p>
+      <p>
+        AI, in my experience, isn’t here to replace creativity—it’s here to
+        amplify it.
+      </p>
+      <p>
+        This means shifting our mindset. Not toward competing with machines, but
+        toward outthinking them. Toward asking sharper questions. Challenging
+        assumptions. Understanding people, behaviors, and contexts more deeply.
+      </p>
+      <p>
+        Because in a world where any prompt can output a hundred variations, our
+        craft becomes less about creation and more about curation. Less about
+        what we can generate, and more about what we choose to keep.
+      </p>
+      <p>
+        This is a return to judgment. To narrative. To human insight as the
+        foundation of meaningful work.
+      </p>
 
-    <h2>AI as a Partner, Not a Proxy</h2>
-    <p>
-      There’s a myth that AI reduces the need for thinking. In practice, it does
-      the opposite.
-    </p>
-    <p>
-      Great AI tools remove friction, not responsibility. They clear the
-      repetitive and procedural, allowing us to focus on higher-order
-      challenges: behavior, structure, intention, emotion.
-    </p>
-    <p>That’s where modern creative leadership lives.</p>
-    <p>
-      When mentoring younger designers, I often say: Your job isn’t to outpace
-      the machine. It’s to know what matters and why. To hold the line when an
-      output is technically correct but emotionally hollow.
-    </p>
-    <p>AI can optimize. Only humans can care.</p>
-    <p>
-      To succeed in 2025, designers must become bilingual—fluent in both human
-      needs and machine capabilities. Because AI isn’t replacing our language.
-      It’s becoming part of it.
-    </p>
+      <h2>AI as a Partner, Not a Proxy</h2>
+      <p>
+        There’s a myth that AI reduces the need for thinking. In practice, it
+        does the opposite.
+      </p>
+      <p>
+        Great AI tools remove friction, not responsibility. They clear the
+        repetitive and procedural, allowing us to focus on higher-order
+        challenges: behavior, structure, intention, emotion.
+      </p>
+      <p>That’s where modern creative leadership lives.</p>
+      <p>
+        When mentoring younger designers, I often say: Your job isn’t to outpace
+        the machine. It’s to know what matters and why. To hold the line when an
+        output is technically correct but emotionally hollow.
+      </p>
+      <p>AI can optimize. Only humans can care.</p>
+      <p>
+        To succeed in 2025, designers must become bilingual—fluent in both human
+        needs and machine capabilities. Because AI isn’t replacing our language.
+        It’s becoming part of it.
+      </p>
 
-    <h2>Design as Strategic Communication</h2>
-    <p>
-      With infinite content at our fingertips, the temptation is to flood the
-      space with more. But “more” isn’t the answer. “Better” is.
-    </p>
-    <p>Paradoxically, making is easier—but mattering is harder.</p>
-    <p>
-      Design must move from aesthetic polishing to strategic storytelling. In
-      2025, brands don’t compete solely on product—they compete on clarity,
-      relevance, and emotional resonance. These are design problems.
-    </p>
-    <p>
-      A great visual system is no longer just about a logo or a palette. It’s a
-      behavioral signal: it tells people what you stand for. It creates trust.
-      It builds consistency in a fragmented landscape.
-    </p>
-    <p>
-      Done right, visual communication becomes a strategic layer—one that
-      simplifies, clarifies, and connects.
-    </p>
+      <h2>Design as Strategic Communication</h2>
+      <p>
+        With infinite content at our fingertips, the temptation is to flood the
+        space with more. But “more” isn’t the answer. “Better” is.
+      </p>
+      <p>Paradoxically, making is easier—but mattering is harder.</p>
+      <p>
+        Design must move from aesthetic polishing to strategic storytelling. In
+        2025, brands don’t compete solely on product—they compete on clarity,
+        relevance, and emotional resonance. These are design problems.
+      </p>
+      <p>
+        A great visual system is no longer just about a logo or a palette. It’s
+        a behavioral signal: it tells people what you stand for. It creates
+        trust. It builds consistency in a fragmented landscape.
+      </p>
+      <p>
+        Done right, visual communication becomes a strategic layer—one that
+        simplifies, clarifies, and connects.
+      </p>
 
-    <h2>From Stylist to Steward</h2>
-    <p>
-      One of the most significant shifts in the past decade is the evolution of
-      our role.
-    </p>
-    <p>
-      We’re no longer just stylists brought in at the end to &quot;make it
-      pretty.&quot; We’re stewards of systems. Authors of intent. Designers of
-      participation.
-    </p>
-    <p>
-      With AI in the mix, our responsibilities expand even further. We must now
-      act as ethical gatekeepers:
-    </p>
-    <p>What data trained this model?</p>
-    <p>Who benefits from this feature—and who’s left out?</p>
-    <p>Are we reinforcing bias, or challenging it?</p>
-    <p>These aren’t edge cases. They are the new core of responsible design.</p>
+      <h2>From Stylist to Steward</h2>
+      <p>
+        One of the most significant shifts in the past decade is the evolution
+        of our role.
+      </p>
+      <p>
+        We’re no longer just stylists brought in at the end to &quot;make it
+        pretty.&quot; We’re stewards of systems. Authors of intent. Designers of
+        participation.
+      </p>
+      <p>
+        With AI in the mix, our responsibilities expand even further. We must
+        now act as ethical gatekeepers:
+      </p>
+      <p>What data trained this model?</p>
+      <p>Who benefits from this feature—and who’s left out?</p>
+      <p>Are we reinforcing bias, or challenging it?</p>
+      <p>
+        These aren’t edge cases. They are the new core of responsible design.
+      </p>
 
-    <h2>A Return to Purpose</h2>
-    <p>
-      Yes, tools will continue to evolve. But our greatest assets remain
-      unchanged: empathy, curiosity, judgment, courage.
-    </p>
-    <p>
-      These qualities don’t show up in any plugin. They’re not automatable.
-      They’re earned—in practice, in conversation, in critique.
-    </p>
-    <p>As AI shifts how we design, it’s up to us to preserve why we design.</p>
-    <p>
-      Because the goal isn’t just to make things—it’s to make things matter.
-    </p>
-    <p>And in 2025, that principle has never been more vital.☻</p>
-    <h2>Share</h2>
-    <SocialShare
-      url={window.location.href}
-      title="Designing in 2025: Navigating the AI-Assisted Creative Landscape"
-    />
-    <div className={styles.similar}>
-      <h2>Similar Reads</h2>
-      <div className={styles["similarList"]}>
-        <Card
-          title="Workflow Tips"
-          link="/blog/workflow-tips"
-          className={`${styles["similarCard"]}`}
-        ></Card>
-        <Card
-          title="Digital Craftsmanship"
-          link="/blog/digital-craftsmanship"
-          className={`${styles["similarCard"]}`}
-        ></Card>
+      <h2>A Return to Purpose</h2>
+      <p>
+        Yes, tools will continue to evolve. But our greatest assets remain
+        unchanged: empathy, curiosity, judgment, courage.
+      </p>
+      <p>
+        These qualities don’t show up in any plugin. They’re not automatable.
+        They’re earned—in practice, in conversation, in critique.
+      </p>
+      <p>
+        As AI shifts how we design, it’s up to us to preserve why we design.
+      </p>
+      <p>
+        Because the goal isn’t just to make things—it’s to make things matter.
+      </p>
+      <p>And in 2025, that principle has never been more vital.☻</p>
+      <h2>Share</h2>
+      <SocialShare
+        url={window.location.href}
+        title="Designing in 2025: Navigating the AI-Assisted Creative Landscape"
+      />
+      <div className={styles.similar}>
+        <h2>Similar Reads</h2>
+        <div className={styles["similarList"]}>
+          <Card
+            title="Workflow Tips"
+            link="/blog/workflow-tips"
+            className={`${styles["similarCard"]}`}
+          ></Card>
+          <Card
+            title="Digital Craftsmanship"
+            link="/blog/digital-craftsmanship"
+            className={`${styles["similarCard"]}`}
+          ></Card>
+        </div>
       </div>
-    </div>
-  </article>
+    </article>
+  </>
 );
 
 export default Designing2025;

--- a/src/pages/posts/DigitalCraftsmanship.tsx
+++ b/src/pages/posts/DigitalCraftsmanship.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet";
 import Avatar from "../../components/Avatar/Avatar";
 import Author from "../../components/Author/Author";
 import styles from "../Article.module.css";
@@ -9,110 +10,139 @@ import Card from "../../components/Card/Card";
 import { SocialShare } from "../../components/SocialShare/SocialShare";
 
 const DigitalCraftsmanship = () => (
-  <article className={styles.article}>
-    <header>
-      <h1>
-        Digital Craftsmanship — Thoughts on Maintaining Quality in a Hurry-Up
-        Culture
-      </h1>
-      <Author name="Petri Lahdelma" imageUrl={VaultBoy} size="32px" />
-    </header>
-    <img src={Pizza} width="100%" alt="Pizza" className={styles.image} />
-    <p>
-      Our very first lecture in design school was led by a passionate advocate
-      for craftsmanship, Professor Tapio Vapaasalo. He began his lecture with
-      showing a two distinctly different youtube videos. The first one featured
-      a parrot that could mimic whatever the owner said, while the second one
-      featured a craftsman who had spent years perfecting his skill. The
-      difference was clear: the parrot could repeat words, but the craftsman
-      created something meaningful.
-    </p>
-    <br />
-    <p>
-      The tools are faster, the deadlines tighter, and the expectations steeper.
-      Somewhere between shipping faster and scaling bigger, something subtle
-      gets lost. Not visibly. But you can feel it — in the way a product
-      handles, in how a brand sounds, in the absence of something quietly
-      intentional.
-    </p>
-    <blockquote>That something is craft.</blockquote>
-    <h2>Speed Isn’t the Enemy — Thoughtlessness Is</h2>
-    <p>
-      I’ve worked long enough in digital to know that slowness doesn’t equal
-      quality. But there’s a difference between moving fast with intent and just
-      pushing to ship. We’ve built pipelines that automate, generate, even
-      decide for us. But no automation substitutes the quiet friction of asking:
-      Does this feel right? Does this deserve to exist this way?
-    </p>
-    <p>That pause is not inefficiency. It’s where meaning starts.</p>
-    <h2>Craft Is in the Edges</h2>
-    <p>
-      Good design isn’t only in the headline or the layout — it lives in the
-      in-between. The microcopy that never sounds off. The loading animation
-      that softens a delay. The way a transition suggests something human was
-      here, thinking about how it would feel — how others would feel using it.
-    </p>
-    <br />
-    <p>
-      Craftsmanship is about honoring the parts that don’t shout but shape the
-      whole. It’s not about polish. It’s about presence.
-    </p>
-    <h2>Quality in the Age of Generators</h2>
-    <p>
-      AI is writing copy, generating layouts, filling in alt texts and icons —
-      and oftentimes doing it quite decently. But the danger isn’t in letting
-      machines help. It’s in letting them decide what “good enough” looks like.
-      When we stop noticing the difference, we stop caring.
-    </p>
-    <br />
-    <p>
-      Craft today, more than ever, means keeping a human fingerprint on the
-      product. Not because we should resist progress or the tools that deliver
-      it, but because we’re still the ones accountable for the emotional
-      resonance.
-    </p>
-    <h2>Leave Traces of Care</h2>
-    <p>
-      In every project, there’s a point where we could cut a corner and no one
-      would notice. But someone always does — even if they can’t name it.
-      Quality has a texture. It lingers. Not just in design, but in the culture
-      it fosters: attention to detail becomes contagious. The team starts to
-      raise their own bar.
-    </p>
-    <blockquote>
-      Digital craftsmanship isn’t about perfection. It’s about giving a damn.
-    </blockquote>
-    <h2>In Praise of Slowness, Even When We’re Fast</h2>
-    <p>
-      We won’t go back to slower cycles. That’s not the point. But we can bake
-      slowness into the process: quick iterations, slow reflection. Fast drafts,
-      considered revisions. Space for questions no prompt can answer. In the
-      end, craft is just a pattern of choices made deliberately, not reactively.
-    </p>
-    <blockquote>
-      In a hurry-up culture, choosing to care is radical.☻
-    </blockquote>
-    <h2>Share</h2>
-    <SocialShare
-      url={window.location.href}
-      title="Maintaining Quality in a Hurry-Up Culture"
-    />
-    <div className={styles.similar}>
-      <h2>Similar Reads</h2>
-      <div className={styles["similarList"]}>
-        <Card
-          title="Workflow Tips"
-          link="/blog/workflow-tips"
-          className={`${styles["similarCard"]} ${styles.teal}`}
-        ></Card>
-        <Card
-          title="Designing in 2025"
-          link="/blog/designing-in-2025"
-          className={`${styles["similarCard"]} ${styles.purple}`}
-        ></Card>
+  <>
+    <Helmet>
+      <title>Digital Craftsmanship | Digitaltableteur</title>
+      <meta
+        name="description"
+        content="Thoughts on maintaining quality in a hurry-up culture."
+      />
+      <meta
+        property="og:title"
+        content="Digital Craftsmanship | Digitaltableteur"
+      />
+      <meta
+        property="og:description"
+        content="Thoughts on maintaining quality in a hurry-up culture."
+      />
+      <meta property="og:image" content="/logo512.png" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta
+        name="twitter:title"
+        content="Digital Craftsmanship | Digitaltableteur"
+      />
+      <meta
+        name="twitter:description"
+        content="Thoughts on maintaining quality in a hurry-up culture."
+      />
+      <meta name="twitter:image" content="/logo512.png" />
+    </Helmet>
+    <article className={styles.article}>
+      <header>
+        <h1>
+          Digital Craftsmanship — Thoughts on Maintaining Quality in a Hurry-Up
+          Culture
+        </h1>
+        <Author name="Petri Lahdelma" imageUrl={VaultBoy} size="32px" />
+      </header>
+      <img src={Pizza} width="100%" alt="Pizza" className={styles.image} />
+      <p>
+        Our very first lecture in design school was led by a passionate advocate
+        for craftsmanship, Professor Tapio Vapaasalo. He began his lecture with
+        showing a two distinctly different youtube videos. The first one
+        featured a parrot that could mimic whatever the owner said, while the
+        second one featured a craftsman who had spent years perfecting his
+        skill. The difference was clear: the parrot could repeat words, but the
+        craftsman created something meaningful.
+      </p>
+      <br />
+      <p>
+        The tools are faster, the deadlines tighter, and the expectations
+        steeper. Somewhere between shipping faster and scaling bigger, something
+        subtle gets lost. Not visibly. But you can feel it — in the way a
+        product handles, in how a brand sounds, in the absence of something
+        quietly intentional.
+      </p>
+      <blockquote>That something is craft.</blockquote>
+      <h2>Speed Isn’t the Enemy — Thoughtlessness Is</h2>
+      <p>
+        I’ve worked long enough in digital to know that slowness doesn’t equal
+        quality. But there’s a difference between moving fast with intent and
+        just pushing to ship. We’ve built pipelines that automate, generate,
+        even decide for us. But no automation substitutes the quiet friction of
+        asking: Does this feel right? Does this deserve to exist this way?
+      </p>
+      <p>That pause is not inefficiency. It’s where meaning starts.</p>
+      <h2>Craft Is in the Edges</h2>
+      <p>
+        Good design isn’t only in the headline or the layout — it lives in the
+        in-between. The microcopy that never sounds off. The loading animation
+        that softens a delay. The way a transition suggests something human was
+        here, thinking about how it would feel — how others would feel using it.
+      </p>
+      <br />
+      <p>
+        Craftsmanship is about honoring the parts that don’t shout but shape the
+        whole. It’s not about polish. It’s about presence.
+      </p>
+      <h2>Quality in the Age of Generators</h2>
+      <p>
+        AI is writing copy, generating layouts, filling in alt texts and icons —
+        and oftentimes doing it quite decently. But the danger isn’t in letting
+        machines help. It’s in letting them decide what “good enough” looks
+        like. When we stop noticing the difference, we stop caring.
+      </p>
+      <br />
+      <p>
+        Craft today, more than ever, means keeping a human fingerprint on the
+        product. Not because we should resist progress or the tools that deliver
+        it, but because we’re still the ones accountable for the emotional
+        resonance.
+      </p>
+      <h2>Leave Traces of Care</h2>
+      <p>
+        In every project, there’s a point where we could cut a corner and no one
+        would notice. But someone always does — even if they can’t name it.
+        Quality has a texture. It lingers. Not just in design, but in the
+        culture it fosters: attention to detail becomes contagious. The team
+        starts to raise their own bar.
+      </p>
+      <blockquote>
+        Digital craftsmanship isn’t about perfection. It’s about giving a damn.
+      </blockquote>
+      <h2>In Praise of Slowness, Even When We’re Fast</h2>
+      <p>
+        We won’t go back to slower cycles. That’s not the point. But we can bake
+        slowness into the process: quick iterations, slow reflection. Fast
+        drafts, considered revisions. Space for questions no prompt can answer.
+        In the end, craft is just a pattern of choices made deliberately, not
+        reactively.
+      </p>
+      <blockquote>
+        In a hurry-up culture, choosing to care is radical.☻
+      </blockquote>
+      <h2>Share</h2>
+      <SocialShare
+        url={window.location.href}
+        title="Maintaining Quality in a Hurry-Up Culture"
+      />
+      <div className={styles.similar}>
+        <h2>Similar Reads</h2>
+        <div className={styles["similarList"]}>
+          <Card
+            title="Workflow Tips"
+            link="/blog/workflow-tips"
+            className={`${styles["similarCard"]} ${styles.teal}`}
+          ></Card>
+          <Card
+            title="Designing in 2025"
+            link="/blog/designing-in-2025"
+            className={`${styles["similarCard"]} ${styles.purple}`}
+          ></Card>
+        </div>
       </div>
-    </div>
-  </article>
+    </article>
+  </>
 );
 
 export default DigitalCraftsmanship;

--- a/src/pages/posts/FigmaMCP.tsx
+++ b/src/pages/posts/FigmaMCP.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet";
 import styles from "../Article.module.css";
 import Author from "../../components/Author/Author";
 import VaultBoy from "../../assets/images/pete-vault-boy.jpg";
@@ -15,155 +16,187 @@ import {
 } from "react-icons/tb";
 
 const FigmaMCP = () => (
-  <article className={styles.article}>
-    <header>
-      <h1>Rethinking Design-to-Product Workflows with Figma MCP</h1>
-      <Author name="Petri Lahdelma" imageUrl={VaultBoy} size="32px" />
-    </header>
-    <img src={MCP} alt="Illustration" style={{ marginBlockEnd: "3rem" }} />
-    <p>
-      Recently, I experimented with Figma’s official MCP (Model Context
-      Protocol) server in tandem with the dt design system, and the results were
-      eye-opening. By enriching the components with machine-readable metadata
-      directly within Figma, I unlocked a new layer of semantic clarity — not
-      just for designers, but for tooling and automation as well. This
-      integration allowed me to embed context such as intent, behavior, and
-      variant logic directly into each component.
-    </p>
-    <br />
-    <p>
-      When combined with a well-structured design system, this metadata forms a
-      bridge between design and development that’s both expressive and
-      efficient. It fundamentally shifts how we think about handoff: instead of
-      static specs, we’re enabling a pipeline where components carry the
-      instructions needed to generate real code or configure runtime behavior.
-      This shift opens the door to smarter tooling, automatic documentation, and
-      even generative UI workflows — all grounded in the source of truth that
-      lives inside the design system.
-    </p>
-    <h2>The Problem with the Current Workflow</h2>
-    <p>
-      Even with well-documented systems, the handoff from designer to developer
-      often involves a layer of translation—interpreting visual intent,
-      cross-referencing token usage, and validating component variants. It’s a
-      process that still relies heavily on human interpretation and manual
-      alignment. Small details, like the exact padding on a card or the semantic
-      use of a color token, can easily slip through the cracks, leading to
-      inconsistencies in implementation. These discrepancies not only require
-      back-and-forth to resolve but can also erode trust in the system itself.
-      As a result, iteration slows down, and teams spend more time fixing gaps
-      than pushing the experience forward.
-    </p>
-    <h2>What MCP Changes</h2>
-    <p>
-      MCP exposes design file data directly to code assistants. Instead of
-      referencing screenshots or static specs, the assistant consumes real
-      components, variants, and tokens right from Figma.
-    </p>
-    <div>
-      <img
-        src={DTmindmap}
-        alt="Digitaltableteur mindmap"
-        style={{ width: "100%", height: "auto" }}
+  <>
+    <Helmet>
+      <title>
+        Figma MCP, Design Systems, and Generative UI | Digitaltableteur
+      </title>
+      <meta
+        name="description"
+        content="How Figma's MCP server speeds up design-to-code workflows."
       />
-    </div>
-    <div>
+      <meta
+        property="og:title"
+        content="Figma MCP, Design Systems, and Generative UI | Digitaltableteur"
+      />
+      <meta
+        property="og:description"
+        content="How Figma's MCP server speeds up design-to-code workflows."
+      />
+      <meta property="og:image" content="/logo512.png" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta
+        name="twitter:title"
+        content="Figma MCP, Design Systems, and Generative UI | Digitaltableteur"
+      />
+      <meta
+        name="twitter:description"
+        content="How Figma's MCP server speeds up design-to-code workflows."
+      />
+      <meta name="twitter:image" content="/logo512.png" />
+    </Helmet>
+    <article className={styles.article}>
+      <header>
+        <h1>Rethinking Design-to-Product Workflows with Figma MCP</h1>
+        <Author name="Petri Lahdelma" imageUrl={VaultBoy} size="32px" />
+      </header>
+      <img src={MCP} alt="Illustration" style={{ marginBlockEnd: "3rem" }} />
       <p>
-        This means the AI can generate code that’s not just visually accurate,
-        but also semantically aligned with the design system’s intent. It
-        understands how components relate to each other, what variants are
-        available, and how tokens should be applied.
+        Recently, I experimented with Figma’s official MCP (Model Context
+        Protocol) server in tandem with the dt design system, and the results
+        were eye-opening. By enriching the components with machine-readable
+        metadata directly within Figma, I unlocked a new layer of semantic
+        clarity — not just for designers, but for tooling and automation as
+        well. This integration allowed me to embed context such as intent,
+        behavior, and variant logic directly into each component.
       </p>
-    </div>
-    <br />
-    <Grid columns={4} gap="2rem">
+      <br />
+      <p>
+        When combined with a well-structured design system, this metadata forms
+        a bridge between design and development that’s both expressive and
+        efficient. It fundamentally shifts how we think about handoff: instead
+        of static specs, we’re enabling a pipeline where components carry the
+        instructions needed to generate real code or configure runtime behavior.
+        This shift opens the door to smarter tooling, automatic documentation,
+        and even generative UI workflows — all grounded in the source of truth
+        that lives inside the design system.
+      </p>
+      <h2>The Problem with the Current Workflow</h2>
+      <p>
+        Even with well-documented systems, the handoff from designer to
+        developer often involves a layer of translation—interpreting visual
+        intent, cross-referencing token usage, and validating component
+        variants. It’s a process that still relies heavily on human
+        interpretation and manual alignment. Small details, like the exact
+        padding on a card or the semantic use of a color token, can easily slip
+        through the cracks, leading to inconsistencies in implementation. These
+        discrepancies not only require back-and-forth to resolve but can also
+        erode trust in the system itself. As a result, iteration slows down, and
+        teams spend more time fixing gaps than pushing the experience forward.
+      </p>
+      <h2>What MCP Changes</h2>
+      <p>
+        MCP exposes design file data directly to code assistants. Instead of
+        referencing screenshots or static specs, the assistant consumes real
+        components, variants, and tokens right from Figma.
+      </p>
       <div>
-        <TbCircleNumber1 size={32} />
-        <h3>Figma MCP</h3>
-        <p>Define structured, variant-rich component data</p>
+        <img
+          src={DTmindmap}
+          alt="Digitaltableteur mindmap"
+          style={{ width: "100%", height: "auto" }}
+        />
       </div>
+      <div>
+        <p>
+          This means the AI can generate code that’s not just visually accurate,
+          but also semantically aligned with the design system’s intent. It
+          understands how components relate to each other, what variants are
+          available, and how tokens should be applied.
+        </p>
+      </div>
+      <br />
+      <Grid columns={4} gap="2rem">
+        <div>
+          <TbCircleNumber1 size={32} />
+          <h3>Figma MCP</h3>
+          <p>Define structured, variant-rich component data</p>
+        </div>
 
-      <div>
-        <TbCircleNumber2 size={32} />
-        <h3>Figma API</h3>
-        <p>Export that structure as JSON</p>
-      </div>
+        <div>
+          <TbCircleNumber2 size={32} />
+          <h3>Figma API</h3>
+          <p>Export that structure as JSON</p>
+        </div>
 
-      <div>
-        <TbCircleNumber3 size={32} />
-        <h3>ChatGPT</h3>
-        <p>Transform exported JSON into reusable React/TS components</p>
-      </div>
+        <div>
+          <TbCircleNumber3 size={32} />
+          <h3>ChatGPT</h3>
+          <p>Transform exported JSON into reusable React/TS components</p>
+        </div>
 
-      <div>
-        <TbCircleNumber4 size={32} />
-        <h3>GitHub Copilot</h3>
-        <p>Assist with logic, styling, and integration in your IDE</p>
+        <div>
+          <TbCircleNumber4 size={32} />
+          <h3>GitHub Copilot</h3>
+          <p>Assist with logic, styling, and integration in your IDE</p>
+        </div>
+      </Grid>
+      <br />
+      <p>
+        In the trials I dropped a component URL into the editor and watched as
+        it generated a nearly complete web component. Minor styling fixes aside,
+        it was surprisingly production ready.
+      </p>
+      <h2>Design Systems as the Enabler</h2>
+      <p>
+        A consistent design system gives the MCP data meaning. Clear token names
+        and predictable component structure help AI tools map design choices to
+        code without guesswork.
+      </p>
+      <h2>Generative UI with Natural Language</h2>
+      <p>
+        I took it a step further by connecting the output to a local tool that
+        generates layouts from text prompts. Typing “Build a login form” or
+        “Create a three column feature grid” produces a quick preview that
+        respects my components and styling conventions.
+      </p>
+      <h2>This Isn’t About Replacing Roles</h2>
+      <p>
+        Engineering still plays a critical role in refining the output, ensuring
+        performance, scalability, and maintainability, while design continues to
+        shape and own the overall user experience. But what’s changing is the
+        nature of that collaboration. By automating the repetitive and
+        predictable parts of the workflow — the boilerplate code, standard
+        layout scaffolding, and component wiring — we’re reclaiming valuable
+        time and cognitive energy. This gives teams space to focus on what
+        actually matters: the edge cases that define polish, the accessibility
+        nuances that ensure inclusivity, and the product vision that ties
+        everything together into something coherent and meaningful. Rather than
+        getting bogged down in tactical execution, both designers and developers
+        can engage more deeply in strategic problem-solving, exploring
+        interactions, flows, and ideas that elevate the product beyond the
+        expected.
+      </p>
+      <h2>Where We’re Headed</h2>
+      <p>
+        At least my personal goal is to make this workflow approachable for
+        bigger teams. With stable tools and repeatable patterns, the gap between
+        idea and implementation keeps shrinking. It’s an exciting time to
+        rethink how we collaborate—and MCP&#39;s are a big part of that
+        conversation.☻
+      </p>
+      <h2>Share</h2>
+      <SocialShare
+        url={window.location.href}
+        title="Rethinking Design-to-Product Workflows with Figma MCP"
+      />
+      <div className={styles.similar}>
+        <h2>Similar Reads</h2>
+        <div className={styles["similarList"]}>
+          <Card
+            title="Designing in 2025"
+            link="/blog/designing-in-2025"
+            className={`${styles["similarCard"]} ${styles.teal}`}
+          ></Card>
+          <Card
+            title="Digital Craftsmanship"
+            link="/blog/digital-craftsmanship"
+            className={`${styles["similarCard"]} ${styles.purple}`}
+          ></Card>
+        </div>
       </div>
-    </Grid>
-    <br />
-    <p>
-      In the trials I dropped a component URL into the editor and watched as it
-      generated a nearly complete web component. Minor styling fixes aside, it
-      was surprisingly production ready.
-    </p>
-    <h2>Design Systems as the Enabler</h2>
-    <p>
-      A consistent design system gives the MCP data meaning. Clear token names
-      and predictable component structure help AI tools map design choices to
-      code without guesswork.
-    </p>
-    <h2>Generative UI with Natural Language</h2>
-    <p>
-      I took it a step further by connecting the output to a local tool that
-      generates layouts from text prompts. Typing “Build a login form” or
-      “Create a three column feature grid” produces a quick preview that
-      respects my components and styling conventions.
-    </p>
-    <h2>This Isn’t About Replacing Roles</h2>
-    <p>
-      Engineering still plays a critical role in refining the output, ensuring
-      performance, scalability, and maintainability, while design continues to
-      shape and own the overall user experience. But what’s changing is the
-      nature of that collaboration. By automating the repetitive and predictable
-      parts of the workflow — the boilerplate code, standard layout scaffolding,
-      and component wiring — we’re reclaiming valuable time and cognitive
-      energy. This gives teams space to focus on what actually matters: the edge
-      cases that define polish, the accessibility nuances that ensure
-      inclusivity, and the product vision that ties everything together into
-      something coherent and meaningful. Rather than getting bogged down in
-      tactical execution, both designers and developers can engage more deeply
-      in strategic problem-solving, exploring interactions, flows, and ideas
-      that elevate the product beyond the expected.
-    </p>
-    <h2>Where We’re Headed</h2>
-    <p>
-      At least my personal goal is to make this workflow approachable for bigger
-      teams. With stable tools and repeatable patterns, the gap between idea and
-      implementation keeps shrinking. It’s an exciting time to rethink how we
-      collaborate—and MCP&#39;s are a big part of that conversation.☻
-    </p>
-    <h2>Share</h2>
-    <SocialShare
-      url={window.location.href}
-      title="Rethinking Design-to-Product Workflows with Figma MCP"
-    />
-    <div className={styles.similar}>
-      <h2>Similar Reads</h2>
-      <div className={styles["similarList"]}>
-        <Card
-          title="Designing in 2025"
-          link="/blog/designing-in-2025"
-          className={`${styles["similarCard"]} ${styles.teal}`}
-        ></Card>
-        <Card
-          title="Digital Craftsmanship"
-          link="/blog/digital-craftsmanship"
-          className={`${styles["similarCard"]} ${styles.purple}`}
-        ></Card>
-      </div>
-    </div>
-  </article>
+    </article>
+  </>
 );
 
 export default FigmaMCP;

--- a/src/pages/posts/PetriLahdelmaBio.tsx
+++ b/src/pages/posts/PetriLahdelmaBio.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet";
 import styles from "../Article.module.css";
 import Author from "../../components/Author/Author";
 import VaultBoy from "../../assets/images/pete-vault-boy.jpg";
@@ -6,72 +7,100 @@ import Card from "../../components/Card/Card";
 import { SocialShare } from "../../components/SocialShare/SocialShare";
 
 const PetriLahdelmaBio = () => (
-  <article className={styles.article}>
-    <header>
-      <h1>Petri Lahdelma: A Biography</h1>
-      <Author name="Petri Lahdelma" imageUrl={VaultBoy} size="32px" />
-    </header>
-    <p>
-      Petri Lahdelma is a Finnish designer, systems thinker, and advocate for
-      professional ethics in design. Raised in Varissuo, a suburb of Turku, his
-      passion for visual culture came from a painter father and a supportive
-      mother. That early spark carried him to the UK for a BA in Graphic Design
-      at the University of Cumbria, and later to Aalto University in Helsinki
-      for a master&#39;s degree.
-    </p>
-    <br />
-    <p>
-      Among the mentors who shaped his craft were Rhiannon Robinson, who
-      sharpened his critical eye, and Tapio Vapaasalo, who instilled a love for
-      craftsmanship and form. After a junior stint at Werklig, Petri spent two
-      decades moving through agencies, startups, and entrepreneurial ventures,
-      always refusing to stand still.
-    </p>
-    <br />
-    <p>
-      Today he leads a design system team in a global enterprise of more than
-      300,000 colleagues, balancing enterprise UX with scalable systems
-      thinking. His portfolio ranges from national infrastructure identities
-      like the Liikennevirasto corporate identity to agile startup brands such
-      as New Things Company, and he laid the strategic groundwork for the
-      Helsinki Design System.
-    </p>
-    <br />
-    <p>
-      Throughout his career Petri has founded and led design guilds and special
-      interest programs, shaping team culture as much as the work itself. He
-      belongs to AIGA, IxDA, and ISTD. While he rarely speaks publicly—a regret
-      of his own—his influence lives in the systems, standards, and ethics he
-      brings to every project.
-    </p>
-    <br />
-    <p>
-      He believes clarity matters more than decoration, that form follows
-      function, and that users seldom say what they really need. Guided by
-      curiosity and care rather than fleeting trends, colleagues know him as a
-      thoughtful, kind collaborator who insists on doing things the right way.
-    </p>
-    <h2>Share</h2>
-    <SocialShare
-      url={window.location.href}
-      title="Petri Lahdelma: A Biography"
-    />
-    <div className={styles.similar}>
-      <h2>Similar Reads</h2>
-      <div className={styles["similarList"]}>
-        <Card
-          title="Digital Craftsmanship"
-          link="/blog/digital-craftsmanship"
-          className={`${styles["similarCard"]} ${styles.purple}`}
-        />
-        <Card
-          title="Designing in 2025"
-          link="/blog/designing-in-2025"
-          className={`${styles["similarCard"]} ${styles.teal}`}
-        />
+  <>
+    <Helmet>
+      <title>Petri Lahdelma: A Biography | Digitaltableteur</title>
+      <meta
+        name="description"
+        content="From Varissuo to leading global design systems."
+      />
+      <meta
+        property="og:title"
+        content="Petri Lahdelma: A Biography | Digitaltableteur"
+      />
+      <meta
+        property="og:description"
+        content="From Varissuo to leading global design systems."
+      />
+      <meta property="og:image" content="/logo512.png" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta
+        name="twitter:title"
+        content="Petri Lahdelma: A Biography | Digitaltableteur"
+      />
+      <meta
+        name="twitter:description"
+        content="From Varissuo to leading global design systems."
+      />
+      <meta name="twitter:image" content="/logo512.png" />
+    </Helmet>
+    <article className={styles.article}>
+      <header>
+        <h1>Petri Lahdelma: A Biography</h1>
+        <Author name="Petri Lahdelma" imageUrl={VaultBoy} size="32px" />
+      </header>
+      <p>
+        Petri Lahdelma is a Finnish designer, systems thinker, and advocate for
+        professional ethics in design. Raised in Varissuo, a suburb of Turku,
+        his passion for visual culture came from a painter father and a
+        supportive mother. That early spark carried him to the UK for a BA in
+        Graphic Design at the University of Cumbria, and later to Aalto
+        University in Helsinki for a master&#39;s degree.
+      </p>
+      <br />
+      <p>
+        Among the mentors who shaped his craft were Rhiannon Robinson, who
+        sharpened his critical eye, and Tapio Vapaasalo, who instilled a love
+        for craftsmanship and form. After a junior stint at Werklig, Petri spent
+        two decades moving through agencies, startups, and entrepreneurial
+        ventures, always refusing to stand still.
+      </p>
+      <br />
+      <p>
+        Today he leads a design system team in a global enterprise of more than
+        300,000 colleagues, balancing enterprise UX with scalable systems
+        thinking. His portfolio ranges from national infrastructure identities
+        like the Liikennevirasto corporate identity to agile startup brands such
+        as New Things Company, and he laid the strategic groundwork for the
+        Helsinki Design System.
+      </p>
+      <br />
+      <p>
+        Throughout his career Petri has founded and led design guilds and
+        special interest programs, shaping team culture as much as the work
+        itself. He belongs to AIGA, IxDA, and ISTD. While he rarely speaks
+        publicly—a regret of his own—his influence lives in the systems,
+        standards, and ethics he brings to every project.
+      </p>
+      <br />
+      <p>
+        He believes clarity matters more than decoration, that form follows
+        function, and that users seldom say what they really need. Guided by
+        curiosity and care rather than fleeting trends, colleagues know him as a
+        thoughtful, kind collaborator who insists on doing things the right way.
+      </p>
+      <h2>Share</h2>
+      <SocialShare
+        url={window.location.href}
+        title="Petri Lahdelma: A Biography"
+      />
+      <div className={styles.similar}>
+        <h2>Similar Reads</h2>
+        <div className={styles["similarList"]}>
+          <Card
+            title="Digital Craftsmanship"
+            link="/blog/digital-craftsmanship"
+            className={`${styles["similarCard"]} ${styles.purple}`}
+          />
+          <Card
+            title="Designing in 2025"
+            link="/blog/designing-in-2025"
+            className={`${styles["similarCard"]} ${styles.teal}`}
+          />
+        </div>
       </div>
-    </div>
-  </article>
+    </article>
+  </>
 );
 
 export default PetriLahdelmaBio;

--- a/src/pages/posts/TemplateArticle.tsx
+++ b/src/pages/posts/TemplateArticle.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet";
 import styles from "../Article.module.css";
 import Author from "../../components/Author/Author";
 import VaultBoy from "../../assets/images/pete-vault-boy.jpg";
@@ -7,38 +8,66 @@ import { SocialShare } from "../../components/SocialShare/SocialShare";
 
 const TemplateArticle = () => {
   return (
-    <article className={styles.article}>
-      <header className={styles.header}>
-        <h1>Template Article Title</h1>
-        <Author name="Digitaltableteur" imageUrl={VaultBoy} size="32px" />
-      </header>
-      <p>
-        This is a template article. Replace this text with the actual content of
-        your article. Ensure that the content is well-structured and formatted
-        according to the design guidelines.
-      </p>
-      <p>Ensure that all media files are properly linked and accessible.</p>
-      <h2>Share</h2>
-      <SocialShare
-        url={window.location.href}
-        title="Thoughts on Future Branding"
-      />
-      <div className={styles.similar}>
-        <h2>Similar Reads</h2>
-        <div className={styles["similarList"]}>
-          <Card
-            title="Title of Similar Article"
-            link="/blog/template-article"
-            className={`${styles["similarCard"]}`}
-          ></Card>
-          <Card
-            title="Title of Similar Article"
-            link="/blog/template-article"
-            className={`${styles["similarCard"]}`}
-          ></Card>
+    <>
+      <Helmet>
+        <title>Template Article Title | Digitaltableteur</title>
+        <meta
+          name="description"
+          content="Template description for future articles."
+        />
+        <meta
+          property="og:title"
+          content="Template Article Title | Digitaltableteur"
+        />
+        <meta
+          property="og:description"
+          content="Template description for future articles."
+        />
+        <meta property="og:image" content="/logo512.png" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+          name="twitter:title"
+          content="Template Article Title | Digitaltableteur"
+        />
+        <meta
+          name="twitter:description"
+          content="Template description for future articles."
+        />
+        <meta name="twitter:image" content="/logo512.png" />
+      </Helmet>
+      <article className={styles.article}>
+        <header className={styles.header}>
+          <h1>Template Article Title</h1>
+          <Author name="Digitaltableteur" imageUrl={VaultBoy} size="32px" />
+        </header>
+        <p>
+          This is a template article. Replace this text with the actual content
+          of your article. Ensure that the content is well-structured and
+          formatted according to the design guidelines.
+        </p>
+        <p>Ensure that all media files are properly linked and accessible.</p>
+        <h2>Share</h2>
+        <SocialShare
+          url={window.location.href}
+          title="Thoughts on Future Branding"
+        />
+        <div className={styles.similar}>
+          <h2>Similar Reads</h2>
+          <div className={styles["similarList"]}>
+            <Card
+              title="Title of Similar Article"
+              link="/blog/template-article"
+              className={`${styles["similarCard"]}`}
+            ></Card>
+            <Card
+              title="Title of Similar Article"
+              link="/blog/template-article"
+              className={`${styles["similarCard"]}`}
+            ></Card>
+          </div>
         </div>
-      </div>
-    </article>
+      </article>
+    </>
   );
 };
 

--- a/src/pages/posts/ThoughtsOnFutureBranding.tsx
+++ b/src/pages/posts/ThoughtsOnFutureBranding.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet";
 import styles from "../Article.module.css";
 import Author from "../../components/Author/Author";
 import VaultBoy from "../../assets/images/pete-vault-boy.jpg";
@@ -15,209 +16,241 @@ import Card from "../../components/Card/Card";
 
 const ThoughtsOnFutureBranding = () => {
   return (
-    <article className={styles.article}>
-      <header className={styles.header}>
-        <h1>Thoughts on Future Branding</h1>
-        <Author name="Petri Lahdelma" imageUrl={VaultBoy} size="32px" />
-      </header>
-      <p>
-        <img src={future1} alt="Future Branding Concept" />
-        <span className={styles.boldText}>
-          Traditionally, an identity or brand has been a tool
-        </span>
-        &nbsp;to help companies distinguish one (a product, an ideal, a set of
-        values, or what the company does) from the other with numerous defining
-        sub-genres and classifications, such as entry-level, iconic, luxury,
-        etc. Usually consisting of a logo (logomark/logotype) and other graphic
-        means designed to increase brand recognition.
-      </p>
-      <p>
-        Brands have now adopted subtler tactics in retrospect to the early days.
-        Brands tell stories on popular platforms—and in a subtle way that is
-        nearly indistinguishable (advertorials) from the media readers already
-        consume. By molding the message to the platform, brands can draw loyal
-        customers and occasionally even make their content go viral. Tone of
-        voice plays a big role in how brands are adopted by the masses. This
-        encapsulates the general zeitgeist of branding today.
-      </p>
-      <blockquote>
-        Brands have now adopted subtler tactics in retrospect to the early days.
-      </blockquote>
-      <p>
-        In recent times, branding has evolved into various workflows and
-        approaches, such as modular, responsive, interactive, or generative
-        brand applications and corresponding identities, and vast variations of
-        design systems to support and maintain the brand image. The craft itself
-        has also somewhat evolved from promoting simple logomarks, and this has
-        made the industry even more intricate.
-      </p>
-      <p>
-        With advancements in machine learning, greater capacity for deeper
-        neural networks (thanks to cloud solutions and Google’s efforts to speed
-        up computing with GPUs), and especially in the field of algorithm-driven
-        design, there’s no limit to the number of powerful tools we have access
-        to. With the right tools and intellectual resources, we can apply the
-        ideas garnered from the data and adapt to tomorrow&apos;s necessities,
-        creating impactful design and successful content delivery, way “outside
-        the box,” and soon beyond the capability of the human mind.
-      </p>
-      <img src={future2} alt="Future Branding Concept" />
-      <caption style={{ display: "block", textAlign: "center" }}>
-        A logotype refers to words or the name of a business that is designed or
-        typeset.
-      </caption>
-      <img src={future3} alt="Future Branding Concept" />
-      <caption
-        style={{
-          display: "block",
-          textAlign: "center",
-          marginBlockEnd: "6em",
-        }}
-      >
-        A logomark is an identifying mark or symbol that doesn’t necessarily
-        contain the business name.
-      </caption>
-      <p>
-        The technologies of tomorrow are bound to change how we design corporate
-        identification systems and brand presence in the future. There’s no
-        avoiding it, and the sci-fi geek in me can’t wait for news on yet
-        another tech or gadget that will completely revolutionize the way we
-        experience, exist, and interact.
-      </p>
-      <p>
-        Thinking outside the box has always been the mantra of the creative
-        industry. The truth is that more times than we’d like to admit, we’re
-        being stuffed into that very box by our clients’ budget, our lack of
-        vision, our fear of failure, or even sheer laziness. I’ve experienced
-        many, if not all, possible pitfalls in my personal career as a designer,
-        and in that sense, I am no better than my fellow designers. But where
-        are the brands and identities that strive to do something more with the
-        vast possibilities at our disposal today?
-      </p>
-      <img src={future4} alt="A futuristic branding concept" />
-      <caption style={{ display: "block", textAlign: "center" }}>
-        A philosophical brand that advocates living instinctively, responding in
-        the moment, and letting change flow. The brand evokes this uniquely
-        Chinese state of mind. By Wolff Olins.
-      </caption>
-      <div
-        className={styles.videoContainer}
-        style={{ marginBlockStart: "2rem", marginBlockEnd: "2rem" }}
-      >
-        <iframe
-          title="vimeo-player"
-          src="https://player.vimeo.com/video/217044558?h=ddc46a1db5"
-          width="100%"
-          height="360"
-          frameBorder="0"
-          allowFullScreen
-        ></iframe>
-      </div>
-      <caption style={{ display: "block", textAlign: "center" }}>
-        Genesis Beijing is a visual tool that explores each state and associated
-        feeling through rich, reactive pattern. By Wolff Olins
-      </caption>
-      <img src={future5} alt="A futuristic branding concept" />
-      <caption style={{ display: "block", textAlign: "center" }}>
-        Identity for Ministry for Foreign Affairs of Finland echoes the world
-        events with changing color schemes. By 358
-      </caption>
-      <img src={future8} alt="A futuristic branding concept" />
-      <caption
-        style={{
-          display: "block",
-          textAlign: "center",
-          marginBlockEnd: "2rem",
-        }}
-      >
-        The applications make great use of the possible variations of the globe
-        that yields some lovely color combinations and compositions. By 358
-      </caption>
-      <div className={styles.videoContainer}>
-        <iframe
-          width="100%"
-          height="315"
-          src="https://www.youtube.com/embed/YZUP4vfDonU?si=uSndXsN5I-dyBAoh"
-          title="YouTube video player"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        ></iframe>
-      </div>
-      <caption style={{ display: "block", textAlign: "center" }}>
-        An organisation that operates in a stable manner in a turbulent world
-        and that works to make the world a better place. Video courtesy of the
-        Ministry for Foreign Affairs of Finland and 358
-      </caption>
-      <p>
-        By focusing on the individual experience instead of the user itself, we
-        can easily draw out the factors that dictate how experiences are
-        perceived. That said, we still like to pick and choose where we follow
-        the more traditional HCD (Human-Centric Design) model, much like our own
-        smörgåsbord for design. We validate design choices in a hive-mind
-        manner, which is made possible by the lack of hierarchy and principles
-        of self-governance within New Things Co.
-      </p>
-      <p>
-        So what technologies could one consider as a designer in a branding or
-        related project? Intelligent, algorithm-driven, reactive, or whatever
-        the choice of tech, beneath the surface still lies an intelligent
-        creative that understands both the given constraints and possibilities
-        or has the capacity for evaluating machine-based output. But through
-        matured systems of smart, tech-driven assets, these new brands will soon
-        serve mankind a genuine, empathetic, positive, and lasting experience.
-      </p>
-      <img
-        src={future7}
-        alt="A futuristic branding concept"
-        className={styles.image}
-      />
-      <caption style={{ display: "block", textAlign: "center" }}>
-        Example of the New Things Co identity mutations. 2016–2018.
-      </caption>
-      <img
-        style={{ marginTop: "4rem" }}
-        src={future6}
-        alt="A futuristic branding concept"
-        className={styles.image}
-      />
-      <caption>
-        The &nbsp;<a href="https://app.brandmark.io/v2/">brandmark.io</a> system
-        has been trained with over 1.4 million images, instantly generating
-        thousands of logo ideas based on user input.
-      </caption>
-      <p>
-        One could suggest an umbrella term “Exponentially-Driven Design” to
-        collect all these technological advancements and bundle them to serve as
-        an aid for design efforts. ED for short, meaning the computer-assisted,
-        exponential advancements in the creative process. However we might call
-        it, as creatives, we need to remember to step back and observe our
-        habits and find smarter, new ways of working. In a word, adapt to
-        changes in a rapidly changing digital landscape.
-      </p>
-      <blockquote>
-        “Everything should be made as simple as possible, but not simpler.”
-      </blockquote>
-      <p>— Albert Einstein</p>
-      <h2>Share</h2>
-      <SocialShare
-        url={window.location.href}
-        title="Thoughts on Future Branding"
-      />
-      <div className={styles.similar}>
-        <h2>Similar Reads</h2>
-        <div className={styles["similarList"]}>
-          <Card
-            title="Designing in 2025"
-            link="/blog/designing-in-2025"
-            className={`${styles["similarCard"]} ${styles.teal}`}
-          />
-          <Card
-            title="Digital Craftsmanship"
-            link="/blog/digital-craftsmanship"
-            className={`${styles["similarCard"]} ${styles.purple}`}
-          />
+    <>
+      <Helmet>
+        <title>Thoughts on Future Branding | Digitaltableteur</title>
+        <meta
+          name="description"
+          content="Exploring branding in the age of AI and exponential design."
+        />
+        <meta
+          property="og:title"
+          content="Thoughts on Future Branding | Digitaltableteur"
+        />
+        <meta
+          property="og:description"
+          content="Exploring branding in the age of AI and exponential design."
+        />
+        <meta property="og:image" content="/logo512.png" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+          name="twitter:title"
+          content="Thoughts on Future Branding | Digitaltableteur"
+        />
+        <meta
+          name="twitter:description"
+          content="Exploring branding in the age of AI and exponential design."
+        />
+        <meta name="twitter:image" content="/logo512.png" />
+      </Helmet>
+      <article className={styles.article}>
+        <header className={styles.header}>
+          <h1>Thoughts on Future Branding</h1>
+          <Author name="Petri Lahdelma" imageUrl={VaultBoy} size="32px" />
+        </header>
+        <p>
+          <img src={future1} alt="Future Branding Concept" />
+          <span className={styles.boldText}>
+            Traditionally, an identity or brand has been a tool
+          </span>
+          &nbsp;to help companies distinguish one (a product, an ideal, a set of
+          values, or what the company does) from the other with numerous
+          defining sub-genres and classifications, such as entry-level, iconic,
+          luxury, etc. Usually consisting of a logo (logomark/logotype) and
+          other graphic means designed to increase brand recognition.
+        </p>
+        <p>
+          Brands have now adopted subtler tactics in retrospect to the early
+          days. Brands tell stories on popular platforms—and in a subtle way
+          that is nearly indistinguishable (advertorials) from the media readers
+          already consume. By molding the message to the platform, brands can
+          draw loyal customers and occasionally even make their content go
+          viral. Tone of voice plays a big role in how brands are adopted by the
+          masses. This encapsulates the general zeitgeist of branding today.
+        </p>
+        <blockquote>
+          Brands have now adopted subtler tactics in retrospect to the early
+          days.
+        </blockquote>
+        <p>
+          In recent times, branding has evolved into various workflows and
+          approaches, such as modular, responsive, interactive, or generative
+          brand applications and corresponding identities, and vast variations
+          of design systems to support and maintain the brand image. The craft
+          itself has also somewhat evolved from promoting simple logomarks, and
+          this has made the industry even more intricate.
+        </p>
+        <p>
+          With advancements in machine learning, greater capacity for deeper
+          neural networks (thanks to cloud solutions and Google’s efforts to
+          speed up computing with GPUs), and especially in the field of
+          algorithm-driven design, there’s no limit to the number of powerful
+          tools we have access to. With the right tools and intellectual
+          resources, we can apply the ideas garnered from the data and adapt to
+          tomorrow&apos;s necessities, creating impactful design and successful
+          content delivery, way “outside the box,” and soon beyond the
+          capability of the human mind.
+        </p>
+        <img src={future2} alt="Future Branding Concept" />
+        <caption style={{ display: "block", textAlign: "center" }}>
+          A logotype refers to words or the name of a business that is designed
+          or typeset.
+        </caption>
+        <img src={future3} alt="Future Branding Concept" />
+        <caption
+          style={{
+            display: "block",
+            textAlign: "center",
+            marginBlockEnd: "6em",
+          }}
+        >
+          A logomark is an identifying mark or symbol that doesn’t necessarily
+          contain the business name.
+        </caption>
+        <p>
+          The technologies of tomorrow are bound to change how we design
+          corporate identification systems and brand presence in the future.
+          There’s no avoiding it, and the sci-fi geek in me can’t wait for news
+          on yet another tech or gadget that will completely revolutionize the
+          way we experience, exist, and interact.
+        </p>
+        <p>
+          Thinking outside the box has always been the mantra of the creative
+          industry. The truth is that more times than we’d like to admit, we’re
+          being stuffed into that very box by our clients’ budget, our lack of
+          vision, our fear of failure, or even sheer laziness. I’ve experienced
+          many, if not all, possible pitfalls in my personal career as a
+          designer, and in that sense, I am no better than my fellow designers.
+          But where are the brands and identities that strive to do something
+          more with the vast possibilities at our disposal today?
+        </p>
+        <img src={future4} alt="A futuristic branding concept" />
+        <caption style={{ display: "block", textAlign: "center" }}>
+          A philosophical brand that advocates living instinctively, responding
+          in the moment, and letting change flow. The brand evokes this uniquely
+          Chinese state of mind. By Wolff Olins.
+        </caption>
+        <div
+          className={styles.videoContainer}
+          style={{ marginBlockStart: "2rem", marginBlockEnd: "2rem" }}
+        >
+          <iframe
+            title="vimeo-player"
+            src="https://player.vimeo.com/video/217044558?h=ddc46a1db5"
+            width="100%"
+            height="360"
+            frameBorder="0"
+            allowFullScreen
+          ></iframe>
         </div>
-      </div>
-    </article>
+        <caption style={{ display: "block", textAlign: "center" }}>
+          Genesis Beijing is a visual tool that explores each state and
+          associated feeling through rich, reactive pattern. By Wolff Olins
+        </caption>
+        <img src={future5} alt="A futuristic branding concept" />
+        <caption style={{ display: "block", textAlign: "center" }}>
+          Identity for Ministry for Foreign Affairs of Finland echoes the world
+          events with changing color schemes. By 358
+        </caption>
+        <img src={future8} alt="A futuristic branding concept" />
+        <caption
+          style={{
+            display: "block",
+            textAlign: "center",
+            marginBlockEnd: "2rem",
+          }}
+        >
+          The applications make great use of the possible variations of the
+          globe that yields some lovely color combinations and compositions. By
+          358
+        </caption>
+        <div className={styles.videoContainer}>
+          <iframe
+            width="100%"
+            height="315"
+            src="https://www.youtube.com/embed/YZUP4vfDonU?si=uSndXsN5I-dyBAoh"
+            title="YouTube video player"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          ></iframe>
+        </div>
+        <caption style={{ display: "block", textAlign: "center" }}>
+          An organisation that operates in a stable manner in a turbulent world
+          and that works to make the world a better place. Video courtesy of the
+          Ministry for Foreign Affairs of Finland and 358
+        </caption>
+        <p>
+          By focusing on the individual experience instead of the user itself,
+          we can easily draw out the factors that dictate how experiences are
+          perceived. That said, we still like to pick and choose where we follow
+          the more traditional HCD (Human-Centric Design) model, much like our
+          own smörgåsbord for design. We validate design choices in a hive-mind
+          manner, which is made possible by the lack of hierarchy and principles
+          of self-governance within New Things Co.
+        </p>
+        <p>
+          So what technologies could one consider as a designer in a branding or
+          related project? Intelligent, algorithm-driven, reactive, or whatever
+          the choice of tech, beneath the surface still lies an intelligent
+          creative that understands both the given constraints and possibilities
+          or has the capacity for evaluating machine-based output. But through
+          matured systems of smart, tech-driven assets, these new brands will
+          soon serve mankind a genuine, empathetic, positive, and lasting
+          experience.
+        </p>
+        <img
+          src={future7}
+          alt="A futuristic branding concept"
+          className={styles.image}
+        />
+        <caption style={{ display: "block", textAlign: "center" }}>
+          Example of the New Things Co identity mutations. 2016–2018.
+        </caption>
+        <img
+          style={{ marginTop: "4rem" }}
+          src={future6}
+          alt="A futuristic branding concept"
+          className={styles.image}
+        />
+        <caption>
+          The &nbsp;<a href="https://app.brandmark.io/v2/">brandmark.io</a>{" "}
+          system has been trained with over 1.4 million images, instantly
+          generating thousands of logo ideas based on user input.
+        </caption>
+        <p>
+          One could suggest an umbrella term “Exponentially-Driven Design” to
+          collect all these technological advancements and bundle them to serve
+          as an aid for design efforts. ED for short, meaning the
+          computer-assisted, exponential advancements in the creative process.
+          However we might call it, as creatives, we need to remember to step
+          back and observe our habits and find smarter, new ways of working. In
+          a word, adapt to changes in a rapidly changing digital landscape.
+        </p>
+        <blockquote>
+          “Everything should be made as simple as possible, but not simpler.”
+        </blockquote>
+        <p>— Albert Einstein</p>
+        <h2>Share</h2>
+        <SocialShare
+          url={window.location.href}
+          title="Thoughts on Future Branding"
+        />
+        <div className={styles.similar}>
+          <h2>Similar Reads</h2>
+          <div className={styles["similarList"]}>
+            <Card
+              title="Designing in 2025"
+              link="/blog/designing-in-2025"
+              className={`${styles["similarCard"]} ${styles.teal}`}
+            />
+            <Card
+              title="Digital Craftsmanship"
+              link="/blog/digital-craftsmanship"
+              className={`${styles["similarCard"]} ${styles.purple}`}
+            />
+          </div>
+        </div>
+      </article>
+    </>
   );
 };
 

--- a/src/pages/posts/WorkflowTips.tsx
+++ b/src/pages/posts/WorkflowTips.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet";
 import styles from "../Article.module.css";
 import Author from "../../components/Author/Author";
 import VaultBoy from "../../assets/images/pete-vault-boy.jpg";
@@ -7,177 +8,205 @@ import Card from "../../components/Card/Card";
 import AI from "../../assets/images/ai.webp";
 
 const WorkflowTips = () => (
-  <article className={styles.article}>
-    <header>
-      <h1>Workflow Tips</h1>
-      <Author name="Petri Lahdelma" imageUrl={VaultBoy} size="32px" />
-    </header>
-    <img src={AI} alt="AI illustration" className={styles.image} />
-    <blockquote>
-      How to work faster, smarter, and more in sync as a designer in the age of
-      automation and AI-enhanced tooling
-    </blockquote>
-    <p>
-      In 2025, the gap between design and development is no longer a chasm—it’s
-      a channel. With smarter tooling, shared metadata, and increasingly
-      semantic design systems, teams can now collaborate in ways that are both
-      more efficient and more meaningful. The rise of Figma’s official MCP
-      (Metadata Component Properties) server, the normalization of token-driven
-      design, and the integration of AI into everyday tooling means we’re not
-      just designing screens — we’re designing systems of understanding.
-    </p>
-    <p>
-      Whether you&#39;re a designer, developer, or someone who lives at the
-      intersection of both, here are key workflow tips to stay effective and
-      aligned in this rapidly evolving landscape.
-    </p>
-    <h2>Treat Your Design System Like a Product</h2>
-    <p>
-      Your design system should no longer be seen as a passive library of
-      components—it’s an active product with its own users (developers,
-      designers), backlog, documentation, and evolution cycle. Robust systems in
-      2025 are:
-    </p>
-    <ul>
-      <li>
-        Token-first: With clear, versioned design tokens driving color,
-        typography, spacing, and elevation.
-      </li>
-      <li>
-        Metadata-aware: Components carry machine-readable data like intent,
-        states, and accessibility traits via MCP.
-      </li>
-      <li>
-        Bi-directional: Design inputs influence code output, and coded
-        components feed back into design for parity.
-      </li>
-    </ul>
-    <p>
-      <strong>Workflow Tip:</strong> Maintain a changelog, version your tokens,
-      and establish governance for components just like you would with APIs.
-    </p>
-    <h2>Use Figma MCP to Build a Smarter Handoff Layer</h2>
-    <p>
-      Figma’s MCP server lets you attach machine-readable context to components.
-      Think of it as giving your design files a brain. You’re not just placing a
-      “button”—you’re tagging it as primary, disabled, semantic:cta, and linking
-      it to the token color-background-primary.
-    </p>
-    <p>
-      When paired with a structured design system, this opens up a
-      design-to-code workflow where tools and AI can assist or even
-      auto-generate scaffolding code.
-    </p>
-    <p>
-      <strong>Workflow Tip:</strong> Standardize naming conventions and metadata
-      structures. Create shared guidelines on how to tag variants, behaviors,
-      and semantic intent.
-    </p>
-    <div className={styles.video}>
-      <iframe
-        width="100%"
-        height="315"
-        src="https://www.youtube.com/embed/m0b_D2JgZgY?si=ssccfFHGfntt_CWQ"
-        title="YouTube video player"
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        referrerPolicy="strict-origin-when-cross-origin"
-        allowFullScreen
-      ></iframe>
-    </div>
-    <h2>Automate the Boring Stuff — Focus on the Edges</h2>
-    Engineers still refine the output and designers still own the experience.
-    But by automating the repetitive tasks—like token mapping, boilerplate
-    scaffolding, and layout generation—you unlock time for high-value work.
-    <p>
-      This means more attention to edge cases, accessibility, motion, responsive
-      logic, and product vision. The time saved is best spent crafting
-      delightful moments and designing inclusively—not renaming layers.
-    </p>
-    <p>
-      <strong>Workflow Tip:</strong> Use automation for grunt work, not
-      decision-making. Let your team spend energy on what machines can’t do
-      well: judgment, intuition, and empathy.
-    </p>
-    <h3>Centralize Knowledge and Make It Machine-Readable</h3>
-    <p>In 2025, wikis and PDFs aren’t enough. Your documentation should be:</p>
-    <ul>
-      <li>
-        <strong>Atomic:</strong> Break things into tokens, components, patterns,
-        principles
-      </li>
-      <li>
-        <strong>Composable:</strong> Easily remixed across tools like Storybook,
-        Figma, Notion
-      </li>
-      <li>
-        <strong>Structured:</strong> Use schemas, JSON, or YAML where possible
-        so tools can read it too
-      </li>
-    </ul>
-    <p>
-      The more you treat your documentation like structured data instead of
-      prose, the more future-proof and useful it becomes—especially for AI
-      tools.
-    </p>
-    <p>
-      <strong>Workflow Tip:</strong> Build your docs once, then publish them
-      everywhere: Figma, Storybook, GitHub, Confluence, even AI chat interfaces.
-    </p>
-    <h2>Build a Shared Language Between Design and Dev</h2>
-    <p>
-      A design system isn’t just about buttons—it’s a communication protocol.
-      When your tokens, components, and behaviors are named clearly and
-      consistently, they become interoperable across people and platforms.
-    </p>
-    <p>
-      A consistent system gives MCP data meaning. A properly named component
-      like <code>Card/Product/Featured</code> combined with a token like&nbsp;
-      <code>spacing-grid-lg</code> enables tools to generate layout logic
-      without human interpretation.
-    </p>
-    <p>
-      <strong>Workflow Tip:</strong> Run regular naming audits and
-      cross-functional reviews to ensure that your naming makes sense to both
-      humans and machines.
-    </p>
-    <h2>Final Thought: Orchestrate, Don’t Just Execute</h2>
-    <p>
-      Design and development roles are shifting from execution toward
-      orchestration. In 2025, the real craft lies in setting up systems that can
-      scale, adapt, and communicate across disciplines and tools.
-    </p>
-    <p>
-      Great workflows today aren’t just fast—they’re intentional. They’re
-      designed for clarity, for automation, and for collaboration at scale.
-    </p>
-    <p>
-      So before you jump into the next Figma file or VSCode tab, ask yourself:
-    </p>
-    <blockquote>
+  <>
+    <Helmet>
+      <title>Workflow Tips | Digitaltableteur</title>
+      <meta
+        name="description"
+        content="A behind-the-scenes look at how we keep projects moving."
+      />
+      <meta property="og:title" content="Workflow Tips | Digitaltableteur" />
+      <meta
+        property="og:description"
+        content="A behind-the-scenes look at how we keep projects moving."
+      />
+      <meta property="og:image" content="/logo512.png" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content="Workflow Tips | Digitaltableteur" />
+      <meta
+        name="twitter:description"
+        content="A behind-the-scenes look at how we keep projects moving."
+      />
+      <meta name="twitter:image" content="/logo512.png" />
+    </Helmet>
+    <article className={styles.article}>
+      <header>
+        <h1>Workflow Tips</h1>
+        <Author name="Petri Lahdelma" imageUrl={VaultBoy} size="32px" />
+      </header>
+      <img src={AI} alt="AI illustration" className={styles.image} />
+      <blockquote>
+        How to work faster, smarter, and more in sync as a designer in the age
+        of automation and AI-enhanced tooling
+      </blockquote>
       <p>
-        &quot;Am I building just a component… or a conversation between design
-        and code?&quot;
+        In 2025, the gap between design and development is no longer a
+        chasm—it’s a channel. With smarter tooling, shared metadata, and
+        increasingly semantic design systems, teams can now collaborate in ways
+        that are both more efficient and more meaningful. The rise of Figma’s
+        official MCP (Metadata Component Properties) server, the normalization
+        of token-driven design, and the integration of AI into everyday tooling
+        means we’re not just designing screens — we’re designing systems of
+        understanding.
       </p>
-    </blockquote>
-    <h2>Share</h2>
-    <SocialShare url={window.location.href} title="Workflow Tips" />
-    <div className={styles.similar}>
-      <h2>Similar Reads</h2>
-      <div className={styles["similar-list"]}>
-        <Card
-          title="Rethinking Design-to-Product Workflows with Figma MCP"
-          link="/blog/figma-mcp-design-systems"
-          className={`${styles["similar-card"]} ${styles.teal}`}
-        />
-        <Card
-          title="Digital Craftsmanship"
-          link="/blog/digital-craftsmanship"
-          className={`${styles["similar-card"]} ${styles.purple}`}
-        />
+      <p>
+        Whether you&#39;re a designer, developer, or someone who lives at the
+        intersection of both, here are key workflow tips to stay effective and
+        aligned in this rapidly evolving landscape.
+      </p>
+      <h2>Treat Your Design System Like a Product</h2>
+      <p>
+        Your design system should no longer be seen as a passive library of
+        components—it’s an active product with its own users (developers,
+        designers), backlog, documentation, and evolution cycle. Robust systems
+        in 2025 are:
+      </p>
+      <ul>
+        <li>
+          Token-first: With clear, versioned design tokens driving color,
+          typography, spacing, and elevation.
+        </li>
+        <li>
+          Metadata-aware: Components carry machine-readable data like intent,
+          states, and accessibility traits via MCP.
+        </li>
+        <li>
+          Bi-directional: Design inputs influence code output, and coded
+          components feed back into design for parity.
+        </li>
+      </ul>
+      <p>
+        <strong>Workflow Tip:</strong> Maintain a changelog, version your
+        tokens, and establish governance for components just like you would with
+        APIs.
+      </p>
+      <h2>Use Figma MCP to Build a Smarter Handoff Layer</h2>
+      <p>
+        Figma’s MCP server lets you attach machine-readable context to
+        components. Think of it as giving your design files a brain. You’re not
+        just placing a “button”—you’re tagging it as primary, disabled,
+        semantic:cta, and linking it to the token color-background-primary.
+      </p>
+      <p>
+        When paired with a structured design system, this opens up a
+        design-to-code workflow where tools and AI can assist or even
+        auto-generate scaffolding code.
+      </p>
+      <p>
+        <strong>Workflow Tip:</strong> Standardize naming conventions and
+        metadata structures. Create shared guidelines on how to tag variants,
+        behaviors, and semantic intent.
+      </p>
+      <div className={styles.video}>
+        <iframe
+          width="100%"
+          height="315"
+          src="https://www.youtube.com/embed/m0b_D2JgZgY?si=ssccfFHGfntt_CWQ"
+          title="YouTube video player"
+          frameBorder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          referrerPolicy="strict-origin-when-cross-origin"
+          allowFullScreen
+        ></iframe>
       </div>
-    </div>
-  </article>
+      <h2>Automate the Boring Stuff — Focus on the Edges</h2>
+      Engineers still refine the output and designers still own the experience.
+      But by automating the repetitive tasks—like token mapping, boilerplate
+      scaffolding, and layout generation—you unlock time for high-value work.
+      <p>
+        This means more attention to edge cases, accessibility, motion,
+        responsive logic, and product vision. The time saved is best spent
+        crafting delightful moments and designing inclusively—not renaming
+        layers.
+      </p>
+      <p>
+        <strong>Workflow Tip:</strong> Use automation for grunt work, not
+        decision-making. Let your team spend energy on what machines can’t do
+        well: judgment, intuition, and empathy.
+      </p>
+      <h3>Centralize Knowledge and Make It Machine-Readable</h3>
+      <p>
+        In 2025, wikis and PDFs aren’t enough. Your documentation should be:
+      </p>
+      <ul>
+        <li>
+          <strong>Atomic:</strong> Break things into tokens, components,
+          patterns, principles
+        </li>
+        <li>
+          <strong>Composable:</strong> Easily remixed across tools like
+          Storybook, Figma, Notion
+        </li>
+        <li>
+          <strong>Structured:</strong> Use schemas, JSON, or YAML where possible
+          so tools can read it too
+        </li>
+      </ul>
+      <p>
+        The more you treat your documentation like structured data instead of
+        prose, the more future-proof and useful it becomes—especially for AI
+        tools.
+      </p>
+      <p>
+        <strong>Workflow Tip:</strong> Build your docs once, then publish them
+        everywhere: Figma, Storybook, GitHub, Confluence, even AI chat
+        interfaces.
+      </p>
+      <h2>Build a Shared Language Between Design and Dev</h2>
+      <p>
+        A design system isn’t just about buttons—it’s a communication protocol.
+        When your tokens, components, and behaviors are named clearly and
+        consistently, they become interoperable across people and platforms.
+      </p>
+      <p>
+        A consistent system gives MCP data meaning. A properly named component
+        like <code>Card/Product/Featured</code> combined with a token like&nbsp;
+        <code>spacing-grid-lg</code> enables tools to generate layout logic
+        without human interpretation.
+      </p>
+      <p>
+        <strong>Workflow Tip:</strong> Run regular naming audits and
+        cross-functional reviews to ensure that your naming makes sense to both
+        humans and machines.
+      </p>
+      <h2>Final Thought: Orchestrate, Don’t Just Execute</h2>
+      <p>
+        Design and development roles are shifting from execution toward
+        orchestration. In 2025, the real craft lies in setting up systems that
+        can scale, adapt, and communicate across disciplines and tools.
+      </p>
+      <p>
+        Great workflows today aren’t just fast—they’re intentional. They’re
+        designed for clarity, for automation, and for collaboration at scale.
+      </p>
+      <p>
+        So before you jump into the next Figma file or VSCode tab, ask yourself:
+      </p>
+      <blockquote>
+        <p>
+          &quot;Am I building just a component… or a conversation between design
+          and code?&quot;
+        </p>
+      </blockquote>
+      <h2>Share</h2>
+      <SocialShare url={window.location.href} title="Workflow Tips" />
+      <div className={styles.similar}>
+        <h2>Similar Reads</h2>
+        <div className={styles["similar-list"]}>
+          <Card
+            title="Rethinking Design-to-Product Workflows with Figma MCP"
+            link="/blog/figma-mcp-design-systems"
+            className={`${styles["similar-card"]} ${styles.teal}`}
+          />
+          <Card
+            title="Digital Craftsmanship"
+            link="/blog/digital-craftsmanship"
+            className={`${styles["similar-card"]} ${styles.purple}`}
+          />
+        </div>
+      </div>
+    </article>
+  </>
 );
 
 export default WorkflowTips;


### PR DESCRIPTION
## Summary
- enhance SEO and social sharing metadata
- add `<Helmet>` tags with Open Graph and Twitter Card metadata for pages and posts

## Testing
- `npx prettier "src/**/*.{ts,tsx,css}" --write`
- `npm run lint`
- `CI=true npm test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6854f2d91484832eab4d84c1a76fb422