### PR TITLE
fix(blog): restore production build by isolating MDX to client boundary

### DIFF
--- a/app/blog/[slug]/BlogArticleMdxBody.tsx
+++ b/app/blog/[slug]/BlogArticleMdxBody.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { getBlogPostBySlug } from "@/nextjs-app/shared/data/blogPosts";
+import { articleProseClassName } from "@/nextjs-app/shared/components/ArticleContent/articleProseClasses";
+
+export function BlogArticleMdxBody({
+  slug,
+  showUnpublished = false,
+}: {
+  slug: string;
+  showUnpublished?: boolean;
+}) {
+  const post = getBlogPostBySlug(slug, { showUnpublished });
+  if (!post) return null;
+
+  const { Component } = post;
+
+  return (
+    <div className={articleProseClassName}>
+      <Component />
+    </div>
+  );
+}

--- a/app/blog/[slug]/ServerArticleContent.tsx
+++ b/app/blog/[slug]/ServerArticleContent.tsx
@@ -1,11 +1,11 @@
 import Image from "next/image";
 import Link from "next/link";
 
-import { getBlogPostBySlug } from "@/nextjs-app/shared/data/blogPosts";
+import { getPostMetaBySlug } from "@/app/blog/postMetadata";
 import { getAuthorBySlug } from "@/nextjs-app/shared/data/authors";
 import { Container } from "@/nextjs-app/shared/components/Container";
-import { articleProseClassName } from "@/nextjs-app/shared/components/ArticleContent/articleProseClasses";
 import { toAbsoluteSiteUrl } from "@/app/lib/siteUrl";
+import { BlogArticleMdxBody } from "./BlogArticleMdxBody";
 import { ServerRelatedPosts } from "./ServerRelatedPosts";
 
 function formatPublishedDate(iso?: string): string {
@@ -26,11 +26,10 @@ export function ServerArticleContent({
   slug: string;
   showUnpublished?: boolean;
 }) {
-  const post = getBlogPostBySlug(slug, { showUnpublished });
+  const post = getPostMetaBySlug(slug, { showUnpublished });
   if (!post) return null;
 
   const {
-    Component,
     title,
     excerpt,
     publishedAt,
@@ -120,9 +119,7 @@ export function ServerArticleContent({
 
       <Container size="md" className="py-8 tablet:py-12">
         <div className="min-w-0">
-          <div className={articleProseClassName}>
-            <Component />
-          </div>
+          <BlogArticleMdxBody slug={slug} showUnpublished={showUnpublished} />
 
           {author ? (
             <aside className="not-prose mt-12 rounded-lg border border-border bg-muted/30 p-6">

--- a/app/blog/[slug]/ServerRelatedPosts.tsx
+++ b/app/blog/[slug]/ServerRelatedPosts.tsx
@@ -1,6 +1,9 @@
 import Link from "next/link";
 
-import { getBlogPosts, getBlogPostBySlug } from "@/nextjs-app/shared/data/blogPosts";
+import {
+  getPostMetaBySlug,
+  getVisiblePosts,
+} from "@/app/blog/postMetadata";
 import { Container } from "@/nextjs-app/shared/components/Container";
 
 export function ServerRelatedPosts({
@@ -10,10 +13,10 @@ export function ServerRelatedPosts({
   currentSlug: string;
   maxPosts?: number;
 }) {
-  const currentPost = getBlogPostBySlug(currentSlug);
+  const currentPost = getPostMetaBySlug(currentSlug);
   const currentTags = new Set(currentPost?.tags ?? []);
 
-  const related = getBlogPosts()
+  const related = getVisiblePosts()
     .filter((post) => post.slug !== currentSlug)
     .map((post) => {
       const sharedTags = (post.tags ?? []).filter((tag) => currentTags.has(tag));


### PR DESCRIPTION
## Summary
Production and preview Vercel builds have been failing since #627 with:

```
Failed to collect page data for /blog/[slug]
TypeError: p.createContext is not a function
```

MDX modules initialize `@mdx-js/react` context at import time. Importing them from server components (`ServerArticleContent`, `ServerRelatedPosts`) pulls MDX into the RSC bundle where React client APIs are unavailable.

This fix keeps article metadata, hero, author box, and related posts on the server while rendering MDX body via a dedicated client component (`BlogArticleMdxBody`).

## Verification
- `npm run build` — pass (was failing before this change)

## Test plan
- [ ] Confirm Vercel production deployment succeeds
- [ ] Open a blog article — title/hero SSR, body renders
- [ ] Check related posts section on an article


Made with [Cursor](https://cursor.com)