### PR TITLE
feat: WebMCP consulting tools for case studies and pricing

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,7 @@ import { SmoothScrollProvider } from "../providers/SmoothScrollProvider";
 import { CookieConsentProvider } from "@/nextjs-app/shared/lib/cookieConsent";
 import { ToasterProvider } from "@/nextjs-app/shared/components/interactive";
 import { NextLayout } from "@dt/NextLayout";
+import { WebMcpProvider } from "../providers/WebMcpProvider";
 import { HtmlLangSync } from "./components/HtmlLangSync";
 import "./globals.css";
 
@@ -178,22 +179,24 @@ export default function RootLayout({
           }}
         />
         <Analytics />
-        <NextThemeProvider>
-          <I18nProvider>
-            <HtmlLangSync />
-            <AnimationProvider>
-              <SmoothScrollProvider>
-                <ToastProvider>
-                  <ToasterProvider position="bottom-right">
-                    <CookieConsentProvider autoShow={true}>
-                      <NextLayout>{children}</NextLayout>
-                    </CookieConsentProvider>
-                  </ToasterProvider>
-                </ToastProvider>
-              </SmoothScrollProvider>
-            </AnimationProvider>
-          </I18nProvider>
-        </NextThemeProvider>
+        <WebMcpProvider>
+          <NextThemeProvider>
+            <I18nProvider>
+              <HtmlLangSync />
+              <AnimationProvider>
+                <SmoothScrollProvider>
+                  <ToastProvider>
+                    <ToasterProvider position="bottom-right">
+                      <CookieConsentProvider autoShow={true}>
+                        <NextLayout>{children}</NextLayout>
+                      </CookieConsentProvider>
+                    </ToasterProvider>
+                  </ToastProvider>
+                </SmoothScrollProvider>
+              </AnimationProvider>
+            </I18nProvider>
+          </NextThemeProvider>
+        </WebMcpProvider>
       </body>
     </html>
   );

--- a/docs/AGENT_READINESS.md
+++ b/docs/AGENT_READINESS.md
@@ -1,6 +1,6 @@
 # Agent readiness (isitagentready.com)
 
-Baseline scan for **https://www.digitaltableteur.com** via [isitagentready.com](https://isitagentready.com/) (Cloudflare Agent Readiness).
+Scan target: **https://www.digitaltableteur.com** via [isitagentready.com](https://isitagentready.com/) (Cloudflare Agent Readiness).
 
 The share URL `https://isitagentready.com/digitaltableteur.com` is client-rendered and may 404 when fetched directly. Use the scan API or MCP instead:
 
@@ -12,48 +12,108 @@ curl -sS -X POST "https://isitagentready.com/api/scan" \
 
 MCP: `POST https://isitagentready.com/mcp` → tool `scan_site`
 
