### PR TITLE
fix: new business heading to name spacing

### DIFF
--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.module.css
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.module.css
@@ -199,12 +199,11 @@
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
-  gap: var(--space-layout-12);
+  gap: var(--space-layout-24);
 }
 
 .newBusinessContent .newBusinessHeading {
   margin: 0;
-  margin-block-end: var(--space-layout-4);
   text-wrap: pretty;
 }
 


### PR DESCRIPTION
### **User description**
## Summary
- Increases gap between \"New Business Inquiries\" and \"Petri Lahdelma\" to `--space-layout-24`

## Test plan
- [ ] Check `/contact` New Business block vertical rhythm

Made with [Cursor](https://cursor.com)


___

### **PR Type**
Bug fix


___

### **Description**
- Adjusts New Business vertical spacing

- Uses `--space-layout-24` content gap

- Removes redundant heading bottom margin


___

### Diagram Walkthrough


```mermaid
flowchart LR
  contact["Contact New Business block"]
  layout["Larger content gap"]
  rhythm["Improved vertical rhythm"]
  contact -- "uses" --> layout
  layout -- "creates" --> rhythm
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ContactPageContentEditorial.module.css</strong><dd><code>Adjust New Business block vertical spacing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.module.css

<ul><li>Updates <code>.newBusinessContent</code> gap to <code>--space-layout-24</code><br> <li> Simplifies heading spacing by relying on parent gap<br> <li> Improves separation between heading and details</ul>


</details>


  </td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/593/files#diff-f6e83fe58abb3753c9aec0d62874b9025f55a19901c68365f5053a0bd62d62bd">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

