### PR TITLE
Improve lint and i18n loading

### DIFF
--- a/api/cors.js
+++ b/api/cors.js
@@ -1,0 +1,21 @@
+export default function handleCors(request, response) {
+  const allowedOrigins = [
+    "https://digitaltableteur.com",
+    "https://www.digitaltableteur.com",
+    "http://localhost:5173",
+    "http://localhost:3000",
+  ];
+  const origin = request.headers.origin;
+  if (allowedOrigins.includes(origin)) {
+    response.setHeader("Access-Control-Allow-Origin", origin);
+  } else {
+    response.setHeader("Access-Control-Allow-Origin", allowedOrigins[0]);
+  }
+  response.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  response.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  if (request.method === "OPTIONS") {
+    response.status(200).end();
+    return true;
+  }
+  return false;
+}

--- a/api/save-contact.js
+++ b/api/save-contact.js
@@ -1,22 +1,8 @@
 import { MongoClient } from "mongodb";
+import handleCors from "./cors";
 
 export default async function handler(request, response) {
-  const allowedOrigins = [
-    "https://digitaltableteur.com",
-    "https://www.digitaltableteur.com",
-    "http://localhost:5173",
-    "http://localhost:3000",
-  ];
-  const origin = request.headers.origin;
-  if (allowedOrigins.includes(origin)) {
-    response.setHeader("Access-Control-Allow-Origin", origin);
-  } else {
-    response.setHeader("Access-Control-Allow-Origin", allowedOrigins[0]);
-  }
-  response.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-  response.setHeader("Access-Control-Allow-Headers", "Content-Type");
-  if (request.method === "OPTIONS") {
-    response.status(200).end();
+  if (handleCors(request, response)) {
     return;
   }
 
@@ -26,8 +12,6 @@ export default async function handler(request, response) {
   }
 
   let body = request.body;
-  // Logging incoming body
-  console.log("Raw request.body:", body);
 
   // If body is undefined or a string, try to parse it
   if (!body || typeof body === "string") {
@@ -45,9 +29,7 @@ export default async function handler(request, response) {
         });
       }
       body = rawBody ? JSON.parse(rawBody) : {};
-      console.log("Parsed body:", body);
     } catch (err) {
-      console.error("Failed to parse body:", err);
       response.status(400).json({ error: "Invalid JSON body" });
       return;
     }
@@ -55,8 +37,9 @@ export default async function handler(request, response) {
 
   const { name, email, phone, interest, message, time } = body || {};
 
-  if (!name || !email) {
-    response.status(400).json({ error: "Missing required fields" });
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!name || !email || !emailRegex.test(email)) {
+    response.status(400).json({ error: "Invalid form data" });
     return;
   }
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "vitest run --config vitest.config.mts",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "lint": "prettier \"src/**/*.{ts,tsx,css}\" --check && eslint -c .eslintrc.cjs \"src/**/*.tsx\" && stylelint \"src/**/*.{css,tsx,html}\"",
+    "lint": "npx prettier \"src/**/*.{ts,tsx,css}\" --check && npx eslint -c .eslintrc.cjs \"src/**/*.{ts,tsx}\" && npx stylelint \"src/**/*.{css,tsx,html}\"",
     "fetch-figma": "node scripts/fetch-figma.js",
     "generate:sitemap": "node scripts/generate-sitemap.js",
     "generate:llms": "node scripts/generate-llms-txt.js",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -3,7 +3,11 @@ import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import Home from "./pages/Home";
 import { I18nextProvider } from "react-i18next";
-import i18n from "./i18n";
+import i18n, { initI18n } from "./i18n";
+
+beforeAll(async () => {
+  await initI18n();
+});
 
 describe("App", () => {
   it("renders the home page title", () => {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,19 +1,24 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
-import en from "./locales/en/translation.json";
-import fi from "./locales/fi/translation.json";
-import sv from "./locales/sv/translation.json";
 
-i18n.use(initReactI18next).init({
-  resources: {
-    en: { translation: en },
-    fi: { translation: fi },
-    sv: { translation: sv },
-  },
-  lng: "en",
-  fallbackLng: "en",
-  interpolation: { escapeValue: false },
-  react: { useSuspense: true },
-});
+export async function initI18n() {
+  const [en, fi, sv] = await Promise.all([
+    import("./locales/en/translation.json"),
+    import("./locales/fi/translation.json"),
+    import("./locales/sv/translation.json"),
+  ]);
+
+  await i18n.use(initReactI18next).init({
+    resources: {
+      en: { translation: en.default },
+      fi: { translation: fi.default },
+      sv: { translation: sv.default },
+    },
+    lng: "en",
+    fallbackLng: "en",
+    interpolation: { escapeValue: false },
+    react: { useSuspense: true },
+  });
+}
 
 export default i18n;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 import { ThemeProvider } from "@dt/ThemeProvider";
 import { HelmetProvider } from "react-helmet-async";
-import "./i18n";
+import { initI18n } from "./i18n";
 
 const redirectPath = sessionStorage.getItem("redirectPath");
 if (redirectPath) {
@@ -31,18 +31,20 @@ if (gaId) {
   document.head.appendChild(inlineScript);
 }
 
-const root = ReactDOM.createRoot(
-  document.getElementById("root") as HTMLElement,
-);
-root.render(
-  <React.StrictMode>
-    <HelmetProvider>
-      <ThemeProvider>
-        <App />
-      </ThemeProvider>
-    </HelmetProvider>
-  </React.StrictMode>,
-);
+initI18n().then(() => {
+  const root = ReactDOM.createRoot(
+    document.getElementById("root") as HTMLElement,
+  );
+  root.render(
+    <React.StrictMode>
+      <HelmetProvider>
+        <ThemeProvider>
+          <App />
+        </ThemeProvider>
+      </HelmetProvider>
+    </React.StrictMode>,
+  );
+});
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))


### PR DESCRIPTION
## Summary
- run linters with `npx`
- lazy load translation JSON files
- init i18n before rendering
- tweak app test for async i18n
- refactor API contact handler with CORS middleware and validation

## Testing
- `npm run lint`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686eac0c4d78832e84df2e7987837ec3