### PR TITLE
fix: code block language alignment specificity

### DIFF
--- a/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.module.css
+++ b/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.module.css
@@ -68,9 +68,9 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--color-muted);
-  margin: 0;
-  margin-inline-start: var(--space-layout-8);
-  line-height: 1;
+  margin: 0 !important;
+  margin-inline-start: var(--space-layout-8) !important;
+  line-height: 1 !important;
 }
 
 .actions {


### PR DESCRIPTION
### **User description**
The Text component base class `line-height: 1.6` overrides the CodeBlockWindow module CSS due to CSS Modules load order. Added `!important` to guarantee margin and line-height overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Force code language style overrides

- Prevent `Text` line-height from leaking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  textBase["Text base styles"] 
  languageRule[" .language  module styles with !important"] 
  alignment["Correct code block language alignment"] 
  textBase -- "was overriding" --> alignment
  languageRule -- "now enforces" --> alignment
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CodeBlockWindow.module.css</strong><dd><code>Strengthen language label style precedence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.module.css

<ul><li>Added <code>!important</code> to <code>.language</code> <code>margin</code><br> <li> Added <code>!important</code> to <code>margin-inline-start</code><br> <li> Added <code>!important</code> to <code>line-height</code><br> <li> Ensures code block language label alignment</ul>


</details>


  </td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/485/files#diff-1ab652f093dcb33ffcd8d47f392ad2e34ff65918330d3c4c749e68574e347a2a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

