### PR TITLE
Localize WorkNav and update contact page styles

### DIFF
--- a/src/components/Contact Form/ContactForm.module.css
+++ b/src/components/Contact Form/ContactForm.module.css
@@ -3,7 +3,7 @@
 
 .contactForm {
   width: 450px;
-  margin: 0 auto;
+  margin: 2rem auto;
   padding: 1.5rem;
   background-color: var(--color-light-bg);
   border: 2px solid var(--color-primary);

--- a/src/components/GroupLabel/GroupLabel.module.css
+++ b/src/components/GroupLabel/GroupLabel.module.css
@@ -4,7 +4,7 @@
 .groupLabel {
   font-size: 1rem;
   font-family: Moderat, sans-serif;
-  font-weight: 600;
+  font-weight: 500;
   display: flex;
   align-items: center;
   gap: 0.5rem; /* 8px */

--- a/src/components/WorkNav/WorkNav.tsx
+++ b/src/components/WorkNav/WorkNav.tsx
@@ -3,13 +3,15 @@ import Button from "../Button/Button";
 import { MdArrowBack, MdArrowForward, MdWork } from "react-icons/md";
 import styles from "./worknav.module.css";
 import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 const workPages = [
-  { path: "/work/new-things-co", label: "New Things Co" },
-  { path: "/work/illustrations", label: "Illustrations" },
+  { path: "/work/new-things-co", labelKey: "workNavNewThingsCo" },
+  { path: "/work/illustrations", labelKey: "workNavIllustrations" },
 ];
 
 const WorkNav: React.FC = () => {
+  const { t } = useTranslation();
   const currentPath = window.location.pathname;
   const currentIndex = workPages.findIndex((p) => p.path === currentPath);
   const navigate = useNavigate();
@@ -22,7 +24,7 @@ const WorkNav: React.FC = () => {
           icon={<MdWork />}
           onClick={() => navigate("/work")}
         >
-          Back to Work
+          {t("workNavBackToWork")}
         </Button>
         <div className={styles.rightNavGroup}>
           <Button
@@ -34,7 +36,7 @@ const WorkNav: React.FC = () => {
               if (currentIndex > 0) navigate(workPages[currentIndex - 1].path);
             }}
           >
-            Prev
+            {t("workNavPrev")}
           </Button>
           <Button
             variant="tertiary"
@@ -46,7 +48,7 @@ const WorkNav: React.FC = () => {
                 navigate(workPages[currentIndex + 1].path);
             }}
           >
-            Next
+            {t("workNavNext")}
           </Button>
         </div>
       </div>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -134,5 +134,10 @@
   "templateArticleMetaTitle": "Template Article Title | Digitaltableteur",
   "templateArticleMetaDescription": "Template description for future articles.",
   "shareHeading": "Share",
-  "siteUnderDevelopment": "Site Under Development! 🚧 Stay tuned!"
+  "siteUnderDevelopment": "Site Under Development! 🚧 Stay tuned!",
+  "workNavBackToWork": "Back to Work",
+  "workNavPrev": "Prev",
+  "workNavNext": "Next",
+  "workNavNewThingsCo": "New Things Co",
+  "workNavIllustrations": "Illustrations"
 }

--- a/src/locales/fi/translation.json
+++ b/src/locales/fi/translation.json
@@ -134,5 +134,10 @@
   "templateArticleMetaTitle": "Mallipohjan otsikko | Digitaltableteur",
   "templateArticleMetaDescription": "Mallikuvaus tuleville artikkeleille.",
   "shareHeading": "Jaa",
-  "siteUnderDevelopment": "Sivusto kehitteillä! 🚧 Pysy kuulolla!"
+  "siteUnderDevelopment": "Sivusto kehitteillä! 🚧 Pysy kuulolla!",
+  "workNavBackToWork": "Takaisin töihin",
+  "workNavPrev": "Edellinen",
+  "workNavNext": "Seuraava",
+  "workNavNewThingsCo": "New Things Co",
+  "workNavIllustrations": "Kuvitukset"
 }

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -134,5 +134,10 @@
   "templateArticleMetaTitle": "Mallartikel Titel | Digitaltableteur",
   "templateArticleMetaDescription": "Mallbeskrivning för framtida artiklar.",
   "shareHeading": "Dela",
-  "siteUnderDevelopment": "Sidan under utveckling! 🚧 Håll utkik!"
+  "siteUnderDevelopment": "Sidan under utveckling! 🚧 Håll utkik!",
+  "workNavBackToWork": "Tillbaka till arbete",
+  "workNavPrev": "Föregående",
+  "workNavNext": "Nästa",
+  "workNavNewThingsCo": "New Things Co",
+  "workNavIllustrations": "Illustrationer"
 }

--- a/src/pages/Contact.module.css
+++ b/src/pages/Contact.module.css
@@ -10,7 +10,7 @@
   font-family: var(--primary-heading-font, serif);
   font-size: 5rem;
   font-weight: var(--primary-heading-weight, 300);
-  margin-block: 6rem;
+  margin-block: 2rem 6rem;
   color: var(--color-primary);
 }
 
@@ -21,15 +21,6 @@
   font-weight: 600;
   margin-bottom: 1rem;
   color: var(--color-secondary);
-}
-
-.contactForm {
-  max-width: var(--size-width-form);
-  margin: 0 auto;
-  padding: 1rem;
-  background-color: var(--color-light-bg);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
 }
 
 .formGroup {
@@ -51,7 +42,6 @@
   text-decoration: underline;
 }
 
-/* Added a class for styling the privacy policy paragraph */
 .contactForm p {
   font-family: Moderat, sans-serif;
   font-size: 0.875rem;
@@ -66,7 +56,6 @@
 
 .contactFormTitle {
   font-family: var(--secondary-heading-font, sans-serif);
-  font-size: 1.8rem;
   text-transform: uppercase;
   font-weight: 600;
   margin-bottom: 1rem;
@@ -76,5 +65,5 @@
 .contactInfo {
   color: var(--color-primary);
   margin-block-end: 2rem;
-  font-size: 1.1rem;
+  font-size: 1rem;
 }

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -32,7 +32,9 @@ const Contact = () => {
       </HelmetProvider>
       <div className={styles.contact}>
         <Title size="L">{t("contactHeroTitle")}</Title>
-        <Text className={styles.contactFormTitle}>{t("contactFormTitle")}</Text>
+        <Title level={2} size="S" className={styles.contactFormTitle}>
+          {t("contactFormTitle")}
+        </Title>
         <Text className={styles.contactInfo}>
           {t("contactInfo")}{" "}
           <Link size="S" href="mailto:mail@digitaltableteur.com">


### PR DESCRIPTION
WorkNav navigation labels are now localized using i18next, with new translation keys added for English, Finnish, and Swedish. Contact page and related component styles have been refined for improved spacing and typography. The contact form title is now rendered as a heading for better accessibility.