### PR TITLE
Fix PR preview instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ The file is saved as `figma.json` in the project root.
 Every pull request is validated with lint and unit tests using GitHub Actions.
 Preview builds are automatically deployed so changes can be reviewed live.
 A comment with a link to the preview URL is posted on each PR once deployment finishes.
+If the workflow fails with a "branch is not allowed to deploy" error, check the
+environment rules for GitHub Pages. Go to **Settings → Environments →
+`github-pages`** and make sure the branch restrictions allow your pull request
+branches, otherwise the preview deployment will be rejected.
 
 ## Folder overview
 


### PR DESCRIPTION
## Summary
- document that the `github-pages` environment must allow PR branches for preview deployments

## Testing
- `NODE_OPTIONS=--experimental-json-modules npm run lint`
- `npx vitest run --config vitest.config.mts`

------
https://chatgpt.com/codex/tasks/task_e_68618c2f8808832ebbd73237a3a8b07e