### PR TITLE
fix: contact new business block production layout

### DIFF
--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.module.css
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.module.css
@@ -111,8 +111,7 @@
   flex-direction: column;
   align-items: flex-start;
   gap: var(--space-layout-24);
-  align-self: flex-start;
-  contain: layout;
+  align-self: start;
 }
 
 @media (width >= 1024px) {
@@ -158,6 +157,12 @@
   gap: var(--space-layout-24);
 }
 
+.newBusinessMedia,
+.newBusinessContent {
+  align-self: start;
+  height: auto;
+}
+
 @media (width >= 768px) {
   .newBusiness {
     grid-template-columns: 10.5rem minmax(0, 1fr);
@@ -190,29 +195,40 @@
 .newBusinessContent {
   display: flex;
   min-width: 0;
+  flex: none;
   flex-direction: column;
   align-items: flex-start;
-  gap: var(--space-layout-24);
+  justify-content: flex-start;
+  gap: var(--space-layout-12);
 }
 
-.newBusinessHeading {
+.newBusinessContent .newBusinessHeading {
   margin: 0;
+  margin-block-end: var(--space-layout-4);
   text-wrap: pretty;
+}
+
+.newBusinessDetails {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-layout-12);
 }
 
 .newBusinessBody {
   display: flex;
   flex-direction: column;
   gap: var(--space-internal-4);
-  line-height: 1;
 }
 
-.newBusinessLine,
-.newBusinessLineMuted {
+.newBusinessContent .newBusinessLine,
+.newBusinessContent .newBusinessLineMuted {
   margin: 0;
 }
 
 .newBusinessLineMuted {
+  font-size: var(--font-size-text-s);
+  line-height: var(--line-height-normal);
   color: var(--color-muted);
 }
 
@@ -221,6 +237,8 @@
   align-items: center;
   gap: var(--space-layout-16);
   width: fit-content;
+  margin: 0;
+  margin-block-start: 0;
   text-decoration: none;
   transition: gap var(--duration-fast) var(--ease-out-cubic);
 }

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx
@@ -205,35 +205,38 @@ export function ContactPageContentEditorial({
                     "New Business Inquiries"
                   )}
                 </Title>
-                <div className={styles.newBusinessBody}>
-                  <Text
-                    as="p"
-                    size="M"
-                    terminals="sans"
-                    className={styles.newBusinessLine}
-                  >
-                    {t("contactNewBusinessName", "Petri Lahdelma")}
-                  </Text>
-                  <Text
-                    as="p"
-                    size="M"
-                    terminals="sans"
-                    className={styles.newBusinessLineMuted}
-                  >
-                    {t(
-                      "contactNewBusinessRole",
-                      "Founder, Head of Design"
-                    )}
-                  </Text>
-                </div>
-                <a href="#contact-form" className={styles.newBusinessCta}>
-                  <span className={styles.email}>
-                    {t("contactNewBusinessLink", "Contact")}
-                  </span>
-                  <span className={styles.newBusinessLinkIcon} aria-hidden>
-                    <Icon name="ArrowRight" size="sm" decorative />
-                  </span>
-                </a>
+                  <div className={styles.newBusinessDetails}>
+                    <div className={styles.newBusinessBody}>
+                      <Text
+                        as="p"
+                        size="M"
+                        terminals="sans"
+                        className={styles.newBusinessLine}
+                      >
+                        {t("contactNewBusinessName", "Petri Lahdelma")}
+                      </Text>
+                      <Text
+                        as="p"
+                        size="S"
+                        terminals="sans"
+                        lineHeight="normal"
+                        className={styles.newBusinessLineMuted}
+                      >
+                        {t(
+                          "contactNewBusinessRole",
+                          "Founder, Head of Design"
+                        )}
+                      </Text>
+                    </div>
+                    <a href="#contact-form" className={styles.newBusinessCta}>
+                      <span className={styles.email}>
+                        {t("contactNewBusinessLink", "Contact")}
+                      </span>
+                      <span className={styles.newBusinessLinkIcon} aria-hidden>
+                        <Icon name="ArrowRight" size="sm" decorative />
+                      </span>
+                    </a>
+                  </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
### **User description**
## Summary
- Stops the new business text column from stretching to portrait height (Contact CTA no longer drops to the bottom in production)
- Overrides Title/Text default margins so bundled CSS order cannot break spacing
- Matches role line to address typography (`text-s`, normal line height)

## Test plan
- [ ] Compare `/contact` in `npm run build && npm start` vs dev — New Business block alignment
- [ ] Confirm Contact CTA sits directly under name/role
- [ ] Verify role line matches address/email styling

Made with [Cursor](https://cursor.com)


___

### **PR Type**
Bug fix


___

### **Description**
- Stabilizes Contact new business layout

- Groups details with CTA link

- Prevents stretched content alignment

- Normalizes heading, text, CTA spacing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Contact new business block"]
  B["Details wrapper"]
  C["CSS alignment fixes"]
  D["Stable portrait and CTA layout"]
  A -- "groups text and link" --> B
  B -- "styled by" --> C
  C -- "prevents stretch" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ContactPageContentEditorial.tsx</strong><dd><code>Group new business details and CTA</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx

<ul><li>Wraps contact name, role, and CTA in <code>newBusinessDetails</code>.<br> <li> Keeps name and role grouped in <code>newBusinessBody</code>.<br> <li> Changes role text to size <code>S</code> with normal line height.<br> <li> Keeps CTA directly under the new business details.</ul>


</details>


  </td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/591/files#diff-3c86a1cea87383a5b80d9afe325b1986b7ab14f1e0b61bab75b214a53a880fbe">+32/-29</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ContactPageContentEditorial.module.css</strong><dd><code>Stabilize new business layout styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.module.css

<ul><li>Uses <code>align-self: start</code> and explicit auto height for media/content.<br> <li> Prevents content flex stretching with <code>flex: none</code>.<br> <li> Adds tighter vertical spacing via <code>newBusinessDetails</code>.<br> <li> Overrides heading, line, muted role, and CTA margins.</ul>


</details>


  </td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/591/files#diff-f6e83fe58abb3753c9aec0d62874b9025f55a19901c68365f5053a0bd62d62bd">+25/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

