### PR TITLE
fix: site-wide mobile layout, margins, and VertaaUX responsive logos

### DIFF
--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -12,6 +12,10 @@
 @custom-variant dark (&:is(.dark *, .themeDark *));
 @custom-variant hcb (&:is(.themeHCB *));
 @custom-variant hcw (&:is(.themeHCW *));
+@custom-variant mobile (@media (width < 768px));
+@custom-variant tablet (@media (width >= 768px));
+@custom-variant desktop (@media (width >= 1024px));
+@custom-variant wide (@media (width >= 1440px));
 
 /*
  * Tailwind theme tokens for shadcn/ui components

--- a/app/work/NextWorkNav.module.css
+++ b/app/work/NextWorkNav.module.css
@@ -1,8 +1,21 @@
 .wrapper {
   display: grid;
   padding-block: 0.75rem;
+  padding-inline: var(--page-margin-mobile);
   width: 100%;
   gap: 0.75rem;
+}
+
+@media (width >= 768px) {
+  .wrapper {
+    padding-inline: var(--page-margin-tablet);
+  }
+}
+
+@media (width >= 1024px) {
+  .wrapper {
+    padding-inline: var(--page-margin-desktop);
+  }
 }
 
 .row {

--- a/nextjs-app/shared/components/Container/Container.module.css
+++ b/nextjs-app/shared/components/Container/Container.module.css
@@ -1,0 +1,27 @@
+.container {
+  box-sizing: border-box;
+  width: 100%;
+  padding-inline: var(--page-margin-mobile);
+}
+
+@media (width >= 768px) {
+  .container {
+    padding-inline: var(--page-margin-tablet);
+  }
+}
+
+@media (width >= 1024px) {
+  .container {
+    padding-inline: var(--page-margin-desktop);
+  }
+}
+
+@media (width >= 1440px) {
+  .container {
+    padding-inline: var(--page-margin-wide);
+  }
+}
+
+.centered {
+  margin-inline: auto;
+}

--- a/nextjs-app/shared/components/Container/Container.tsx
+++ b/nextjs-app/shared/components/Container/Container.tsx
@@ -1,6 +1,8 @@
 import { type ReactNode, type ElementType } from "react";
 import { cn } from "@/lib/utils";
 
+import styles from "./Container.module.css";
+
 export interface ContainerProps {
   children: ReactNode;
   size?: "sm" | "md" | "lg" | "xl" | "full";
@@ -30,9 +32,9 @@ export function Container({
   return (
     <Component
       className={cn(
-        "w-full px-4 tablet:px-8 desktop:px-12",
+        styles.container,
         sizeClasses[size],
-        center && "mx-auto",
+        center && styles.centered,
         className
       )}
     >

--- a/nextjs-app/shared/components/Layout/Layout.module.css
+++ b/nextjs-app/shared/components/Layout/Layout.module.css
@@ -4,10 +4,13 @@
   display: flex;
   min-height: 100vh;
   flex-direction: column;
+  overflow-x: clip;
 }
 
 .main {
   flex: 1;
+  min-width: 0;
+  overflow-x: clip;
 }
 
 /* Main is not an interactive element; focus is only set programmatically for skip link scroll target */

--- a/nextjs-app/shared/components/Title/Title.module.css
+++ b/nextjs-app/shared/components/Title/Title.module.css
@@ -85,3 +85,10 @@
     font-optical-sizing: auto;
   }
 }
+
+@media (width < 768px) {
+  .title {
+    max-width: 100%;
+    overflow-wrap: anywhere;
+  }
+}

--- a/nextjs-app/shared/components/pages/Colophon/colophon.module.css
+++ b/nextjs-app/shared/components/pages/Colophon/colophon.module.css
@@ -4,6 +4,8 @@
   margin-inline: auto;
   padding-block: var(--space-layout-64);
   padding-inline: var(--page-margin-mobile);
+  box-sizing: border-box;
+  min-width: 0;
   max-width: var(--container-md);
 }
 
@@ -50,7 +52,7 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 260px), 1fr));
   gap: var(--space-layout-24);
 }
 