-## Baseline (May 2026) — Level 1/5
-
-| Check | Status |
-|-------|--------|
-| robots.txt | pass |
-| sitemap.xml | pass |
-| Link headers | fail → fixed in this branch |
-| DNS-AID | fail (DNS infra — not app code) |
-| Content Signals | fail → fixed via `app/robots.txt/route.ts` body directive |
-| Markdown negotiation | fail → middleware sets `x-accept-markdown`; `/llms.txt` returns `text/markdown` |
-| API catalog | fail → `/.well-known/api-catalog` |
-| A2A agent card | fail → `/.well-known/agent-card.json` |
-| Agent skills index | fail → `/.well-known/agent-skills/index.json` |
-| MCP server card | fail (no public MCP server) |
-| OAuth / Auth.md | fail (not applicable — public marketing site) |
-| WebMCP | fail (optional browser API) |
-
-## Implemented discovery endpoints
-
-| URL | Purpose |
-|-----|---------|
-| `/llms.txt` | LLM site index |
-| `/llms-full.txt` | Expanded context |
-| `/.well-known/agent.json` | Legacy agent card |
-| `/.well-known/agent-card.json` | A2A agent card |
-| `/.well-known/api-catalog` | RFC 9727 API linkset |
-| `/.well-known/agent-skills/index.json` | Project `dt-*` skills |
-| `/.well-known/agent-skills/{name}` | Individual skill markdown |
-
-## Expected level after deploy
-
-- **Level 2** (Bot-Aware): Content Signals in robots.txt
-- **Level 3** (Agent-Readable): + markdown negotiation on `/`
-- **Level 4** (Agent-Integrated): + API catalog, A2A card, and/or agent skills index
-
-DNS-AID, OAuth, MCP server card, and WebMCP remain out of scope unless infra/product decisions change.
-
-## Re-scan after deploy
+Quick level check:
 
 ```bash
 curl -sS -X POST "https://isitagentready.com/api/scan" \
   -H "Content-Type: application/json" \
   -d '{"url":"https://www.digitaltableteur.com","format":"json"}' \
   | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['level'], d['levelName'])"
+```
+
+---
+
+## Current status (May 2026) — Level 4/5 Agent-Integrated
+
+**Last scan:** 2026-05-29 (post PR #613 + #614 deploy)
+
+| Check | Status |
+|-------|--------|
+| robots.txt | pass |
+| sitemap.xml | pass |
+| Link headers | pass |
+| Content Signals | pass — `Content-Signal` in robots.txt body |
+| Markdown negotiation | pass — `Accept: text/markdown` → `text/markdown` |
+| API catalog | pass — `/.well-known/api-catalog` (2 APIs) |
+| A2A agent card | pass — `/.well-known/agent-card.json` |
+| Agent skills index | pass — 7 `dt-*` skills |
+| robots.txt AI rules | pass — wildcard allow |
+| DNS-AID | fail — DNS infra (Cloudflare records) |
+| MCP server card | fail — no public MCP server |
+| OAuth / auth.md | fail — not applicable for public marketing site |
+| WebMCP | pending deploy — 9 read-only tools via `WebMcpProvider` |
+
+### Progression
+
+| Date | Level | Trigger |
+|------|-------|---------|
+| May 2026 (initial) | 1/5 Basic Web Presence | robots + sitemap only |
+| May 2026 (PR #613) | 1/5 headline, partial L4 checks | API catalog, A2A card, skills, link headers |
+| May 2026 (PR #614) | **4/5 Agent-Integrated** | Content-Signal body + markdown negotiation |
+
+---
+
+## Implemented discovery endpoints
+
+| URL | Purpose |
+|-----|---------|
+| `/llms.txt` | LLM site index (+ agent skills section) |
+| `/llms-full.txt` | Expanded context |
+| `/.well-known/agent.json` | Legacy agent card |
+| `/.well-known/agent-card.json` | A2A agent card |
+| `/.well-known/api-catalog` | RFC 9727 API linkset |
+| `/.well-known/agent-skills/index.json` | Project `dt-*` skills |
+| `/.well-known/agent-skills/{name}` | Individual skill markdown |
+| `/.well-known/agent-skills/{name}/references/{ref}.md` | Skill reference docs (e.g. workflow templates) |
+
+---
+
+## Level 5 (Agent-Native) — remaining gaps
+
+Scanner requirements for next level:
+
+| Check | Effort | Notes |
+|-------|--------|-------|
+| **auth.md** | Low–medium | Publish `/auth.md` describing how agents authenticate (even if "no auth required for public endpoints") |
+| **MCP server card** | High | Requires hosting a public MCP server + `/.well-known/mcp.json` |
+| DNS-AID | DNS | `_index._agents` SVCB/HTTPS records at Cloudflare — infra, not app code |
+
+For a public marketing/consultancy site, **Level 4 is the practical target**. Level 5 also implies **auth.md** and a public **MCP server card** unless you productize agent APIs.
+
+### WebMCP tools (in-browser agents)
+
+Implemented in `providers/WebMcpProvider.tsx`. Registered on page load when `navigator.modelContext` exists:
+
+| Tool | Data |
+|------|------|
+| `list_case_studies` | Portfolio from `projects.ts` |
+| `get_case_study` | `{ slug }` |
+| `list_pricing_packages` | Fixed packages €8–20k |
+| `get_hourly_rate` | €90/h typical, €90–150/h range |
+| `list_services` | pseo services catalog |
+| `list_expertise_stacks` | React, Next.js, Figma, etc. |
+| `list_audiences` | Startups, scaleups, enterprise |
+| `get_open_hours` | Europe/Helsinki schedule |
+| `get_consulting_fit` | Map problem → service |
+
+Canonical data: `nextjs-app/shared/data/consulting-catalog.ts`
+
+Manual test: Chrome with `#enable-webmcp-testing`, then `navigator.modelContextTesting?.listTools()` in DevTools.
+
+---
+
+## Manual verification commands
+
+```bash
+# Content-Signal in robots.txt body
+curl -sS https://www.digitaltableteur.com/robots.txt | rg Content-Signal
+
+# Markdown negotiation
+curl -sSI https://www.digitaltableteur.com/ -H "Accept: text/markdown" | rg -i content-type
+
+# Agent skills (expect 7 dt-* skills after PR #614)
+curl -sS https://www.digitaltableteur.com/.well-known/agent-skills/index.json | python3 -m json.tool
+
+# Workflow templates
+curl -sS https://www.digitaltableteur.com/.well-known/agent-skills/dt-workflow/references/templates.md | head
 ```

--- a/nextjs-app/shared/data/consulting-catalog.test.ts
+++ b/nextjs-app/shared/data/consulting-catalog.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getCaseStudyBySlug,
+  getConsultingPackages,
+  getHourlyRate,
+  mapProblemToService,
+} from "./consulting-catalog";
+
+describe("consulting-catalog", () => {
+  it("exposes hourly rate €90 typical, €90–150 range", () => {
+    const rate = getHourlyRate();
+    expect(rate.typicalEur).toBe(90);
+    expect(rate.rangeEur.min).toBe(90);
+    expect(rate.rangeEur.max).toBe(150);
+    expect(rate.currency).toBe("EUR");
+  });
+
+  it("lists three fixed packages from €8k", () => {
+    const packages = getConsultingPackages();
+    expect(packages).toHaveLength(3);
+    expect(packages[0]?.name).toBe("UX Sprint");
+    expect(packages[0]?.priceRangeEur).toMatch(/€8/);
+  });
+
+  it("finds case study by slug", () => {
+    const study = getCaseStudyBySlug("dsharp-design-system");
+    expect(study?.title).toContain("DSharp");
+    expect(study?.url).toContain("/work/dsharp-design-system");
+  });
+
+  it("maps token problems to design tokens service", () => {
+    const fit = mapProblemToService("We need dark mode and design tokens");
+    expect(fit.service.slug).toBe("design-tokens-setup");
+    expect(fit.confidence).toBe("high");
+  });
+
+  it("maps vague problems to audit with medium confidence", () => {
+    const fit = mapProblemToService("We need help with our product");
+    expect(fit.confidence).toBe("medium");
+    expect(fit.service.slug).toBe("design-system-audit");
+  });
+});

--- a/nextjs-app/shared/data/consulting-catalog.ts
+++ b/nextjs-app/shared/data/consulting-catalog.ts
@@ -1,0 +1,252 @@
+/**
+ * Structured consulting data for WebMCP tools, agent cards, and future API surfaces.
+ * English canonical copy — UI pages may localize via i18n keys separately.
+ */
+
+import { getPseoCatalog } from "@/lib/pseo/catalog";
+import { WEEKLY_HOURS } from "@/nextjs-app/shared/data/openHours";
+import { projects, type Project } from "@/nextjs-app/shared/data/projects";
+
+const baseUrl =
+  process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ||
+  "https://www.digitaltableteur.com";
+
+export interface ConsultingPackage {
+  id: string;
+  name: string;
+  priceRangeEur: string;
+  duration: string;
+  description: string;
+  pricingModel: "fixed_package";
+}
+
+export interface HourlyRate {
+  typicalEur: number;
+  rangeEur: { min: number; max: number };
+  currency: "EUR";
+  unit: "hour";
+  note: string;
+}
+
+export interface CaseStudySummary {
+  slug: string;
+  title: string;
+  description?: string;
+  category: string;
+  tags: string[];
+  client?: string;
+  duration?: string;
+  featured?: boolean;
+  url: string;
+}
+
+export interface ServiceSummary {
+  slug: string;
+  name: string;
+  description: string;
+}
+
+export interface ConsultingFitResult {
+  service: ServiceSummary;
+  confidence: "high" | "medium";
+  rationale: string;
+}
+
+export const HOURLY_RATE: HourlyRate = {
+  typicalEur: 90,
+  rangeEur: { min: 90, max: 150 },
+  currency: "EUR",
+  unit: "hour",
+  note:
+    "Typical rate is €90/h. Complex or urgent engagements may be quoted up to €150/h. Fixed packages are usually preferred for defined outcomes.",
+};
+
+export const CONSULTING_PACKAGES: ConsultingPackage[] = [
+  {
+    id: "ux-sprint",
+    name: "UX Sprint",
+    priceRangeEur: "€8–14k",
+    duration: "2 weeks",
+    description:
+      "Prototype, eval plan and handoff your team can ship.",
+    pricingModel: "fixed_package",
+  },
+  {
+    id: "ai-ready-designops",
+    name: "AI-Ready DesignOps",
+    priceRangeEur: "€11–17k",
+    duration: "3 weeks",
+    description:
+      "Design workflow setup, component governance, AI tooling hooks and a DesignOps playbook your team can run.",
+    pricingModel: "fixed_package",
+  },
+  {
+    id: "design-system-lift-off",
+    name: "Design System Lift-Off",
+    priceRangeEur: "€14–20k",
+    duration: "4 weeks",
+    description:
+      "Audit, tokens, core components, Storybook and an adoption playbook.",
+    pricingModel: "fixed_package",
+  },
+];
+
+const SERVICE_KEYWORDS: Array<{
+  serviceSlug: string;
+  keywords: string[];
+}> = [
+  {
+    serviceSlug: "design-system-audit",
+    keywords: [
+      "audit",
+      "assess",
+      "inconsistent",
+      "gap",
+      "roadmap",
+      "review",
+      "health",
+    ],
+  },
+  {
+    serviceSlug: "component-library-build",
+    keywords: [
+      "component library",
+      "storybook",
+      "components",
+      "library build",
+      "from scratch",
+    ],
+  },
+  {
+    serviceSlug: "design-tokens-setup",
+    keywords: [
+      "token",
+      "theming",
+      "theme",
+      "dark mode",
+      "brand consistency",
+      "variables",
+    ],
+  },
+  {
+    serviceSlug: "ai-designops-automation",
+    keywords: [
+      "automate",
+      "ai",
+      "designops",
+      "scaling design",
+      "design debt",
+      "workflow",
+      "agent",
+    ],
+  },
+];
+
+function toCaseStudySummary(project: Project): CaseStudySummary {
+  return {
+    slug: project.slug,
+    title: project.title,
+    description: project.description,
+    category: project.category,
+    tags: project.tags,
+    client: project.client,
+    duration: project.duration,
+    featured: project.featured,
+    url: `${baseUrl}/work/${project.slug}`,
+  };
+}
+
+export function getCaseStudies(options?: {
+  featuredOnly?: boolean;
+}): CaseStudySummary[] {
+  let list = [...projects].sort(
+    (a, b) => (a.order ?? 999) - (b.order ?? 999),
+  );
+  if (options?.featuredOnly) {
+    list = list.filter((p) => p.featured);
+  }
+  return list.map(toCaseStudySummary);
+}
+
+export function getCaseStudyBySlug(
+  slug: string,
+): CaseStudySummary | undefined {
+  const project = projects.find((p) => p.slug === slug);
+  return project ? toCaseStudySummary(project) : undefined;
+}
+
+export function getConsultingPackages(): ConsultingPackage[] {
+  return CONSULTING_PACKAGES;
+}
+
+export function getHourlyRate(): HourlyRate {
+  return HOURLY_RATE;
+}
+
+export function getServices(): ServiceSummary[] {
+  return getPseoCatalog().services.map((s) => ({
+    slug: s.slug,
+    name: s.name,
+    description: s.shortDescription,
+  }));
+}
+
+export function getExpertiseStacks(): ServiceSummary[] {
+  return getPseoCatalog().stacks.map((s) => ({
+    slug: s.slug,
+    name: s.name,
+    description: s.shortDescription,
+  }));
+}
+
+export function getAudiences(): ServiceSummary[] {
+  return getPseoCatalog().audiences.map((s) => ({
+    slug: s.slug,
+    name: s.name,
+    description: s.shortDescription,
+  }));
+}
+
+export function getOpenHoursSummary(): {
+  timezone: string;
+  schedule: typeof WEEKLY_HOURS;
+  summary: string;
+} {
+  return {
+    timezone: "Europe/Helsinki",
+    schedule: WEEKLY_HOURS,
+    summary: "Monday–Friday 09:00–17:00 (Europe/Helsinki). Weekends closed.",
+  };
+}
+
+export function mapProblemToService(problem: string): ConsultingFitResult {
+  const normalized = problem.toLowerCase();
+  const services = getServices();
+
+  for (const { serviceSlug, keywords } of SERVICE_KEYWORDS) {
+    if (keywords.some((kw) => normalized.includes(kw))) {
+      const service = services.find((s) => s.slug === serviceSlug);
+      if (service) {
+        return {
+          service,
+          confidence: "high",
+          rationale: `Matched keywords for ${service.name}.`,
+        };
+      }
+    }
+  }
+
+  const fallback =
+    services.find((s) => s.slug === "design-system-audit") ?? services[0];
+
+  return {
+    service: fallback,
+    confidence: "medium",
+    rationale:
+      "No strong keyword match — defaulting to design system audit. Ask whether they are starting fresh or improving an existing system.",
+  };
+}
+
+export function getConsultingCatalogBaseUrl(): string {
+  return baseUrl;
+}

--- a/nextjs-app/shared/lib/webmcp/register-consulting-tools.test.ts
+++ b/nextjs-app/shared/lib/webmcp/register-consulting-tools.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildConsultingWebMcpTools,
+  registerConsultingWebMcpTools,
+} from "./register-consulting-tools";
+
+describe("register-consulting-tools", () => {
+  it("builds nine read-only consulting tools", () => {
+    const tools = buildConsultingWebMcpTools();
+    expect(tools).toHaveLength(9);
+    expect(tools.every((t) => t.annotations?.readOnlyHint)).toBe(true);
+    expect(tools.map((t) => t.name)).toContain("get_hourly_rate");
+    expect(tools.map((t) => t.name)).toContain("list_case_studies");
+  });
+
+  it("registers all tools on modelContext", () => {
+    const registerTool = vi.fn();
+    const count = registerConsultingWebMcpTools({ registerTool });
+    expect(count).toBe(9);
+    expect(registerTool).toHaveBeenCalledTimes(9);
+  });
+
+  it("get_hourly_rate execute returns €90–150 range", async () => {
+    const tool = buildConsultingWebMcpTools().find(
+      (t) => t.name === "get_hourly_rate",
+    );
+    expect(tool).toBeDefined();
+    const result = await tool!.execute!();
+    const text = result.content[0]?.text ?? "";
+    expect(text).toContain("90");
+    expect(text).toContain("150");
+  });
+});

--- a/nextjs-app/shared/lib/webmcp/register-consulting-tools.ts
+++ b/nextjs-app/shared/lib/webmcp/register-consulting-tools.ts
@@ -1,0 +1,175 @@
+import {
+  getAudiences,
+  getCaseStudies,
+  getCaseStudyBySlug,
+  getConsultingPackages,
+  getExpertiseStacks,
+  getHourlyRate,
+  getOpenHoursSummary,
+  getServices,
+  mapProblemToService,
+} from "@/nextjs-app/shared/data/consulting-catalog";
+
+import type {
+  WebMcpModelContext,
+  WebMcpToolDefinition,
+  WebMcpToolResult,
+} from "./types";
+
+const READ_ONLY = { readOnlyHint: true } as const;
+
+function jsonResult(data: unknown): WebMcpToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+function textResult(text: string): WebMcpToolResult {
+  return { content: [{ type: "text", text }] };
+}
+
+export const CONSULTING_WEBMCP_TOOL_NAMES = [
+  "list_case_studies",
+  "get_case_study",
+  "list_pricing_packages",
+  "get_hourly_rate",
+  "list_services",
+  "list_expertise_stacks",
+  "list_audiences",
+  "get_open_hours",
+  "get_consulting_fit",
+] as const;
+
+export type ConsultingWebMcpToolName =
+  (typeof CONSULTING_WEBMCP_TOOL_NAMES)[number];
+
+export function buildConsultingWebMcpTools(): WebMcpToolDefinition[] {
+  return [
+    {
+      name: "list_case_studies",
+      description:
+        "List Digitaltableteur portfolio case studies with slug, title, category, tags, and URLs.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          featuredOnly: {
+            type: "boolean",
+            description: "If true, return only featured case studies.",
+          },
+        },
+      },
+      annotations: READ_ONLY,
+      execute: (args) => {
+        const featuredOnly = Boolean(args?.featuredOnly);
+        return jsonResult(getCaseStudies({ featuredOnly }));
+      },
+    },
+    {
+      name: "get_case_study",
+      description:
+        "Get one case study by URL slug (e.g. dsharp-design-system, helsinki-design-system).",
+      inputSchema: {
+        type: "object",
+        properties: {
+          slug: { type: "string", description: "Case study slug from /work/{slug}" },
+        },
+        required: ["slug"],
+      },
+      annotations: READ_ONLY,
+      execute: (args) => {
+        const slug = String(args?.slug ?? "").trim();
+        if (!slug) {
+          return textResult("Error: slug is required.");
+        }
+        const study = getCaseStudyBySlug(slug);
+        if (!study) {
+          return textResult(`No case study found for slug: ${slug}`);
+        }
+        return jsonResult(study);
+      },
+    },
+    {
+      name: "list_pricing_packages",
+      description:
+        "List fixed consulting packages with EUR price ranges and duration (preferred over hourly for defined outcomes).",
+      inputSchema: { type: "object", properties: {} },
+      annotations: READ_ONLY,
+      execute: () => jsonResult(getConsultingPackages()),
+    },
+    {
+      name: "get_hourly_rate",
+      description:
+        "Get typical and range hourly consulting rates in EUR (€90/h typical, €90–150/h depending on scope).",
+      inputSchema: { type: "object", properties: {} },
+      annotations: READ_ONLY,
+      execute: () => jsonResult(getHourlyRate()),
+    },
+    {
+      name: "list_services",
+      description:
+        "List core consulting services (design system audit, component library, tokens, AI DesignOps).",
+      inputSchema: { type: "object", properties: {} },
+      annotations: READ_ONLY,
+      execute: () => jsonResult(getServices()),
+    },
+    {
+      name: "list_expertise_stacks",
+      description:
+        "List technology and practice areas (React, Next.js, Storybook, Figma, TypeScript, etc.).",
+      inputSchema: { type: "object", properties: {} },
+      annotations: READ_ONLY,
+      execute: () => jsonResult(getExpertiseStacks()),
+    },
+    {
+      name: "list_audiences",
+      description:
+        "List client audiences Digitaltableteur serves (startups, scaleups, enterprise, etc.).",
+      inputSchema: { type: "object", properties: {} },
+      annotations: READ_ONLY,
+      execute: () => jsonResult(getAudiences()),
+    },
+    {
+      name: "get_open_hours",
+      description:
+        "Get Digitaltableteur office hours in Europe/Helsinki timezone.",
+      inputSchema: { type: "object", properties: {} },
+      annotations: READ_ONLY,
+      execute: () => jsonResult(getOpenHoursSummary()),
+    },
+    {
+      name: "get_consulting_fit",
+      description:
+        "Map a visitor problem statement to the best-matching consulting service.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          problem: {
+            type: "string",
+            description: "Short description of the visitor need or pain point.",
+          },
+        },
+        required: ["problem"],
+      },
+      annotations: READ_ONLY,
+      execute: (args) => {
+        const problem = String(args?.problem ?? "").trim();
+        if (!problem) {
+          return textResult("Error: problem is required.");
+        }
+        return jsonResult(mapProblemToService(problem));
+      },
+    },
+  ];
+}
+
+/** Register all consulting WebMCP tools; returns count registered. */
+export function registerConsultingWebMcpTools(
+  modelContext: WebMcpModelContext,
+  signal?: AbortSignal,
+): number {
+  const tools = buildConsultingWebMcpTools();
+  for (const tool of tools) {
+    modelContext.registerTool(tool, signal ? { signal } : undefined);
+  }
+  return tools.length;
+}

