### PR TITLE
fix: new business heading to name spacing (32px)

### DIFF
--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.module.css
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.module.css
@@ -199,7 +199,7 @@
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
-  gap: var(--space-layout-24);
+  gap: var(--space-layout-32);
 }
 
 .newBusinessContent .newBusinessHeading {


### PR DESCRIPTION
### **User description**
## Summary
- Increases gap between \"New Business Inquiries\" and \"Petri Lahdelma\" from 24px to 32px (`--space-layout-32`)

## Test plan
- [ ] Verify `/contact` New Business block spacing after deploy

Made with [Cursor](https://cursor.com)


___

### **PR Type**
Bug fix


___

### **Description**
- Increases New Business content spacing

- Uses `--space-layout-32` gap token


___

### Diagram Walkthrough


```mermaid
flowchart LR
  spacingToken["Spacing token"]
  newBusinessContent["New Business content"]
  visualGap["Larger heading-to-name gap"]
  spacingToken -- "applies `--space-layout-32`" --> newBusinessContent
  newBusinessContent -- "renders" --> visualGap
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ContactPageContentEditorial.module.css</strong><dd><code>Increase New Business Content Gap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.module.css

<ul><li>Updates <code>.newBusinessContent</code> gap value.<br> <li> Replaces <code>--space-layout-24</code> with <code>--space-layout-32</code>.<br> <li> Increases spacing between heading and contact name.</ul>


</details>


  </td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/594/files#diff-f6e83fe58abb3753c9aec0d62874b9025f55a19901c68365f5053a0bd62d62bd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