--- a/nextjs-app/shared/components/pages/Pseo/PseoIndexPage.module.css
+++ b/nextjs-app/shared/components/pages/Pseo/PseoIndexPage.module.css
@@ -1,6 +1,7 @@
 .root {
+  box-sizing: border-box;
   margin: 0 auto;
-  padding: 2rem;
+  min-width: 0;
   max-width: 100%;
   font-family: var(--primary-body-font);
   font-size: 1rem;

--- a/nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css
+++ b/nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css
@@ -1,6 +1,7 @@
 .root {
+  box-sizing: border-box;
   margin: 0 auto;
-  padding: 2rem;
+  min-width: 0;
   max-width: 100%;
   font-family: var(--primary-body-font);
   font-size: 1rem;
@@ -50,7 +51,7 @@
 
 .relatedGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
   gap: 1rem;
   margin-top: 1rem;
 }

--- a/nextjs-app/shared/components/pages/Pseo/PseoPillarPage.module.css
+++ b/nextjs-app/shared/components/pages/Pseo/PseoPillarPage.module.css
@@ -1,6 +1,7 @@
 .root {
+  box-sizing: border-box;
   margin: 0 auto;
-  padding: 2rem;
+  min-width: 0;
   max-width: 100%;
   font-family: var(--primary-body-font);
   font-size: 1rem;
@@ -21,7 +22,7 @@
 
 .list {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
   gap: 1rem;
   margin-top: 2rem;
 }

--- a/nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/helsinkiDesignSystem.module.css
+++ b/nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/helsinkiDesignSystem.module.css
@@ -1,7 +1,22 @@
 .caseStudy {
-  padding: 2.5rem 1.5rem 1.5rem;
+  box-sizing: border-box;
+  padding-block: 2.5rem 1.5rem;
+  padding-inline: var(--page-margin-mobile);
   min-height: 100vh;
+  min-width: 0;
   background: var(--main-body-background-color);
+}
+
+@media (width >= 768px) {
+  .caseStudy {
+    padding-inline: var(--page-margin-tablet);
+  }
+}
+
+@media (width >= 1024px) {
+  .caseStudy {
+    padding-inline: var(--page-margin-desktop);
+  }
 }
 
 /* Hero Section */

--- a/nextjs-app/shared/components/pages/Work/Illustrations/illustrations.module.css
+++ b/nextjs-app/shared/components/pages/Work/Illustrations/illustrations.module.css
@@ -49,10 +49,13 @@
 
 .galleryItem {
   position: relative;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   border-radius: var(--radius-m);
   background-color: var(--color-muted-background);
   box-shadow: 0 4px 20px rgb(0 0 0 / 15%);
-  overflow: visible;
+  overflow: hidden;
 }
 
 .galleryItem > img {
@@ -61,10 +64,13 @@
 
 .galleryItemSharp {
   position: relative;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   border-radius: 0;
   background-color: var(--color-muted-background);
   box-shadow: 0 4px 20px rgb(0 0 0 / 15%);
-  overflow: visible;
+  overflow: hidden;
 }
 
 .galleryImage {
@@ -235,6 +241,21 @@
 
   .handle {
     display: none;
+  }
+
+  .gallery {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .galleryItem,
+  .galleryItemSharp {
+    position: static !important;
+    width: 100% !important;
+    max-width: 100%;
+    min-width: 0;
+    transform: none !important;
   }
 }
 
@@ -451,7 +472,7 @@
 }
 
 .heroText {
-  min-width: 280px;
+  min-width: 0;
   flex: 1 1 320px;
 }
 
@@ -483,7 +504,7 @@
 
 .heroImage {
   display: flex;
-  min-width: 280px;
+  min-width: 0;
   flex: 1 1 320px;
   justify-content: flex-end;
   align-items: flex-end;
@@ -544,7 +565,7 @@
 }
 
 .twoCol > div {
-  min-width: 240px;
+  min-width: 0;
   flex: 1 1 320px;
 }
 

--- a/nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx
@@ -42,6 +42,7 @@ export function VertaaUXPage({ nav }: { nav?: React.ReactNode }) {
           liveUrl={project.liveUrl}
           variant="contained"
           showScrollIndicator={true}
+          className={styles.hero}
         />
       }
       relatedProjects={<RelatedProjects currentSlug={project.slug} />}
@@ -285,84 +286,115 @@ export function VertaaUXPage({ nav }: { nav?: React.ReactNode }) {
       <div className={styles.logoGridSection}>
         <div className={styles.logoGrid}>
           <figure className={styles.logoCard}>
-            <div className={styles.logoCardDark}>
+            <div className={`${styles.logoCardDark} ${styles.logoCardMark}`}>
               <img
                 src="/images/portfolio/vertaaux/logo-mint-on-black.svg"
                 alt="VertaaUX mint teal logo on dark background"
-                className={styles.logoImage}
+                className={styles.logoImageMark}
+                width={512}
+                height={512}
+                loading="lazy"
+                decoding="async"
               />
             </div>
             <figcaption className={styles.logoCaption}>Primary — dark background</figcaption>
           </figure>
           <figure className={styles.logoCard}>
-            <div className={styles.logoCardLight}>
+            <div className={`${styles.logoCardLight} ${styles.logoCardMark}`}>
               <img
                 src="/images/portfolio/vertaaux/logo-mint-on-white.svg"
                 alt="VertaaUX mint teal logo on light background"
-                className={styles.logoImage}
+                className={styles.logoImageMark}
+                width={512}
+                height={512}
+                loading="lazy"
+                decoding="async"
               />
             </div>
             <figcaption className={styles.logoCaption}>Primary — light background</figcaption>
           </figure>
           <figure className={styles.logoCard}>
-            <div className={styles.logoCardDark}>
+            <div className={`${styles.logoCardDark} ${styles.logoCardMark}`}>
               <img
                 src="/images/portfolio/vertaaux/logo-on-black.svg"
                 alt="VertaaUX mono logo on black"
-                className={styles.logoImage}
+                className={styles.logoImageMark}
+                width={512}
+                height={512}
+                loading="lazy"
+                decoding="async"
               />
             </div>
             <figcaption className={styles.logoCaption}>Mono — On black</figcaption>
           </figure>
           <figure className={styles.logoCard}>
-            <div className={styles.logoCardLight}>
+            <div className={`${styles.logoCardLight} ${styles.logoCardMark}`}>
               <img
                 src="/images/portfolio/vertaaux/logo-on-white.svg"
                 alt="VertaaUX logo on light background"
-                className={styles.logoImage}
+                className={styles.logoImageMark}
+                width={512}
+                height={512}
+                loading="lazy"
+                decoding="async"
               />
             </div>
             <figcaption className={styles.logoCaption}>Mono — On white</figcaption>
           </figure>
-
         </div>
-        <div className={styles.logoGrid}>
+        <div className={`${styles.logoGrid} ${styles.logoGridWordmarks}`}>
           <figure className={styles.logoCard}>
-            <div className={styles.logoCardDark}>
+            <div className={`${styles.logoCardDark} ${styles.logoCardWordmark}`}>
               <img
                 src="/images/portfolio/vertaaux/wordmark-on-black.svg"
                 alt="VertaaUX wordmark with mint logo on black"
-                className={styles.logoImage}
+                className={styles.logoImageWordmark}
+                width={1346}
+                height={416}
+                loading="lazy"
+                decoding="async"
               />
             </div>
             <figcaption className={styles.logoCaption}>Wordmark — On black</figcaption>
           </figure>
           <figure className={styles.logoCard}>
-            <div className={styles.logoCardLight}>
+            <div className={`${styles.logoCardLight} ${styles.logoCardWordmark}`}>
               <img
                 src="/images/portfolio/vertaaux/wordmark-on-white.svg"
                 alt="VertaaUX wordmark with mint logo on white"
-                className={styles.logoImage}
+                className={styles.logoImageWordmark}
+                width={1346}
+                height={416}
+                loading="lazy"
+                decoding="async"
               />
             </div>
             <figcaption className={styles.logoCaption}>Wordmark — On white</figcaption>
           </figure>
           <figure className={styles.logoCard}>
-            <div className={styles.logoCardDark}>
+            <div className={`${styles.logoCardDark} ${styles.logoCardWordmark}`}>
               <img
                 src="/images/portfolio/vertaaux/wordmark-white-on-black.svg"
                 alt="VertaaUX wordmark white on black"
-                className={styles.logoImage}
+                className={styles.logoImageWordmark}
+                width={1346}
+                height={416}
+                loading="lazy"
+                decoding="async"
               />
             </div>
             <figcaption className={styles.logoCaption}>Wordmark mono — On black</figcaption>
           </figure>
           <figure className={styles.logoCard}>
-            <div className={styles.logoCardLight}>
+            <div className={`${styles.logoCardLight} ${styles.logoCardWordmark}`}>
               <img
                 src="/images/portfolio/vertaaux/wordmark-black-on-white.svg"
                 alt="VertaaUX wordmark black on white"
-                className={styles.logoImage}
+                className={styles.logoImageWordmark}
+                width={1346}
+                height={416}
+                loading="lazy"
+                decoding="async"
               />
             </div>
             <figcaption className={styles.logoCaption}>Wordmark mono — On white</figcaption>

--- a/nextjs-app/shared/components/pages/Work/VertaaUX/vertaaux.module.css
+++ b/nextjs-app/shared/components/pages/Work/VertaaUX/vertaaux.module.css
@@ -7,6 +7,38 @@
   overflow-x: clip;
 }
 
+/* Hero — tighter mobile type, image spacing */
+
+.hero {
+  padding-block-start: var(--space-layout-16);
+}
+
+@media (width >= 768px) {
+  .hero {
+    padding-block-start: 0;
+  }
+}
+
+@media (width < 768px) {
+  .hero :global(h1) {
+    font-size: clamp(1.75rem, 8vw, 2.25rem);
+    line-height: 1.12;
+    letter-spacing: -0.02em;
+    max-width: 100%;
+    overflow-wrap: anywhere;
+  }
+
+  .hero :global(p) {
+    font-size: 1rem;
+    line-height: 1.6;
+  }
+}
+
+.hero :global(img) {
+  margin-block-start: var(--space-layout-24);
+  border-radius: var(--radius-lg, 0.75rem);
+}
+
 /* Rounded image corners for specific sections */
 
 .roundedImage img {
@@ -92,7 +124,6 @@
 .processSection {
   margin-block: var(--space-layout-80);
   padding-block: var(--space-layout-48);
-  padding-inline: var(--page-margin-mobile);
   background: linear-gradient(
     180deg,
     var(--color-light-bg) 0%,
@@ -100,15 +131,10 @@
   );
 }
 
-@media (width >= 768px) {
+@media (width < 768px) {
   .processSection {
-    padding-inline: var(--page-margin-tablet);
-  }
-}
-
-@media (width >= 1024px) {
-  .processSection {
-    padding-inline: var(--page-margin-desktop);
+    margin-block: var(--space-layout-48);
+    padding-block: var(--space-layout-32);
   }
 }
 
@@ -116,6 +142,12 @@
 
 .storySection {
   margin-block: var(--space-layout-64);
+}
+
+@media (width < 768px) {
+  .storySection {
+    margin-block: var(--space-layout-48);
+  }
 }
 
 /* Problem mindmap styling */
@@ -131,19 +163,12 @@
 
 .approachSection {
   padding-block: var(--space-layout-48);
-  padding-inline: var(--page-margin-mobile);
   background-color: var(--color-light-bg);
 }
 
-@media (width >= 768px) {
+@media (width < 768px) {
   .approachSection {
-    padding-inline: var(--page-margin-tablet);
-  }
-}
-
-@media (width >= 1024px) {
-  .approachSection {
-    padding-inline: var(--page-margin-desktop);
+    padding-block: var(--space-layout-32);
   }
 }
 
@@ -152,20 +177,8 @@
 .storySectionAlt {
   margin-block: var(--space-layout-64);
   padding-block: var(--space-layout-48);
-  padding-inline: var(--page-margin-mobile);
+  padding-inline: var(--cs-page-inset);
   background-color: var(--color-light-bg);
-}
-
-@media (width >= 768px) {
-  .storySectionAlt {
-    padding-inline: var(--page-margin-tablet);
-  }
-}
-
-@media (width >= 1024px) {
-  .storySectionAlt {
-    padding-inline: var(--page-margin-desktop);
-  }
 }
 
 /* Logo grid section - custom 2x2 layout */
@@ -173,20 +186,8 @@
 .logoGridSection {
   margin-block-end: var(--space-layout-64);
   margin-inline: auto;
-  padding-inline: var(--page-margin-mobile);
+  padding-inline: var(--cs-page-inset);
   max-width: var(--container-md);
-}
-
-@media (width >= 768px) {
-  .logoGridSection {
-    padding-inline: var(--page-margin-tablet);
-  }
-}
-
-@media (width >= 1024px) {
-  .logoGridSection {
-    padding-inline: var(--page-margin-desktop);
-  }
 }
 
 .logoGrid {
@@ -194,6 +195,16 @@
   min-width: 0;
   grid-template-columns: 1fr 1fr;
   gap: var(--space-layout-32) var(--space-layout-24);
+}
+
+.logoGridWordmarks {
+  grid-template-columns: 1fr;
+}
+
+@media (width >= 640px) {
+  .logoGridWordmarks {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
 .logoGrid + .logoGrid {
@@ -223,40 +234,58 @@
   justify-content: center;
   align-items: center;
   border-radius: 0.75rem;
-  aspect-ratio: 16 / 9;
+  padding: clamp(1rem, 4vw, var(--space-layout-48));
+}
+
+/* Square mark variants (icon-only logos) */
+.logoCardMark {
+  aspect-ratio: 1;
+  max-height: min(280px, 72vw);
+}
+
+/* Wide wordmark variants — match SVG viewBox (~1346×416) */
+.logoCardWordmark {
+  aspect-ratio: 1346 / 416;
+  width: 100%;
 }
 
 .logoCardDark {
-  padding: var(--space-layout-48);
   background-color: #0D0D0D;
 }
 
 .logoCardLight {
-  padding: var(--space-layout-48);
   border: 1px solid var(--color-border);
   background-color: #fff;
 }
 
 @media (width < 768px) {
-  .logoCardDark,
-  .logoCardLight,
-  .logoCardGradient {
+  .logoCardMark {
+    max-height: min(240px, 65vw);
+  }
+
+  .logoCardWordmark {
     padding: var(--space-layout-16);
-    aspect-ratio: 4 / 3;
   }
 }
 
 .logoCardGradient {
-  padding: var(--space-layout-48);
   background-color: #141414;
 }
 
-.logoImage {
+.logoImageMark {
+  display: block;
+  flex: 0 1 auto;
+  width: clamp(4rem, 42vw, 10rem);
+  max-width: 100%;
+  height: auto;
+  object-fit: contain;
+}
+
+.logoImageWordmark {
   display: block;
   width: 100%;
-  max-width: min(80%, 100%);
   height: auto;
-  max-height: 80%;
+  max-height: 100%;
   object-fit: contain;
 }
 
@@ -287,22 +316,10 @@
   display: grid;
   margin-block-end: var(--space-layout-48);
   margin-inline: auto;
-  padding-inline: var(--page-margin-mobile);
+  padding-inline: var(--cs-page-inset);
   max-width: var(--container-lg);
   grid-template-columns: repeat(4, 1fr);
   gap: var(--space-layout-24);
-}
-
-@media (width >= 768px) {
-  .paletteGrid {
-    padding-inline: var(--page-margin-tablet);
-  }
-}
-
-@media (width >= 1024px) {
-  .paletteGrid {
-    padding-inline: var(--page-margin-desktop);
-  }
 }
 
 @media (width < 640px) {
@@ -429,20 +446,8 @@
 .paletteSection {
   margin-block-end: var(--space-layout-48);
   margin-inline: auto;
-  padding-inline: var(--page-margin-mobile);
+  padding-inline: var(--cs-page-inset);
   max-width: var(--container-lg);
-}
-
-@media (width >= 768px) {
-  .paletteSection {
-    padding-inline: var(--page-margin-tablet);
-  }
-}
-
-@media (width >= 1024px) {
-  .paletteSection {
-    padding-inline: var(--page-margin-desktop);
-  }
 }
 
 .paletteSectionTitle {
@@ -479,23 +484,11 @@
   display: grid;
   margin-block-end: var(--space-layout-64);
   margin-inline: auto;
-  padding-inline: var(--page-margin-mobile);
-  max-width: var(--container-lg);
+  padding-inline: var(--cs-page-inset);
   min-width: 0;
+  max-width: var(--container-lg);
   grid-template-columns: 1fr 1fr;
   gap: var(--space-layout-48);
-}
-
-@media (width >= 768px) {
-  .fontWaterfall {
-    padding-inline: var(--page-margin-tablet);
-  }
-}
-
-@media (width >= 1024px) {
-  .fontWaterfall {
-    padding-inline: var(--page-margin-desktop);
-  }
 }
 
 @media (width < 640px) {
@@ -529,7 +522,6 @@
   padding-block: 0.15em;
   line-height: 1.35;
   overflow-wrap: anywhere;
-  word-break: break-word;
   color: var(--color-text);
 }
 
@@ -580,22 +572,10 @@
   display: grid;
   margin-block-end: var(--space-layout-48);
   margin-inline: auto;
-  padding-inline: var(--page-margin-mobile);
+  padding-inline: var(--cs-page-inset);
   max-width: var(--container-lg);
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: var(--space-layout-24);
-}
-
-@media (width >= 768px) {
-  .brandImageGrid {
-    padding-inline: var(--page-margin-tablet);
-  }
-}
-
-@media (width >= 1024px) {
-  .brandImageGrid {
-    padding-inline: var(--page-margin-desktop);
-  }
 }
 
 .brandFigure {
@@ -632,20 +612,15 @@
 .metricsSection {
   margin-block: var(--space-layout-80);
   padding-block: var(--space-layout-64);
-  padding-inline: var(--page-margin-mobile);
+  padding-inline: var(--cs-page-inset);
   background-color: #0D0D0D;
   color: #F2F2F2;
 }
 
-@media (width >= 768px) {
+@media (width < 768px) {
   .metricsSection {
-    padding-inline: var(--page-margin-tablet);
-  }
-}
-
-@media (width >= 1024px) {
-  .metricsSection {
-    padding-inline: var(--page-margin-desktop);
+    margin-block: var(--space-layout-48);
+    padding-block: var(--space-layout-48);
   }
 }
 

--- a/nextjs-app/shared/patterns/PageLayout/PageLayout.module.css
+++ b/nextjs-app/shared/patterns/PageLayout/PageLayout.module.css
@@ -3,6 +3,7 @@
 .pageLayout {
   box-sizing: border-box;
   width: 100%;
+  min-width: 0;
 }
 
 /* Maximum width constraints */

--- a/nextjs-app/shared/styles/caseStudyPageInset.css
+++ b/nextjs-app/shared/styles/caseStudyPageInset.css
@@ -19,3 +19,9 @@
     --cs-page-inset: var(--page-margin-desktop);
   }
 }
+
+@media (width >= 1440px) {
+  .page {
+    --cs-page-inset: var(--page-margin-wide);
+  }
+}


### PR DESCRIPTION
## Summary
- Restore site-wide horizontal page margins by moving Container padding into a CSS module and registering Tailwind `mobile`/`tablet`/`desktop`/`wide` variants so responsive utilities work again.
- Clip layout overflow so homepage logo marquee and similar full-bleed sections no longer cause horizontal scroll on phones.
- Fix VertaaUX case study mobile spacing and split logo marks vs wordmarks into responsive grids.
- Harden mobile layouts on Illustrations, Colophon, PSEO, Helsinki DS, and shared Title/PageLayout patterns.

## Verification
- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run test:ci` — 1747 tests pass (8 known Vitest teardown flakes in HomePage.test.tsx)
- Playwright overflow audit at 320px and 390px — 0 horizontal overflow across 26 routes (home, marketing, blog, all major case studies)

## Test plan
- [ ] Spot-check VertaaUX logos on iPhone-width viewport (marks + wordmarks)
- [ ] Confirm Illustrations gallery stacks without horizontal scroll on mobile
- [ ] Confirm home page has no sideways scroll with logo marquee animating
- [ ] Smoke-test /pseo and /colophon on mobile


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive viewport width breakpoints for mobile, tablet, desktop, and wide screens to enhance responsive design capabilities.

* **Style**
  * Improved responsive spacing and padding consistency across components.
  * Enhanced title wrapping behavior on narrow viewports.
  * Fixed horizontal overflow handling in layouts and flex containers.
  * Better responsive gallery and content display across screen sizes.
  * Optimized responsive margins and page inset spacing for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->