--- a/nextjs-app/shared/lib/webmcp/types.ts
+++ b/nextjs-app/shared/lib/webmcp/types.ts
@@ -1,0 +1,31 @@
+/** Minimal WebMCP types (W3C preview — not yet in TypeScript DOM lib). */
+
+export interface WebMcpTextContent {
+  type: "text";
+  text: string;
+}
+
+export interface WebMcpToolResult {
+  content: WebMcpTextContent[];
+}
+
+export type WebMcpExecuteArgs = Record<string, unknown>;
+
+export interface WebMcpToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute: (args?: WebMcpExecuteArgs) => Promise<WebMcpToolResult> | WebMcpToolResult;
+  annotations?: { readOnlyHint?: boolean };
+}
+
+export interface WebMcpModelContext {
+  registerTool: (
+    tool: WebMcpToolDefinition,
+    options?: { signal?: AbortSignal },
+  ) => void;
+}
+
+export interface NavigatorWithWebMcp extends Navigator {
+  modelContext?: WebMcpModelContext;
+}

--- a/providers/WebMcpProvider.tsx
+++ b/providers/WebMcpProvider.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { registerConsultingWebMcpTools } from "@/nextjs-app/shared/lib/webmcp/register-consulting-tools";
+import type { NavigatorWithWebMcp } from "@/nextjs-app/shared/lib/webmcp/types";
+
+/**
+ * Registers read-only WebMCP tools for in-browser AI agents (Chrome preview).
+ * No-op when navigator.modelContext is unavailable.
+ */
+export function WebMcpProvider({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    const nav = navigator as NavigatorWithWebMcp;
+    const modelContext = nav.modelContext;
+    if (!modelContext || typeof modelContext.registerTool !== "function") {
+      return;
+    }
+
+    const controller = new AbortController();
+    try {
+      registerConsultingWebMcpTools(modelContext, controller.signal);
+    } catch {
+      // Duplicate registration or unsupported runtime — safe to ignore
+    }
+
+    return () => controller.abort();
+  }, []);
+
+  return children;
+}


