### PR TITLE
fix: KnobSmith dark theme hotfix

### DIFF
--- a/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.module.css
+++ b/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.module.css
@@ -68,6 +68,7 @@
   letter-spacing: 0.08em;
   color: var(--color-muted);
   margin: 0;
+  margin-inline-start: var(--space-layout-8);
 }
 
 .actions {

--- a/nextjs-app/shared/components/pages/Work/KnobSmithAudio/knobSmithAudio.module.css
+++ b/nextjs-app/shared/components/pages/Work/KnobSmithAudio/knobSmithAudio.module.css
@@ -146,9 +146,6 @@
   max-width: 1777px;
   height: auto;
   border-radius: var(--radius-m);
-  margin-block-start: -12%;
-  margin-block-end: -12%;
-  clip-path: inset(12% 0 12% 0 round var(--radius-m));
 }
 
 .knobsVideoContainer {
@@ -156,7 +153,6 @@
   max-width: 355px;
   height: 66.67%;
   border-radius: var(--radius-m);
-  background-color: var(--color-light-bg);
   overflow: hidden;
 }
 
@@ -165,7 +161,6 @@
   height: 100%;
   display: block;
   object-fit: cover;
-  mix-blend-mode: multiply;
 }
 
 .videoCaption {


### PR DESCRIPTION
### **User description**
## Summary
- Remove mix-blend-mode: multiply from knobs video — invisible on dark backgrounds
- Remove clip-path and negative margins from VU meter — white box artifact on dark theme

## Test plan
- [ ] KnobSmith page: knobs video visible on dark/HCB themes
- [ ] KnobSmith page: VU meter renders without white box on dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix KnobSmith media rendering in dark themes

- Remove knob video theme-breaking style overrides

- Remove VU meter clipping artifacts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  a["KnobSmith media styles"]
  b["Remove forced light media styling"]
  c["Remove meter clipping and offsets"]
  d["Dark theme rendering fixed"]
  a -- "update knobs video" --> b
  a -- "update VU meter" --> c
  b -- "restores visibility" --> d
  c -- "removes white artifact" --> d
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>knobSmithAudio.module.css</strong><dd><code>Fix dark theme media CSS issues</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nextjs-app/shared/components/pages/Work/KnobSmithAudio/knobSmithAudio.module.css

<ul><li>Remove negative margins from <code>.meterVideo</code><br> <li> Remove <code>clip-path</code> cropping on the VU meter<br> <li> Remove forced light background from <code>.knobsVideoContainer</code><br> <li> Remove <code>mix-blend-mode</code> from <code>.knobsVideo</code></ul>


</details>


  </td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/483/files#diff-656224fed200942ff143dbdacbc5236697c0bf0f4bb936b0e07a0d18c974e473">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified visual styling for media elements in the Work section, removing certain visual effects while maintaining layout and core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->