### PR TITLE
fix(home): restore stacked Design Sprints section layout

### DIFF
--- a/nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.module.css
+++ b/nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.module.css
@@ -1,3 +1,91 @@
+/* Stacked layout — intentional single column (not side-by-side at desktop). */
+.layout {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-layout-48);
+}
+
+.intro {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-layout-24);
+  max-width: 36rem;
+}
+
+.title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: var(--font-size-title-m);
+  font-weight: 700;
+  line-height: var(--line-height-tight);
+  color: var(--color-foreground);
+}
+
+.description {
+  margin: 0;
+  max-width: 36rem;
+  font-family: var(--font-body);
+  font-size: var(--font-size-text-l);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-muted-foreground);
+}
+
+.benefitsGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-layout-16);
+}
+
+@media (width >= 768px) {
+  .benefitsGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.benefitCard {
+  display: flex;
+  align-items: center;
+  gap: var(--space-layout-16);
+  padding: var(--space-layout-16);
+  border: 1px solid color-mix(in srgb, var(--color-border) 50%, transparent);
+  border-radius: var(--radius-lg);
+  background-color: color-mix(in srgb, var(--color-background) 60%, transparent);
+  backdrop-filter: blur(8px);
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.benefitCard:hover {
+  border-color: var(--color-border);
+  background-color: color-mix(in srgb, var(--color-background) 80%, transparent);
+}
+
+.benefitIcon {
+  display: flex;
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  justify-content: center;
+  align-items: center;
+  border-radius: 9999px;
+  background-color: color-mix(in srgb, var(--color-primary) 10%, transparent);
+  color: var(--color-primary);
+}
+
+.benefitLabel {
+  font-family: var(--font-body);
+  font-size: var(--font-size-text-m);
+  font-weight: 500;
+  color: var(--color-foreground);
+}
+
+.ctaRow {
+  display: flex;
+  justify-content: center;
+  padding-block-start: var(--space-layout-32);
+}
+
 .iconCircle {
   background-color: var(--logo-background);
 

--- a/nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.tsx
+++ b/nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import React from "react";
 import { useTranslation } from "react-i18next";
-import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { Section } from "../../components/Section";
 import { Container } from "../../components/Container";
@@ -37,7 +35,6 @@ function SprintButton({ label }: { label: string }) {
         "cursor-pointer"
       )}
     >
-      {/* Text */}
       <span
         className={cn(
           "relative z-10 whitespace-nowrap",
@@ -48,7 +45,6 @@ function SprintButton({ label }: { label: string }) {
         {label}
       </span>
 
-      {/* Icon circle - wrapper handles position, inner circle handles rotation */}
       <span
         className={cn(
           "absolute top-1/2 -translate-y-1/2 z-20",
@@ -73,11 +69,6 @@ function SprintButton({ label }: { label: string }) {
 
 /**
  * DesignSprintsSection - Showcases the rapid brand design sprint offering
- * 
- * Features:
- * - Compelling headline and description about fast, quality design
- * - Grid of benefits with check icons
- * - CTA to get started
  */
 export function DesignSprintsSection({
   id = "design-sprints",
@@ -86,7 +77,6 @@ export function DesignSprintsSection({
 }: DesignSprintsSectionProps) {
   const { t } = useTranslation();
 
-  // Get benefits array from translations
   const benefits = t("homeDesignSprintsBenefits", {
     returnObjects: true,
     defaultValue: [],
@@ -101,88 +91,47 @@ export function DesignSprintsSection({
       className={className}
     >
       <Container size="lg">
-        <div className="grid gap-12 desktop:grid-cols-2 desktop:gap-16 items-center">
-          {/* Content column */}
-          <div className="space-y-6">
+        <div className={styles.layout}>
+          <div className={styles.intro}>
             <FadeIn direction="up" delay={0} distance={20}>
-              <h2
-                className={cn(
-                  "font-display font-bold",
-                  "text-3xl tablet:text-4xl desktop:text-5xl",
-                  "text-foreground leading-tight"
-                )}
-              >
+              <h2 className={styles.title}>
                 {t("homeDesignSprintsTitle", "Exceptional design, without the wait")}
               </h2>
             </FadeIn>
 
             <FadeIn direction="up" delay={0.1} distance={20}>
-              <p
-                className={cn(
-                  "font-body text-lg tablet:text-xl",
-                  "text-muted-foreground leading-relaxed",
-                  "max-w-xl"
-                )}
-              >
+              <p className={styles.description}>
                 {t(
                   "homeDesignSprintsDescription",
                   "We believe world-class design shouldn't take months. That's why we created Design Sprints—polished, timeless branding delivered in just two weeks."
                 )}
               </p>
             </FadeIn>
-
           </div>
 
-          {/* Benefits column - 2x2 grid with CTA below */}
-          <div className="space-y-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {benefits.map((benefit, index) => (
-                <FadeIn
-                  key={benefit}
-                  direction="left"
-                  delay={0.1 + index * 0.08}
-                  distance={30}
-                >
-                  <div
-                    className={cn(
-                      "flex items-center gap-4",
-                      "p-4 rounded-lg",
-                      "bg-background/60 backdrop-blur-sm",
-                      "border border-border/50",
-                      "transition-all duration-200",
-                      "hover:bg-background/80 hover:border-border"
-                    )}
-                  >
-                    <div
-                      className={cn(
-                        "flex-shrink-0",
-                        "w-8 h-8 rounded-full",
-                        "bg-primary/10 text-primary",
-                        "flex items-center justify-center"
-                      )}
-                    >
-                      <Check className="w-4 h-4" />
-                    </div>
-                    <span
-                      className={cn(
-                        "font-body font-medium",
-                        "text-base tablet:text-lg",
-                        "text-foreground"
-                      )}
-                    >
-                      {benefit}
-                    </span>
+          <div className={styles.benefitsGrid}>
+            {benefits.map((benefit, index) => (
+              <FadeIn
+                key={benefit}
+                direction="left"
+                delay={0.1 + index * 0.08}
+                distance={30}
+              >
+                <div className={styles.benefitCard}>
+                  <div className={styles.benefitIcon}>
+                    <Check className="w-4 h-4" />
                   </div>
-                </FadeIn>
-              ))}
-            </div>
-
-            <FadeIn direction="up" delay={0.4} distance={20}>
-              <div className="flex justify-center pt-8">
-                <SprintButton label={t("homeDesignSprintsCta", "Start your sprint")} />
-              </div>
-            </FadeIn>
+                  <span className={styles.benefitLabel}>{benefit}</span>
+                </div>
+              </FadeIn>
+            ))}
           </div>
+
+          <FadeIn direction="up" delay={0.4} distance={20}>
+            <div className={styles.ctaRow}>
+              <SprintButton label={t("homeDesignSprintsCta", "Start your sprint")} />
+            </div>
+          </FadeIn>
         </div>
       </Container>
     </Section>


### PR DESCRIPTION
## Summary
Restores the Design Sprints homepage band to the pre-#629 stacked layout (headline → description → benefit grid → CTA). The Tailwind custom-variant fix accidentally turned on `desktop:grid-cols-2` here without an explicit design review.

## Test plan
- [ ] Homepage `#design-sprints` is stacked, not two columns at desktop
- [ ] CTA pill still works and links to contact with design-sprint param


Made with [Cursor](https://cursor.com)