### PR TITLE
Add serverless logging of contact form submissions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@ VITE_APP_EMAIL_TEMPLATE_ID=your_template_id
 VITE_APP_EMAIL_PUBLIC_KEY=your_public_key
 VITE_GA_ID=your_ga_measurement_id
 OPENAI_API_KEY=your_openai_api_key
+MONGODB_URI=your_mongodb_connection_string
+MONGODB_DB=your_database_name

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ cp .env.example .env
 ```
 
 Set `REACT_APP_GA_ID` to your Google Analytics measurement ID if you want to collect usage statistics.
+To save contact form submissions to a database, provide `MONGODB_URI` and `MONGODB_DB` in the `.env` file with your MongoDB connection details.
 
 ### Run the development server
 

--- a/api/save-contact.js
+++ b/api/save-contact.js
@@ -1,0 +1,37 @@
+import { MongoClient } from "mongodb";
+
+export default async function handler(request, response) {
+  if (request.method !== "POST") {
+    response.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  const { name, email, phone, interest, message, time } = request.body || {};
+
+  if (!name || !email) {
+    response.status(400).json({ error: "Missing required fields" });
+    return;
+  }
+
+  const uri = process.env.MONGODB_URI;
+  const dbName = process.env.MONGODB_DB || "digitaltableteur";
+
+  if (!uri) {
+    response.status(500).json({ error: "Database not configured" });
+    return;
+  }
+
+  const client = new MongoClient(uri);
+
+  try {
+    await client.connect();
+    const db = client.db(dbName);
+    const contacts = db.collection("contacts");
+    await contacts.insertOne({ name, email, phone, interest, message, time });
+    response.status(200).json({ status: "ok" });
+  } catch (err) {
+    response.status(500).json({ error: err.message });
+  } finally {
+    await client.close();
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "framer-motion": "^12.16.0",
         "i18next": "^25.3.0",
         "jsdom": "^26.1.0",
+        "mongodb": "^6.5.0",
         "node-fetch": "^3.3.2",
         "openai": "5.8.2",
         "react": "^18.2.0",
@@ -2591,6 +2592,15 @@
         "react": ">=16"
       }
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.0.tgz",
+      "integrity": "sha512-zlayKCsIjYb7/IdfqxorK5+xUMyi4vOKcFy10wKJYc63NSdKI8mNME+uJqfatkPmOSMMUiojrL58IePKBm3gvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3920,6 +3930,21 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -5034,6 +5059,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "node_modules/buffer": {
@@ -11029,6 +11063,12 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
+    },
     "node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -11223,6 +11263,62 @@
         "pathe": "^2.0.1",
         "pkg-types": "^1.3.0",
         "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.5.0.tgz",
+      "integrity": "sha512-Fozq68InT+JKABGLqctgtb8P56pRrJFkbhW0ux+x1mdHeyinor8oNzJqwLjV/t5X5nJGfTlluxfyMnOXNggIUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.5",
+        "bson": "^6.4.0",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
       }
     },
     "node_modules/motion-dom": {
@@ -13881,6 +13977,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
       }
     },
     "node_modules/spawn-wrap": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "framer-motion": "^12.16.0",
     "i18next": "^25.3.0",
     "jsdom": "^26.1.0",
+    "mongodb": "^6.5.0",
     "node-fetch": "^3.3.2",
     "openai": "5.8.2",
     "react": "^18.2.0",

--- a/secure-proxy/api/save-contact.js
+++ b/secure-proxy/api/save-contact.js
@@ -1,0 +1,37 @@
+import { MongoClient } from "mongodb";
+
+export default async function handler(request, response) {
+  if (request.method !== "POST") {
+    response.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  const { name, email, phone, interest, message, time } = request.body || {};
+
+  if (!name || !email) {
+    response.status(400).json({ error: "Missing required fields" });
+    return;
+  }
+
+  const uri = process.env.MONGODB_URI;
+  const dbName = process.env.MONGODB_DB || "digitaltableteur";
+
+  if (!uri) {
+    response.status(500).json({ error: "Database not configured" });
+    return;
+  }
+
+  const client = new MongoClient(uri);
+
+  try {
+    await client.connect();
+    const db = client.db(dbName);
+    const contacts = db.collection("contacts");
+    await contacts.insertOne({ name, email, phone, interest, message, time });
+    response.status(200).json({ status: "ok" });
+  } catch (err) {
+    response.status(500).json({ error: err.message });
+  } finally {
+    await client.close();
+  }
+}

--- a/src/components/Contact Form/ContactForm.tsx
+++ b/src/components/Contact Form/ContactForm.tsx
@@ -64,6 +64,20 @@ const ContactForm = () => {
       PUBLIC_KEY,
     )
       .then(() => {
+        fetch("/api/save-contact", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: formData.fullName,
+            email: formData.email,
+            phone: formData.phone,
+            interest: formData.interest,
+            message: formData.message,
+            time,
+          }),
+        }).catch(() => {
+          // Silently ignore logging failures
+        });
         setIsModalOpen(true);
         setFormData({
           fullName: "",


### PR DESCRIPTION
## Summary
- add MongoDB logging endpoints to api/ and secure-proxy/api/
- store submissions from ContactForm via new `/api/save-contact`
- document MongoDB variables in README and `.env.example`
- install mongodb package

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686d01c9ba10832e9af6c0a0e16f8ae3