### PR TITLE
fix: compact cookie consent bar on first visit

### DIFF
--- a/nextjs-app/shared/components/CookieConsent/CookieConsent.module.css
+++ b/nextjs-app/shared/components/CookieConsent/CookieConsent.module.css
@@ -41,7 +41,7 @@
 .categories {
   display: flex;
   margin-block: var(--space-m);
-  padding-block: calc(var(--space-layout-4) + 2rem);
+  padding-block: var(--space-layout-16);
   flex-direction: column;
   gap: 1rem;
   border-block: 1px solid var(--color-border);

--- a/nextjs-app/shared/components/CookieConsent/CookieConsent.test.tsx
+++ b/nextjs-app/shared/components/CookieConsent/CookieConsent.test.tsx
@@ -1,17 +1,15 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { vi, beforeEach, afterEach, describe, it, expect } from "vitest";
+import { vi, beforeEach, describe, it, expect } from "vitest";
 import CookieConsent from "@dt/CookieConsent";
 import { CookieConsentProvider } from "../../lib/cookieConsent";
 
-// Minimal i18n mock: return keys as-is
 const mockT = vi.fn((key: string) => key);
 const mockI18n = { language: "en" };
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: mockT, i18n: mockI18n }),
 }));
 
-// In-memory localStorage for consent persistence
 const consentStore: Record<string, string> = {};
 const localStorageMock = {
   getItem: vi.fn((key: string) => consentStore[key] ?? null),
@@ -48,7 +46,7 @@ describe("CookieConsent", () => {
     mockI18n.language = "en";
   });
 
-  it("renders modal when no cookie consent is stored", () => {
+  it("renders compact banner when no cookie consent is stored", () => {
     localStorageMock.getItem.mockReturnValue(null);
     render(
       <CookieConsentProvider autoShow>
@@ -56,12 +54,15 @@ describe("CookieConsent", () => {
       </CookieConsentProvider>,
     );
     expect(
-      screen.getByRole("heading", { name: /cookieConsent.title/i }),
+      screen.getByRole("region", { name: /cookieConsent.bannerLabel/i }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/cookieConsent.description/i)).toBeInTheDocument();
+    expect(screen.getByText(/cookieConsent.bannerSummary/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: /cookieConsent.title/i }),
+    ).not.toBeInTheDocument();
   });
 
-  it("does not render modal when cookie consent exists", async () => {
+  it("does not render banner when cookie consent exists", async () => {
     consentStore["dt-cookie-consent"] = sampleConsent;
     localStorageMock.getItem.mockImplementation(
       (key: string) => consentStore[key] ?? null,
@@ -73,12 +74,12 @@ describe("CookieConsent", () => {
     );
     await waitFor(() => {
       expect(
-        screen.queryByRole("heading", { name: /cookieConsent.title/i }),
+        screen.queryByRole("region", { name: /cookieConsent.bannerLabel/i }),
       ).not.toBeInTheDocument();
     });
   });
 
-  it("renders action buttons", () => {
+  it("renders action buttons on the compact banner", () => {
     render(
       <CookieConsentProvider autoShow>
         <CookieConsent />
@@ -94,6 +95,20 @@ describe("CookieConsent", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /cookieConsent.acceptAllButton/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens settings modal from customize button", () => {
+    render(
+      <CookieConsentProvider autoShow>
+        <CookieConsent />
+      </CookieConsentProvider>,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /cookieConsent.customizeButton/i }),
+    );
+    expect(
+      screen.getByRole("heading", { name: /cookieConsent.title/i }),
     ).toBeInTheDocument();
   });
 
@@ -129,7 +144,7 @@ describe("CookieConsent", () => {
     );
   });
 
-  it("renders cookie policy link", () => {
+  it("renders cookie policy link on the banner", () => {
     render(
       <CookieConsentProvider autoShow>
         <CookieConsent />

--- a/nextjs-app/shared/components/CookieConsent/CookieConsent.tsx
+++ b/nextjs-app/shared/components/CookieConsent/CookieConsent.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 /**
- * Enhanced Cookie Consent Banner Component
- * Granular category controls inspired by Helsinki Design System
+ * Cookie consent — compact bottom bar by default; settings open a modal.
  */
 
 import React, { useState, useEffect } from "react";
@@ -13,11 +12,7 @@ import Link from "@dt/Link";
 import Badge from "@dt/Badge";
 import { useCookieConsent } from "../../lib/cookieConsent";
 import type { CookieCategory } from "../../lib/cookieConsent/types";
-import {
-  loadMinimizedState,
-  saveMinimizedState,
-  clearMinimizedState,
-} from "../../lib/cookieConsent/storage";
+import { clearMinimizedState } from "../../lib/cookieConsent/storage";
 import CookieConsentBanner from "./CookieConsentBanner";
 import styles from "./CookieConsent.module.css";
 
@@ -30,10 +25,9 @@ export interface CookieConsentProps {
  * CookieConsent component.
  */
 export const CookieConsent: React.FC<CookieConsentProps> = () => {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const {
     isBannerOpen,
-    closeBanner,
     acceptAll,
     acceptEssentialOnly,
     setConsents,
@@ -41,16 +35,10 @@ export const CookieConsent: React.FC<CookieConsentProps> = () => {
     isReady,
   } = useCookieConsent();
 
-  const [showDetails, setShowDetails] = useState(false);
-  // Only load minimized state if we're client-side
-  const [isMinimized, setIsMinimized] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return loadMinimizedState();
-  });
+  const [showCustomize, setShowCustomize] = useState(false);
   const [customConsents, setCustomConsents] = useState<
     Record<CookieCategory, boolean>
   >(() => {
-    // Initialize with current consents
     const initial: Record<string, boolean> = {};
     consents.forEach((c) => {
       initial[c.category] = c.consented;
@@ -58,7 +46,6 @@ export const CookieConsent: React.FC<CookieConsentProps> = () => {
     return initial as Record<CookieCategory, boolean>;
   });
 
-  // Sync customConsents with consents from context when they change
   useEffect(() => {
     const updated: Record<string, boolean> = {};
     consents.forEach((c) => {
@@ -67,14 +54,11 @@ export const CookieConsent: React.FC<CookieConsentProps> = () => {
     setCustomConsents(updated as Record<CookieCategory, boolean>);
   }, [consents]);
 
-  /**
-   * Handle custom consent toggle
-   */
   const handleToggleCategory = (
     category: CookieCategory,
     required: boolean,
   ) => {
-    if (required) return; // Can't toggle required categories
+    if (required) return;
 
     setCustomConsents((prev) => ({
       ...prev,
@@ -82,184 +66,109 @@ export const CookieConsent: React.FC<CookieConsentProps> = () => {
     }));
   };
 
-  /**
-   * Save custom selections
-   */
   const handleSaveCustom = () => {
     setConsents(customConsents);
     clearMinimizedState();
+    setShowCustomize(false);
   };
 
-  /**
-   * Get cookie policy link based on language
-   */
-  const getCookiePolicyLink = () => {
-    return "/privacy-policy";
+  const handleAcceptAll = () => {
+    acceptAll();
+    clearMinimizedState();
+    setShowCustomize(false);
   };
 
-  /**
-   * Handle modal close - minimize to banner instead
-   */
-  const handleModalClose = () => {
-    setIsMinimized(true);
-    saveMinimizedState(true);
-  };
-
-  /**
-   * Expand from banner back to full modal
-   */
-  const handleExpand = () => {
-    setIsMinimized(false);
-    saveMinimizedState(false);
+  const handleAcceptEssential = () => {
+    acceptEssentialOnly();
+    clearMinimizedState();
+    setShowCustomize(false);
   };
 
   if (!isReady || !isBannerOpen) {
     return null;
   }
 
-  // If minimized, show compact banner
-  if (isMinimized) {
-    return <CookieConsentBanner onExpand={handleExpand} />;
-  }
-
-  // Otherwise show full modal
   return (
-    <Modal
-      isOpen={true}
-      title={t("cookieConsent.title")}
-      titleSize="S"
-      className={styles.consentModal}
-      footer={
-        <div className={styles.footerActions}>
-          <div className={styles.leftActions}>
-            {!showDetails ? (
-              <Button
-                variant="tertiary"
-                icon="caret-down"
-                size="l"
-                onClick={handleModalClose}
-              >
-                {t("cookieConsent.minimizeModal")}
-              </Button>
-            ) : (
-              <Link href={getCookiePolicyLink()} size="S">
-                {t("cookieConsent.viewFullPolicy")}
-              </Link>
-            )}
-          </div>
-          <div className={styles.rightActions}>
-            {showDetails ? (
-              <>
-                <Button
-                  variant="secondary"
-                  size="l"
-                  onClick={() => setShowDetails(false)}
-                >
-                  {t("cookieConsent.backButton")}
-                </Button>
-                <Button variant="primary" size="l" onClick={handleSaveCustom}>
-                  {t("cookieConsent.saveButton")}
-                </Button>
-              </>
-            ) : (
-              <>
-                <Button
-                  variant="secondary"
-                  icon="gear"
-                  size="l"
-                  onClick={() => setShowDetails(true)}
-                  aria-expanded={showDetails}
-                >
-                  {t("cookieConsent.customizeButton")}
-                </Button>
-                <Button
-                  variant="secondary"
-                  size="l"
-                  onClick={acceptEssentialOnly}
-                >
+    <>
+      <CookieConsentBanner onCustomize={() => setShowCustomize(true)} />
+
+      {showCustomize ? (
+        <Modal
+          isOpen={true}
+          onClose={() => setShowCustomize(false)}
+          title={t("cookieConsent.title")}
+          titleSize="S"
+          className={styles.consentModal}
+          footer={
+            <div className={styles.footerActions}>
+              <div className={styles.leftActions}>
+                <Link href="/privacy-policy" size="S">
+                  {t("cookieConsent.viewFullPolicy")}
+                </Link>
+              </div>
+              <div className={styles.rightActions}>
+                <Button variant="secondary" size="m" onClick={handleAcceptEssential}>
                   {t("cookieConsent.acceptEssentialButton")}
                 </Button>
-                <Button variant="primary" size="l" onClick={acceptAll}>
+                <Button variant="primary" size="m" onClick={handleSaveCustom}>
+                  {t("cookieConsent.saveButton")}
+                </Button>
+                <Button variant="primary" size="m" onClick={handleAcceptAll}>
                   {t("cookieConsent.acceptAllButton")}
                 </Button>
-              </>
-            )}
-          </div>
-        </div>
-      }
-    >
-      {!showDetails ? (
-        // Simple view - description and quick actions
-        <div className={styles.simpleView}>
-          <p className={styles.description}>{t("cookieConsent.description")}</p>
-          <p className={styles.policyLink}>
-            {t("cookieConsent.readOur")}{" "}
-            <Link href={getCookiePolicyLink()} size="S">
-              {t("cookieConsent.policyLinkText")}
-            </Link>{" "}
-            {t("cookieConsent.toLearnMore")}
-          </p>
-        </div>
-      ) : (
-        // Detailed view - category toggles
-        <div className={styles.detailedView}>
-          <p className={styles.description}>
-            {t("cookieConsent.detailedDescription")
-              .split("<Link>")
-              .map((part, i) => {
-                if (i === 0) return part;
-                const [linkText, rest] = part.split("</Link>");
-                return (
-                  <React.Fragment key={i}>
-                    <Link href={getCookiePolicyLink()} size="S">
-                      {linkText}
-                    </Link>
-                    {rest}
-                  </React.Fragment>
-                );
-              })}
-          </p>
-
-          <div className={styles.categories}>
-            {consents.map((consent) => (
-              <div key={consent.category} className={styles.categoryRow}>
-                <div className={styles.categoryInfo}>
-                  <h3 className={styles.categoryTitle}>
-                    {t(`cookieConsent.categories.${consent.category}.title`)}
-                  </h3>
-                  <p className={styles.categoryDescription}>
-                    {t(
-                      `cookieConsent.categories.${consent.category}.description`,
-                    )}
-                  </p>
-                </div>
-                <div className={styles.categoryToggle}>
-                  {consent.required && (
-                    <Badge size="s" design="secondary" state="info">
-                      {t("cookieConsent.required")}
-                    </Badge>
-                  )}
-                  <label className={styles.switch}>
-                    <input
-                      type="checkbox"
-                      checked={customConsents[consent.category]}
-                      onChange={() =>
-                        handleToggleCategory(consent.category, consent.required)
-                      }
-                      disabled={consent.required}
-                      aria-label={t(
-                        `cookieConsent.categories.${consent.category}.toggleLabel`,
-                      )}
-                    />
-                    <span className={styles.slider} aria-hidden="true" />
-                  </label>
-                </div>
               </div>
-            ))}
+            </div>
+          }
+        >
+          <div className={styles.detailedView}>
+            <p className={styles.description}>
+              {t("cookieConsent.detailedDescription")}
+            </p>
+
+            <div className={styles.categories}>
+              {consents.map((consent) => (
+                <div key={consent.category} className={styles.categoryRow}>
+                  <div className={styles.categoryInfo}>
+                    <h3 className={styles.categoryTitle}>
+                      {t(`cookieConsent.categories.${consent.category}.title`)}
+                    </h3>
+                    <p className={styles.categoryDescription}>
+                      {t(
+                        `cookieConsent.categories.${consent.category}.description`,
+                      )}
+                    </p>
+                  </div>
+                  <div className={styles.categoryToggle}>
+                    {consent.required ? (
+                      <Badge size="s" design="secondary" state="info">
+                        {t("cookieConsent.required")}
+                      </Badge>
+                    ) : null}
+                    <label className={styles.switch}>
+                      <input
+                        type="checkbox"
+                        checked={customConsents[consent.category]}
+                        onChange={() =>
+                          handleToggleCategory(
+                            consent.category,
+                            consent.required,
+                          )
+                        }
+                        disabled={consent.required}
+                        aria-label={t(
+                          `cookieConsent.categories.${consent.category}.toggleLabel`,
+                        )}
+                      />
+                      <span className={styles.slider} aria-hidden="true" />
+                    </label>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
-      )}
-    </Modal>
+        </Modal>
+      ) : null}
+    </>
   );
 };
 

--- a/nextjs-app/shared/components/CookieConsent/CookieConsentBanner.module.css
+++ b/nextjs-app/shared/components/CookieConsent/CookieConsentBanner.module.css
@@ -5,19 +5,22 @@
   inset-inline: 0;
   inset-block-end: 0;
   z-index: 9998;
+  display: flex;
+  align-items: center;
   border-block-start: 1px solid var(--color-border);
   background-color: color-mix(
     in srgb,
     var(--main-body-background-color, #fff) 94%,
     transparent
   );
-  padding-block: var(--space-layout-12);
+  padding-block: var(--space-layout-16);
   padding-inline: max(var(--page-margin-mobile), env(safe-area-inset-left))
     max(var(--page-margin-mobile), env(safe-area-inset-right));
   padding-block-end: max(
-    var(--space-layout-12),
+    var(--space-layout-16),
     env(safe-area-inset-bottom)
   );
+  overflow: visible;
   backdrop-filter: blur(10px);
 }
 
@@ -27,14 +30,44 @@
   width: 100%;
   max-width: var(--container-lg);
   align-items: center;
-  gap: var(--space-layout-16);
+  min-block-size: 2.5rem;
+  gap: var(--space-layout-24);
 }
 
+/*
+ * Optical vertical center: flex aligns to layout box, but the wavy underline
+ * extends below the link via padding-bottom. Pull decoration out of flow so
+ * centering matches the cap height, then nudge down for underline mass.
+ */
 .copy {
+  --cookie-banner-underline-depth: 6px;
+  --cookie-banner-optical-shift: calc(var(--cookie-banner-underline-depth) / 2 - 2px);
+
+  display: flex;
   flex: 1 1 auto;
+  align-items: center;
+  min-block-size: 2.5rem;
   min-width: 0;
+  overflow: visible;
+}
+
+.copyText {
   margin: 0;
+  font-family: var(--font-body), system-ui, sans-serif;
+  font-size: var(--font-size-text-m);
+  line-height: var(--line-height-normal);
   color: var(--color-text);
+  transform: translateY(var(--cookie-banner-optical-shift));
+}
+
+/* Global wavyUnderline adds padding-bottom — exclude from layout metrics here */
+.copyText :global(.wavyUnderline) {
+  padding-bottom: 0;
+}
+
+.copyText :global(.wavyUnderline::after) {
+  bottom: calc(-1 * var(--cookie-banner-underline-depth));
+  height: var(--cookie-banner-underline-depth);
 }
 
 .actions {
@@ -43,7 +76,7 @@
   flex-wrap: wrap;
   justify-content: flex-end;
   align-items: center;
-  gap: var(--space-layout-8);
+  gap: var(--space-layout-16);
 }
 
 @media (width >= 768px) {
@@ -64,15 +97,20 @@
   .bar {
     flex-direction: column;
     align-items: stretch;
-    gap: var(--space-layout-12);
+    gap: var(--space-layout-16);
+  }
+
+  .copy {
+    min-block-size: auto;
   }
 
   .actions {
     justify-content: stretch;
+    gap: var(--space-layout-12, 0.75rem);
   }
 
   .actions > * {
-    flex: 1 1 calc(50% - var(--space-layout-4));
+    flex: 1 1 calc(50% - var(--space-layout-6));
     min-width: 0;
   }
 

--- a/nextjs-app/shared/components/CookieConsent/CookieConsentBanner.module.css
+++ b/nextjs-app/shared/components/CookieConsent/CookieConsentBanner.module.css
@@ -1,101 +1,106 @@
-/* Compact Cookie Consent Banner - Footer fixed position */
+/* Compact bottom bar — site stays visible; no modal on first visit */
 
 .banner {
   position: fixed;
   inset-inline: 0;
-  z-index: 9998; /* Below modal (9999) but above everything else */
-  margin-block-end: 2rem;
-  margin-inline-start: 2rem;
-  padding: 1.5rem;
-  max-width: 46rem;
-  border-block-start: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  background-color: var(--color-white);
-  box-shadow: 0 -2px 8px rgb(0 0 0 / 10%);
   inset-block-end: 0;
+  z-index: 9998;
+  border-block-start: 1px solid var(--color-border);
+  background-color: color-mix(
+    in srgb,
+    var(--main-body-background-color, #fff) 94%,
+    transparent
+  );
+  padding-block: var(--space-layout-12);
+  padding-inline: max(var(--page-margin-mobile), env(safe-area-inset-left))
+    max(var(--page-margin-mobile), env(safe-area-inset-right));
+  padding-block-end: max(
+    var(--space-layout-12),
+    env(safe-area-inset-bottom)
+  );
+  backdrop-filter: blur(10px);
 }
 
-.container {
+.bar {
   display: flex;
   margin-inline: auto;
-  padding-block: var(--space-m);
-  padding-inline: var(--space-l);
-  max-inline-size: 1200px;
-  align-items: center;
-  gap: var(--space-m);
-}
-
-.expandButton {
-  display: flex;
-  padding: var(--space-xs);
-  flex-shrink: 0;
-  justify-content: center;
-  align-items: center;
-  gap: 0.5rem;
-  border: none;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--color-primary);
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.expandButton:hover {
-  background-color: var(--color-primary-light);
-}
-
-.expandButton:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
-}
-
-.expandButton svg {
-  display: block;
-  block-size: 24px;
-  inline-size: 24px;
-}
-
-.actions {
-  display: flex;
-  margin-inline-start: auto;
+  width: 100%;
+  max-width: var(--container-lg);
   align-items: center;
   gap: var(--space-layout-16);
 }
 
-/* Responsive adjustments */
-@media (width <= 768px) {
-  .container {
-    padding-block: var(--space-s);
-    padding-inline: var(--space-m);
-    flex-wrap: wrap;
-  }
+.copy {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0;
+  color: var(--color-text);
+}
 
-  .title {
-    font-size: var(--font-size-body-l);
-  }
+.actions {
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--space-layout-8);
+}
 
-  .actions {
-    margin-inline-start: 0;
-    inline-size: 100%;
-    justify-content: stretch;
-  }
-
-  .actions button {
-    flex: 1;
+@media (width >= 768px) {
+  .banner {
+    padding-inline: max(var(--page-margin-tablet), env(safe-area-inset-left))
+      max(var(--page-margin-tablet), env(safe-area-inset-right));
   }
 }
 
-@media (width <= 480px) {
-  .container {
-    gap: var(--space-s);
+@media (width >= 1024px) {
+  .banner {
+    padding-inline: max(var(--page-margin-desktop), env(safe-area-inset-left))
+      max(var(--page-margin-desktop), env(safe-area-inset-right));
+  }
+}
+
+@media (width <= 767px) {
+  .bar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-layout-12);
   }
 
   .actions {
-    flex-direction: column;
-    gap: var(--space-xs);
+    justify-content: stretch;
   }
 
-  .actions button {
-    inline-size: 100%;
+  .actions > * {
+    flex: 1 1 calc(50% - var(--space-layout-4));
+    min-width: 0;
+  }
+
+  .actions > :first-child {
+    flex-basis: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .banner {
+    animation: cookie-bar-in 220ms ease-out;
+  }
+}
+
+@keyframes cookie-bar-in {
+  from {
+    opacity: 0;
+    transform: translateY(100%);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .banner {
+    animation: none;
   }
 }

--- a/nextjs-app/shared/components/CookieConsent/CookieConsentBanner.test.tsx
+++ b/nextjs-app/shared/components/CookieConsent/CookieConsentBanner.test.tsx
@@ -4,15 +4,16 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import CookieConsentBanner from "./CookieConsentBanner";
 
-// Mock dependencies
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string) => {
       const translations: Record<string, string> = {
-        "cookieConsent.bannerLabel": "Cookie Consent Banner",
-        "cookieConsent.expandBanner": "Expand Banner",
-        "cookieConsent.acceptEssentialButton": "Accept Essential",
-        "cookieConsent.acceptAllButton": "Accept All",
+        "cookieConsent.bannerLabel": "Cookie preferences",
+        "cookieConsent.bannerSummary": "We use cookies to improve your experience.",
+        "cookieConsent.policyLinkText": "cookie policy",
+        "cookieConsent.customizeButton": "Customize settings",
+        "cookieConsent.acceptEssentialButton": "Only essential",
+        "cookieConsent.acceptAllButton": "Accept all",
       };
       return translations[key] || key;
     },
@@ -28,41 +29,46 @@ vi.mock("../../lib/cookieConsent", () => ({
 
 describe("CookieConsentBanner", () => {
   it("renders banner with correct region role", () => {
-    render(<CookieConsentBanner onExpand={vi.fn()} />);
+    render(<CookieConsentBanner onCustomize={vi.fn()} />);
     expect(
-      screen.getByRole("region", { name: "Cookie Consent Banner" }),
+      screen.getByRole("region", { name: "Cookie preferences" }),
     ).toBeInTheDocument();
   });
 
-  it("renders expand button", () => {
-    render(<CookieConsentBanner onExpand={vi.fn()} />);
+  it("renders summary copy and policy link", () => {
+    render(<CookieConsentBanner onCustomize={vi.fn()} />);
     expect(
-      screen.getByRole("button", { name: "Expand Banner" }),
+      screen.getByText(/We use cookies to improve your experience/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "cookie policy" })).toHaveAttribute(
+      "href",
+      "/privacy-policy",
+    );
+  });
+
+  it("renders customize button", () => {
+    render(<CookieConsentBanner onCustomize={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: "Customize settings" }),
     ).toBeInTheDocument();
   });
 
   it("renders accept essential button", () => {
-    render(<CookieConsentBanner onExpand={vi.fn()} />);
-    expect(screen.getByText("Accept Essential")).toBeInTheDocument();
+    render(<CookieConsentBanner onCustomize={vi.fn()} />);
+    expect(screen.getByText("Only essential")).toBeInTheDocument();
   });
 
   it("renders accept all button", () => {
-    render(<CookieConsentBanner onExpand={vi.fn()} />);
-    expect(screen.getByText("Accept All")).toBeInTheDocument();
+    render(<CookieConsentBanner onCustomize={vi.fn()} />);
+    expect(screen.getByText("Accept all")).toBeInTheDocument();
   });
 
-  it("calls onExpand when expand button clicked", async () => {
+  it("calls onCustomize when customize button clicked", async () => {
     const user = userEvent.setup();
-    const onExpand = vi.fn();
-    render(<CookieConsentBanner onExpand={onExpand} />);
+    const onCustomize = vi.fn();
+    render(<CookieConsentBanner onCustomize={onCustomize} />);
 
-    await user.click(screen.getByRole("button", { name: "Expand Banner" }));
-    expect(onExpand).toHaveBeenCalledTimes(1);
-  });
-
-  it("has proper accessible name on expand button", () => {
-    render(<CookieConsentBanner onExpand={vi.fn()} />);
-    const expandButton = screen.getByRole("button", { name: "Expand Banner" });
-    expect(expandButton).toHaveAttribute("aria-label", "Expand Banner");
+    await user.click(screen.getByRole("button", { name: "Customize settings" }));
+    expect(onCustomize).toHaveBeenCalledTimes(1);
   });
 });

--- a/nextjs-app/shared/components/CookieConsent/CookieConsentBanner.tsx
+++ b/nextjs-app/shared/components/CookieConsent/CookieConsentBanner.tsx
@@ -1,24 +1,23 @@
 "use client";
 
 /**
- * Compact Cookie Consent Banner
- * Minimized footer banner shown when user closes the full modal
- * Forces user to make a choice before entering the site
+ * Compact cookie consent bar — default first-touch UI (no modal overlay).
  */
 
 import React from "react";
 import { useTranslation } from "react-i18next";
 import Button from "@dt/Button";
-import Title from "@dt/Title";
+import Link from "@dt/Link";
+import Text from "@dt/Text";
 import { useCookieConsent } from "../../lib/cookieConsent";
 import styles from "./CookieConsentBanner.module.css";
 
-interface CookieConsentBannerProps {
-  onExpand: () => void;
+export interface CookieConsentBannerProps {
+  onCustomize: () => void;
 }
 
 const CookieConsentBanner: React.FC<CookieConsentBannerProps> = ({
-  onExpand,
+  onCustomize,
 }) => {
   const { t } = useTranslation();
   const { acceptAll, acceptEssentialOnly } = useCookieConsent();
@@ -29,27 +28,21 @@ const CookieConsentBanner: React.FC<CookieConsentBannerProps> = ({
       role="region"
       aria-label={t("cookieConsent.bannerLabel")}
     >
-      <div className={styles.container}>
-        <Button
-          size="l"
-          variant="tertiary"
-          icon="caret-up"
-          className={styles.expandButton}
-          onClick={onExpand}
-          aria-label={t("cookieConsent.expandBanner")}
-        >
-          {t("cookieConsent.expandBanner")}
-        </Button>
+      <div className={styles.bar}>
+        <Text as="p" size="S" terminals="sans" className={styles.copy}>
+          {t("cookieConsent.bannerSummary")}{" "}
+          <Link href="/privacy-policy" size="S">
+            {t("cookieConsent.policyLinkText")}
+          </Link>
+        </Text>
         <div className={styles.actions}>
-          <Button
-            variant="secondary"
-            size="l"
-            onClick={acceptEssentialOnly}
-            icon="cookie"
-          >
+          <Button variant="tertiary" size="s" onClick={onCustomize}>
+            {t("cookieConsent.customizeButton")}
+          </Button>
+          <Button variant="secondary" size="s" onClick={acceptEssentialOnly}>
             {t("cookieConsent.acceptEssentialButton")}
           </Button>
-          <Button variant="primary" size="l" onClick={acceptAll} icon="check">
+          <Button variant="primary" size="s" onClick={acceptAll}>
             {t("cookieConsent.acceptAllButton")}
           </Button>
         </div>

--- a/nextjs-app/shared/components/CookieConsent/CookieConsentBanner.tsx
+++ b/nextjs-app/shared/components/CookieConsent/CookieConsentBanner.tsx
@@ -8,7 +8,6 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import Button from "@dt/Button";
 import Link from "@dt/Link";
-import Text from "@dt/Text";
 import { useCookieConsent } from "../../lib/cookieConsent";
 import styles from "./CookieConsentBanner.module.css";
 
@@ -29,20 +28,22 @@ const CookieConsentBanner: React.FC<CookieConsentBannerProps> = ({
       aria-label={t("cookieConsent.bannerLabel")}
     >
       <div className={styles.bar}>
-        <Text as="p" size="S" terminals="sans" className={styles.copy}>
-          {t("cookieConsent.bannerSummary")}{" "}
-          <Link href="/privacy-policy" size="S">
-            {t("cookieConsent.policyLinkText")}
-          </Link>
-        </Text>
+        <div className={styles.copy}>
+          <p className={styles.copyText}>
+            {t("cookieConsent.bannerSummary")}{" "}
+            <Link href="/privacy-policy" size="M">
+              {t("cookieConsent.policyLinkText")}
+            </Link>
+          </p>
+        </div>
         <div className={styles.actions}>
-          <Button variant="tertiary" size="s" onClick={onCustomize}>
+          <Button variant="tertiary" size="m" onClick={onCustomize}>
             {t("cookieConsent.customizeButton")}
           </Button>
-          <Button variant="secondary" size="s" onClick={acceptEssentialOnly}>
+          <Button variant="secondary" size="m" onClick={acceptEssentialOnly}>
             {t("cookieConsent.acceptEssentialButton")}
           </Button>
-          <Button variant="primary" size="s" onClick={acceptAll}>
+          <Button variant="primary" size="m" onClick={acceptAll}>
             {t("cookieConsent.acceptAllButton")}
           </Button>
         </div>

--- a/nextjs-app/shared/locales/en/translation.json
+++ b/nextjs-app/shared/locales/en/translation.json
@@ -497,6 +497,8 @@
   "errorRetry": "Try again",
   "cookieConsent": {
     "title": "Cookie consent",
+    "bannerLabel": "Cookie preferences",
+    "bannerSummary": "We use cookies to improve your experience.",
     "description": "Digitaltableteur uses cookies to improve your experience. You can customize which cookies we use, accept all, or accept only essential cookies required for the site to function.",
     "detailedDescription": "Customize which categories of cookies you want to allow. Essential cookies cannot be disabled as they are required for basic site functionality.",
     "customizeButton": "Customize settings",

--- a/nextjs-app/shared/locales/fi/translation.json
+++ b/nextjs-app/shared/locales/fi/translation.json
@@ -497,6 +497,8 @@
   "errorRetry": "Yritä uudelleen",
   "cookieConsent": {
     "title": "Evästehyväksyntä",
+    "bannerLabel": "Evästeasetukset",
+    "bannerSummary": "Käytämme evästeitä parantaaksemme kokemustasi.",
     "description": "Digitaltableteur käyttää evästeitä parantaakseen kokemustasi. Voit mukauttaa, mitä evästeitä käytämme, hyväksyä kaikki tai hyväksyä vain sivuston toiminnalle välttämättömät evästeet.",
     "detailedDescription": "Mukauta, mitkä evästeluokat haluat sallia. Välttämättömiä evästeitä ei voi poistaa käytöstä, sillä ne ovat välttämättömiä sivuston perustoiminnoille.",
     "customizeButton": "Mukauta asetuksia",

--- a/nextjs-app/shared/locales/sv/translation.json
+++ b/nextjs-app/shared/locales/sv/translation.json
@@ -497,6 +497,8 @@
   "errorRetry": "Försök igen",
   "cookieConsent": {
     "title": "Cookie-godkännande",
+    "bannerLabel": "Cookie-inställningar",
+    "bannerSummary": "Vi använder cookies för att förbättra din upplevelse.",
     "description": "Digitaltableteur använder cookies för att förbättra din upplevelse. Du kan anpassa vilka cookies vi använder, godkänna alla eller godkänna endast nödvändiga cookies som krävs för sidans funktion.",
     "detailedDescription": "Anpassa vilka kategorier av cookies du vill tillåta. Nödvändiga cookies kan inte inaktiveras eftersom de krävs för grundläggande sidfunktioner.",
     "customizeButton": "Anpassa inställningar",

--- a/shared/locales/en/translation.json
+++ b/shared/locales/en/translation.json
@@ -495,6 +495,7 @@
     "expandBanner": "Expand cookie settings",
     "minimizeModal": "Minimize",
     "bannerLabel": "Cookie consent banner",
+    "bannerSummary": "We use cookies to improve your experience.",
     "readOur": "Read our",
     "policyLinkText": "privacy policy",
     "toLearnMore": "to learn more.",

--- a/shared/locales/fi/translation.json
+++ b/shared/locales/fi/translation.json
@@ -497,6 +497,7 @@
     "expandBanner": "Laajenna",
     "minimizeModal": "Pienennä",
     "bannerLabel": "Evästehyväksyntäbanneri",
+    "bannerSummary": "Käytämme evästeitä parantaaksemme kokemustasi.",
     "readOur": "Lue",
     "policyLinkText": "tietosuojakäytäntömme",
     "toLearnMore": "saadaksesi lisätietoja.",

--- a/shared/locales/sv/translation.json
+++ b/shared/locales/sv/translation.json
@@ -497,6 +497,7 @@
     "expandBanner": "Expandera",
     "minimizeModal": "Minimera",
     "bannerLabel": "Cookie-godkännandebanner",
+    "bannerSummary": "Vi använder cookies för att förbättra din upplevelse.",
     "readOur": "Läs vår",
     "policyLinkText": "integritetspolicy",
     "toLearnMore": "för att lära dig mer.",


### PR DESCRIPTION
### **User description**
## Summary
- Replace blocking cookie modal on first visit with a compact bottom bar; settings open only via Customize
- Add `cookieConsent.bannerSummary` to runtime locale files (`shared/locales`) so translated copy renders correctly
- Use medium design-system buttons, taller bar padding, and optical vertical centering for copy with wavy policy link underline

## Test plan
- [x] `SKIP_STORYBOOK_TESTS=1 npm test -- CookieConsent` (13/13)
- [ ] Hard refresh in incognito — banner shows translated summary, medium buttons, visually centered copy
- [ ] Customize opens modal; Accept all / Only essential dismiss bar
- [ ] Verify EN/FI/SV banner summary strings


Made with [Cursor](https://cursor.com)


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Default to compact bottom cookie bar

- Customize opens detailed consent modal

- Add banner i18n across locales

- Update banner and consent tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["First visit"] 
  B["Compact bottom banner"]
  C["Customize settings"]
  D["Detailed consent modal"]
  E["Accept or save preferences"]
  F["Consent stored"]

  A -- "shows" --> B
  B -- "customize" --> C
  C -- "opens" --> D
  B -- "quick actions" --> E
  D -- "modal actions" --> E
  E -- "persists" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>CookieConsent.test.tsx</strong><dd><code>Update tests for compact banner behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/619/files#diff-e7bf4c59965fe71a03fab036071daefa8fd1e4c00f42b4589760f5d6e3653406">+25/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CookieConsentBanner.test.tsx</strong><dd><code>Cover banner copy and customize action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/619/files#diff-0352322b9751dd88958d56dd642a8131dae6065458fbc17349b1d8032bad2618">+31/-25</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>CookieConsent.tsx</strong><dd><code>Switch default consent UI to banner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/619/files#diff-37fc763aca10fe4e5c95cbb83227fbbd42a6a9c03fa613209308fda1d717af0e">+86/-177</a></td>

</tr>

<tr>
  <td><strong>CookieConsentBanner.tsx</strong><dd><code>Redesign banner with inline consent actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/619/files#diff-bf9e32b2ea0e1aa6f63b7c841ea7ad8e95b0948abc3fae378ad5779d80860131">+19/-25</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Styling</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>CookieConsent.module.css</strong><dd><code>Adjust detailed modal category spacing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/619/files#diff-9c0645a6c5419732d42c340bc7ec385f012a857c3c69b9c14b2220433bd3809c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CookieConsentBanner.module.css</strong><dd><code>Restyle responsive bottom consent bar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/619/files#diff-3ce129fee7c8058aac89a59061ea6da40ca494d31b805a8d8d41680702732793">+99/-56</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Localization</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>translation.json</strong><dd><code>Add English compact banner translations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/619/files#diff-301719a84ba7f6832d9046c9ce58e3456910e453cecf646a5bcf23c1ab3b1b8f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>translation.json</strong><dd><code>Add Finnish compact banner translations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/619/files#diff-da2606dbc611e91dfb7f6ada145a5b4ea2e2e31ec4e7eaa588ffc965915564d0">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>translation.json</strong><dd><code>Add Swedish compact banner translations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/619/files#diff-4ff1e0417dd8c56bdd49ebe53050828c670c29dd8742a015419302aef845c5a5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>translation.json</strong><dd><code>Add shared English banner summary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/619/files#diff-49c16e68e49ad78bdc892b1491dc291991490e2076130febb1524433f2a38d5c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>translation.json</strong><dd><code>Add shared Finnish banner summary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/619/files#diff-a5112cc051e0d2aff327d81ef793e938553dbf53d2ee4418af3fff673d3225b5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>translation.json</strong><dd><code>Add shared Swedish banner summary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PetriLahdelma/digitaltableteur/pull/619/files#diff-4cbf7ca0c6f1a7739e00f8b9a177e7fbad608d3d1229806fc3cfbd894617c889">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