### PR DESCRIPTION
### **User description**
## Summary

- Adds **`consulting-catalog.ts`** as canonical source for packages, hourly rates (€90/h typical, €90–150/h range), case studies, services, stacks, and audiences
- Registers **9 read-only WebMCP tools** on page load via `WebMcpProvider` when `navigator.modelContext` is available (Chrome preview)
- Tools cover case studies, pricing packages, hourly rate, expertise areas, open hours, and consulting-fit mapping
- Updates `docs/AGENT_READINESS.md` with WebMCP tool inventory and testing notes

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `SKIP_STORYBOOK_TESTS=1 npx vitest run nextjs-app/shared/data/consulting-catalog.test.ts nextjs-app/shared/lib/webmcp/register-consulting-tools.test.ts`
- [ ] After deploy: Chrome with `#enable-webmcp-testing` → `navigator.modelContextTesting?.listTools()` shows 9 tools
- [ ] Re-run https://isitagentready.com scan (WebMCP check depends on scanner browser support)


Made with [Cursor](https://cursor.com)


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Adds WebMCP consulting tool registration

- Introduces structured consulting catalog data

- Covers catalog and tool behavior tests

- Updates agent-readiness documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Root layout"] -- "wraps app" --> B["WebMcpProvider"]
  B -- "registers" --> C["9 read-only WebMCP tools"]
  C -- "serve" --> D["Consulting catalog data"]
  D -- "sources" --> E["Projects, PSEO, open hours"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>layout.tsx</strong><dd><code>Wrap application with WebMCP provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/615/files#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030b">+19/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>consulting-catalog.ts</strong><dd><code>Add canonical consulting catalog data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/615/files#diff-98b346a5b1c44463238a4e665a75a20aeb2b90dd76df2c6bdf845bb36502cde2">+252/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>register-consulting-tools.ts</strong><dd><code>Define nine read-only WebMCP tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/615/files#diff-b7cbdf8bb87b3ebdf43c9c2cffb66ecf5925b726ff3c20ca34eeafec14117741">+175/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Add minimal WebMCP TypeScript types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/615/files#diff-066ac7218dbe8a26c1dd70b2b27867bd6f177f5d41ea2f0274f1fd657c7eca19">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WebMcpProvider.tsx</strong><dd><code>Register WebMCP tools in browser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/615/files#diff-e5a5829d763dc6227d583c8627d580538268e6418bfca171550b68fc41f2881e">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>consulting-catalog.test.ts</strong><dd><code>Test consulting catalog helper behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/615/files#diff-8fb4b4f91e9d75b1b75100a6855acecf2d07ecf497aaa45ef02f29bb694eb5ae">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>register-consulting-tools.test.ts</strong><dd><code>Test WebMCP consulting tool registration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/615/files#diff-55c70dcf2c170d90bfee0f997da5a466f5d3dcd624e9a168fb398bb23f378923">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>AGENT_READINESS.md</strong><dd><code>Document agent readiness and WebMCP tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/615/files#diff-3252c04b80a101ea1f0609513af181c9707a018281171f7513d357c67f920f0a">+83/-23</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

