### PR TITLE
fix: remove nested panel border and bg from code block

### DIFF
--- a/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.module.css
+++ b/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.module.css
@@ -96,9 +96,9 @@
 .pre {
   margin: 0;
   padding: var(--space-layout-16);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  background-color: var(--color-light-bg);
+  border-radius: 0;
+  border: none;
+  background-color: transparent;
   overflow-x: auto;
   overflow-y: hidden;
 }


### PR DESCRIPTION
### **User description**
Remove border, border-radius, and background-color from the inner `<pre>` element — the outer container already provides these, creating an unwanted nested panel look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Remove inner code block chrome

- Make nested `<pre>` fully transparent

- Rely on outer container styling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  pre["Inner <pre> styles"] 
  container["Outer code block container"] 
  pre -- "remove border, radius, background" --> container
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CodeBlockWindow.module.css</strong><dd><code>Simplify inner code block panel styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.module.css

<ul><li>Reset <code>.pre</code> border radius to <code>0</code><br> <li> Remove <code>.pre</code> border styling entirely<br> <li> Make <code>.pre</code> background transparent<br> <li> Preserve scrolling and spacing behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/486/files#diff-1ab652f093dcb33ffcd8d47f392ad2e34ff65918330d3c4c749e68574e347a2a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

