### PR TITLE
fix: contact new business CTA spacing

### DIFF
--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.module.css
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.module.css
@@ -212,7 +212,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: var(--space-layout-12);
+  gap: var(--space-layout-24);
 }
 
 .newBusinessBody {


### PR DESCRIPTION
### **User description**
## Summary
- Increases space between the role line and Contact link (`--space-layout-24`)

## Test plan
- [ ] Verify `/contact` New Business block spacing in production build

Made with [Cursor](https://cursor.com)


___

### **PR Type**
Bug fix


___

### **Description**
- Increases new business CTA spacing

- Aligns contact block visual rhythm


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["New Business details"] -- "uses larger gap" --> B["Contact CTA spacing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ContactPageContentEditorial.module.css</strong><dd><code>Increase New Business CTA spacing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.module.css

<ul><li>Updates <code>.newBusinessDetails</code> column gap.<br> <li> Changes spacing from <code>--space-layout-12</code> to <code>--space-layout-24</code>.<br> <li> Adds more separation before the Contact CTA.</ul>


</details>


  </td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/592/files#diff-f6e83fe58abb3753c9aec0d62874b9025f55a19901c68365f5053a0bd62d62bd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

