### PR TITLE
fix: ProcessBlock activity lists full width on mobile

### DIFF
--- a/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.module.css
+++ b/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.module.css
@@ -115,6 +115,8 @@
 /* Custom em dash list markers */
 
 .activityList :global(li) {
+  /* List defaults to 20ch; process activities need full column width when stacked */
+  max-inline-size: 100%;
   padding-inline-start: 1.5em;
   text-indent: -1.5em;
 }


### PR DESCRIPTION
## Summary
- Override `List`’s default `max-inline-size: 20ch` for ProcessBlock activity items so they fill their column when process phases stack on mobile.

## Test plan
- [x] `ProcessBlock` unit tests (30/30)
- [ ] VertaaUX (or any case study) process section at 320px — list items span full column width


Made with [Cursor](https://cursor.com)