### PR TITLE
feat: PSEO pilot playbooks and hero spacing fix

### DIFF
--- a/app/pseo/[slug]/page.tsx
+++ b/app/pseo/[slug]/page.tsx
@@ -8,8 +8,11 @@ import {
   getRelatedPseoLeafPages,
 } from "@/lib/pseo/catalog";
 import { getPseoPageCopy } from "@/lib/pseo/copy";
+import { mergeLeafCopy } from "@/lib/pseo/leaf-blocks";
+import { isPseoLeafIndexable } from "@/lib/pseo/indexing";
 import {
   getBreadcrumbSchema,
+  getFaqSchema,
   getWebPageSchema,
   stringifyJsonLd,
 } from "@/app/lib/structuredData";
@@ -37,6 +40,7 @@ export async function generateMetadata({
   const url = `${siteBase}/pseo/${page.slug}`;
   const title = `${page.title} | Digitaltableteur`;
   const description = page.description;
+  const indexable = isPseoLeafIndexable(slug);
 
   return {
     title,
@@ -57,10 +61,18 @@ export async function generateMetadata({
       description,
     },
     robots: {
-      index: true,
+      index: indexable,
       follow: true,
     },
   };
+}
+
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/\*\*(.*?)\*\*/g, "$1")
+    .replace(/\[(.*?)\]\(.*?\)/g, "$1")
+    .replace(/[#*_`]/g, "")
+    .trim();
 }
 
 export default async function PseoLeafRoute({
@@ -75,9 +87,10 @@ export default async function PseoLeafRoute({
   const copy = getPseoPageCopy(slug);
   const relatedLimit = getPseoCatalog().generation?.relatedLinksPerPage ?? 8;
   const relatedPages = getRelatedPseoLeafPages(page, relatedLimit);
+  const { blocks } = mergeLeafCopy(page, copy);
 
   const url = `${siteBase}/pseo/${page.slug}`;
-  const structuredData = [
+  const structuredData: Record<string, unknown>[] = [
     getWebPageSchema({
       name: page.title,
       description: page.description,
@@ -86,12 +99,15 @@ export default async function PseoLeafRoute({
     }),
     getBreadcrumbSchema([
       { name: "Home", url: siteBase },
-      { name: "PSEO", url: `${siteBase}/pseo` },
+      { name: "Playbooks", url: `${siteBase}/pseo` },
       {
         name: page.service.name,
         url: `${siteBase}/pseo/services/${page.service.slug}`,
       },
-      { name: page.stack.name, url: `${siteBase}/pseo/stacks/${page.stack.slug}` },
+      {
+        name: page.stack.displayName ?? page.stack.name,
+        url: `${siteBase}/pseo/stacks/${page.stack.slug}`,
+      },
       {
         name: page.audience.name,
         url: `${siteBase}/pseo/audiences/${page.audience.slug}`,
@@ -99,6 +115,17 @@ export default async function PseoLeafRoute({
       { name: page.title, url },
     ]),
   ];
+
+  if (blocks.faqs.length > 0) {
+    structuredData.push(
+      getFaqSchema(
+        blocks.faqs.map((faq) => ({
+          question: faq.question,
+          answer: stripMarkdown(faq.answerMarkdown),
+        })),
+      ),
+    );
+  }
 
   return (
     <>

--- a/app/pseo/page.tsx
+++ b/app/pseo/page.tsx
@@ -4,21 +4,21 @@ import { getPseoCatalog, getPseoLeafPages } from "@/lib/pseo/catalog";
 import { PseoIndexPage } from "@dt-pages/Pseo/PseoIndexPage";
 
 export const metadata: Metadata = {
-  title: "Design System Guides | Digitaltableteur",
+  title: "Design System Playbooks | Digitaltableteur",
   description:
-    "Comprehensive library of design system and DesignOps guides. Structured content covering services, technology stacks, and audience-specific implementation strategies.",
+    "Practical design system and DesignOps playbooks by service, stack, and team context. Situation briefs, checklists, and case-study proof.",
   openGraph: {
-    title: "Design System Guides | Digitaltableteur",
+    title: "Design System Playbooks | Digitaltableteur",
     description:
-      "Comprehensive library of design system and DesignOps guides. Structured content covering services, technology stacks, and audience-specific implementation strategies.",
+      "Practical design system and DesignOps playbooks by service, stack, and team context. Situation briefs, checklists, and case-study proof.",
     type: "website",
     siteName: "Digitaltableteur",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Design System Guides | Digitaltableteur",
+    title: "Design System Playbooks | Digitaltableteur",
     description:
-      "Comprehensive library of design system and DesignOps guides. Structured content covering services, technology stacks, and audience-specific implementation strategies.",
+      "Practical design system and DesignOps playbooks by service, stack, and team context. Situation briefs, checklists, and case-study proof.",
   },
   alternates: {
     canonical: "/pseo",

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,7 +2,12 @@ import type { MetadataRoute } from "next";
 
 import { getVisiblePosts } from "./blog/postMetadata";
 import { getAuthors } from "@/nextjs-app/shared/data/authors";
-import { getPseoCatalog, getPseoLeafPages } from "@/lib/pseo/catalog";
+import {
+  getPseoCatalog,
+  getPseoCatalogUpdatedAt,
+  getPseoLeafPages,
+} from "@/lib/pseo/catalog";
+import { getPseoPageCopy } from "@/lib/pseo/copy";
 import type { PseoCatalogItem, PseoLeafPage } from "@/lib/pseo/types";
 import { toAbsoluteSiteUrl } from "./lib/siteUrl";
 
@@ -75,10 +80,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   const pseoCatalog = getPseoCatalog();
   const pseoLeafPages = getPseoLeafPages();
+  const pseoCatalogUpdated = getPseoCatalogUpdatedAt();
 
   const pseoIndexRoutes: MetadataRoute.Sitemap = ["/pseo"].map((path) => ({
     url: toUrl(path),
-    lastModified: today,
+    lastModified: pseoCatalogUpdated,
     changeFrequency: "weekly",
     priority: 0.5,
   }));
@@ -93,18 +99,27 @@ export default function sitemap(): MetadataRoute.Sitemap {
     ),
   ].map((path) => ({
     url: toUrl(path),
-    lastModified: today,
+    lastModified: pseoCatalogUpdated,
     changeFrequency: "monthly",
     priority: 0.5,
   }));
 
   const pseoLeafRoutes: MetadataRoute.Sitemap = pseoLeafPages.map(
-    (page: PseoLeafPage) => ({
-      url: toUrl(`/pseo/${page.slug}`),
-      lastModified: today,
-      changeFrequency: "monthly",
-      priority: 0.5,
-    }),
+    (page: PseoLeafPage) => {
+      const copyUpdated = getPseoPageCopy(page.slug)?.updatedAt;
+      const lastModified = copyUpdated
+        ? new Date(copyUpdated)
+        : pseoCatalogUpdated;
+
+      return {
+        url: toUrl(`/pseo/${page.slug}`),
+        lastModified: Number.isNaN(lastModified.getTime())
+          ? pseoCatalogUpdated
+          : lastModified,
+        changeFrequency: "monthly" as const,
+        priority: 0.5,
+      };
+    },
   );
 
   return [

--- a/content/pseo/canonical/services.json
+++ b/content/pseo/canonical/services.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "services": {
+    "design-system-audit": {
+      "excerpt": "A design system audit inventories what ships in production—not what lives in Figma alone. We sample high-traffic flows, score findings by user impact and fix cost, and produce a roadmap stakeholders can actually follow. The goal is not a 200-slide deck; it is a prioritized list of standards that remove rework without freezing delivery.",
+      "bannedPhrases": ["This guide explains how", "programmatic SEO", "comprehensive overview"]
+    },
+    "design-tokens-setup": {
+      "excerpt": "Tokens fail when design and code use different names for the same decision. We define primitive → semantic → component layers, wire Figma variables to exports your CI can validate, and plan theme rollout so dark mode is designed—not bolted on. Brand updates should touch semantic tokens, not every component file.",
+      "bannedPhrases": ["This guide explains how", "programmatic SEO", "comprehensive overview"]
+    },
+    "component-library-build": {
+      "excerpt": "A component library earns adoption when it matches how squads actually compose UI—not when it wins a Storybook beauty contest. We prioritize by traffic and a11y risk, define composition patterns before variants multiply, and pilot with one squad before declaring victory. Docs must cover keyboard behavior and failure states, not just the happy path.",
+      "bannedPhrases": ["This guide explains how", "programmatic SEO", "comprehensive overview"]
+    },
+    "ai-designops-automation": {
+      "excerpt": "DesignOps automation works when guardrails are explicit: what agents may change, what requires human review, and how drift is caught in CI. We map where time is lost—spec, build, review, release—and automate one workflow end-to-end before scaling. Throughput gains mean nothing if error rate climbs.",
+      "bannedPhrases": ["This guide explains how", "programmatic SEO", "comprehensive overview"]
+    }
+  }
+}

--- a/content/pseo/catalog.json
+++ b/content/pseo/catalog.json
@@ -1,84 +1,256 @@
 {
-  "version": 1,
+  "version": 2,
+  "catalogUpdatedAt": "2026-05-28T00:00:00.000Z",
   "services": [
     {
       "slug": "design-system-audit",
       "name": "Design system audit",
-      "shortDescription": "Assess your current UI foundation, identify gaps, and create a prioritized roadmap."
+      "shortDescription": "Assess your current UI foundation, identify gaps, and create a prioritized roadmap.",
+      "painPoints": [
+        "Components look similar but behave differently across squads",
+        "Accessibility issues repeat because patterns are undocumented",
+        "Design and engineering disagree on what is 'in the system'",
+        "Token renames break multiple apps because naming is inconsistent"
+      ],
+      "deliverables": [
+        "Inventory of components, tokens, and patterns in use",
+        "Severity-ranked findings with effort estimates",
+        "90-day roadmap with quick wins vs structural fixes",
+        "Governance recommendations (RFC, review, release cadence)"
+      ],
+      "typicalTimeline": "1–2 weeks",
+      "pricingPackageSlug": "ux-sprint",
+      "packageFitReason": "UX Sprint covers a focused audit, eval plan, and handoff your team can ship within two weeks.",
+      "relatedWorkSlugs": ["helsinki-design-system", "dsharp-design-system", "project-spine"],
+      "proofReasons": {
+        "helsinki-design-system": "City-scale design system audit and adoption across multiple product teams.",
+        "dsharp-design-system": "Enterprise audit baseline before AI-assisted component governance.",
+        "project-spine": "Structured assessment of component contracts and documentation gaps."
+      },
+      "playbookSteps": [
+        "Map live UI surfaces and who owns each pattern family.",
+        "Sample high-traffic flows for consistency, a11y, and token usage.",
+        "Score findings by user impact, rework cost, and fix complexity.",
+        "Agree on minimal standards and an adoption sequence stakeholders will follow."
+      ]
     },
     {
       "slug": "design-tokens-setup",
       "name": "Design tokens setup",
-      "shortDescription": "Define tokens, align design + code, and ship a scalable theming foundation."
+      "shortDescription": "Define tokens, align design + code, and ship a scalable theming foundation.",
+      "painPoints": [
+        "Figma variables and CSS custom properties use different names",
+        "Dark mode is bolted on instead of designed as a theme",
+        "Brand updates require manual find-and-replace across repos",
+        "Spacing and typography drift because primitives are undefined"
+      ],
+      "deliverables": [
+        "Token taxonomy (primitive → semantic → component)",
+        "Figma variables and code export pipeline",
+        "Theme switching strategy (light/dark/high-contrast)",
+        "Migration guide for existing hardcoded values"
+      ],
+      "typicalTimeline": "2–3 weeks",
+      "pricingPackageSlug": "design-system-lift-off",
+      "packageFitReason": "Design System Lift-Off includes token architecture, core components, and Storybook setup.",
+      "relatedWorkSlugs": ["helsinki-design-system", "project-spine"],
+      "proofReasons": {
+        "helsinki-design-system": "Production token pipeline for a multi-team municipal design system.",
+        "project-spine": "Token contracts shared between design tools and React components."
+      },
+      "playbookSteps": [
+        "Audit existing color, type, and spacing decisions in design and code.",
+        "Define semantic tokens that survive brand refreshes.",
+        "Wire Figma variables to code exports your CI can validate.",
+        "Roll out themes incrementally with a deprecation plan for legacy values."
+      ]
     },
     {
       "slug": "component-library-build",
       "name": "Component library build",
-      "shortDescription": "Build production-ready components with accessibility, documentation, and governance."
+      "shortDescription": "Build production-ready components with accessibility, documentation, and governance.",
+      "painPoints": [
+        "Every squad ships slightly different buttons, forms, and modals",
+        "Storybook exists but stories do not match production usage",
+        "Props APIs grow organically and become hard to learn",
+        "Visual regressions slip through because testing is manual"
+      ],
+      "deliverables": [
+        "Core component set with typed props and a11y baselines",
+        "Storybook docs with usage dos/don'ts",
+        "Visual regression or interaction test hooks",
+        "Contribution guide and review checklist"
+      ],
+      "typicalTimeline": "3–4 weeks",
+      "pricingPackageSlug": "design-system-lift-off",
+      "packageFitReason": "Lift-Off is scoped for audit through core components, Storybook, and adoption playbook.",
+      "relatedWorkSlugs": ["helsinki-design-system", "sap-build-apps", "dsharp-design-system"],
+      "proofReasons": {
+        "helsinki-design-system": "Large-scale React component library with municipal accessibility requirements.",
+        "sap-build-apps": "Enterprise component patterns for low-code and pro-code surfaces.",
+        "dsharp-design-system": "AI-guardrailed component architecture with enforcement tooling."
+      },
+      "playbookSteps": [
+        "Prioritize components by traffic, rework cost, and a11y risk.",
+        "Define composition patterns before building one-off variants.",
+        "Document states, edge cases, and keyboard behavior in Storybook.",
+        "Pilot with one product squad, then expand with measured adoption metrics."
+      ]
     },
     {
       "slug": "ai-designops-automation",
       "name": "AI-powered DesignOps automation",
-      "shortDescription": "Automate workflows, reduce design debt, and scale consistent execution."
+      "shortDescription": "Automate workflows, reduce design debt, and scale consistent execution.",
+      "painPoints": [
+        "Design review bottlenecks when headcount does not scale with output",
+        "Handoffs still rely on screenshots and Slack threads",
+        "No single source of truth for what agents or tools may change",
+        "Design debt accumulates faster than manual QA can catch"
+      ],
+      "deliverables": [
+        "DesignOps workflow map with automation candidates",
+        "Agent/tool guardrails for design-system changes",
+        "Linting or CI checks for token and component drift",
+        "Playbook for human-in-the-loop review"
+      ],
+      "typicalTimeline": "2–3 weeks",
+      "pricingPackageSlug": "ai-ready-designops",
+      "packageFitReason": "AI-Ready DesignOps packages workflow setup, governance, and tooling hooks in three weeks.",
+      "relatedWorkSlugs": ["dsharp-design-system", "llm-component-schema"],
+      "proofReasons": {
+        "dsharp-design-system": "MCP, CLI, and Rhythmguard enforcement for AI-assisted design systems.",
+        "llm-component-schema": "Structured schemas so LLMs generate components that pass review."
+      },
+      "playbookSteps": [
+        "Map where time is lost: spec, build, review, or release.",
+        "Identify safe automation targets vs decisions that need human judgment.",
+        "Prototype one workflow end-to-end (e.g. token PR or component scaffold).",
+        "Measure throughput and error rate before expanding automation scope."
+      ]
     }
   ],
   "stacks": [
     {
       "slug": "react",
       "name": "React",
-      "shortDescription": "Modern component architecture with typed props and predictable composition."
+      "displayName": "React",
+      "shortDescription": "Modern component architecture with typed props and predictable composition.",
+      "implementationNotes": [
+        "Prefer composition over prop explosion; use compound components for complex UI.",
+        "Colocate styles with CSS Modules or tokens; avoid inline one-offs.",
+        "Test keyboard and screen-reader behavior—not just visual snapshots."
+      ],
+      "commonPitfalls": [
+        "Copy-pasting MUI/Chakra patterns without aligning to your token layer",
+        "Uncontrolled vs controlled input bugs in shared form components",
+        "Context providers nested so deeply that tree-shaking and testing suffer"
+      ]
     },
     {
       "slug": "nextjs",
       "name": "Next.js",
-      "shortDescription": "App Router-ready UI systems with performance and SEO built in."
+      "displayName": "Next.js",
+      "shortDescription": "App Router-ready UI systems with performance and SEO built in.",
+      "implementationNotes": [
+        "Separate server and client component boundaries in your design system docs.",
+        "Use dynamic imports for heavy client-only widgets in marketing surfaces.",
+        "Align metadata and OG patterns with shared layout primitives."
+      ],
+      "commonPitfalls": [
+        "Marking entire design-system shells as client components unnecessarily",
+        "Hydration mismatches from theme or locale stored only in localStorage",
+        "Duplicated layout code between marketing and app routes"
+      ]
     },
     {
       "slug": "storybook",
       "name": "Storybook",
-      "shortDescription": "Component-driven development, documentation, and visual regression workflows."
+      "displayName": "Storybook",
+      "shortDescription": "Component-driven development, documentation, and visual regression workflows.",
+      "implementationNotes": [
+        "Stories should reflect real product compositions—not isolated atoms only.",
+        "Document controls for every meaningful prop; hide internal ones.",
+        "Wire visual regression on PRs for components above a traffic threshold."
+      ],
+      "commonPitfalls": [
+        "Stories that pass while production usage breaks because args are unrealistic",
+        "Missing dark-mode or RTL variants in the story matrix",
+        "Docs pages that drift from the actual exported API"
+      ]
     },
     {
       "slug": "figma",
       "name": "Figma",
-      "shortDescription": "Design-to-code alignment, tokens, and component specs that engineers can ship."
+      "displayName": "Figma",
+      "shortDescription": "Design-to-code alignment, tokens, and component specs that engineers can ship.",
+      "implementationNotes": [
+        "Mirror code component names and variant props in Figma component properties.",
+        "Use variables for semantic tokens; avoid hardcoded hex in component sets.",
+        "Publish a changelog when library updates affect downstream files."
+      ],
+      "commonPitfalls": [
+        "Detached instances proliferate because the library is hard to find",
+        "Auto-layout specs that do not map to flex/grid in code",
+        "Designers and engineers maintaining parallel token spreadsheets"
+      ]
     },
     {
       "slug": "typescript",
       "name": "TypeScript",
-      "shortDescription": "Type-safe design systems and predictable component APIs."
+      "displayName": "TypeScript",
+      "shortDescription": "Type-safe design systems and predictable component APIs.",
+      "implementationNotes": [
+        "Export discriminated unions for variant props instead of loose strings.",
+        "Generate docs from types where possible (Storybook docgen, TSDoc).",
+        "Strict mode for the library package even if app code is gradual."
+      ],
+      "commonPitfalls": [
+        "Over-wide props types that accept any string and hide invalid combinations",
+        "Breaking changes shipped without codemods or deprecation warnings",
+        "Duplicate type definitions between design tokens and component props"
+      ]
     }
   ],
   "audiences": [
     {
       "slug": "startups",
       "name": "startup teams",
-      "shortDescription": "Move fast without creating UI debt that blocks your roadmap."
+      "shortDescription": "Move fast without creating UI debt that blocks your roadmap.",
+      "constraints": ["1–2 designers", "small eng team", "need shippable UI in weeks not quarters"],
+      "successMetric": "Consistent MVP UI in 2–4 weeks without a rewrite at Series A"
     },
     {
       "slug": "scaleups",
       "name": "scaleup teams",
-      "shortDescription": "Standardize UI and workflows across multiple squads and surfaces."
+      "shortDescription": "Standardize UI and workflows across multiple squads and surfaces.",
+      "constraints": ["3+ product squads", "legacy and greenfield code coexist", "release trains already exist"],
+      "successMetric": "One shared component source with measurable adoption across squads"
     },
     {
       "slug": "enterprises",
       "name": "enterprise teams",
-      "shortDescription": "Governance, accessibility, and multi-team alignment for long-term scale."
+      "shortDescription": "Governance, accessibility, and multi-team alignment for long-term scale.",
+      "constraints": ["procurement and a11y compliance", "multiple vendors", "long approval cycles"],
+      "successMetric": "Documented governance model with WCAG-aligned baselines and audit trail"
     },
     {
       "slug": "designops",
       "name": "DesignOps teams",
-      "shortDescription": "Tooling, process, and automation to improve throughput and consistency."
+      "shortDescription": "Tooling, process, and automation to improve throughput and consistency.",
+      "constraints": ["serve many designers", "tooling budget scrutiny", "must prove ROI"],
+      "successMetric": "Reduced review cycle time and fewer design-to-dev regressions"
     },
     {
       "slug": "product-teams",
       "name": "product teams",
-      "shortDescription": "Faster shipping with better UX and fewer regressions."
+      "shortDescription": "Faster shipping with better UX and fewer regressions.",
+      "constraints": ["designers embedded in squads", "OKR pressure", "mixed skill levels"],
+      "successMetric": "Faster feature delivery with fewer UI bugs in QA"
     }
   ],
   "generation": {
     "maxLeafPages": 120,
-    "relatedLinksPerPage": 8
+    "relatedLinksPerPage": 8,
+    "indexedLeafSlugs": []
   }
 }
-

--- a/content/pseo/copy.json
+++ b/content/pseo/copy.json
@@ -1,5 +1,833 @@
 {
   "version": 1,
-  "pages": {}
+  "pages": {
+    "design-system-audit-react-startups": {
+      "introMarkdown": "Startup teams using React often face unique challenges in maintaining a cohesive UI. An audit of your design system can reveal inconsistencies, accessibility issues, and misalignments between design and engineering. By identifying these gaps, we help you create a prioritized roadmap that enables rapid shipping without accruing UI debt. This audit focuses on your production environment, ensuring that what you deliver meets user needs effectively.",
+      "sections": [
+        {
+          "id": "playbook",
+          "title": "Audit Playbook Steps",
+          "bodyMarkdown": "1. **Inventory Existing Components**: Review all components currently in production. Use tools like Storybook to visualize and document each component's behavior and usage.\n\n2. **Evaluate Component Consistency**: Compare similar components across squads. Identify discrepancies in behavior, styling, and accessibility. Document these findings to highlight areas needing standardization.\n\n3. **Assess Accessibility Compliance**: Conduct accessibility testing using tools like Axe or Lighthouse. Focus on keyboard navigation and screen-reader compatibility. Document issues and prioritize fixes based on user impact.\n\n4. **Engage Stakeholders**: Facilitate workshops with design and engineering teams to align on what constitutes 'in the system.' Use this opportunity to clarify component usage and naming conventions.\n\n5. **Create a Prioritized Roadmap**: Based on the findings, develop a roadmap that prioritizes fixes and enhancements. Ensure that the roadmap is actionable and aligns with your team's shipping timelines."
+        },
+        {
+          "id": "situation",
+          "title": "Current Landscape",
+          "bodyMarkdown": "Many startup teams struggle with UI consistency due to rapid development cycles. Components may appear similar but behave differently, leading to confusion and inefficiencies. Accessibility issues often recur because patterns are undocumented, and disagreements between design and engineering can stall progress. Token renames can disrupt multiple applications, causing further delays. An audit helps clarify these issues and sets a clear path forward."
+        },
+        {
+          "id": "failure-modes",
+          "title": "Common Pitfalls",
+          "bodyMarkdown": "1. **Inconsistent Component Behavior**: Teams may unknowingly use similar components that function differently, leading to user confusion.\n\n2. **Neglected Accessibility**: Without proper documentation, accessibility issues can go unnoticed, impacting user experience for those relying on assistive technologies.\n\n3. **Misalignment Between Teams**: Disagreements on what components are 'in the system' can lead to wasted effort and duplicated work, hindering delivery timelines."
+        }
+      ],
+      "faqs": [
+        {
+          "question": "How does a design system audit benefit startup teams using React?",
+          "answerMarkdown": "A design system audit identifies inconsistencies and accessibility issues in your UI, enabling you to streamline development. By creating a prioritized roadmap, you can focus on high-impact changes that facilitate faster shipping without accumulating UI debt."
+        },
+        {
+          "question": "What specific challenges do startup teams face with their design systems?",
+          "answerMarkdown": "Startup teams often deal with rapid iterations, leading to inconsistent component behavior and undocumented patterns. This can result in accessibility issues and misalignment between design and engineering, making a design system audit essential for maintaining quality."
+        },
+        {
+          "question": "What tools are recommended for conducting a design system audit in React?",
+          "answerMarkdown": "Utilize tools like Storybook for component visualization, Axe for accessibility testing, and collaborative platforms for stakeholder engagement. These tools help ensure a thorough and effective audit process."
+        }
+      ],
+      "related": [
+        {
+          "slug": "design-system-audit-react-designops",
+          "reasonMarkdown": "Read this if you're looking to integrate design operations into your React workflow."
+        },
+        {
+          "slug": "design-system-audit-react-enterprises",
+          "reasonMarkdown": "Read this if you're scaling your design system for enterprise-level applications."
+        },
+        {
+          "slug": "design-system-audit-react-product-teams",
+          "reasonMarkdown": "Read this if you're focused on enhancing product delivery through design system improvements."
+        },
+        {
+          "slug": "design-system-audit-react-scaleups",
+          "reasonMarkdown": "Read this if you're in a scale-up phase and need to refine your design system for growth."
+        },
+        {
+          "slug": "design-system-audit-figma-startups",
+          "reasonMarkdown": "Read this if you're using Figma and want to ensure alignment with your React components."
+        },
+        {
+          "slug": "design-system-audit-nextjs-startups",
+          "reasonMarkdown": "Read this if you're leveraging Next.js and need a cohesive design system."
+        },
+        {
+          "slug": "design-system-audit-storybook-startups",
+          "reasonMarkdown": "Read this if you're using Storybook and want to enhance your design system documentation."
+        },
+        {
+          "slug": "design-system-audit-typescript-startups",
+          "reasonMarkdown": "Read this if you're implementing TypeScript and need to ensure type safety in your design system."
+        }
+      ],
+      "updatedAt": "2026-05-31T23:58:15.931Z"
+    },
+    "design-system-audit-nextjs-startups": {
+      "introMarkdown": "Startup teams leveraging Next.js face unique challenges in maintaining a cohesive UI. A design system audit identifies inconsistencies and gaps in your current UI foundation, ensuring that your team can ship high-quality products rapidly. By focusing on actionable insights, this audit helps prioritize improvements that align with your fast-paced development cycles.",
+      "sections": [
+        {
+          "id": "playbook",
+          "title": "Design System Audit Playbook",
+          "bodyMarkdown": "1. **Inventory Existing Components**: Begin by cataloging all UI components currently in use across your applications. Use tools like Storybook to visualize and document these components.  \n2. **Evaluate Component Behavior**: Assess how components behave in different contexts. Identify discrepancies in functionality and appearance across squads.  \n3. **Accessibility Review**: Conduct an accessibility audit to pinpoint issues that may hinder user experience. Utilize tools like Axe or Lighthouse to automate parts of this process.  \n4. **Stakeholder Interviews**: Engage with design and engineering teams to clarify what is considered 'in the system.' Document differing perspectives to align on a unified definition.  \n5. **Token Consistency Check**: Review design tokens for naming conventions. Ensure that any renames are documented and communicated to avoid breaking changes across applications.  \n6. **Roadmap Creation**: Synthesize findings into a prioritized roadmap. Focus on high-impact, low-effort fixes that can be implemented quickly to reduce UI debt and enhance delivery speed."
+        },
+        {
+          "id": "situation",
+          "title": "Current Situation",
+          "bodyMarkdown": "Many startup teams using Next.js struggle with UI consistency. Components may look similar but behave differently, leading to confusion and increased development time. Accessibility issues often recur due to undocumented patterns, and misalignment between design and engineering teams can result in wasted effort. Inconsistent naming of design tokens can also disrupt multiple applications, creating a cycle of rework."
+        },
+        {
+          "id": "failure-modes",
+          "title": "Common Failure Modes",
+          "bodyMarkdown": "1. **Inconsistent Component Usage**: Teams may unknowingly create duplicate components, leading to a fragmented user experience.  \n2. **Accessibility Oversights**: Without proper documentation, accessibility issues can persist, affecting user engagement and compliance.  \n3. **Miscommunication Between Teams**: Differing definitions of what constitutes a 'standard' can lead to friction and inefficiencies in the development process."
+        }
+      ],
+      "faqs": [
+        {
+          "question": "How does a design system audit benefit startup teams using Next.js?",
+          "answerMarkdown": "A design system audit provides a clear inventory of your UI components, identifies inconsistencies, and creates a prioritized roadmap for improvements. This is crucial for startup teams needing to ship quickly without accruing UI debt."
+        },
+        {
+          "question": "What specific challenges does this audit address for small engineering teams?",
+          "answerMarkdown": "The audit tackles common pain points such as inconsistent component behavior, accessibility issues, and misalignment between design and engineering. By addressing these, teams can streamline their workflow and enhance product quality."
+        },
+        {
+          "question": "Can this audit help with performance and SEO in Next.js applications?",
+          "answerMarkdown": "Yes, the audit includes recommendations for optimizing component performance and aligning metadata with shared layout primitives, ensuring your applications are both fast and SEO-friendly."
+        }
+      ],
+      "related": [
+        {
+          "slug": "design-system-audit-nextjs-designops",
+          "reasonMarkdown": "Read this if you want to integrate design operations into your Next.js workflow."
+        },
+        {
+          "slug": "design-system-audit-nextjs-enterprises",
+          "reasonMarkdown": "Read this if you're scaling your design system for enterprise-level applications."
+        },
+        {
+          "slug": "design-system-audit-nextjs-product-teams",
+          "reasonMarkdown": "Read this if you're focused on product development and need a robust design foundation."
+        },
+        {
+          "slug": "design-system-audit-nextjs-scaleups",
+          "reasonMarkdown": "Read this if you're in a scale-up phase and need to optimize your design processes."
+        },
+        {
+          "slug": "design-system-audit-figma-startups",
+          "reasonMarkdown": "Read this if you're using Figma and want to ensure your designs translate effectively into code."
+        },
+        {
+          "slug": "design-system-audit-react-startups",
+          "reasonMarkdown": "Read this if you're also working with React and need insights applicable across frameworks."
+        },
+        {
+          "slug": "design-system-audit-storybook-startups",
+          "reasonMarkdown": "Read this if you're utilizing Storybook for component documentation and need to enhance your system."
+        },
+        {
+          "slug": "design-system-audit-typescript-startups",
+          "reasonMarkdown": "Read this if you're implementing TypeScript and want to ensure type safety in your design system."
+        }
+      ],
+      "updatedAt": "2026-05-31T23:58:27.891Z"
+    },
+    "design-system-audit-figma-scaleups": {
+      "introMarkdown": "Scaleup teams using Figma face unique challenges in maintaining a cohesive design system. As multiple squads work concurrently, inconsistencies in UI components and accessibility issues can hinder progress. A design system audit focuses on assessing your current UI foundation, identifying gaps, and creating a prioritized roadmap tailored to your specific needs. This audit not only aligns design and engineering but also ensures that your design system evolves alongside your product.",
+      "sections": [
+        {
+          "id": "playbook",
+          "title": "Audit Playbook Steps",
+          "bodyMarkdown": "1. **Inventory Current Components**: Review all existing components in Figma and compare them against the production UI. Identify discrepancies in appearance and behavior across squads.\n\n2. **User Impact Assessment**: Sample high-traffic user flows to evaluate the impact of inconsistencies. Score findings based on user experience and potential fix costs.\n\n3. **Accessibility Review**: Conduct an accessibility audit on the sampled flows. Document recurring issues and ensure patterns are well-defined and accessible.\n\n4. **Stakeholder Alignment**: Facilitate workshops with design and engineering teams to clarify what constitutes 'in the system'. Establish a shared understanding of component behavior and naming conventions.\n\n5. **Token Standardization**: Implement semantic tokens in Figma, avoiding hardcoded hex values. Ensure that component properties mirror code component names and variant props for seamless design-to-code alignment.\n\n6. **Changelog Implementation**: Develop a changelog for library updates that affect downstream files. This ensures all squads are informed of changes that may impact their work.\n\n7. **Prioritized Roadmap Creation**: Synthesize findings into a prioritized list of standards and actionable items. This roadmap should focus on removing rework while maintaining delivery timelines."
+        },
+        {
+          "id": "situation",
+          "title": "Current Landscape",
+          "bodyMarkdown": "Scaleup teams often operate with a mix of legacy and greenfield codebases, leading to inconsistencies in UI components. With 3+ product squads, the challenge is compounded by differing interpretations of design patterns and accessibility standards. Components may visually resemble one another but behave differently, resulting in user confusion and inefficiencies. Moreover, undocumented patterns lead to repeated accessibility issues, while inconsistent token naming can disrupt multiple applications. A design system audit is essential to address these pain points and create a unified approach."
+        },
+        {
+          "id": "failure-modes",
+          "title": "Common Pitfalls",
+          "bodyMarkdown": "1. **Inconsistent Component Behavior**: Without a clear definition of components, squads may implement variations that lead to user confusion.\n\n2. **Accessibility Oversights**: Repeated issues arise when patterns are undocumented, causing teams to overlook critical accessibility standards.\n\n3. **Misalignment Between Design and Engineering**: Disagreements on what is 'in the system' can lead to wasted effort and frustration.\n\n4. **Token Naming Confusion**: Renaming tokens without a consistent strategy can break multiple applications, complicating the development process."
+        }
+      ],
+      "faqs": [
+        {
+          "question": "How does a design system audit benefit scaleup teams using Figma?",
+          "answerMarkdown": "A design system audit helps scaleup teams identify inconsistencies in their UI components and accessibility issues. By creating a prioritized roadmap, teams can align design and engineering efforts, ensuring a more cohesive user experience across multiple squads."
+        },
+        {
+          "question": "What specific challenges does this audit address for teams with legacy and greenfield code?",
+          "answerMarkdown": "The audit addresses challenges such as inconsistent component behavior, repeated accessibility issues, and misalignment between design and engineering. By documenting patterns and establishing clear standards, teams can mitigate these issues effectively."
+        },
+        {
+          "question": "How does the Figma stack enhance the design system audit process?",
+          "answerMarkdown": "Using Figma allows for seamless design-to-code alignment. By implementing semantic tokens and ensuring component properties mirror code, teams can streamline the development process and reduce discrepancies between design and production."
+        }
+      ],
+      "related": [
+        {
+          "slug": "design-system-audit-figma-designops",
+          "reasonMarkdown": "Read this if you want to integrate design operations into your audit process."
+        },
+        {
+          "slug": "design-system-audit-figma-enterprises",
+          "reasonMarkdown": "Read this if you're scaling design systems in larger organizational contexts."
+        },
+        {
+          "slug": "design-system-audit-figma-product-teams",
+          "reasonMarkdown": "Read this if you're focused on enhancing product team collaboration."
+        },
+        {
+          "slug": "design-system-audit-figma-startups",
+          "reasonMarkdown": "Read this if you're a startup looking to establish a robust design foundation."
+        },
+        {
+          "slug": "design-system-audit-nextjs-scaleups",
+          "reasonMarkdown": "Read this if you're implementing Next.js and need a compatible design system."
+        },
+        {
+          "slug": "design-system-audit-react-scaleups",
+          "reasonMarkdown": "Read this if you're using React and want to ensure component consistency."
+        },
+        {
+          "slug": "design-system-audit-storybook-scaleups",
+          "reasonMarkdown": "Read this if you're leveraging Storybook for component documentation."
+        },
+        {
+          "slug": "design-system-audit-typescript-scaleups",
+          "reasonMarkdown": "Read this if you're developing with TypeScript and need to align your design system."
+        }
+      ],
+      "updatedAt": "2026-05-31T23:58:41.423Z"
+    },
+    "design-system-audit-typescript-enterprises": {
+      "introMarkdown": "Enterprise teams leveraging TypeScript face unique challenges in maintaining a cohesive design system. An audit reveals the discrepancies between design intentions and engineering implementations, ensuring alignment across squads. By identifying gaps and prioritizing actionable steps, teams can enhance governance, accessibility, and collaboration, ultimately leading to a more robust UI foundation.",
+      "sections": [
+        {
+          "id": "playbook",
+          "title": "Audit Playbook Steps",
+          "bodyMarkdown": "1. **Inventory Existing Components**: Catalog all UI components currently in use across applications. Utilize TypeScript's type-safe features to ensure accurate documentation of component properties and behaviors.\n\n2. **Evaluate Component Consistency**: Assess the visual and functional consistency of components. Identify discrepancies in behavior across squads, focusing on those that appear similar but function differently.\n\n3. **Accessibility Review**: Conduct an accessibility audit using automated tools and manual testing. Document recurring issues and prioritize fixes based on user impact.\n\n4. **Stakeholder Interviews**: Engage with design and engineering teams to clarify what constitutes 'in the system.' Gather insights on pain points and discrepancies in understanding.\n\n5. **Roadmap Development**: Create a prioritized roadmap that addresses identified gaps. Focus on standardizing component behavior, improving documentation, and establishing naming conventions for design tokens.\n\n6. **Implementation Strategy**: Recommend exporting discriminated unions for variant props to enhance type safety. Encourage generating documentation directly from TypeScript types using tools like Storybook docgen and TSDoc. Enforce strict mode for the library package to ensure consistency, even if app code transitions gradually."
+        },
+        {
+          "id": "situation",
+          "title": "Current Landscape",
+          "bodyMarkdown": "Enterprise teams often operate with multiple vendors and face long approval cycles, complicating design system governance. Components may look similar but behave inconsistently, leading to user confusion and increased rework. Accessibility issues frequently arise due to undocumented patterns, and disagreements between design and engineering teams hinder progress. A thorough audit is essential to align these teams and establish a unified approach."
+        },
+        {
+          "id": "failure-modes",
+          "title": "Common Pitfalls",
+          "bodyMarkdown": "1. **Inconsistent Component Behavior**: Teams may unknowingly use similar components that function differently, leading to user frustration.\n\n2. **Undocumented Patterns**: Repeated accessibility issues often stem from a lack of documentation, resulting in non-compliance and poor user experiences.\n\n3. **Token Renaming Confusion**: Inconsistent naming conventions for design tokens can break multiple applications, complicating updates and maintenance."
+        }
+      ],
+      "faqs": [
+        {
+          "question": "How does a design system audit benefit enterprise teams using TypeScript?",
+          "answerMarkdown": "A design system audit provides enterprise teams with a clear understanding of their current UI foundation, identifying gaps and inconsistencies. By leveraging TypeScript's type safety, teams can create a more predictable and maintainable component library, ultimately improving collaboration and reducing rework."
+        },
+        {
+          "question": "What specific challenges do enterprise teams face when implementing a design system with TypeScript?",
+          "answerMarkdown": "Enterprise teams often deal with multiple vendors, long approval cycles, and varying interpretations of design standards. These challenges can lead to inconsistent component behavior and accessibility issues, making a thorough audit essential for establishing a cohesive design system."
+        },
+        {
+          "question": "How can TypeScript enhance the effectiveness of a design system audit?",
+          "answerMarkdown": "TypeScript's type-safe features allow for better documentation and understanding of component APIs. By exporting discriminated unions and generating documentation from types, teams can ensure consistency and clarity, which are crucial for successful implementation and governance."
+        }
+      ],
+      "related": [
+        {
+          "slug": "design-system-audit-typescript-designops",
+          "reasonMarkdown": "Read this if you're focused on operationalizing design systems within TypeScript environments."
+        },
+        {
+          "slug": "design-system-audit-typescript-product-teams",
+          "reasonMarkdown": "Read this if you're part of a product team looking to streamline UI consistency and accessibility."
+        },
+        {
+          "slug": "design-system-audit-typescript-scaleups",
+          "reasonMarkdown": "Read this if you're scaling your design system and need to address growing complexity."
+        },
+        {
+          "slug": "design-system-audit-typescript-startups",
+          "reasonMarkdown": "Read this if you're a startup aiming to establish a strong design foundation from the outset."
+        },
+        {
+          "slug": "design-system-audit-figma-enterprises",
+          "reasonMarkdown": "Read this if you're integrating Figma designs into your TypeScript-based design system."
+        },
+        {
+          "slug": "design-system-audit-nextjs-enterprises",
+          "reasonMarkdown": "Read this if you're using Next.js and need to align your design system with server-side rendering."
+        },
+        {
+          "slug": "design-system-audit-react-enterprises",
+          "reasonMarkdown": "Read this if you're implementing a design system in a React environment with TypeScript."
+        },
+        {
+          "slug": "design-system-audit-storybook-enterprises",
+          "reasonMarkdown": "Read this if you're utilizing Storybook for documenting your TypeScript components."
+        }
+      ],
+      "updatedAt": "2026-05-31T23:58:54.568Z"
+    },
+    "design-tokens-setup-react-startups": {
+      "introMarkdown": "For startup teams leveraging React, establishing a robust design token setup is crucial for maintaining design consistency and accelerating development. By defining tokens that bridge design and code, teams can create a scalable theming foundation that adapts to brand changes without extensive refactoring. This approach minimizes UI debt, enabling rapid delivery of shippable UI components while ensuring alignment between design and engineering.",
+      "sections": [
+        {
+          "id": "playbook",
+          "title": "Playbook Steps",
+          "bodyMarkdown": "1. **Define Design Tokens**: Start by identifying your design primitives—colors, typography, spacing, and elevation. Use a consistent naming convention that aligns with Figma variables to avoid discrepancies.  \n2. **Map Tokens to Components**: Create a mapping of your design tokens to React components. Utilize CSS Modules or styled-components to colocate styles, ensuring that each component pulls from the defined tokens.  \n3. **Implement Theming**: Design your theme structure to support dark mode from the outset. Use semantic tokens to manage theme variations, allowing for easy updates without altering component files.  \n4. **Integrate with CI/CD**: Wire your Figma variables to your CI pipeline, enabling automated validation of design decisions against code. This ensures that any changes in design are reflected in the codebase without manual intervention.  \n5. **Test Accessibility**: Conduct thorough testing for keyboard navigation and screen-reader compatibility. This step is crucial for ensuring that your UI is usable for all users, not just visually compliant.  \n6. **Iterate and Refine**: As your product evolves, continuously revisit your tokens and component mappings. Gather feedback from designers and developers to refine the system, ensuring it remains aligned with your brand and user needs."
+        },
+        {
+          "id": "situation",
+          "title": "Situation",
+          "bodyMarkdown": "Startup teams often face the challenge of rapid development cycles while maintaining design integrity. With limited resources, the need for a cohesive design system becomes paramount. Misalignment between design tools like Figma and code can lead to inconsistencies, making it difficult to implement brand updates or new features efficiently."
+        },
+        {
+          "id": "failure-modes",
+          "title": "Failure Modes",
+          "bodyMarkdown": "1. **Inconsistent Naming**: When design tokens and code use different names, it leads to confusion and implementation errors.  \n2. **Bolted-on Dark Mode**: Treating dark mode as an afterthought results in a disjointed user experience.  \n3. **Manual Updates**: Relying on manual find-and-replace for brand updates can introduce errors and slow down the development process.  \n4. **Undefined Primitives**: Without clear definitions for spacing and typography, visual elements may drift, leading to a fragmented UI."
+        }
+      ],
+      "faqs": [
+        {
+          "question": "How do design tokens benefit startup teams using React?",
+          "answerMarkdown": "Design tokens provide a unified language between design and development, allowing startup teams to implement consistent UI elements quickly. This alignment reduces the risk of UI debt and accelerates the delivery of shippable components."
+        },
+        {
+          "question": "What challenges do startup teams face when implementing design tokens?",
+          "answerMarkdown": "Common challenges include discrepancies between design tools and code, the complexity of managing themes like dark mode, and the need for manual updates across multiple repositories. A well-defined token strategy addresses these issues."
+        },
+        {
+          "question": "Can design tokens help with accessibility in React applications?",
+          "answerMarkdown": "Yes, by establishing a consistent design language and ensuring that components are built with accessibility in mind, design tokens can enhance the usability of React applications for all users, including those relying on assistive technologies."
+        }
+      ],
+      "related": [
+        {
+          "slug": "design-tokens-setup-react-designops",
+          "reasonMarkdown": "Read this if you're looking to streamline design operations alongside your token setup."
+        },
+        {
+          "slug": "design-tokens-setup-react-enterprises",
+          "reasonMarkdown": "Read this if you're scaling design tokens for larger enterprise applications."
+        },
+        {
+          "slug": "design-tokens-setup-react-product-teams",
+          "reasonMarkdown": "Read this if you're part of a product team needing rapid iteration with design tokens."
+        },
+        {
+          "slug": "design-tokens-setup-react-scaleups",
+          "reasonMarkdown": "Read this if you're transitioning from startup to scaleup and need to refine your design system."
+        },
+        {
+          "slug": "design-tokens-setup-figma-startups",
+          "reasonMarkdown": "Read this if you're using Figma and want to align your design tokens with your React components."
+        },
+        {
+          "slug": "design-tokens-setup-nextjs-startups",
+          "reasonMarkdown": "Read this if you're implementing design tokens in a Next.js environment."
+        },
+        {
+          "slug": "design-tokens-setup-storybook-startups",
+          "reasonMarkdown": "Read this if you're documenting your components with Storybook while using design tokens."
+        },
+        {
+          "slug": "design-tokens-setup-typescript-startups",
+          "reasonMarkdown": "Read this if you're working with TypeScript and want to ensure type safety in your design tokens."
+        }
+      ],
+      "updatedAt": "2026-05-31T23:59:09.216Z"
+    },
+    "component-library-build-storybook-enterprises": {
+      "introMarkdown": "Building a component library for enterprise teams using Storybook requires a strategic approach that prioritizes accessibility, governance, and alignment across multiple squads. The goal is to create production-ready components that not only meet design standards but also reflect real-world usage. By focusing on how teams actually compose UI, we can ensure that the library is adopted and utilized effectively, reducing discrepancies in component implementation across the organization.",
+      "sections": [
+        {
+          "id": "playbook",
+          "title": "Component Library Playbook",
+          "bodyMarkdown": "1. **Define Composition Patterns**: Start by analyzing existing UI components across squads. Identify common patterns and establish a baseline for how components should be composed. This reduces variance and ensures consistency.\n\n2. **Create Realistic Stories**: In Storybook, develop stories that reflect actual product compositions rather than isolated components. This involves integrating multiple components to showcase their interactions and behaviors in a real-world context.\n\n3. **Document Meaningful Props**: Ensure that all meaningful props are documented clearly in Storybook. Internal props should be hidden to avoid confusion. This documentation should include usage examples and edge cases to facilitate understanding.\n\n4. **Implement Visual Regression Testing**: Set up visual regression tests for components that exceed a defined traffic threshold. This ensures that any visual changes are caught early in the development process, reducing the risk of regressions slipping through.\n\n5. **Pilot with One Squad**: Before rolling out the component library organization-wide, pilot the implementation with a single squad. Gather feedback and make necessary adjustments to improve usability and adoption.\n\n6. **Focus on Accessibility**: Ensure that all components meet accessibility standards. Document keyboard behaviors and failure states, not just the happy path, to provide a comprehensive understanding of component functionality."
+        },
+        {
+          "id": "situation",
+          "title": "Current Situation",
+          "bodyMarkdown": "Enterprise teams often face challenges with component consistency, especially when multiple squads are involved. Each squad may implement slightly different versions of buttons, forms, and modals, leading to a fragmented user experience. Additionally, while Storybook is available, the stories often do not align with production usage, making it difficult for teams to leverage the library effectively. The organic growth of Props APIs can create a steep learning curve, and manual testing for visual regressions can result in missed issues."
+        },
+        {
+          "id": "failure-modes",
+          "title": "Potential Failure Modes",
+          "bodyMarkdown": "1. **Inconsistent Component Usage**: If squads do not adhere to defined composition patterns, discrepancies will continue to arise, undermining the library's effectiveness.\n\n2. **Poor Documentation**: Inadequate documentation of props and usage can lead to confusion and misuse of components, resulting in a lack of adoption.\n\n3. **Neglected Accessibility**: Failing to prioritize accessibility can alienate users and create compliance issues, particularly in enterprise environments with strict procurement standards."
+        }
+      ],
+      "faqs": [
+        {
+          "question": "How does this service address component consistency across teams?",
+          "answerMarkdown": "By defining composition patterns and creating realistic stories in Storybook, we ensure that all squads are aligned on how components should be implemented, reducing discrepancies and fostering a unified user experience."
+        },
+        {
+          "question": "What measures are taken to ensure accessibility compliance?",
+          "answerMarkdown": "Accessibility is prioritized by documenting keyboard behaviors and failure states for each component. This ensures that all components meet necessary standards and are usable by all individuals, aligning with enterprise procurement requirements."
+        },
+        {
+          "question": "How does visual regression testing fit into the component library build?",
+          "answerMarkdown": "Visual regression testing is integrated for components that exceed a specific traffic threshold, allowing teams to catch visual discrepancies early in the development process and maintain a high-quality user interface."
+        }
+      ],
+      "related": [
+        {
+          "slug": "component-library-build-storybook-designops",
+          "reasonMarkdown": "Read this if you want to streamline design operations with a cohesive component library."
+        },
+        {
+          "slug": "component-library-build-storybook-product-teams",
+          "reasonMarkdown": "Read this if you're part of a product team looking to enhance component consistency."
+        },
+        {
+          "slug": "component-library-build-storybook-scaleups",
+          "reasonMarkdown": "Read this if you're scaling your design system and need robust governance."
+        },
+        {
+          "slug": "component-library-build-storybook-startups",
+          "reasonMarkdown": "Read this if you're a startup aiming for rapid component development with Storybook."
+        },
+        {
+          "slug": "component-library-build-figma-enterprises",
+          "reasonMarkdown": "Read this if you need to integrate Figma designs with your component library."
+        },
+        {
+          "slug": "component-library-build-nextjs-enterprises",
+          "reasonMarkdown": "Read this if you're implementing a component library in a Next.js environment."
+        },
+        {
+          "slug": "component-library-build-react-enterprises",
+          "reasonMarkdown": "Read this if you're building a React-based component library for enterprise use."
+        },
+        {
+          "slug": "component-library-build-typescript-enterprises",
+          "reasonMarkdown": "Read this if you're developing a TypeScript component library to enhance type safety."
+        }
+      ],
+      "updatedAt": "2026-06-01T00:03:22.701Z"
+    },
+    "design-tokens-setup-figma-product-teams": {
+      "introMarkdown": "Establishing a robust design token setup in Figma is essential for product teams aiming to streamline design-to-code workflows. By aligning design and code through semantic tokens, teams can enhance user experience while reducing regression issues. This approach not only facilitates faster shipping but also ensures that design updates are manageable, even under OKR pressures. With a focus on scalability and maintainability, this playbook provides actionable steps tailored for mixed-skill teams navigating the complexities of modern design systems.",
+      "sections": [
+        {
+          "id": "playbook",
+          "title": "Playbook Steps",
+          "bodyMarkdown": "1. **Define Primitive Tokens**: Start by identifying the foundational styles such as colors, typography, and spacing. Use consistent naming conventions that reflect their purpose. For instance, instead of hardcoding hex values, create semantic variables like `--color-primary`.\n\n2. **Map to Semantic Tokens**: Translate primitive tokens into semantic tokens that represent design decisions. For example, map `--color-primary` to `--color-button-background`. This ensures clarity in design and code alignment.\n\n3. **Implement in Figma**: Use Figma's variable system to create these tokens. Ensure that component properties mirror the semantic token names, allowing designers to easily apply them without confusion.\n\n4. **Dark Mode Planning**: Design dark mode as a core theme rather than an afterthought. Create separate semantic tokens for dark mode that align with your light mode counterparts, ensuring a seamless transition between themes.\n\n5. **Version Control and Changelog**: Establish a version control system for your design tokens. Publish a changelog whenever updates are made that affect downstream files, ensuring all team members are aware of changes and can adapt accordingly."
+        },
+        {
+          "id": "situation",
+          "title": "Current Challenges",
+          "bodyMarkdown": "Product teams often face significant hurdles when integrating design tokens into their workflows. Figma variables and CSS custom properties frequently use different naming conventions, leading to confusion and inconsistencies. Additionally, dark mode is often treated as an add-on rather than a fully integrated theme, complicating the design process. Manual updates for brand changes across multiple repositories can be time-consuming and error-prone. Furthermore, undefined spacing and typography primitives can lead to visual drift, undermining the overall design integrity."
+        },
+        {
+          "id": "failure-modes",
+          "title": "Common Pitfalls",
+          "bodyMarkdown": "1. **Inconsistent Naming**: Failing to align naming conventions between design and code can lead to confusion and errors. Ensure that all team members understand and adhere to the established naming standards.\n\n2. **Neglecting Dark Mode**: Treating dark mode as an afterthought can result in a disjointed user experience. Plan for it from the outset to ensure a cohesive design.\n\n3. **Manual Updates**: Relying on manual find-and-replace for brand updates can introduce errors. Use semantic tokens to streamline this process and minimize the risk of oversight."
+        }
+      ],
+      "faqs": [
+        {
+          "question": "How do design tokens improve collaboration between designers and developers?",
+          "answerMarkdown": "Design tokens create a shared language between designers and developers, reducing miscommunication. By using semantic tokens that both teams understand, the risk of inconsistencies is minimized, leading to a smoother workflow."
+        },
+        {
+          "question": "What are the key benefits of using Figma for design tokens?",
+          "answerMarkdown": "Figma's variable system allows for easy implementation of design tokens, enabling real-time updates and collaboration. This ensures that design changes are immediately reflected in the code, facilitating faster iterations."
+        },
+        {
+          "question": "How can we ensure our design tokens are scalable?",
+          "answerMarkdown": "To achieve scalability, define a clear hierarchy of tokens from primitive to semantic. Regularly review and update your tokens based on user feedback and design evolution, ensuring they remain relevant and effective."
+        }
+      ],
+      "related": [
+        {
+          "slug": "design-tokens-setup-figma-designops",
+          "reasonMarkdown": "Read this if you want to optimize design operations with a focus on token management."
+        },
+        {
+          "slug": "design-tokens-setup-figma-enterprises",
+          "reasonMarkdown": "Read this if you're part of a large organization needing scalable design solutions."
+        },
+        {
+          "slug": "design-tokens-setup-figma-scaleups",
+          "reasonMarkdown": "Read this if you're in a growing company looking to enhance design consistency."
+        },
+        {
+          "slug": "design-tokens-setup-figma-startups",
+          "reasonMarkdown": "Read this if you're in a startup environment needing rapid design iterations."
+        },
+        {
+          "slug": "design-tokens-setup-nextjs-product-teams",
+          "reasonMarkdown": "Read this if you're integrating design tokens with Next.js for streamlined development."
+        },
+        {
+          "slug": "design-tokens-setup-react-product-teams",
+          "reasonMarkdown": "Read this if you're using React and want to align your design tokens effectively."
+        },
+        {
+          "slug": "design-tokens-setup-storybook-product-teams",
+          "reasonMarkdown": "Read this if you're utilizing Storybook to document and showcase your design tokens."
+        },
+        {
+          "slug": "design-tokens-setup-typescript-product-teams",
+          "reasonMarkdown": "Read this if you're working with TypeScript and need to ensure type safety in your design tokens."
+        }
+      ],
+      "updatedAt": "2026-06-01T00:04:40.607Z"
+    },
+    "design-tokens-setup-typescript-scaleups": {
+      "introMarkdown": "For scaleup teams leveraging TypeScript, establishing a robust design token setup is crucial for maintaining consistency across multiple product squads. This approach not only aligns design and code but also facilitates a scalable theming foundation. By addressing common pain points such as naming discrepancies and manual updates, teams can streamline their workflows and enhance collaboration between design and development.",
+      "sections": [
+        {
+          "id": "playbook",
+          "title": "Implementation Steps",
+          "bodyMarkdown": "1. **Define Design Tokens**: Start by creating a clear mapping of design tokens that includes colors, typography, spacing, and other UI elements. Ensure that these tokens are named consistently across Figma and TypeScript to avoid confusion.\n\n2. **Utilize TypeScript Types**: Implement TypeScript's discriminated unions for variant props instead of using loose strings. This ensures type safety and reduces errors during development.\n\n3. **Integrate Figma Variables**: Wire Figma variables directly to your TypeScript exports. This allows for real-time validation in your CI pipeline, ensuring that design changes are reflected in code without manual intervention.\n\n4. **Plan for Dark Mode**: Design dark mode as a core theme rather than an afterthought. Create semantic tokens that can easily switch between light and dark themes, ensuring a seamless user experience.\n\n5. **Automate Documentation**: Generate documentation from your TypeScript types using tools like Storybook docgen and TSDoc. This keeps your documentation in sync with your codebase and reduces the overhead of manual updates.\n\n6. **Enforce Strict Mode**: Implement strict mode for your library package, even if your application code is gradually adopting TypeScript. This will help catch potential issues early and enforce best practices across your teams."
+        },
+        {
+          "id": "situation",
+          "title": "Current Challenges",
+          "bodyMarkdown": "Scaleup teams often face challenges when integrating design tokens into their workflows. With multiple product squads working on both legacy and greenfield code, inconsistencies arise from differing naming conventions between design tools and code. Additionally, dark mode is frequently added as an afterthought, leading to a disjointed user experience. Manual updates for brand changes across repositories can be time-consuming and error-prone, while undefined spacing and typography primitives can lead to visual drift."
+        },
+        {
+          "id": "failure-modes",
+          "title": "Common Pitfalls",
+          "bodyMarkdown": "1. **Inconsistent Naming**: When design and code use different names for the same tokens, it leads to confusion and errors. Establish a clear naming convention early on.\n\n2. **Neglecting Dark Mode**: Failing to design dark mode as a core theme can result in a poor user experience. Plan for it from the start to ensure consistency.\n\n3. **Manual Updates**: Relying on manual find-and-replace for brand updates can introduce bugs. Use semantic tokens to automate this process and minimize risk."
+        }
+      ],
+      "faqs": [
+        {
+          "question": "How do design tokens improve collaboration between design and development teams?",
+          "answerMarkdown": "Design tokens create a shared vocabulary between design and development, ensuring that both teams are aligned on the same visual language. By using consistent naming conventions and integrating Figma variables with TypeScript, teams can reduce misunderstandings and streamline their workflows."
+        },
+        {
+          "question": "What are the benefits of using TypeScript for design tokens?",
+          "answerMarkdown": "TypeScript provides type safety, which helps catch errors early in the development process. By using discriminated unions for variant props, teams can ensure that only valid values are used, reducing the likelihood of runtime errors and improving overall code quality."
+        },
+        {
+          "question": "How can we effectively manage dark mode in our design token setup?",
+          "answerMarkdown": "To manage dark mode effectively, design it as a core theme from the outset. Create semantic tokens that can easily switch between light and dark modes, ensuring a cohesive user experience. This approach prevents dark mode from being an afterthought and integrates it seamlessly into your design system."
+        }
+      ],
+      "related": [
+        {
+          "slug": "design-tokens-setup-typescript-designops",
+          "reasonMarkdown": "Read this if you're looking to streamline design operations with TypeScript."
+        },
+        {
+          "slug": "design-tokens-setup-typescript-enterprises",
+          "reasonMarkdown": "Read this if you're part of an enterprise needing scalable design solutions."
+        },
+        {
+          "slug": "design-tokens-setup-typescript-product-teams",
+          "reasonMarkdown": "Read this if you're a product team aiming for consistency across multiple squads."
+        },
+        {
+          "slug": "design-tokens-setup-typescript-startups",
+          "reasonMarkdown": "Read this if you're a startup looking to establish a solid design foundation."
+        },
+        {
+          "slug": "design-tokens-setup-figma-scaleups",
+          "reasonMarkdown": "Read this if you want to integrate Figma with your design token strategy."
+        },
+        {
+          "slug": "design-tokens-setup-nextjs-scaleups",
+          "reasonMarkdown": "Read this if you're using Next.js and want to enhance your design token setup."
+        },
+        {
+          "slug": "design-tokens-setup-react-scaleups",
+          "reasonMarkdown": "Read this if you're working with React and need a cohesive design system."
+        },
+        {
+          "slug": "design-tokens-setup-storybook-scaleups",
+          "reasonMarkdown": "Read this if you're using Storybook for documentation and want to integrate design tokens."
+        }
+      ],
+      "updatedAt": "2026-06-01T00:05:58.458Z"
+    },
+    "ai-designops-automation-storybook-designops": {
+      "introMarkdown": "AI-powered DesignOps automation enhances the efficiency of DesignOps teams utilizing Storybook. By automating workflows, reducing design debt, and ensuring consistent execution, teams can focus on delivering high-quality designs without the bottlenecks of manual processes. This playbook provides actionable insights tailored for DesignOps teams, addressing common pain points and leveraging Storybook's capabilities to streamline operations.",
+      "sections": [
+        {
+          "id": "playbook",
+          "title": "Playbook Steps",
+          "bodyMarkdown": "1. **Assess Current Workflows**: Identify existing bottlenecks in design reviews and handoffs. Document where time is lost, focusing on spec, build, review, and release phases.\n\n2. **Define Automation Scope**: Determine which workflows can be automated. Prioritize those that yield the highest ROI and reduce design debt.\n\n3. **Implement Storybook Stories**: Create stories that reflect real product compositions rather than isolated components. Ensure every meaningful prop is documented, while hiding internal ones to maintain clarity.\n\n4. **Integrate Visual Regression Testing**: Wire visual regression tests on pull requests for components exceeding a defined traffic threshold. This ensures that changes are validated against existing designs, catching drift early.\n\n5. **Establish Guardrails**: Clearly define what agents may change, what requires human review, and how drift is monitored in CI. This clarity helps maintain quality while scaling automation.\n\n6. **Iterate and Scale**: After automating one workflow end-to-end, analyze results and iterate. Gradually scale automation across additional workflows, ensuring throughput gains do not compromise error rates."
+        },
+        {
+          "id": "situation",
+          "title": "Current Landscape",
+          "bodyMarkdown": "DesignOps teams face increasing pressure to deliver high-quality designs rapidly. However, as output scales, headcount often does not keep pace, leading to review bottlenecks. Handoffs still rely on outdated methods like screenshots and Slack threads, creating a fragmented source of truth. This environment fosters the accumulation of design debt, which manual QA struggles to manage effectively. Implementing AI-powered automation with Storybook can address these challenges, providing a cohesive solution that enhances throughput and consistency."
+        },
+        {
+          "id": "failure-modes",
+          "title": "Common Pitfalls",
+          "bodyMarkdown": "1. **Neglecting Documentation**: Failing to document controls for props can lead to confusion and errors during development. Ensure all meaningful props are clearly defined.\n\n2. **Overlooking Visual Regression**: Not implementing visual regression testing can result in unnoticed drift, causing inconsistencies in the final product. Prioritize this step to maintain design integrity.\n\n3. **Scaling Without Strategy**: Automating workflows without a clear understanding of existing pain points can exacerbate issues. Start with a focused approach, addressing the most critical workflows first."
+        }
+      ],
+      "faqs": [
+        {
+          "question": "How does AI-powered automation improve DesignOps workflows?",
+          "answerMarkdown": "AI-powered automation streamlines repetitive tasks, reduces manual intervention, and enhances consistency in design execution. By integrating with Storybook, teams can automate visual regression testing and documentation, allowing designers to focus on creative work rather than administrative overhead."
+        },
+        {
+          "question": "What role does Storybook play in DesignOps automation?",
+          "answerMarkdown": "Storybook serves as a central hub for component-driven development, enabling teams to document and visualize components effectively. By leveraging Storybook's capabilities, DesignOps teams can automate workflows, ensuring that design changes are validated and consistent across the board."
+        },
+        {
+          "question": "How can DesignOps teams prove ROI from automation?",
+          "answerMarkdown": "ROI can be demonstrated through metrics such as reduced design debt, faster review cycles, and improved throughput. By automating key workflows, teams can track time saved and increased output, providing tangible evidence of the benefits of AI-powered DesignOps automation."
+        }
+      ],
+      "related": [
+        {
+          "slug": "ai-designops-automation-storybook-enterprises",
+          "reasonMarkdown": "Read this if you're in an enterprise setting looking to scale DesignOps efficiently."
+        },
+        {
+          "slug": "ai-designops-automation-storybook-product-teams",
+          "reasonMarkdown": "Read this if you're part of a product team needing to streamline design processes."
+        },
+        {
+          "slug": "ai-designops-automation-storybook-scaleups",
+          "reasonMarkdown": "Read this if you're in a scale-up environment aiming to enhance design throughput."
+        },
+        {
+          "slug": "ai-designops-automation-storybook-startups",
+          "reasonMarkdown": "Read this if you're a startup seeking cost-effective DesignOps solutions."
+        },
+        {
+          "slug": "ai-designops-automation-figma-designops",
+          "reasonMarkdown": "Read this if you're integrating Figma into your DesignOps workflows."
+        },
+        {
+          "slug": "ai-designops-automation-nextjs-designops",
+          "reasonMarkdown": "Read this if you're leveraging Next.js in your design and development processes."
+        },
+        {
+          "slug": "ai-designops-automation-react-designops",
+          "reasonMarkdown": "Read this if you're utilizing React and want to optimize your DesignOps."
+        },
+        {
+          "slug": "ai-designops-automation-typescript-designops",
+          "reasonMarkdown": "Read this if you're working with TypeScript and need to enhance your DesignOps efficiency."
+        }
+      ],
+      "updatedAt": "2026-06-01T00:07:21.308Z"
+    },
+    "ai-designops-automation-nextjs-designops": {
+      "introMarkdown": "AI-powered DesignOps automation leverages Next.js to streamline workflows, reduce design debt, and enhance execution consistency. Tailored for DesignOps teams, this approach addresses common pain points such as design review bottlenecks and fragmented communication. By integrating automation into your design processes, you can ensure that your team operates efficiently, even under budget scrutiny, while proving ROI through measurable improvements.",
+      "sections": [
+        {
+          "id": "playbook",
+          "title": "Playbook for AI-Powered DesignOps Automation",
+          "bodyMarkdown": "1. **Identify Bottlenecks**: Conduct a thorough analysis of your current design workflow. Pinpoint areas where delays occur, such as design reviews and handoffs. Use analytics tools to gather data on time spent in each phase.\n\n2. **Define Automation Points**: Based on your analysis, determine which tasks can be automated. Focus on repetitive tasks like asset management and feedback collection. Leverage Next.js features like dynamic imports to optimize performance for client-only components.\n\n3. **Implement Guardrails**: Establish clear guidelines on what can be automated and what requires human oversight. Document these guardrails in your design system to ensure all team members are aligned.\n\n4. **Integrate CI/CD**: Utilize Continuous Integration/Continuous Deployment (CI/CD) practices to automate testing and deployment. This helps catch design drift early and ensures that updates are consistent across all platforms.\n\n5. **Monitor and Iterate**: After implementing automation, continuously monitor the workflow for improvements. Gather feedback from designers and adjust the automation processes as necessary to enhance efficiency."
+        },
+        {
+          "id": "situation",
+          "title": "Current Situation",
+          "bodyMarkdown": "DesignOps teams face increasing pressure to deliver high-quality outputs quickly. With limited resources, the risk of design debt accumulation rises, leading to inefficiencies. Traditional handoff methods, such as screenshots and Slack threads, create confusion and slow down the process. A lack of a single source of truth exacerbates these issues, making it difficult to track changes and maintain consistency."
+        },
+        {
+          "id": "failure-modes",
+          "title": "Common Failure Modes",
+          "bodyMarkdown": "1. **Inconsistent Outputs**: Without automation, design outputs can vary significantly, leading to brand inconsistency.\n\n2. **Increased Design Debt**: Manual processes often result in unaddressed design debt, which compounds over time and becomes harder to manage.\n\n3. **Communication Breakdowns**: Relying on fragmented communication tools can lead to misunderstandings and missed feedback, further delaying project timelines."
+        }
+      ],
+      "faqs": [
+        {
+          "question": "How does AI-powered automation improve DesignOps workflows?",
+          "answerMarkdown": "AI-powered automation streamlines repetitive tasks, allowing designers to focus on high-value work. By integrating with Next.js, teams can automate handoffs and reviews, reducing bottlenecks and enhancing throughput."
+        },
+        {
+          "question": "What role does Next.js play in this automation?",
+          "answerMarkdown": "Next.js provides a robust framework for building performant applications. Its features, like dynamic imports and optimized routing, enhance the user experience while supporting the automation of design workflows."
+        },
+        {
+          "question": "How can I measure the ROI of implementing this service?",
+          "answerMarkdown": "ROI can be measured by tracking improvements in throughput, reduction in design debt, and time saved in the review process. Establish baseline metrics before implementation to quantify the impact of automation."
+        }
+      ],
+      "related": [
+        {
+          "slug": "ai-designops-automation-nextjs-enterprises",
+          "reasonMarkdown": "Read this if your enterprise needs scalable DesignOps solutions."
+        },
+        {
+          "slug": "ai-designops-automation-nextjs-product-teams",
+          "reasonMarkdown": "Read this if you're a product team looking to enhance design efficiency."
+        },
+        {
+          "slug": "ai-designops-automation-nextjs-scaleups",
+          "reasonMarkdown": "Read this if your scaleup is facing growing design challenges."
+        },
+        {
+          "slug": "ai-designops-automation-nextjs-startups",
+          "reasonMarkdown": "Read this if you're a startup aiming to establish efficient design processes."
+        },
+        {
+          "slug": "ai-designops-automation-figma-designops",
+          "reasonMarkdown": "Read this if you use Figma and want to integrate automation."
+        },
+        {
+          "slug": "ai-designops-automation-react-designops",
+          "reasonMarkdown": "Read this if you're leveraging React in your DesignOps strategy."
+        },
+        {
+          "slug": "ai-designops-automation-storybook-designops",
+          "reasonMarkdown": "Read this if you're using Storybook for component management."
+        },
+        {
+          "slug": "ai-designops-automation-typescript-designops",
+          "reasonMarkdown": "Read this if your team is implementing TypeScript in your design workflows."
+        }
+      ],
+      "updatedAt": "2026-06-01T00:08:35.326Z"
+    },
+    "component-library-build-react-scaleups": {
+      "introMarkdown": "Scaleup teams face unique challenges when building a component library in React. With multiple squads shipping components, inconsistencies arise in UI elements like buttons and forms. This playbook provides a structured approach to create a cohesive, production-ready component library that emphasizes accessibility, documentation, and governance. By aligning on best practices and leveraging modern React capabilities, teams can streamline their workflows and enhance collaboration across legacy and greenfield projects.",
+      "sections": [
+        {
+          "id": "playbook",
+          "title": "Playbook Steps",
+          "bodyMarkdown": "1. **Define Core Components**: Identify the most frequently used UI elements across squads. Prioritize components based on traffic and accessibility risk.  \n2. **Establish Composition Patterns**: Use compound components to manage complex UIs without overwhelming prop APIs. This approach simplifies usage and enhances readability.  \n3. **Implement CSS Modules or Tokens**: Colocate styles with components to ensure consistency and avoid inline one-offs. This practice aids in maintainability and scalability.  \n4. **Integrate Accessibility Testing**: Test keyboard and screen-reader behavior alongside visual snapshots. Ensure that all components meet accessibility standards before deployment.  \n5. **Pilot with One Squad**: Launch the component library with a single squad to gather feedback and iterate. This step helps identify pain points and areas for improvement before broader adoption.  \n6. **Document Thoroughly**: Create documentation that covers not just the happy path but also keyboard behavior and failure states. This ensures all squads can effectively utilize the library."
+        },
+        {
+          "id": "situation",
+          "title": "Current Challenges",
+          "bodyMarkdown": "Scaleup teams often struggle with inconsistent UI elements due to multiple squads working in parallel. Each squad may implement buttons, forms, and modals differently, leading to a fragmented user experience. Existing Storybook instances may not accurately reflect production usage, complicating onboarding and knowledge transfer. As prop APIs evolve organically, they can become unwieldy, making it difficult for developers to learn and utilize components effectively. Additionally, manual testing processes can result in visual regressions slipping through, impacting the overall quality of the product."
+        },
+        {
+          "id": "failure-modes",
+          "title": "Potential Pitfalls",
+          "bodyMarkdown": "1. **Inconsistent Component Usage**: Without clear guidelines, squads may continue to create their own versions of components, leading to a lack of uniformity.  \n2. **Overcomplicated APIs**: Allowing prop APIs to grow unchecked can confuse developers, making it hard to understand how to use components correctly.  \n3. **Neglecting Accessibility**: Failing to prioritize accessibility testing can alienate users and create compliance issues.  \n4. **Insufficient Documentation**: Inadequate documentation can hinder adoption and lead to misuse of components, ultimately affecting the user experience."
+        }
+      ],
+      "faqs": [
+        {
+          "question": "How does this component library address the needs of scaleup teams?",
+          "answerMarkdown": "The component library is designed specifically for scaleup teams by standardizing UI elements across multiple squads. It emphasizes accessibility and thorough documentation, ensuring that all team members can effectively use the components regardless of their experience level."
+        },
+        {
+          "question": "What are the key benefits of using React for our component library?",
+          "answerMarkdown": "React's modern component architecture allows for predictable composition and typed props, which simplifies the development process. This leads to a more maintainable codebase and enhances collaboration among squads, especially when legacy and greenfield code coexist."
+        },
+        {
+          "question": "How can we ensure our components remain consistent and accessible?",
+          "answerMarkdown": "By implementing strict governance around component design and usage, and by integrating accessibility testing into the development process, teams can maintain consistency and ensure that all components meet necessary accessibility standards."
+        }
+      ],
+      "related": [
+        {
+          "slug": "component-library-build-react-designops",
+          "reasonMarkdown": "Read this if you want to align design operations with component development."
+        },
+        {
+          "slug": "component-library-build-react-enterprises",
+          "reasonMarkdown": "Read this if you're scaling component libraries in enterprise environments."
+        },
+        {
+          "slug": "component-library-build-react-product-teams",
+          "reasonMarkdown": "Read this if you're part of product teams looking to unify UI across products."
+        },
+        {
+          "slug": "component-library-build-react-startups",
+          "reasonMarkdown": "Read this if you're a startup aiming for rapid UI development with React."
+        },
+        {
+          "slug": "component-library-build-figma-scaleups",
+          "reasonMarkdown": "Read this if you want to integrate Figma designs with your component library."
+        },
+        {
+          "slug": "component-library-build-nextjs-scaleups",
+          "reasonMarkdown": "Read this if you're using Next.js and want to enhance your component library."
+        },
+        {
+          "slug": "component-library-build-storybook-scaleups",
+          "reasonMarkdown": "Read this if you're looking to improve Storybook integration with your components."
+        },
+        {
+          "slug": "component-library-build-typescript-scaleups",
+          "reasonMarkdown": "Read this if you want to leverage TypeScript for better type safety in your components."
+        }
+      ],
+      "updatedAt": "2026-06-01T00:11:35.281Z"
+    },
+    "component-library-build-nextjs-product-teams": {
+      "introMarkdown": "Building a component library for product teams using Next.js requires a focus on accessibility, documentation, and governance. This playbook addresses the unique challenges faced by squads under OKR pressure, ensuring that components are consistent, reusable, and easy to integrate. By leveraging Next.js, we can create a performant UI system that enhances user experience while reducing visual regressions and mismatched implementations across teams.",
+      "sections": [
+        {
+          "id": "playbook",
+          "title": "Component Library Playbook",
+          "bodyMarkdown": "1. **Define Core Components**: Start by identifying the most commonly used UI elements across squads, such as buttons, forms, and modals. Use analytics to prioritize components based on traffic and accessibility risk.\n\n2. **Establish Composition Patterns**: Before creating variants, define how these components will be composed. This prevents unnecessary complexity and ensures that all teams are on the same page.\n\n3. **Implement Accessibility Standards**: Ensure all components meet WCAG guidelines. Document keyboard interactions and failure states to provide a comprehensive understanding of component behavior.\n\n4. **Utilize Next.js Features**: Separate server and client component boundaries in your documentation. Use dynamic imports for heavy client-only widgets to optimize performance on marketing surfaces.\n\n5. **Pilot with One Squad**: Test the library with a single squad to gather feedback and iterate. This allows for adjustments before a wider rollout.\n\n6. **Documentation and Governance**: Create thorough documentation that covers not just the happy path but also edge cases. Establish governance to maintain consistency and quality as the library evolves."
+        },
+        {
+          "id": "situation",
+          "title": "Current Challenges",
+          "bodyMarkdown": "Product teams face inconsistencies in UI components, leading to a fragmented user experience. Each squad tends to implement buttons, forms, and modals differently, which complicates maintenance and user interaction. Storybook may exist, but the stories often do not reflect actual production usage, creating confusion. As props APIs grow organically, they become difficult to learn and use effectively. Manual testing leads to visual regressions slipping through, impacting the overall quality of the product."
+        },
+        {
+          "id": "failure-modes",
+          "title": "Potential Failure Modes",
+          "bodyMarkdown": "1. **Inconsistent Component Usage**: Without a centralized library, teams may continue to create their own versions of components, leading to a lack of cohesion.\n\n2. **Accessibility Oversights**: Failing to prioritize accessibility can alienate users and lead to compliance issues.\n\n3. **Documentation Gaps**: Insufficient documentation can result in misunderstandings about component usage, leading to errors in implementation.\n\n4. **Performance Issues**: Not leveraging Next.js features effectively can lead to slow-loading components, negatively impacting user experience."
+        }
+      ],
+      "faqs": [
+        {
+          "question": "How does this component library improve collaboration among product teams?",
+          "answerMarkdown": "By providing a standardized set of components, teams can work more cohesively, reducing discrepancies in UI implementation. This fosters better collaboration and speeds up the development process."
+        },
+        {
+          "question": "What role does accessibility play in the component library?",
+          "answerMarkdown": "Accessibility is a core focus, ensuring that all components meet WCAG standards. This not only broadens the user base but also mitigates legal risks associated with non-compliance."
+        },
+        {
+          "question": "How can Next.js enhance the performance of the component library?",
+          "answerMarkdown": "Next.js allows for optimized loading through features like dynamic imports and server-side rendering, ensuring that components are delivered quickly and efficiently, which is crucial for maintaining a high-quality user experience."
+        }
+      ],
+      "related": [
+        {
+          "slug": "component-library-build-nextjs-designops",
+          "reasonMarkdown": "Read this if you want to align design operations with component library development."
+        },
+        {
+          "slug": "component-library-build-nextjs-enterprises",
+          "reasonMarkdown": "Read this if you're in an enterprise setting looking to standardize UI components."
+        },
+        {
+          "slug": "component-library-build-nextjs-scaleups",
+          "reasonMarkdown": "Read this if you're scaling your product and need a robust component library."
+        },
+        {
+          "slug": "component-library-build-nextjs-startups",
+          "reasonMarkdown": "Read this if you're a startup aiming for rapid development with consistent UI."
+        },
+        {
+          "slug": "component-library-build-figma-product-teams",
+          "reasonMarkdown": "Read this if you want to integrate Figma designs with your component library."
+        },
+        {
+          "slug": "component-library-build-react-product-teams",
+          "reasonMarkdown": "Read this if you're using React and want to enhance your component library."
+        },
+        {
+          "slug": "component-library-build-storybook-product-teams",
+          "reasonMarkdown": "Read this if you're utilizing Storybook and want to improve component documentation."
+        },
+        {
+          "slug": "component-library-build-typescript-product-teams",
+          "reasonMarkdown": "Read this if you're implementing TypeScript in your component library for better type safety."
+        }
+      ],
+      "updatedAt": "2026-06-01T00:13:28.852Z"
+    }
+  }
 }
-

--- a/content/pseo/pilot-slugs.json
+++ b/content/pseo/pilot-slugs.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "description": "Phase 3 pilot — 12 slugs selected for generation and human review before indexation.",
+  "generationStatus": "complete",
+  "generatedAt": "2026-05-28",
+  "rationale": "Core services, site stack (Next.js), strong proof links, and differentiated DesignOps combos.",
+  "slugs": [
+    "design-system-audit-react-startups",
+    "design-system-audit-nextjs-startups",
+    "design-system-audit-figma-scaleups",
+    "design-system-audit-typescript-enterprises",
+    "component-library-build-react-scaleups",
+    "component-library-build-nextjs-product-teams",
+    "component-library-build-storybook-enterprises",
+    "design-tokens-setup-figma-product-teams",
+    "design-tokens-setup-react-startups",
+    "design-tokens-setup-typescript-scaleups",
+    "ai-designops-automation-storybook-designops",
+    "ai-designops-automation-nextjs-designops"
+  ]
+}

--- a/docs/PSEO_IMPROVEMENT_PLAN.md
+++ b/docs/PSEO_IMPROVEMENT_PLAN.md
@@ -1,0 +1,271 @@
+# PSEO Improvement Plan — Believable, Helpful Playbooks
+
+**Status:** Phase 0 complete · Phase 1–2 in progress (2026-05-28)  
+**Owner:** Digitaltableteur  
+**Goal:** Turn `/pseo` from thin, repetitive “obvious PSEO” into expert playbooks that rank, convert, and genuinely help practitioners — without index-bloat or scaled-content-abuse risk.
+
+> **Context:** May 2026 site audit flagged PSEO as the **#1 search risk**. Today all **100 leaf pages** share identical fallback copy; `copy.json` is empty; the UI says “Programmatic Guides” and breadcrumb “PSEO”.
+
+---
+
+## Diagnosis (current state)
+
+| Signal | Today | Risk |
+|--------|-------|------|
+| Unique copy in `copy.json` | **0 / 100** pages | Thin / duplicate content |
+| Fallback template | Same 4 sections on every leaf | Mad-libs pattern |
+| Index H1 | “Programmatic Guides” | Self-identifies as PSEO |
+| Breadcrumb label | “PSEO” | Jargon, not user intent |
+| Title formula | `Service for Audience using Stack` + broken `titleCase` (“Next.Js”) | Low CTR, unprofessional |
+| Proof / portfolio | None in body | No E-E-A-T |
+| Package mapping | No link to `/pricing` packages | Weak conversion path |
+| FAQ schema | Missing despite FAQ sections | Missed SERP features |
+| Section render bug | Body markdown rendered **twice** per section | UX + crawl noise |
+| Sitemap `lastModified` | Always “today” for all 115 URLs | Freshness spam |
+| i18n | English only | OK for v1 if quality-first |
+
+**Architecture is sound** (catalog → pillars → leaves → sitemap → agent tools). **Content and presentation are not.**
+
+---
+
+## Strategic shift
+
+### From → To
+
+| Old mental model | New mental model |
+|------------------|------------------|
+| 100 SEO landing pages | **Playbook library** for design-system practitioners |
+| Swap keywords in one template | **Combo-specific** guidance (service × stack × audience) |
+| Generate everything at once | **Progressive rollout** with quality gates |
+| “Programmatic SEO” in UI | **“Design system playbooks”** (human language) |
+| Generic CTA | **Contextual next step** (audit checklist → contact, package match → pricing) |
+
+### Standalone value test (every published leaf must pass)
+
+> *Would this page be worth publishing if no other similar page existed?*
+
+If no → do not index until it passes.
+
+---
+
+## Target content model
+
+Each leaf page should feel like a **senior consultant wrote one focused memo**, not a mail-merge.
+
+### Required blocks (leaf template v2)
+
+1. **Situation** — Who this is for, constraints of this audience + stack (2–3 sentences, combo-specific).
+2. **What goes wrong** — 3–5 bullets grounded in real failure modes (not generic “inconsistency”).
+3. **Playbook** — Numbered steps with stack-specific tactics (React vs Figma vs Storybook differ).
+4. **Deliverables checklist** — Copy-paste checklist; varies by **service**.
+5. **Proof** — Link to relevant `/work/*` case study or blog post (mapped in catalog).
+6. **Package fit** — Which `/pricing` package applies and why (UX Sprint vs Design System Lift-Off, etc.).
+7. **FAQ** — 2–3 Q&As that reference **this** combo (timeline, team size, existing codebase).
+8. **Related guides** — 3–5 with **specific** “read this if…” reasons (already scaffolded).
+
+### Catalog enrichment (`content/pseo/catalog.json` v2)
+
+Extend items beyond `name` + `shortDescription`:
+
+```jsonc
+{
+  "services": [{
+    "slug": "design-system-audit",
+    "painPoints": ["…"],
+    "deliverables": ["…"],
+    "typicalTimeline": "1–2 weeks",
+    "pricingPackageSlug": "ux-sprint",
+    "relatedWorkSlugs": ["helsinki-design-system"],
+    "relatedBlogSlugs": ["…"]
+  }],
+  "stacks": [{
+    "slug": "nextjs",
+    "displayName": "Next.js",           // preserves “Next.js” casing
+    "implementationNotes": ["App Router", "RSC boundaries", "…"]
+  }],
+  "audiences": [{
+    "slug": "startups",
+    "constraints": ["small team", "…"],
+    "successMetric": "shippable MVP UI in 2–4 weeks"
+  }]
+}
+```
+
+### Copy storage
+
+Keep `content/pseo/copy.json` for LLM-assisted **narrative** sections, but **never** publish a leaf without:
+
+- Catalog-backed structured fields (deterministic, unique per combo)
+- ≥40% unique word count vs any sibling page (automated check)
+- Human review on pilot batch (100% review) and sample review on later batches (10%)
+
+---
+
+## Phased delivery
+
+```mermaid
+flowchart LR
+  P0[P0 Stabilize] --> P1[P1 Content model]
+  P1 --> P2[P2 Template + UX]
+  P2 --> P3[P3 Pilot 12 pages]
+  P3 --> P4[P4 Scale batches]
+  P4 --> P5[P5 Measure + iterate]
+```
+
+---
+
+### Phase 0 — Stabilize & de-risk (1–2 days)
+
+**Goal:** Stop actively harming UX/SEO while we rebuild content.
+
+| Task | Files / area |
+|------|----------------|
+| Fix duplicate section render | `PseoLeafPage.tsx` (remove second `MarkdownMessage`) |
+| Rename UI copy: “Design system playbooks” (not “Programmatic Guides”) | `PseoIndexPage.tsx`, metadata in `app/pseo/page.tsx` |
+| Breadcrumb: “Guides” or “Playbooks” (not “PSEO”) | `PseoLeafPage.tsx` |
+| Fix title casing (`Next.js`, `TypeScript`) | `lib/pseo/catalog.ts` — use `displayName` or preserve known tokens |
+| **noindex** all leaf pages until pilot passes quality gate | `app/pseo/[slug]/page.tsx` metadata `robots: { index: false }` — remove after Phase 3 |
+| Keep pillars + index indexed (hub pages) | pillars get editorial intros in Phase 2 |
+| Sitemap: stable `lastModified` from `copy.updatedAt` or catalog version date | `app/sitemap.ts` |
+| Add `scripts/pseo/check-pseo-quality.mjs` | uniqueness %, word count, missing proof links |
+
+**Exit criteria:** Build green; no duplicate body; leaves noindex; quality script runs in CI.
+
+---
+
+### Phase 1 — Content model & generation (3–5 days)
+
+**Goal:** Make uniqueness structurally inevitable, not prompt-hoped.
+
+| Task | Detail |
+|------|--------|
+| Catalog v2 schema + migration | Enrich 4×5×5 entries with pain points, deliverables, work/blog links |
+| Author **4 service canonical playbooks** (human-written, ~800 words each) | Source of truth for LLM; store in `content/pseo/canonical/` |
+| Rewrite `generate-pseo-copy.ts` prompts | Inject canonical excerpts, anti-template rules, word-count floors, banned phrases (“This guide explains how…”) |
+| Structured sections in code | Render checklist + proof + package blocks from catalog (not LLM) |
+| Map services → pricing packages | Reuse `consulting-catalog.ts` / `PricingPageContent` package slugs |
+| Map combos → work case studies | Manual curation table in catalog (quality > automation) |
+
+**Exit criteria:** `--limit 3` generation produces visibly different pages; quality script passes on samples.
+
+---
+
+### Phase 2 — Template & hub redesign (3–4 days)
+
+**Goal:** Pages look like editorial product content, not SEO filler.
+
+| Task | Detail |
+|------|--------|
+| Leaf layout v2 | Situation / failure modes / playbook / checklist / proof card / package callout |
+| Index page v2 | Hero + “Start here” paths (by role, by stack) + featured playbooks, not raw grids |
+| Pillar pages v2 | 200–400 word editorial intro per pillar; “best for” and “not for” |
+| Internal linking | Blog posts link to relevant playbooks; playbooks link to `/pricing`, `/contact?mode=book`, `/work/*` |
+| Schema | `FAQPage` on leaves with unique FAQs; `HowTo` where playbook steps qualify |
+| OG images | Combo-specific subtitle on dynamic OG (optional) |
+
+**Exit criteria:** Storybook stories for new blocks; visual review on index + 1 leaf + 1 pillar.
+
+---
+
+### Phase 3 — Pilot launch (12 pages) (1 week)
+
+**Goal:** Prove quality before scaling index.
+
+**Pilot selection** (high intent, good proof coverage):
+
+| Service | Stack | Audience | Rationale |
+|---------|-------|----------|-----------|
+| design-system-audit | react | startups | Core offer + strong portfolio |
+| design-system-audit | nextjs | startups | Matches site stack |
+| component-library-build | react | scaleups | High search intent |
+| design-tokens-setup | figma | product-teams | Token expertise |
+| ai-designops-automation | storybook | designops | Differentiated niche |
+| … | … | … | **12 total** — fill from GSC/query research |
+
+**Workflow:**
+
+1. Enrich catalog entries for pilot slugs only  
+2. `npm run pseo:generate -- --slugs <pilot-list>`  
+3. **100% human edit** pass (Petri) — tone, accuracy, remove AI tells  
+4. Quality script: ≥40% unique, ≥600 words, proof link present  
+5. Remove `noindex` for pilot slugs only  
+6. Submit sitemap; monitor GSC for 2–4 weeks  
+
+**Exit criteria:** 12 indexed leaves pass quality script + manual review; avg time-on-page baseline captured.
+
+---
+
+### Phase 4 — Scale in batches (ongoing)
+
+**Goal:** Grow to full 100 without penalty risk.
+
+| Batch | Size | Review |
+|-------|------|--------|
+| Batch A | +25 pages | 100% review |
+| Batch B–D | +25 each | 10% sample + automated gates |
+| Long tail | Remaining | Consolidate or **noindex** combos with no proof / weak intent |
+
+**Consolidation rule:** If two leaves would be >70% similar after generation, merge into one canonical page and redirect — do not publish both.
+
+**Exit criteria:** Full cluster live or consciously pruned; noindex count documented.
+
+---
+
+### Phase 5 — Measure & iterate (continuous)
+
+| Metric | Tool | Target |
+|--------|------|--------|
+| Indexation | GSC URL Inspection | Pilot pages indexed within 14 days |
+| Impressions / CTR | GSC | CTR ↑ vs formula titles (after title rewrite) |
+| Engagement | GA4 | Scroll depth, CTA clicks to contact/pricing |
+| Conversion | Contact + `/contact?mode=book` | Track `data-donny-interest="pseo-contact"` |
+| Uniqueness | `check-pseo-quality.mjs` | ≥40% on every published leaf |
+| LLM citations | Manual / AEO checks | Playbooks cited with correct URLs |
+
+---
+
+## Quality gates (CI)
+
+Add to PR validation when `content/pseo/**` changes:
+
+```bash
+node scripts/pseo/check-pseo-quality.mjs --min-unique-percent 40 --min-words 600
+node scripts/pseo/check-pseo-quality.mjs --require-proof-link --require-package-link
+```
+
+**Hard stop:** Do not remove leaf `noindex` in bulk without `--approve-bulk-index` flag and audit log.
+
+---
+
+## Human-only steps
+
+| Step | Owner | When |
+|------|-------|------|
+| Choose pilot 12 combos | Petri | Phase 3 start |
+| Edit generated copy for voice & accuracy | Petri | After each batch |
+| Map case studies to services (proof table) | Petri | Phase 1 |
+| GSC baseline export (queries, impressions) | Petri | Before pilot index |
+| Approve batch indexation (remove noindex) | Petri | After quality pass |
+| Optional: FI/SV for top 10 playbooks only | Later | Post-EN validation |
+
+---
+
+## Immediate next actions (recommended order)
+
+1. **Approve this plan** (or adjust scope: e.g. cap at 40 pages instead of 100).  
+2. **Execute Phase 0** — quick fixes + leaf noindex (safe, same day).  
+3. **Workshop pilot 12** — pick combos with portfolio backing.  
+4. **Phase 1 catalog enrichment** — start with 4 services + 5 stacks depth.  
+
+---
+
+## Related docs
+
+- [`docs/PSEO_LLM_LINK_BUILDING.md`](./PSEO_LLM_LINK_BUILDING.md) — current technical pipeline  
+- [`docs/audits/2026-05-31-digitaltableteur-site-audit.md`](./audits/2026-05-31-digitaltableteur-site-audit.md) — PSEO risk flag  
+- [`content/pseo/catalog.json`](../content/pseo/catalog.json) — data source  
+- [`scripts/pseo/generate-pseo-copy.ts`](../scripts/pseo/generate-pseo-copy.ts) — generation script  
+
+---
+
+**End of plan.** Update **Status** at top when Phase 0 begins.

--- a/docs/PSEO_LLM_LINK_BUILDING.md
+++ b/docs/PSEO_LLM_LINK_BUILDING.md
@@ -44,14 +44,21 @@ npx tsx scripts/pseo/generate-pseo-copy.ts --only-missing --limit 5
 npx tsx scripts/pseo/generate-pseo-copy.ts --slugs design-system-audit-react-startups,design-tokens-setup-nextjs-scaleups
 ```
 
-Required env:
+Required env (either provider):
 
 ```bash
+# Preferred for batch generation (avoids direct OpenAI quota limits)
+AI_GATEWAY_API_KEY=...
+AI_GATEWAY_MODEL=openai/gpt-4o-mini   # optional
+
+# Fallback
 OPENAI_API_KEY=...
-# Optional
-OPENAI_MODEL=gpt-4o-mini
-OPENAI_API_URL=https://api.openai.com/v1/chat/completions
+OPENAI_MODEL=gpt-4o-mini            # optional
 ```
+
+Use `--provider gateway` or `--provider openai` to force a backend. By default the script tries Gateway first, then OpenAI.
+
+Pilot slugs are tracked in `content/pseo/pilot-slugs.json`.
 
 ## Next steps (recommended workflow)
 

--- a/docs/audits/2026-05-31-digitaltableteur-site-audit.md
+++ b/docs/audits/2026-05-31-digitaltableteur-site-audit.md
@@ -1,0 +1,721 @@
+# Digitaltableteur Site Audit
+
+Date: 2026-05-31
+
+Scope: full local repository audit of the Next.js site, representative runtime pages, SEO/AEO surfaces, conversion paths, portfolio/blog content, recruiter/candidate paths, security/privacy posture, and build/test health.
+
+Primary goal: attract more clients, recruiters, and employee candidates while increasing visibility, trust, lead quality, and profit.
+
+## Executive Verdict
+
+Digitaltableteur has unusually strong ingredients: a clear design-system niche, visible pricing, a polished design language, strong agent/LLM discovery endpoints, real case-study breadth, and a credible author/founder voice. The main growth problem is not lack of quality. It is that the site still makes high-intent visitors work too hard to answer three buying questions:
+
+1. What exactly should I buy first?
+2. Why should I trust this team for my context?
+3. What is the next step that preserves momentum?
+
+The biggest blockers are more technical than strategic right now:
+
+- Production build currently fails on `/api/download-cv`.
+- The default `npm test` suite is broken before tests execute.
+- Programmatic SEO pages render duplicate section bodies and are mostly generic generated copy.
+- Analytics and tracking scripts load before the cookie consent layer can gate them.
+- The homepage headline changes after hydration, weakening stable positioning and SEO clarity.
+
+Fix those first. Then turn the existing credibility into revenue by making each commercial path more specific: package-specific booking CTAs, proof tied to each package, recruiter/candidate pages, stronger case-study metrics, and Search Console backed content expansion around design systems, AI-ready DesignOps, and agent-ready component libraries.
+
+## Evidence Gathered
+
+Commands and checks:
+
+- `npm run typecheck`: passed.
+- `npm run lint`: passed with warnings.
+- `npm test -- --runInBand`: invalid Vitest flag for this project.
+- `npm test`: failed before executing tests due Storybook browser setup importing Node-only `fs` into the browser project.
+- `npm run test:ci`: passed, 204 files and 1747 tests.
+- `npm run build`: failed while collecting page data for `/api/download-cv`.
+- Local dev runtime checks on `/`, `/pricing`, `/contact?mode=book`, `/pseo/design-system-audit-react-startups`, `/robots.txt`, `/llms.txt`, and sitemap/metadata surfaces.
+- Browser snapshots on desktop and mobile for the homepage and mobile contact booking path.
+- Repository content inspection for blog, portfolio, PSEO catalog, structured data, sitemap, analytics, contact form, CV download, and layout/navigation.
+- Cross-check against Google Search Central and web.dev guidance listed in "Sources".
+
+Local screenshots captured:
+
+- `/tmp/digitaltableteur-home-desktop.png`
+- `/tmp/digitaltableteur-home-mobile.png`
+- `/tmp/digitaltableteur-contact-book-mobile.png`
+
+## P0: Must Fix Before Growth Work
+
+### 1. Production Build Fails
+
+`npm run build` compiled, then failed during page data collection:
+
+```text
+PageNotFoundError: Cannot find module for page: /api/download-cv
+Build error occurred
+Failed to collect page data for /api/download-cv
+```
+
+Relevant file:
+
+- `app/api/download-cv/route.ts:69`
+
+Why it matters:
+
+- A site that cannot produce a production build is the highest revenue risk. It blocks deployment confidence, SEO validation, bundle analysis, and proper performance measurement.
+- The CV route is also part of the recruiter path, so the failure intersects with a growth audience.
+
+Recommended fix:
+
+- Isolate why Next treats `/api/download-cv` as a missing module during page-data collection.
+- Add a focused route test for successful auth, failed auth, missing `CV_PASSWORD`, missing file, CORS OPTIONS, and cache headers.
+- Re-run `npm run build` and only then run production Lighthouse/PageSpeed/bundle analysis.
+
+### 2. Default Test Command Is Broken
+
+`npm test` fails before executing tests. Storybook browser tests import `.storybook/vitest.setup.ts`, which imports `.storybook/lib/resolve-figma-from-contract.ts`, which imports Node `fs`; browser Vitest then errors because `node:fs` is externalized for browser compatibility.
+
+Observed warnings also include:
+
+- Storybook 10.3 automatically applies `setProjectAnnotations`, but setup still contains it.
+- Storybook `test.include` is ignored in favor of `stories`.
+- Mixed `vitest@4.1.7` and `@vitest/browser@4.0.18` are unsupported.
+- PostCSS warning: `@import "tw-animate-css"` appears after `@plugin "@tailwindcss/typography"`.
+
+Why it matters:
+
+- `npm run test:ci` passes, but the default test command is the command most agents and humans will try first.
+- Broken default tests slow down every future improvement pass and make automated QA less trustworthy.
+
+Recommended fix:
+
+- Split browser-safe Storybook setup from Node-only Figma contract resolution.
+- Align Vitest and `@vitest/browser` versions.
+- Update Storybook 10 config to remove deprecated/manual setup.
+- Fix Tailwind/PostCSS import order.
+
+### 3. Build-Time Type And Lint Checks Are Disabled
+
+`next.config.ts:153` says build validation is disabled because of older type conflicts:
+
+- `next.config.ts:157` has `eslint.ignoreDuringBuilds: true`.
+- `next.config.ts:160` has `typescript.ignoreBuildErrors: true`.
+
+Current `npm run typecheck` passes, which means the comment is likely stale.
+
+Why it matters:
+
+- Silent production builds with ignored lint/type errors are acceptable only as a temporary migration escape hatch.
+- The site is now in a phase where commercial confidence matters more than keeping an old workaround.
+
+Recommended fix:
+
+- Re-enable TypeScript and ESLint checks in build once the `/api/download-cv` build failure is resolved.
+- If any build-only type errors appear, fix them directly and delete the stale TODO.
+
+## P1: Revenue And Conversion
+
+### 4. The Homepage Proposition Is Too Volatile
+
+The homepage hero selects headline and subtext variants from session storage after hydration:
+
+- `nextjs-app/shared/patterns/HomeHero/HomeHero.tsx:73`
+- `nextjs-app/shared/patterns/HomeHero/HomeHero.tsx:87`
+- `nextjs-app/shared/patterns/HomeHero/HomeHero.tsx:129`
+
+Observed:
+
+- SSR HTML contained a different H1 than the browser-rendered page.
+- Browser-rendered H1: "World-class design. Startup speed."
+
+Why it matters:
+
+- The first viewport is polished, but the core business promise is not stable.
+- Search engines, AI summarizers, social previews, returning users, and screenshots may see different propositions.
+- For high-value B2B leads, clarity beats novelty.
+
+Recommended fix:
+
+- Use one stable H1 that states the literal offer and buyer outcome.
+- Move variant testing into controlled experiments with analytics event tracking, not random session selection.
+- Strong candidate: "AI-ready design systems for teams shipping faster."
+- Make the subtext name the buyer and result: "We audit, design, and implement component systems that help product teams ship consistent interfaces without slowing engineering."
+
+### 5. Pricing Exists, But Package CTAs Are Not Specific Enough
+
+The pricing page is a major strength. It already has visible package ranges:
+
+- UX Sprint: EUR 8-14k.
+- AI-Ready DesignOps: EUR 11-17k.
+- Design System Lift-Off: EUR 14-20k.
+
+Relevant file:
+
+- `nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx:60`
+- The only primary CTA is `/contact?mode=book` at `PricingPageContent.tsx:301`.
+
+Gap:
+
+- Package cards do not have their own CTAs.
+- Package clicks do not pass package context into contact or booking.
+- Proof is not tied to the package a buyer is considering.
+
+Recommended fix:
+
+- Add package-specific CTAs:
+  - `/contact?mode=book&package=ux-sprint`
+  - `/contact?mode=book&package=ai-ready-designops`
+  - `/contact?mode=book&package=design-system-lift-off`
+- Preselect/expand matching form fields from `package`.
+- Add one proof module under each package: case study, outcome, artifact preview, or before/after.
+- Add "best for" and "not for" copy so qualified buyers self-select faster.
+
+### 6. Booking Can Fall Back To "Not Live"
+
+The contact booking path has a configured path and a fallback:
+
+- `nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx:107`
+- Fallback copy at `ContactInquiryPanel.tsx:110`
+
+Local runtime showed Cal.com is configured, which is good. But if env config is absent in production, the main pricing CTA can land a buyer on "Online scheduling is not live yet."
+
+Recommended fix:
+
+- Add a smoke test or deploy check that fails when pricing CTAs are live but booking env is missing.
+- If booking is missing, automatically redirect to the message form with package context and a high-intent subject.
+
+### 7. Contact Form Captures Leads, But Does Not Close The Loop
+
+The form posts to `/api/contact` and collects useful optional context:
+
+- `nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx:347`
+
+Server behavior:
+
+- Sends Resend email first.
+- Inserts MongoDB record second.
+- If Mongo fails after email sends, the client receives a 500 and may retry, creating duplicate emails.
+
+Relevant file:
+
+- `app/api/contact/route.ts:181`
+
+Recommended fix:
+
+- Persist lead first with a status, then send email, then mark sent.
+- Or return success when email succeeds and DB logging fails, while logging the DB failure separately.
+- Add conversion events for:
+  - contact form viewed
+  - optional details expanded
+  - package selected
+  - form submitted
+  - booking clicked
+  - booking opened externally
+
+## P1: SEO, AEO, And AI Search Visibility
+
+### 8. Programmatic SEO Is Currently The Biggest Search Risk
+
+The PSEO system generates 100 leaf pages from 4 services, 5 stacks, and 5 audiences:
+
+- `lib/pseo/catalog.ts:33`
+
+But custom PSEO copy is empty:
+
+- `content/pseo/copy.json:1`
+
+And each section body is rendered twice:
+
+- `nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx:153`
+- duplicate `MarkdownMessage` at `PseoLeafPage.tsx:158` and `PseoLeafPage.tsx:163`
+
+Additional issue:
+
+- `titleCase()` at `lib/pseo/catalog.ts:13` turns names like "Next.js" into "Next.Js".
+
+Why it matters:
+
+- Google guidance warns that scaled generated pages without added value may violate scaled-content spam policies.
+- Duplicated content wastes crawl budget and weakens perceived quality.
+- AI search features still depend on indexable, helpful, textual content. Thin templated pages are less likely to be cited or trusted.
+
+Recommended fix:
+
+- Remove the duplicate body render immediately.
+- Either noindex PSEO leaf pages until unique copy exists, or reduce the set to a small number of genuinely useful pages.
+- For each retained page, add:
+  - unique buyer problem
+  - concrete deliverables
+  - proof/example
+  - pricing or engagement model
+  - FAQ visible on page if structured
+  - internal links to relevant case studies and pricing package
+- Replace naive title casing with explicit display names.
+
+### 9. FAQ Structured Data Is Low ROI And Potentially Stale
+
+The homepage emits JSON-LD FAQ-like structured data that is not visible as matching FAQ content in the first viewport/content inspection.
+
+Google now states FAQ rich results no longer appear in Search as of May 7, 2026 and support is being removed from tools. It also requires FAQ content to be visible on the source page for eligibility.
+
+Recommended fix:
+
+- Remove FAQPage JSON-LD unless the matching FAQ is visibly present and strategically useful.
+- Prefer Organization, WebSite, BreadcrumbList, Article, Person, Service, and Product/Offer-like schema only where each maps to visible page content.
+- Validate high-value pages with Rich Results Test and URL Inspection after deploy.
+
+### 10. Sitemap Uses "Today" For Too Many Stable URLs
+
+`app/sitemap.ts:13` sets `today = new Date()` and applies it to static, work, author, PSEO, and pillar routes.
+
+Why it matters:
+
+- Artificially changing `lastModified` can make the site look noisier to crawlers.
+- It hides which pages actually changed.
+
+Recommended fix:
+
+- Use real modified dates from content metadata, project metadata, or a checked-in route manifest.
+- For stable pages, set a fixed last meaningful update date.
+- For generated PSEO pages, tie `lastModified` to the source catalog/copy version.
+
+### 11. Blog Metadata Is Incomplete
+
+Observed from `app/blog/postMetadata.ts`:
+
+- Visible posts include strong topics, and scheduled June 2026 posts show an agentic design systems editorial plan.
+- Several visible older posts lack `mainImageUrl`.
+- All visible inspected posts lacked explicit `seoTitle` and `seoDescription`.
+
+Relevant fields:
+
+- `app/blog/postMetadata.ts:17`
+- `app/blog/postMetadata.ts:22`
+
+Recommended fix:
+
+- Add SEO titles/descriptions for every visible post.
+- Add OG images for every post, especially the older posts that still rank or get shared.
+- Build topic clusters:
+  - agent-ready design systems
+  - design-system audits
+  - AI DesignOps
+  - component contracts
+  - Figma to code governance
+  - Storybook adoption
+- Each post should link to a relevant package and one case study.
+
+### 12. LLM Discovery Is Strong, But Do Not Treat It As A Ranking Shortcut
+
+The site has `llms.txt`, `llms-full.txt`, `.well-known` endpoints, and crawler-specific robots handling. This is ahead of many competitors.
+
+But Google's current AI Search guidance says no special machine-readable AI text files or special schema are required to appear in AI features. The fundamentals still matter: crawlability, internal links, page experience, textual content, high-quality media, and structured data matching visible content.
+
+Recommended fix:
+
+- Keep LLM files because they help agents and non-Google tools.
+- Use them as a content distribution surface, not a replacement for strong public pages.
+- Add examples, pricing, case studies, and proof to agent-readable summaries so AI tools can answer "why Digitaltableteur?" with specifics.
+
+## P1: Portfolio And Proof
+
+### 13. Case Studies Need Business Outcomes
+
+The portfolio breadth is good: 12 projects, 7 featured. The gap is measurable outcomes.
+
+Observed:
+
+- Project data has no `metrics` field usage for the inspected projects.
+- Several projects lack `liveUrl`.
+- Work index ends after the grid with no next conversion step.
+
+Relevant files:
+
+- `nextjs-app/shared/data/projects.ts`
+- `nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx:67`
+
+Recommended fix:
+
+- Add a metrics model to project data:
+  - adoption
+  - delivery speed
+  - accessibility score
+  - component count
+  - Storybook/test coverage
+  - design debt reduced
+  - team size supported
+  - time saved
+- Add a bottom CTA to the work index:
+  - "Want this level of system clarity in your product?"
+  - CTAs: "Book a design-system audit" and "See pricing"
+- Add case-study-specific CTAs:
+  - Client path: "Audit our system"
+  - Recruiter path: "Request CV"
+  - Candidate/collaborator path: "Work with us"
+
+### 14. Some High-Value Work Pages Lack Route-Specific OG Assets
+
+Several work pages do not appear to have route-specific `opengraph-image.tsx` equivalents:
+
+- `dsharp-design-system`
+- `rhythmguard`
+- `project-spine`
+- `llm-component-schema`
+
+Why it matters:
+
+- Portfolio links are shared in recruiter/client contexts.
+- Missing strong OG images wastes a trust moment in Slack, LinkedIn, email, and AI citation previews.
+
+Recommended fix:
+
+- Generate route-specific OG images for every featured case study.
+- Include the client/product name, role, and one measurable outcome.
+
+### 15. Project Spine Page Uses Legacy Next Image Props
+
+Runtime dev server reported legacy `layout` prop warnings for Project Spine images:
+
+- `nextjs-app/shared/components/pages/Work/ProjectSpine/ProjectSpinePage.tsx:152`
+- `ProjectSpinePage.tsx:177`
+- `ProjectSpinePage.tsx:202`
+
+Recommended fix:
+
+- Replace legacy `layout` prop with modern Next Image sizing.
+- Run the codemod or update manually.
+
+## P1: Recruiters And Candidates
+
+### 16. Recruiter Path Exists, But It Is Too Hidden
+
+The site has About and secure CV download components, but the main navigation does not explicitly serve recruiter intent. The CV component posts to an external proxy:
+
+- `nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.tsx:55`
+- `nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.tsx:105`
+
+Why it matters:
+
+- Recruiters and hiring managers need fast answers: role fit, CV, availability, location/time zone, work authorization, seniority, and proof.
+- An external `digitaltableteursecureproxy.vercel.app` endpoint may lower trust compared with the main domain.
+
+Recommended fix:
+
+- Fix and use the local `/api/download-cv` route or put the proxy behind the main domain.
+- Add a recruiter-focused page or section:
+  - "Senior design systems, product design, and frontend leadership"
+  - CV request
+  - short role matrix
+  - availability
+  - location/time zone
+  - selected proof
+  - LinkedIn/GitHub links
+- Add structured Person/ProfilePage data where it maps to visible content.
+
+### 17. Candidate/Collaborator Path Is Underdeveloped
+
+If the goal includes employee candidates, the site needs an explicit reason to join or collaborate.
+
+Recommended fix:
+
+- Add a "Work with Digitaltableteur" page or section.
+- Include:
+  - operating principles
+  - current/future roles
+  - collaboration model
+  - expectations
+  - benefits of working on design systems, AI tooling, and product craft
+  - candidate contact CTA
+- Link it from About and footer. Only add top-nav placement if hiring is an active priority.
+
+## P2: UX, Accessibility, And Trust
+
+### 18. Duplicate Skip Links
+
+There are two skip links:
+
+- `app/layout.tsx:151`
+- `nextjs-app/shared/components/NextLayout/NextLayout.tsx:33`
+
+Browser accessibility snapshot confirmed two "Skip to main content" links.
+
+Recommended fix:
+
+- Keep one skip link in the layout system, not both root layout and `NextLayout`.
+
+### 19. Mobile Contact Booking Starts With Contact Copy, Not Booking Context
+
+The mobile contact booking screenshot shows the "Let's talk." intro and bottom tab navigation, but the booking context is not immediately visible in the screenshot.
+
+Recommended fix:
+
+- When `?mode=book`, make the booking tab and booking content visually primary above the fold.
+- Keep the message tab available, but do not force booking visitors to infer where the booking UI is.
+
+### 20. Chat Widget Competes With Primary CTAs
+
+The chat bubble is visually strong and appears on the homepage and mobile contact path.
+
+Potential issue:
+
+- It can help conversion if it answers buying questions.
+- It can also distract from booking/contact CTAs if not measured.
+
+Recommended fix:
+
+- Track chat opens and assisted conversions.
+- If chat does not assist leads, suppress it on high-intent checkout-style pages like pricing/contact or make it less visually dominant.
+
+## P2: Privacy, Consent, And Security
+
+### 21. Analytics Load Before Consent
+
+Tracking scripts are rendered before the cookie consent provider:
+
+- GTM at `app/layout.tsx:123`
+- Ahrefs at `app/layout.tsx:132`
+- gtag at `app/layout.tsx:137`
+- Vercel Analytics at `app/layout.tsx:181`
+- Cookie consent provider starts at `app/layout.tsx:190`
+
+Why it matters:
+
+- This is a trust and compliance issue, especially for EU visitors.
+- It also weakens the credibility of analytics consent claims.
+
+Recommended fix:
+
+- Default analytics consent to denied before loading tracking.
+- Load analytics only after consent or use consent mode where appropriate.
+- Keep essential operational telemetry separate from marketing analytics.
+
+### 22. CV Download Response Should Be Explicitly Non-Cacheable
+
+The CV route returns PDF headers but no explicit private/no-store cache header:
+
+- `app/api/download-cv/route.ts:171`
+
+Recommended fix:
+
+- Add `Cache-Control: private, no-store, max-age=0`.
+- Consider `X-Robots-Tag: noindex, noarchive`.
+- Remove the duplicated `CV_PASSWORD` configuration check at `app/api/download-cv/route.ts:90` and `app/api/download-cv/route.ts:124`.
+
+### 23. CSP Still Allows Unsafe Inline
+
+Production CSP allows `unsafe-inline` for scripts/styles in `next.config.ts` security headers.
+
+Recommended fix:
+
+- Keep as-is only if required by current Next/analytics setup.
+- Long term, move toward nonce/hashes for scripts and reduce inline style reliance.
+- Align `X-Frame-Options: SAMEORIGIN` with `frame-ancestors 'none'` to avoid mixed intent.
+
+## P2: Performance
+
+### 24. Bundle And Runtime Need Production Measurement After Build Is Fixed
+
+Dev cold routes were slow:
+
+- `/`: 200 after compile, about 122 KB HTML.
+- `/pricing`: 200 after compile, about 91 KB HTML.
+- `/contact?mode=book`: 200 after compile, about 102 KB HTML.
+- `/pseo/design-system-audit-react-startups`: 200 after compile, about 379 KB HTML.
+
+These are not production metrics, but they point to areas to measure:
+
+- animation libraries
+- chat widget
+- analytics tags
+- PSEO Markdown/render payload
+- homepage hero animation
+- cookie/chat overlays
+
+Recommended fix:
+
+- Fix build first.
+- Run production `next build` with bundle analyzer.
+- Run PageSpeed/Lighthouse on production or a local production server.
+- Track Core Web Vitals using field data, especially LCP, INP, and CLS at the 75th percentile.
+
+## Growth Opportunities
+
+### A. Make The Offer Ladder Explicit
+
+Current packages are close to useful. Turn them into a clear ladder:
+
+1. Audit: lower-friction entry offer, fixed price, fast turnaround.
+2. Sprint: prototype/eval/handoff.
+3. Lift-Off: design-system implementation.
+4. Retainer: governance, components, and agent-ready operations.
+
+Each offer should have:
+
+- price range or starting price
+- duration
+- deliverables
+- best fit
+- not a fit
+- sample output
+- proof
+- package-specific booking CTA
+
+### B. Create Three Landing Pages For Three Audiences
+
+Clients:
+
+- `/services/design-system-audit`
+- `/services/ai-ready-designops`
+- `/services/design-system-lift-off`
+
+Recruiters:
+
+- `/hire-petri-lahdelma` or `/cv`
+- CV, role fit, availability, proof, and contact.
+
+Candidates/collaborators:
+
+- `/work-with-us`
+- collaboration model, values, open opportunities, and contact.
+
+### C. Turn Case Studies Into Sales Assets
+
+For each priority service, create a proof chain:
+
+- Service page
+- Pricing package
+- Case study
+- Blog article
+- Contact/booking CTA
+
+Example:
+
+- "Design System Lift-Off" package links to Helsinki Design System, SAP Build Apps, D# Design System, and a blog post about component contracts.
+
+### D. Build Search Demand Around Specific Problems
+
+The strongest content topics are not generic "design systems". They are high-intent problems:
+
+- "design system audit"
+- "Storybook design system audit"
+- "AI-ready design system"
+- "Figma to Storybook governance"
+- "component contract examples"
+- "design system adoption playbook"
+- "design tokens governance"
+- "frontend design system consultant"
+
+Each topic should answer:
+
+- symptoms
+- cost of inaction
+- diagnostic checklist
+- example output
+- pricing/engagement model
+- case-study proof
+- CTA
+
+### E. Add A Trust Strip Near Every CTA
+
+Use concrete proof near CTAs:
+
+- selected clients/products
+- years of experience
+- shipped systems
+- components/tokens/tests count where accurate
+- accessibility or performance outcomes
+- testimonials with attribution
+- logos only where permission exists
+
+Avoid anonymous testimonials on pricing unless attribution is impossible and the copy clearly labels it as representative feedback.
+
+### F. Build A Measurement Plan
+
+Required events:
+
+- `view_home_hero`
+- `click_primary_cta`
+- `view_pricing`
+- `select_package`
+- `click_book_call`
+- `open_cal`
+- `submit_contact`
+- `contact_success`
+- `download_cv_attempt`
+- `download_cv_success`
+- `open_chat`
+- `chat_lead`
+
+Required dimensions:
+
+- package
+- source page
+- language
+- audience intent
+- CTA label
+- form mode
+- consent state
+
+## 30/60/90 Day Plan
+
+### First 7 Days
+
+- Fix production build for `/api/download-cv`.
+- Fix default `npm test`.
+- Re-enable build type/lint checks.
+- Remove duplicate PSEO body rendering.
+- Remove or noindex thin PSEO leaf pages until unique content exists.
+- Add consent-gated analytics loading.
+- Add one stable homepage H1.
+- Add package query params from pricing to contact/booking.
+
+### Days 8-30
+
+- Add package-specific proof modules and CTAs.
+- Add portfolio metrics fields and update top 5 case studies.
+- Add recruiter/CV page or improve About with recruiter-specific path.
+- Add missing blog SEO metadata and OG images.
+- Fix sitemap `lastModified` values.
+- Add conversion tracking events.
+- Run production PageSpeed, Search Console URL inspection, and Rich Results validation.
+
+### Days 31-60
+
+- Publish three high-intent service pages.
+- Publish 4-6 problem-led articles tied to service pages.
+- Add route-specific OG images for featured case studies.
+- Add bottom CTA to Work index and case-study pages.
+- Add candidate/collaborator page if hiring/collaboration is active.
+- Build a lead dashboard: source, package, CTA, conversion rate, close rate.
+
+### Days 61-90
+
+- Expand only the PSEO pages that show impressions or clear demand.
+- Turn successful posts into lead magnets or diagnostic checklists.
+- Add email follow-up for contact/booking leads.
+- Test homepage proposition variants with tracked experiments.
+- Build public proof assets: audits, teardown posts, component contract examples, short video walkthroughs.
+
+## Priority Stack Rank
+
+1. Fix build failure.
+2. Fix default tests.
+3. Stop shipping build with ignored type/lint checks.
+4. Repair/noindex PSEO leaf pages.
+5. Consent-gate analytics.
+6. Stabilize homepage proposition.
+7. Add package-specific CTAs and lead context.
+8. Add proof and metrics to pricing and portfolio.
+9. Build recruiter/CV path on main domain.
+10. Add measurement and Search Console feedback loops.
+
+## Sources
+
+- Google Search Central, AI features and your website: https://developers.google.com/search/docs/appearance/ai-features
+- Google Search Central, using generative AI content on your website: https://developers.google.com/search/docs/fundamentals/using-gen-ai-content
+- Google Search Central, SEO Starter Guide: https://developers.google.com/search/docs/fundamentals/seo-starter-guide
+- Google Search Central, General structured data guidelines: https://developers.google.com/search/docs/appearance/structured-data/sd-policies
+- Google Search Central, FAQ structured data: https://developers.google.com/search/docs/appearance/structured-data/faqpage
+- web.dev, Web Vitals: https://web.dev/articles/vitals
+- web.dev, Core Web Vitals thresholds: https://web.dev/articles/defining-core-web-vitals-thresholds

--- a/lib/pseo/catalog.test.ts
+++ b/lib/pseo/catalog.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildLeafDescription,
+  buildLeafTitle,
+  getStackDisplayName,
+} from "./display";
+import { getPseoLeafPages } from "./catalog";
+import { buildLeafStructuredBlocks } from "./leaf-blocks";
+import { isPseoLeafIndexable } from "./indexing";
+
+describe("pseo display", () => {
+  it("preserves Next.js and TypeScript casing in titles", () => {
+    const pages = getPseoLeafPages();
+    const nextPage = pages.find((p) => p.stack.slug === "nextjs");
+    const tsPage = pages.find((p) => p.stack.slug === "typescript");
+
+    expect(nextPage?.title).toContain("Next.js");
+    expect(nextPage?.title).not.toContain("Next.Js");
+    expect(tsPage?.title).toContain("TypeScript");
+  });
+
+  it("builds leaf titles without broken title case", () => {
+    const title = buildLeafTitle(
+      { slug: "design-system-audit", name: "Design system audit", shortDescription: "" },
+      { slug: "nextjs", name: "Next.js", displayName: "Next.js", shortDescription: "" },
+      { slug: "startups", name: "startup teams", shortDescription: "" },
+    );
+    expect(title).toBe(
+      "Design system audit for startup teams using Next.js",
+    );
+  });
+
+  it("uses displayName for stacks", () => {
+    expect(
+      getStackDisplayName({
+        slug: "nextjs",
+        name: "Next.js",
+        shortDescription: "",
+      }),
+    ).toBe("Next.js");
+  });
+
+  it("builds descriptions with stack display names", () => {
+    const description = buildLeafDescription(
+      { slug: "s", name: "Design system audit", shortDescription: "Assess UI." },
+      { slug: "nextjs", name: "Next.js", displayName: "Next.js", shortDescription: "" },
+      { slug: "startups", name: "startup teams", shortDescription: "" },
+    );
+    expect(description).toContain("Next.js");
+  });
+});
+
+describe("pseo leaf blocks", () => {
+  it("produces combo-specific structured content", () => {
+    const pages = getPseoLeafPages();
+    const reactStartup = pages.find(
+      (p) =>
+        p.service.slug === "design-system-audit" &&
+        p.stack.slug === "react" &&
+        p.audience.slug === "startups",
+    );
+    const figmaEnterprise = pages.find(
+      (p) =>
+        p.service.slug === "design-tokens-setup" &&
+        p.stack.slug === "figma" &&
+        p.audience.slug === "enterprises",
+    );
+
+    expect(reactStartup).toBeDefined();
+    expect(figmaEnterprise).toBeDefined();
+
+    const reactBlocks = buildLeafStructuredBlocks(reactStartup!);
+    const figmaBlocks = buildLeafStructuredBlocks(figmaEnterprise!);
+
+    expect(reactBlocks.situationMarkdown).toContain("startup teams");
+    expect(figmaBlocks.situationMarkdown).toContain("enterprise teams");
+    expect(reactBlocks.proofLinks.length).toBeGreaterThan(0);
+    expect(reactBlocks.packageFit?.slug).toBe("ux-sprint");
+    expect(figmaBlocks.packageFit?.slug).toBe("design-system-lift-off");
+  });
+});
+
+describe("pseo indexing", () => {
+  it("defaults leaves to noindex until pilot slugs are listed", () => {
+    expect(isPseoLeafIndexable("design-system-audit-react-startups")).toBe(false);
+  });
+});

--- a/lib/pseo/catalog.ts
+++ b/lib/pseo/catalog.ts
@@ -6,28 +6,25 @@ import type {
 } from "./types";
 
 import catalog from "@/content/pseo/catalog.json";
+import {
+  buildLeafDescription,
+  buildLeafTitle,
+} from "./display";
 
 const toLeafSlug = ({ serviceSlug, stackSlug, audienceSlug }: PseoLeafPageKey) =>
   `${serviceSlug}-${stackSlug}-${audienceSlug}`;
 
-const titleCase = (text: string) =>
-  text.replace(/\b\w/g, (match) => match.toUpperCase());
-
-const buildLeafTitle = (
-  service: PseoCatalogItem,
-  stack: PseoCatalogItem,
-  audience: PseoCatalogItem,
-) => `${service.name} for ${audience.name} using ${stack.name}`;
-
-const buildLeafDescription = (
-  service: PseoCatalogItem,
-  stack: PseoCatalogItem,
-  audience: PseoCatalogItem,
-) =>
-  `${service.shortDescription} Tailored for ${audience.name} shipping with ${stack.name}.`;
-
 export function getPseoCatalog(): PseoCatalog {
   return catalog as unknown as PseoCatalog;
+}
+
+export function getPseoCatalogUpdatedAt(): Date {
+  const raw = getPseoCatalog().catalogUpdatedAt;
+  if (raw) {
+    const parsed = new Date(raw);
+    if (!Number.isNaN(parsed.getTime())) return parsed;
+  }
+  return new Date("2026-05-28T00:00:00.000Z");
 }
 
 export function getPseoLeafPages(): PseoLeafPage[] {
@@ -44,7 +41,7 @@ export function getPseoLeafPages(): PseoLeafPage[] {
         });
         pages.push({
           slug,
-          title: titleCase(buildLeafTitle(service, stack, audience)),
+          title: buildLeafTitle(service, stack, audience),
           description: buildLeafDescription(service, stack, audience),
           service,
           stack,
@@ -100,4 +97,3 @@ export function getRelatedPseoLeafPages(
     .slice(0, limit)
     .map((entry) => entry.candidate);
 }
-

--- a/lib/pseo/display.ts
+++ b/lib/pseo/display.ts
@@ -1,0 +1,38 @@
+import type { PseoCatalogItem } from "./types";
+
+/** Known product names that must not be title-cased incorrectly (e.g. Next.Js). */
+const PRESERVED_TOKENS: Record<string, string> = {
+  nextjs: "Next.js",
+  typescript: "TypeScript",
+  storybook: "Storybook",
+  figma: "Figma",
+  react: "React",
+};
+
+export function getStackDisplayName(item: PseoCatalogItem): string {
+  return item.displayName ?? PRESERVED_TOKENS[item.slug] ?? item.name;
+}
+
+export function getServiceDisplayName(item: PseoCatalogItem): string {
+  return item.displayName ?? item.name;
+}
+
+export function getAudienceDisplayName(item: PseoCatalogItem): string {
+  return item.displayName ?? item.name;
+}
+
+export function buildLeafTitle(
+  service: PseoCatalogItem,
+  stack: PseoCatalogItem,
+  audience: PseoCatalogItem,
+): string {
+  return `${getServiceDisplayName(service)} for ${getAudienceDisplayName(audience)} using ${getStackDisplayName(stack)}`;
+}
+
+export function buildLeafDescription(
+  service: PseoCatalogItem,
+  stack: PseoCatalogItem,
+  audience: PseoCatalogItem,
+): string {
+  return `${service.shortDescription} Tailored for ${getAudienceDisplayName(audience)} shipping with ${getStackDisplayName(stack)}.`;
+}

--- a/lib/pseo/indexing.ts
+++ b/lib/pseo/indexing.ts
@@ -1,0 +1,11 @@
+import { getPseoCatalog } from "./catalog";
+
+/** Leaf slugs approved for search indexing (pilot / batch rollout). */
+export function getIndexedPseoLeafSlugs(): Set<string> {
+  const slugs = getPseoCatalog().generation?.indexedLeafSlugs ?? [];
+  return new Set(slugs);
+}
+
+export function isPseoLeafIndexable(slug: string): boolean {
+  return getIndexedPseoLeafSlugs().has(slug);
+}

--- a/lib/pseo/leaf-blocks.ts
+++ b/lib/pseo/leaf-blocks.ts
@@ -1,0 +1,231 @@
+import {
+  CONSULTING_PACKAGES,
+  getCaseStudyBySlug,
+} from "@/nextjs-app/shared/data/consulting-catalog";
+
+import {
+  buildLeafDescription,
+  getAudienceDisplayName,
+  getStackDisplayName,
+} from "./display";
+import type { PseoCatalogItem, PseoLeafPage, PseoPageCopy } from "./types";
+
+export type PseoProofLink = {
+  slug: string;
+  title: string;
+  href: string;
+  reason: string;
+};
+
+export type PseoPackageFit = {
+  slug: string;
+  name: string;
+  priceRangeEur: string;
+  duration: string;
+  reason: string;
+};
+
+export type PseoLeafStructuredBlocks = {
+  situationMarkdown: string;
+  failureModesMarkdown: string;
+  deliverablesMarkdown: string;
+  playbookMarkdown: string;
+  proofLinks: PseoProofLink[];
+  packageFit: PseoPackageFit | null;
+  faqs: Array<{ question: string; answerMarkdown: string }>;
+};
+
+const defaultPlaybookSteps = [
+  "Baseline the current UI surface area and ownership model.",
+  "Identify the highest-friction inconsistencies blocking delivery.",
+  "Define the smallest set of standards that removes rework.",
+  "Implement, document, and agree on how changes get reviewed.",
+];
+
+function resolvePackageFit(service: PseoCatalogItem): PseoPackageFit | null {
+  const slug = service.pricingPackageSlug;
+  if (!slug) return null;
+
+  const pkg = CONSULTING_PACKAGES.find((entry) => entry.id === slug);
+  if (!pkg) return null;
+
+  return {
+    slug: pkg.id,
+    name: pkg.name,
+    priceRangeEur: pkg.priceRangeEur,
+    duration: pkg.duration,
+    reason:
+      service.packageFitReason ??
+      `${pkg.name} matches the scope and timeline for ${service.name.toLowerCase()}.`,
+  };
+}
+
+function resolveProofLinks(service: PseoCatalogItem): PseoProofLink[] {
+  const slugs = service.relatedWorkSlugs ?? [];
+  return slugs
+    .map((slug) => {
+      const study = getCaseStudyBySlug(slug);
+      if (!study) return null;
+      return {
+        slug,
+        title: study.title,
+        href: `/work/${slug}`,
+        reason:
+          service.proofReasons?.[slug] ??
+          `Relevant case study for ${service.name.toLowerCase()}.`,
+      };
+    })
+    .filter((entry): entry is PseoProofLink => entry !== null);
+}
+
+function buildSituation(page: PseoLeafPage): string {
+  const stackName = getStackDisplayName(page.stack);
+  const audienceName = getAudienceDisplayName(page.audience);
+  const constraints = page.audience.constraints?.length
+    ? page.audience.constraints.join(", ")
+    : page.audience.shortDescription;
+  const stackNotes = page.stack.implementationNotes ?? [];
+  const stackPitfall = page.stack.commonPitfalls?.[0];
+
+  const lines = [
+    `**Who this is for:** ${audienceName} shipping ${page.service.name.toLowerCase()} on ${stackName}.`,
+    `**Typical constraints:** ${constraints}.`,
+  ];
+
+  if (page.audience.successMetric) {
+    lines.push(`**Success looks like:** ${page.audience.successMetric}.`);
+  }
+
+  if (stackNotes.length > 0) {
+    lines.push(
+      `**${stackName} focus areas:** ${stackNotes.slice(0, 2).join("; ")}.`,
+    );
+  }
+
+  if (stackPitfall) {
+    lines.push(`**Watch for:** ${stackPitfall}`);
+  }
+
+  return lines.join("\n\n");
+}
+
+function buildFailureModes(service: PseoCatalogItem, stack: PseoCatalogItem): string {
+  const servicePains = service.painPoints ?? [];
+  const stackPains = stack.commonPitfalls ?? [];
+  const bullets = [...servicePains, ...stackPains];
+
+  if (bullets.length === 0) {
+    return "- UI patterns diverge squad by squad\n- Accessibility regressions ship under deadline pressure\n- Design tokens and code tokens drift apart";
+  }
+
+  return bullets.map((point) => `- ${point}`).join("\n");
+}
+
+function buildDeliverables(service: PseoCatalogItem): string {
+  const items = service.deliverables ?? [
+    "Prioritized findings and scope boundaries",
+    "Accessibility and QA checklist",
+    "Implementation roadmap with owners",
+    "Documentation your team can maintain",
+  ];
+
+  return items.map((item) => `- ${item}`).join("\n");
+}
+
+function buildDefaultPlaybook(
+  page: PseoLeafPage,
+  service: PseoCatalogItem,
+): string {
+  const stackName = getStackDisplayName(page.stack);
+  const steps = service.playbookSteps ?? defaultPlaybookSteps;
+  const stackNotes = page.stack.implementationNotes ?? [];
+
+  const numbered = steps
+    .map((step, index) => `${index + 1}. ${step}`)
+    .join("\n");
+
+  const stackSection =
+    stackNotes.length > 0
+      ? `\n\n**${stackName} specifics:**\n${stackNotes.map((note) => `- ${note}`).join("\n")}`
+      : "";
+
+  return `${numbered}${stackSection}`;
+}
+
+function buildDefaultFaqs(page: PseoLeafPage, service: PseoCatalogItem) {
+  const stackName = getStackDisplayName(page.stack);
+  const audienceName = getAudienceDisplayName(page.audience);
+  const timeline = service.typicalTimeline ?? "1–4 weeks depending on surface area";
+
+  return [
+    {
+      question: `How long does ${service.name.toLowerCase()} take for ${audienceName} on ${stackName}?`,
+      answerMarkdown: `Most engagements run **${timeline}**. We scope against your live ${stackName} codebase—not a generic template.`,
+    },
+    {
+      question: `Can you ${service.name.toLowerCase()} without pausing ${stackName} feature work?`,
+      answerMarkdown:
+        "Yes. We sequence work around your release calendar and land changes incrementally so squads keep shipping.",
+    },
+    {
+      question: `What should ${audienceName} prepare before kickoff?`,
+      answerMarkdown: `Repo or Storybook access, your primary Figma library, and one decision-maker who can define done for ${stackName} UI standards.`,
+    },
+  ];
+}
+
+export function buildLeafStructuredBlocks(
+  page: PseoLeafPage,
+): PseoLeafStructuredBlocks {
+  return {
+    situationMarkdown: buildSituation(page),
+    failureModesMarkdown: buildFailureModes(page.service, page.stack),
+    deliverablesMarkdown: buildDeliverables(page.service),
+    playbookMarkdown: buildDefaultPlaybook(page, page.service),
+    proofLinks: resolveProofLinks(page.service),
+    packageFit: resolvePackageFit(page.service),
+    faqs: buildDefaultFaqs(page, page.service),
+  };
+}
+
+export function mergeLeafCopy(
+  page: PseoLeafPage,
+  copy?: PseoPageCopy,
+): {
+  introMarkdown: string;
+  blocks: PseoLeafStructuredBlocks;
+  description: string;
+} {
+  const blocks = buildLeafStructuredBlocks(page);
+
+  const introMarkdown =
+    copy?.introMarkdown ??
+    `${buildLeafDescription(page.service, page.stack, page.audience)}\n\nUse this playbook to scope work, align design and engineering, and avoid the failure modes we see most often on **${getStackDisplayName(page.stack)}** teams.`;
+
+  if (copy?.sections?.length) {
+    for (const section of copy.sections) {
+      if (section.id === "playbook" && section.bodyMarkdown.trim()) {
+        blocks.playbookMarkdown = section.bodyMarkdown;
+      }
+      if (section.id === "failure-modes" && section.bodyMarkdown.trim()) {
+        blocks.failureModesMarkdown = section.bodyMarkdown;
+      }
+      if (section.id === "situation" && section.bodyMarkdown.trim()) {
+        blocks.situationMarkdown = section.bodyMarkdown;
+      }
+      if (section.id === "deliverables" && section.bodyMarkdown.trim()) {
+        blocks.deliverablesMarkdown = section.bodyMarkdown;
+      }
+    }
+  }
+
+  if (copy?.faqs?.length) {
+    blocks.faqs = copy.faqs;
+  }
+
+  return {
+    introMarkdown,
+    blocks,
+    description: page.description,
+  };
+}

--- a/lib/pseo/types.ts
+++ b/lib/pseo/types.ts
@@ -2,16 +2,46 @@ export type PseoCatalogItem = {
   slug: string;
   name: string;
   shortDescription: string;
+  /** Preferred display label (preserves Next.js, TypeScript, etc.) */
+  displayName?: string;
+  /** Service-only: common client pain points */
+  painPoints?: string[];
+  /** Service-only: tangible outputs */
+  deliverables?: string[];
+  /** Service-only: typical engagement length */
+  typicalTimeline?: string;
+  /** Service-only: maps to CONSULTING_PACKAGES id */
+  pricingPackageSlug?: string;
+  /** Service-only: why this package fits */
+  packageFitReason?: string;
+  /** Service-only: portfolio slugs under /work */
+  relatedWorkSlugs?: string[];
+  /** Service-only: slug → one-line proof reason */
+  proofReasons?: Record<string, string>;
+  /** Service-only: ordered playbook steps */
+  playbookSteps?: string[];
+  /** Stack-only: stack-specific implementation notes */
+  implementationNotes?: string[];
+  /** Stack-only: frequent mistakes on this stack */
+  commonPitfalls?: string[];
+  /** Audience-only: team constraints */
+  constraints?: string[];
+  /** Audience-only: outcome metric */
+  successMetric?: string;
 };
 
 export type PseoCatalog = {
   version: number;
+  /** ISO date for stable sitemap lastModified on hub routes */
+  catalogUpdatedAt?: string;
   services: PseoCatalogItem[];
   stacks: PseoCatalogItem[];
   audiences: PseoCatalogItem[];
   generation?: {
     maxLeafPages?: number;
     relatedLinksPerPage?: number;
+    /** Leaf slugs approved for index (pilot / batch rollout) */
+    indexedLeafSlugs?: string[];
   };
 };
 
@@ -54,4 +84,3 @@ export type PseoCopyFile = {
   version: number;
   pages: Record<string, PseoPageCopy>;
 };
-

--- a/nextjs-app/shared/components/Section/Section.stories.tsx
+++ b/nextjs-app/shared/components/Section/Section.stories.tsx
@@ -27,7 +27,7 @@ const meta = {
     children: { control: false, description: "Section content" },
     spacing: {
       control: "select",
-      options: ["none", "sm", "md", "lg", "xl"],
+      options: ["none", "sm", "md", "lg", "xl", "hero", "follow"],
       description: "Block padding scale",
       table: { defaultValue: { summary: "md" } },
     },

--- a/nextjs-app/shared/components/Section/Section.tsx
+++ b/nextjs-app/shared/components/Section/Section.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 
 export interface SectionProps {
   children: ReactNode;
-  spacing?: "none" | "sm" | "md" | "lg" | "xl";
+  spacing?: "none" | "sm" | "md" | "lg" | "xl" | "hero" | "follow";
   background?: "default" | "muted" | "accent" | "inverse";
   className?: string;
   id?: string;
@@ -19,6 +19,10 @@ const spacingClasses = {
   md: "py-12 tablet:py-16 desktop:py-24",
   lg: "py-16 tablet:py-24 desktop:py-32",
   xl: "py-24 tablet:py-32 desktop:py-48",
+  /** Page hero — generous top, tight bottom (pair with `follow`) */
+  hero: "pt-16 tablet:pt-24 desktop:pt-32 pb-8 tablet:pb-10 desktop:pb-12",
+  /** Content directly after a page hero — avoids double vertical gap */
+  follow: "pt-0 pb-16 tablet:pb-24 desktop:pb-32",
 } as const;
 
 const backgroundClasses = {

--- a/nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx
+++ b/nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx
@@ -1,14 +1,13 @@
 import type { PseoCatalog, PseoLeafPage } from "@/lib/pseo/types";
 
+import { getStackDisplayName } from "@/lib/pseo/display";
+
 import PageLayout from "../../../patterns/PageLayout/PageLayout";
 import Card from "@dt/Card";
 import NextLink from "next/link";
 import Text from "@dt/Text";
 import Title from "@dt/Title";
 import styles from "./PseoIndexPage.module.css";
-
-const titleCase = (text: string) =>
-  text.replace(/\b\w/g, (match) => match.toUpperCase());
 
 export function PseoIndexPage({
   catalog,
@@ -21,17 +20,17 @@ export function PseoIndexPage({
     <PageLayout as="main" maxWidth="lg" spacing="comfortable">
       <div className={styles.root}>
         <Title terminals="sans" level={1} size="L">
-          Programmatic Guides
+          Design system playbooks
         </Title>
         <Text className={styles.lead} size="L" terminals="sans">
-          A structured library of design system and DesignOps playbooks. Each
-          guide is built with clear headings, a table of contents, and internal
-          links for both humans and LLMs.
+          Practical guides for design systems and DesignOps—organized by service,
+          stack, and team context. Each playbook includes a situation brief,
+          failure modes, checklist, and links to relevant case work.
         </Text>
 
         <section className={styles.section}>
           <Title terminals="sans" level={2} size="S">
-            Services
+            Start by service
           </Title>
           <div className={`${styles.grid} ${styles.gridTwo}`.trim()}>
             {catalog.services.map((service) => (
@@ -39,10 +38,10 @@ export function PseoIndexPage({
                 key={service.slug}
                 className={styles.card}
                 link={`/pseo/services/${service.slug}`}
-                linkLabel={`Open ${titleCase(service.name)}`}
+                linkLabel={`Open ${service.name}`}
                 hoverable
                 size="full"
-                title={titleCase(service.name)}
+                title={service.name}
                 titleProps={{
                   terminals: "sans",
                   level: 3,
@@ -62,7 +61,7 @@ export function PseoIndexPage({
 
         <section className={styles.section}>
           <Title terminals="sans" level={2} size="S">
-            Stacks
+            Browse by stack
           </Title>
           <div className={`${styles.grid} ${styles.gridTwo}`.trim()}>
             {catalog.stacks.map((stack) => (
@@ -70,10 +69,10 @@ export function PseoIndexPage({
                 key={stack.slug}
                 className={styles.card}
                 link={`/pseo/stacks/${stack.slug}`}
-                linkLabel={`Open ${titleCase(stack.name)}`}
+                linkLabel={`Open ${getStackDisplayName(stack)}`}
                 hoverable
                 size="full"
-                title={titleCase(stack.name)}
+                title={getStackDisplayName(stack)}
                 titleProps={{
                   terminals: "sans",
                   level: 3,
@@ -93,7 +92,7 @@ export function PseoIndexPage({
 
         <section className={styles.section}>
           <Title terminals="sans" level={2} size="S">
-            Audiences
+            Browse by audience
           </Title>
           <div className={`${styles.grid} ${styles.gridThree}`.trim()}>
             {catalog.audiences.map((audience) => (
@@ -101,10 +100,10 @@ export function PseoIndexPage({
                 key={audience.slug}
                 className={styles.card}
                 link={`/pseo/audiences/${audience.slug}`}
-                linkLabel={`Open ${titleCase(audience.name)}`}
+                linkLabel={`Open ${audience.name}`}
                 hoverable
                 size="full"
-                title={titleCase(audience.name)}
+                title={audience.name}
                 titleProps={{
                   terminals: "sans",
                   level: 3,
@@ -124,10 +123,11 @@ export function PseoIndexPage({
 
         <section className={styles.section}>
           <Title terminals="sans" level={2} size="S">
-            Sample pages
+            Featured playbooks
           </Title>
           <Text terminals="sans">
-            A few example landing pages from the full catalog:
+            A sample from the full library—pick a service and stack that matches
+            your team:
           </Text>
           <ul className={styles.smallList}>
             {samplePages.map((page) => (

--- a/nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css
+++ b/nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css
@@ -49,6 +49,42 @@
   margin-top: 2.5rem;
 }
 
+.proofGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.proofCard {
+  max-width: 100%;
+  height: 100%;
+}
+
+.proofReason {
+  opacity: 0.85;
+}
+
+.callout {
+  padding: 1.5rem;
+  border: 1px solid rgb(255 255 255 / 12%);
+  border-radius: 16px;
+  background: rgb(255 255 255 / 2%);
+  margin-top: 2.5rem;
+}
+
+.faqList {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+.faqItem {
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgb(255 255 255 / 8%);
+}
+
 .relatedGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));

--- a/nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx
+++ b/nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { mergeLeafCopy } from "@/lib/pseo/leaf-blocks";
 import type { PseoLeafPage, PseoPageCopy, PseoRelatedLinkCopy } from "@/lib/pseo/types";
 
 import Card from "@dt/Card";
@@ -16,41 +17,22 @@ type RelatedViewModel = {
   reasonMarkdown: string;
 };
 
-const defaultIntro = (page: PseoLeafPage) =>
-  `This guide explains how **${page.service.name.toLowerCase()}** works for **${page.audience.name}** when your product stack includes **${page.stack.name}**.\n\nIt is written as a practical playbook: clear headings, copy-pasteable checklists, and internal links to related topics.`;
-
-const buildDefaultSections = (page: PseoLeafPage) => [
-  {
-    id: "overview",
-    title: "Overview",
-    bodyMarkdown: `**Goal:** Ship a UI foundation that stays consistent as your product grows.\n\n**Context:** ${page.audience.shortDescription} ${page.stack.shortDescription}`,
-  },
-  {
-    id: "deliverables",
-    title: "What you get",
-    bodyMarkdown:
-      "- A pragmatic scope (what to standardize now vs later)\n- Accessibility and QA checklist\n- A roadmap you can execute with your team\n- Documentation and ownership model",
-  },
-  {
-    id: "process",
-    title: "Process",
-    bodyMarkdown:
-      "1. Baseline assessment (components, tokens, patterns)\n2. Identify sources of inconsistency and rework\n3. Define minimal viable standards\n4. Implement, document, and set governance",
-  },
-  {
-    id: "faq",
-    title: "FAQ",
-    bodyMarkdown:
-      "**How long does this take?** Usually days to weeks depending on surface area.\n\n**Do you work with existing code?** Yes—auditing and upgrading incrementally is often the fastest path.",
-  },
-];
+const SECTION_NAV = [
+  { id: "situation", title: "Situation" },
+  { id: "failure-modes", title: "What goes wrong" },
+  { id: "playbook", title: "Playbook" },
+  { id: "deliverables", title: "Deliverables checklist" },
+  { id: "proof", title: "Proof" },
+  { id: "package", title: "Package fit" },
+  { id: "faq", title: "FAQ" },
+] as const;
 
 const buildFallbackReason = (from: PseoLeafPage, to: PseoLeafPage): string => {
   if (from.service.slug === to.service.slug) {
     return `Same service, different angle: compare how **${from.service.name.toLowerCase()}** shifts depending on stack and team context.`;
   }
   if (from.stack.slug === to.stack.slug) {
-    return `Same stack focus: additional guidance for shipping a design system with **${from.stack.name}**.`;
+    return `Same stack focus: additional guidance for shipping a design system with **${from.stack.displayName ?? from.stack.name}**.`;
   }
   if (from.audience.slug === to.audience.slug) {
     return `Same audience: more tactics tailored for **${from.audience.name}**.`;
@@ -86,24 +68,22 @@ export function PseoLeafPageView({
   copy?: PseoPageCopy;
   relatedPages: PseoLeafPage[];
 }) {
-  const sections =
-    copy?.sections?.length && copy.sections.length > 0
-      ? copy.sections
-      : buildDefaultSections(page);
-
+  const { introMarkdown, blocks } = mergeLeafCopy(page, copy);
   const related = mergeRelated(page, relatedPages, copy?.related);
 
   return (
     <PageLayout as="main" maxWidth="md" spacing="comfortable">
       <div className={styles.root}>
         <nav className={styles.breadcrumbs} aria-label="Breadcrumb">
-          <Link href="/pseo">PSEO</Link>
+          <Link href="/pseo">Playbooks</Link>
           <span aria-hidden="true">/</span>
           <Link href={`/pseo/services/${page.service.slug}`}>
             {page.service.name}
           </Link>
           <span aria-hidden="true">/</span>
-          <Link href={`/pseo/stacks/${page.stack.slug}`}>{page.stack.name}</Link>
+          <Link href={`/pseo/stacks/${page.stack.slug}`}>
+            {page.stack.displayName ?? page.stack.name}
+          </Link>
           <span aria-hidden="true">/</span>
           <span>{page.audience.name}</span>
         </nav>
@@ -121,14 +101,14 @@ export function PseoLeafPageView({
           serviceHref={`/pseo/services/${page.service.slug}`}
           serviceName={page.service.name}
           stackHref={`/pseo/stacks/${page.stack.slug}`}
-          stackName={page.stack.name}
+          stackName={page.stack.displayName ?? page.stack.name}
           audienceHref={`/pseo/audiences/${page.audience.slug}`}
           audienceName={page.audience.name}
         />
 
         <section className={styles.section} aria-label="Introduction">
           <MarkdownMessage
-            content={copy?.introMarkdown ?? defaultIntro(page)}
+            content={introMarkdown}
             renderWithDesignSystem
             designSystemTextSize="S"
           />
@@ -139,7 +119,7 @@ export function PseoLeafPageView({
             Table of contents
           </Title>
           <ol className={styles.tocList}>
-            {sections.map((section) => (
+            {SECTION_NAV.map((section) => (
               <li key={section.id}>
                 <a href={`#${section.id}`}>{section.title}</a>
               </li>
@@ -150,23 +130,133 @@ export function PseoLeafPageView({
           </ol>
         </aside>
 
-        {sections.map((section) => (
-          <section key={section.id} id={section.id} className={styles.section}>
+        <section id="situation" className={styles.section}>
+          <Title terminals="sans" level={2} size="S">
+            Situation
+          </Title>
+          <MarkdownMessage
+            content={blocks.situationMarkdown}
+            renderWithDesignSystem
+            designSystemTextSize="S"
+          />
+        </section>
+
+        <section id="failure-modes" className={styles.section}>
+          <Title terminals="sans" level={2} size="S">
+            What goes wrong
+          </Title>
+          <MarkdownMessage
+            content={blocks.failureModesMarkdown}
+            renderWithDesignSystem
+            designSystemTextSize="S"
+          />
+        </section>
+
+        <section id="playbook" className={styles.section}>
+          <Title terminals="sans" level={2} size="S">
+            Playbook
+          </Title>
+          <MarkdownMessage
+            content={blocks.playbookMarkdown}
+            renderWithDesignSystem
+            designSystemTextSize="S"
+          />
+        </section>
+
+        <section id="deliverables" className={styles.section}>
+          <Title terminals="sans" level={2} size="S">
+            Deliverables checklist
+          </Title>
+          <MarkdownMessage
+            content={blocks.deliverablesMarkdown}
+            renderWithDesignSystem
+            designSystemTextSize="S"
+          />
+        </section>
+
+        {blocks.proofLinks.length > 0 ? (
+          <section id="proof" className={styles.section}>
             <Title terminals="sans" level={2} size="S">
-              {section.title}
+              Proof
             </Title>
-            <MarkdownMessage
-              content={section.bodyMarkdown}
-              renderWithDesignSystem
-              designSystemTextSize="S"
-            />
-            <MarkdownMessage
-              content={section.bodyMarkdown}
-              renderWithDesignSystem
-              designSystemTextSize="S"
-            />
+            <div className={styles.proofGrid}>
+              {blocks.proofLinks.map((proof) => (
+                <Card
+                  key={proof.slug}
+                  className={styles.proofCard}
+                  link={proof.href}
+                  linkLabel={`View case study: ${proof.title}`}
+                  hoverable
+                  size="full"
+                  title={proof.title}
+                  titleProps={{
+                    terminals: "sans",
+                    level: 3,
+                    size: "S",
+                    as: "h3",
+                  }}
+                  description={proof.reason}
+                  descriptionProps={{
+                    size: "S",
+                    as: "p",
+                    className: styles.proofReason,
+                  }}
+                />
+              ))}
+            </div>
           </section>
-        ))}
+        ) : null}
+
+        {blocks.packageFit ? (
+          <section id="package" className={styles.callout}>
+            <Title terminals="sans" level={2} size="S">
+              Package fit
+            </Title>
+            <Text terminals="sans">{blocks.packageFit.reason}</Text>
+            <Text terminals="sans" size="S">
+              {blocks.packageFit.name} · {blocks.packageFit.duration} ·{" "}
+              {blocks.packageFit.priceRangeEur}
+            </Text>
+            <div className={styles.ctaActions}>
+              <Button
+                href="/pricing"
+                variant="secondary"
+                size="m"
+                data-donny-interest="pseo-pricing"
+              >
+                View pricing
+              </Button>
+              <Button
+                href="/contact?mode=book"
+                variant="primary"
+                size="m"
+                data-donny-interest="pseo-contact"
+              >
+                Book a call
+              </Button>
+            </div>
+          </section>
+        ) : null}
+
+        <section id="faq" className={styles.section}>
+          <Title terminals="sans" level={2} size="S">
+            FAQ
+          </Title>
+          <div className={styles.faqList}>
+            {blocks.faqs.map((faq) => (
+              <div key={faq.question} className={styles.faqItem}>
+                <Title terminals="sans" level={3} size="XS" as="h3">
+                  {faq.question}
+                </Title>
+                <MarkdownMessage
+                  content={faq.answerMarkdown}
+                  renderWithDesignSystem
+                  designSystemTextSize="S"
+                />
+              </div>
+            ))}
+          </div>
+        </section>
 
         <section id="related" className={styles.section}>
           <Title terminals="sans" level={2} size="S">
@@ -206,8 +296,8 @@ export function PseoLeafPageView({
             Want help implementing this?
           </Title>
           <Text terminals="sans">
-            If you want to move faster with a production-grade design system,
-            send a message and describe your current stack and constraints.
+            Describe your stack, team size, and timeline—we will suggest a
+            scoped engagement or point you to the right playbook next step.
           </Text>
           <div className={styles.ctaActions}>
             <Button href="/contact" variant="primary" size="l" data-donny-interest="pseo-contact">

--- a/nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx
+++ b/nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx
@@ -27,7 +27,7 @@ export function PseoPillarPage({
   siblingItems: PseoCatalogItem[];
 }) {
   const metaLinks = [
-    { href: "/pseo", label: "All guides" },
+    { href: "/pseo", label: "All playbooks" },
     ...siblingItems
       .filter((sibling) => sibling.slug !== item.slug)
       .slice(0, 6)

--- a/nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx
@@ -51,7 +51,7 @@ export function WorkIndexPage({ nav }: WorkIndexPageProps) {
       <WorkHero />
 
       {/* Projects Section */}
-      <Section spacing="lg" background="default">
+      <Section spacing="follow" background="default">
         <Container size="lg">
           {/* Filter Bar with entrance animation */}
           <FadeIn delay={0.3} direction="up" distance={20} className="mb-12 tablet:mb-16">

--- a/nextjs-app/shared/patterns/BlogHero/BlogHero.tsx
+++ b/nextjs-app/shared/patterns/BlogHero/BlogHero.tsx
@@ -49,7 +49,7 @@ export function BlogHero({
   return (
     <Section
       id={id}
-      spacing={isFullHeight ? "none" : "lg"}
+      spacing={isFullHeight ? "none" : "hero"}
       background="default"
       className={cn(
         "relative overflow-hidden",

--- a/nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx
+++ b/nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx
@@ -128,7 +128,7 @@ function BlogIndexContentInner({
       )}
 
       {/* Content */}
-      <Section id="blog-content" spacing="lg" background="default">
+      <Section id="blog-content" spacing="follow" background="default">
         <Container size="md">
           {/* Filter */}
           {showFilter && allTags.length > 0 && (

--- a/nextjs-app/shared/patterns/WorkHero/WorkHero.tsx
+++ b/nextjs-app/shared/patterns/WorkHero/WorkHero.tsx
@@ -32,7 +32,7 @@ export function WorkHero({
   return (
     <Section
       id={id}
-      spacing="lg"
+      spacing="hero"
       background="default"
       className={cn("relative overflow-hidden", className)}
     >

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "test:security:category": "node tests/security/run-security-tests.mjs --category",
     "precommit:guard": "bash scripts/precommit-guard.sh",
     "pseo:generate": "npx tsx scripts/pseo/generate-pseo-copy.ts --only-missing",
+    "pseo:check-quality": "node scripts/pseo/check-pseo-quality.mjs",
     "validate:components": "tsx scripts/design-system/validate-components.ts",
     "validate:agent-docs": "node scripts/validate-agent-docs.mjs",
     "audit:catalog": "node scripts/design-system/audit-catalog-coverage.mjs",

--- a/scripts/pseo/check-pseo-quality.mjs
+++ b/scripts/pseo/check-pseo-quality.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+/**
+ * PSEO quality gate — word count, uniqueness, proof/package links.
+ *
+ * Usage:
+ *   node scripts/pseo/check-pseo-quality.mjs
+ *   node scripts/pseo/check-pseo-quality.mjs --min-unique-percent 40 --min-words 600
+ *   node scripts/pseo/check-pseo-quality.mjs --slug design-system-audit-react-startups
+ *   node scripts/pseo/check-pseo-quality.mjs --require-proof-link --require-package-link
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const catalogPath = path.join(repoRoot, "content/pseo/catalog.json");
+const copyPath = path.join(repoRoot, "content/pseo/copy.json");
+
+const args = process.argv.slice(2);
+
+const parseNumberFlag = (flag, fallback) => {
+  const idx = args.indexOf(flag);
+  if (idx === -1) return fallback;
+  const num = Number(args[idx + 1]);
+  return Number.isFinite(num) ? num : fallback;
+};
+
+const parseStringFlag = (flag) => {
+  const idx = args.indexOf(flag);
+  if (idx === -1) return undefined;
+  return args[idx + 1];
+};
+
+const hasFlag = (flag) => args.includes(flag);
+
+const minUniquePercent = parseNumberFlag("--min-unique-percent", 0);
+const minWords = parseNumberFlag("--min-words", 0);
+const slugFilter = parseStringFlag("--slug");
+const requireProofLink = hasFlag("--require-proof-link");
+const requirePackageLink = hasFlag("--require-package-link");
+const indexedOnly = hasFlag("--indexed-only");
+
+const PRESERVED_TOKENS = {
+  nextjs: "Next.js",
+  typescript: "TypeScript",
+  storybook: "Storybook",
+  figma: "Figma",
+  react: "React",
+};
+
+const getStackDisplayName = (item) =>
+  item.displayName ?? PRESERVED_TOKENS[item.slug] ?? item.name;
+
+const buildLeafTitle = (service, stack, audience) =>
+  `${service.displayName ?? service.name} for ${audience.displayName ?? audience.name} using ${getStackDisplayName(stack)}`;
+
+const buildLeafDescription = (service, stack, audience) =>
+  `${service.shortDescription} Tailored for ${audience.displayName ?? audience.name} shipping with ${getStackDisplayName(stack)}.`;
+
+const buildLeafPages = (catalog) => {
+  const pages = [];
+  for (const service of catalog.services) {
+    for (const stack of catalog.stacks) {
+      for (const audience of catalog.audiences) {
+        pages.push({
+          slug: `${service.slug}-${stack.slug}-${audience.slug}`,
+          title: buildLeafTitle(service, stack, audience),
+          description: buildLeafDescription(service, stack, audience),
+          service,
+          stack,
+          audience,
+        });
+      }
+    }
+  }
+  const max = catalog.generation?.maxLeafPages;
+  return typeof max === "number" ? pages.slice(0, max) : pages;
+};
+
+const tokenize = (text) =>
+  text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter(Boolean);
+
+const jaccardDissimilarity = (a, b) => {
+  const setA = new Set(tokenize(a));
+  const setB = new Set(tokenize(b));
+  if (setA.size === 0 && setB.size === 0) return 0;
+  let intersection = 0;
+  for (const token of setA) {
+    if (setB.has(token)) intersection += 1;
+  }
+  const union = setA.size + setB.size - intersection;
+  return union === 0 ? 0 : 1 - intersection / union;
+};
+
+const wordCount = (text) => tokenize(text).length;
+
+const buildSituation = (page) => {
+  const stackName = getStackDisplayName(page.stack);
+  const audienceName = page.audience.displayName ?? page.audience.name;
+  const constraints = page.audience.constraints?.length
+    ? page.audience.constraints.join(", ")
+    : page.audience.shortDescription;
+  const parts = [
+    `Who this is for: ${audienceName} running ${stackName} in production.`,
+    `Typical constraints: ${constraints}.`,
+  ];
+  if (page.audience.successMetric) {
+    parts.push(`Success looks like: ${page.audience.successMetric}.`);
+  }
+  return parts.join(" ");
+};
+
+const buildFailureModes = (service, stack) => {
+  const bullets = [...(service.painPoints ?? []), ...(stack.commonPitfalls ?? [])];
+  return bullets.join(" ");
+};
+
+const buildDeliverables = (service) => (service.deliverables ?? []).join(" ");
+
+const buildDefaultPlaybook = (page, service) => {
+  const steps = service.playbookSteps ?? [];
+  const stackNotes = page.stack.implementationNotes ?? [];
+  return [...steps, ...stackNotes].join(" ");
+};
+
+const buildDefaultFaqs = (page, service) => {
+  const stackName = getStackDisplayName(page.stack);
+  const timeline = service.typicalTimeline ?? "1-4 weeks";
+  return [
+    `How long does ${service.name.toLowerCase()} take with ${stackName}? Most engagements run ${timeline}.`,
+    "Can you work with an existing codebase? Yes, incremental upgrades are often faster.",
+    "What do you need from us to start? Repo access, Figma library, and a product owner.",
+  ].join(" ");
+};
+
+const renderPageText = (page, copy) => {
+  const intro =
+    copy?.introMarkdown ??
+    `${buildLeafDescription(page.service, page.stack, page.audience)} Use this playbook to scope work and align design and engineering.`;
+
+  const sections = [
+    intro,
+    buildSituation(page),
+    buildFailureModes(page.service, page.stack),
+    buildDeliverables(page.service),
+    buildDefaultPlaybook(page, page.service),
+    buildDefaultFaqs(page, page.service),
+  ];
+
+  if (copy?.sections?.length) {
+    for (const section of copy.sections) {
+      sections.push(section.bodyMarkdown ?? "");
+    }
+  }
+
+  if (copy?.faqs?.length) {
+    for (const faq of copy.faqs) {
+      sections.push(`${faq.question} ${faq.answerMarkdown}`);
+    }
+  }
+
+  return sections.join("\n\n");
+};
+
+const hasProofLink = (service) => (service.relatedWorkSlugs ?? []).length > 0;
+const hasPackageLink = (service) => Boolean(service.pricingPackageSlug);
+
+const catalog = JSON.parse(readFileSync(catalogPath, "utf8"));
+const copyFile = JSON.parse(readFileSync(copyPath, "utf8"));
+const pages = buildLeafPages(catalog);
+const indexedSlugs = new Set(catalog.generation?.indexedLeafSlugs ?? []);
+
+const targets = pages.filter((page) => {
+  if (slugFilter && page.slug !== slugFilter) return false;
+  if (indexedOnly && !indexedSlugs.has(page.slug)) return false;
+  return true;
+});
+
+const rendered = targets.map((page) => ({
+  page,
+  text: renderPageText(page, copyFile.pages[page.slug]),
+}));
+
+const failures = [];
+
+for (const entry of rendered) {
+  const { page, text } = entry;
+  const words = wordCount(text);
+
+  if (minWords > 0 && words < minWords) {
+    failures.push(`${page.slug}: ${words} words (min ${minWords})`);
+  }
+
+  if (requireProofLink && !hasProofLink(page.service)) {
+    failures.push(`${page.slug}: missing proof links in catalog`);
+  }
+
+  if (requirePackageLink && !hasPackageLink(page.service)) {
+    failures.push(`${page.slug}: missing pricing package mapping`);
+  }
+}
+
+if (minUniquePercent > 0 && rendered.length > 1) {
+  for (let i = 0; i < rendered.length; i += 1) {
+    let maxSimilarity = 0;
+    for (let j = 0; j < rendered.length; j += 1) {
+      if (i === j) continue;
+      const similarity = 1 - jaccardDissimilarity(rendered[i].text, rendered[j].text);
+      if (similarity > maxSimilarity) maxSimilarity = similarity;
+    }
+    const uniquePercent = Math.round((1 - maxSimilarity) * 100);
+    if (uniquePercent < minUniquePercent) {
+      failures.push(
+        `${rendered[i].page.slug}: ${uniquePercent}% unique vs nearest sibling (min ${minUniquePercent}%)`,
+      );
+    }
+  }
+}
+
+const indexedCount = indexedSlugs.size;
+console.log(
+  `[pseo-quality] Checked ${targets.length} pages (${indexedCount} indexed). Failures: ${failures.length}`,
+);
+
+if (failures.length > 0) {
+  for (const failure of failures.slice(0, 30)) {
+    console.error(`  ✗ ${failure}`);
+  }
+  if (failures.length > 30) {
+    console.error(`  … and ${failures.length - 30} more`);
+  }
+  process.exitCode = 1;
+} else {
+  console.log("[pseo-quality] All checks passed.");
+}

--- a/scripts/pseo/generate-pseo-copy.ts
+++ b/scripts/pseo/generate-pseo-copy.ts
@@ -1,10 +1,22 @@
+import { config as loadEnv } from "dotenv";
 import { promises as fs } from "fs";
 import path from "path";
+
+type LlmBackend = "gateway" | "openai";
 
 type CatalogItem = {
   slug: string;
   name: string;
   shortDescription: string;
+  displayName?: string;
+  painPoints?: string[];
+  deliverables?: string[];
+  typicalTimeline?: string;
+  playbookSteps?: string[];
+  implementationNotes?: string[];
+  commonPitfalls?: string[];
+  constraints?: string[];
+  successMetric?: string;
 };
 
 type PseoCatalog = {
@@ -15,6 +27,7 @@ type PseoCatalog = {
   generation?: {
     maxLeafPages?: number;
     relatedLinksPerPage?: number;
+    indexedLeafSlugs?: string[];
   };
 };
 
@@ -32,6 +45,7 @@ type PseoRelatedLinkCopy = {
 type PseoPageCopy = {
   introMarkdown?: string;
   sections?: PseoCopySection[];
+  faqs?: Array<{ question: string; answerMarkdown: string }>;
   related?: PseoRelatedLinkCopy[];
   updatedAt?: string;
 };
@@ -52,13 +66,158 @@ type LeafPage = {
 };
 
 const repoRoot = process.cwd();
+loadEnv({ path: path.join(repoRoot, ".env.local") });
+
 const catalogPath = path.join(repoRoot, "content", "pseo", "catalog.json");
 const copyPath = path.join(repoRoot, "content", "pseo", "copy.json");
+const canonicalPath = path.join(
+  repoRoot,
+  "content",
+  "pseo",
+  "canonical",
+  "services.json",
+);
 
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
-const OPENAI_API_URL =
-  process.env.OPENAI_API_URL || "https://api.openai.com/v1/chat/completions";
-const OPENAI_MODEL = process.env.OPENAI_MODEL || "gpt-4o-mini";
+const PRESERVED_STACK_NAMES: Record<string, string> = {
+  nextjs: "Next.js",
+  typescript: "TypeScript",
+  storybook: "Storybook",
+  figma: "Figma",
+  react: "React",
+};
+
+const getStackDisplayName = (item: CatalogItem & { displayName?: string }) =>
+  item.displayName ?? PRESERVED_STACK_NAMES[item.slug] ?? item.name;
+
+const getOpenAiModel = () => process.env.OPENAI_MODEL?.trim() || "gpt-4o-mini";
+
+const getGatewayModel = () => {
+  const gatewayModel = process.env.AI_GATEWAY_MODEL?.trim();
+  if (gatewayModel) return gatewayModel;
+  const openAiModel = process.env.OPENAI_MODEL?.trim();
+  if (!openAiModel) return "openai/gpt-4o-mini";
+  return openAiModel.includes("/") ? openAiModel : `openai/${openAiModel}`;
+};
+
+const getGatewayChatUrl = () => {
+  const base = process.env.AI_GATEWAY_URL?.trim()?.replace(/\/$/, "");
+  if (!base) return "https://ai-gateway.vercel.sh/v1/chat/completions";
+  if (base.endsWith("/v1/ai")) {
+    return base.replace(/\/v1\/ai$/, "/v1/chat/completions");
+  }
+  if (base.endsWith("/v1")) return `${base}/chat/completions`;
+  return "https://ai-gateway.vercel.sh/v1/chat/completions";
+};
+
+const resolveLlmBackends = (args: string[]): LlmBackend[] => {
+  const explicit = parseStringFlag(args, "--provider")?.toLowerCase();
+  const hasOpenAi = Boolean(process.env.OPENAI_API_KEY?.trim());
+  const hasGateway = Boolean(process.env.AI_GATEWAY_API_KEY?.trim());
+
+  if (explicit === "openai" && hasOpenAi) return ["openai"];
+  if (explicit === "gateway" && hasGateway) return ["gateway"];
+
+  // Batch generation: prefer Gateway when configured (avoids direct OpenAI quota limits).
+  const order: LlmBackend[] = [];
+  if (hasGateway) order.push("gateway");
+  if (hasOpenAi) order.push("openai");
+  return order;
+};
+
+const SYSTEM_PROMPT =
+  "You write practical design-system playbooks for a senior consultancy. Output strict JSON only. Write like a consultant memo—not SEO filler. Never use phrases like 'This guide explains how' or 'comprehensive overview'.";
+
+async function callChatCompletions(
+  prompt: string,
+  backend: LlmBackend,
+): Promise<string> {
+  const url =
+    backend === "gateway"
+      ? getGatewayChatUrl()
+      : process.env.OPENAI_API_URL?.trim() ||
+        "https://api.openai.com/v1/chat/completions";
+
+  const apiKey =
+    backend === "gateway"
+      ? process.env.AI_GATEWAY_API_KEY?.trim()
+      : process.env.OPENAI_API_KEY?.trim();
+
+  if (!apiKey) {
+    throw new Error(
+      `[pseo] Missing ${backend === "gateway" ? "AI_GATEWAY_API_KEY" : "OPENAI_API_KEY"}.`,
+    );
+  }
+
+  const model = backend === "gateway" ? getGatewayModel() : getOpenAiModel();
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      temperature: 0.2,
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: prompt },
+      ],
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`[pseo] ${backend} error ${res.status}: ${text}`);
+  }
+
+  const json = (await res.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+  const content = json.choices?.[0]?.message?.content;
+  if (!content) {
+    throw new Error(`[pseo] ${backend} response missing content`);
+  }
+  return content;
+}
+
+async function callLlm(prompt: string, backends: LlmBackend[]): Promise<string> {
+  if (backends.length === 0) {
+    throw new Error(
+      "[pseo] No LLM provider configured. Set AI_GATEWAY_API_KEY or OPENAI_API_KEY in .env.local.",
+    );
+  }
+
+  let lastError: unknown;
+  for (const backend of backends) {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        return await callChatCompletions(prompt, backend);
+      } catch (err) {
+        lastError = err;
+        const message = err instanceof Error ? err.message : String(err);
+        const retryable =
+          message.includes("429") ||
+          message.includes("503") ||
+          message.includes("rate");
+        if (retryable && attempt < 2) {
+          const waitMs = 2000 * (attempt + 1);
+          console.warn(
+            `[pseo] ${backend} rate limited, waiting ${waitMs}ms (attempt ${attempt + 1}/3)…`,
+          );
+          await sleep(waitMs);
+          continue;
+        }
+        console.warn(
+          `[pseo] ${backend} failed${message ? `: ${message.slice(0, 120)}` : ""}`,
+        );
+        break;
+      }
+    }
+  }
+
+  throw lastError;
+}
 
 const parseNumberFlag = (args: string[], flag: string): number | undefined => {
   const idx = args.indexOf(flag);
@@ -77,21 +236,19 @@ const parseStringFlag = (args: string[], flag: string): string | undefined => {
 
 const hasFlag = (args: string[], flag: string) => args.includes(flag);
 
-const toTitleCase = (text: string) =>
-  text.replace(/\b\w/g, (match) => match.toUpperCase());
-
 const buildLeafTitle = (
   service: CatalogItem,
   stack: CatalogItem,
   audience: CatalogItem,
-) => `${service.name} for ${audience.name} using ${stack.name}`;
+) =>
+  `${service.name} for ${audience.name} using ${getStackDisplayName(stack)}`;
 
 const buildLeafDescription = (
   service: CatalogItem,
   stack: CatalogItem,
   audience: CatalogItem,
 ) =>
-  `${service.shortDescription} Tailored for ${audience.name} shipping with ${stack.name}.`;
+  `${service.shortDescription} Tailored for ${audience.name} shipping with ${getStackDisplayName(stack)}.`;
 
 const buildLeafPages = (catalog: PseoCatalog): LeafPage[] => {
   const pages: LeafPage[] = [];
@@ -101,7 +258,7 @@ const buildLeafPages = (catalog: PseoCatalog): LeafPage[] => {
         const slug = `${service.slug}-${stack.slug}-${audience.slug}`;
         pages.push({
           slug,
-          title: toTitleCase(buildLeafTitle(service, stack, audience)),
+          title: buildLeafTitle(service, stack, audience),
           description: buildLeafDescription(service, stack, audience),
           service,
           stack,
@@ -151,48 +308,9 @@ const extractJson = (raw: string): unknown => {
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-async function callOpenAI(prompt: string): Promise<string> {
-  if (!OPENAI_API_KEY) {
-    throw new Error(
-      "[pseo] Missing OPENAI_API_KEY. Add it to .env.local before running.",
-    );
-  }
-
-  const res = await fetch(OPENAI_API_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${OPENAI_API_KEY}`,
-    },
-    body: JSON.stringify({
-      model: OPENAI_MODEL,
-      temperature: 0.2,
-      messages: [
-        {
-          role: "system",
-          content:
-            "You write concise, practical SEO copy for a design systems / DesignOps studio website. Output must be strict JSON and must not contain any additional keys.",
-        },
-        { role: "user", content: prompt },
-      ],
-    }),
-  });
-
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`[pseo] OpenAI error ${res.status}: ${text}`);
-  }
-
-  const json = (await res.json()) as {
-    choices?: Array<{ message?: { content?: string } }>;
-  };
-  const content = json.choices?.[0]?.message?.content;
-  if (!content) throw new Error("[pseo] OpenAI response missing content");
-  return content;
-}
-
 async function main() {
   const args = process.argv.slice(2);
+  const llmBackends = resolveLlmBackends(args);
 
   const onlyMissing = hasFlag(args, "--only-missing");
   const dryRun = hasFlag(args, "--dry-run");
@@ -202,6 +320,15 @@ async function main() {
   const catalog = JSON.parse(
     await fs.readFile(catalogPath, "utf8"),
   ) as PseoCatalog;
+
+  const canonical = JSON.parse(
+    await fs.readFile(canonicalPath, "utf8"),
+  ) as {
+    services: Record<
+      string,
+      { excerpt: string; bannedPhrases?: string[] }
+    >;
+  };
 
   const existingCopy = JSON.parse(
     await fs.readFile(copyPath, "utf8"),
@@ -230,59 +357,80 @@ async function main() {
   }
 
   console.log(
-    `[pseo] Generating copy for ${targets.length} pages (model: ${OPENAI_MODEL})`,
+    `[pseo] Generating copy for ${targets.length} pages (providers: ${llmBackends.join(" → ")})`,
   );
 
   for (const page of targets) {
     const related = getRelated(page, allLeafPages, relatedLinksPerPage);
+    const serviceCanonical = canonical.services[page.service.slug];
+    const painPoints = (page.service.painPoints ?? []).join("; ");
+    const stackNotes = (page.stack.implementationNotes ?? []).join("; ");
+    const audienceConstraints = (page.audience.constraints ?? []).join("; ");
 
     const prompt = [
-      "Generate content for a programmatic SEO landing page.",
+      "Generate narrative copy for a design system playbook page.",
+      "Catalog-backed blocks (situation, deliverables, proof, package) are rendered separately—focus on intro, playbook depth, and FAQs.",
       "",
       `Page title: ${page.title}`,
       `Meta description: ${page.description}`,
       `Service: ${page.service.name} (${page.service.shortDescription})`,
-      `Stack: ${page.stack.name} (${page.stack.shortDescription})`,
+      `Stack: ${getStackDisplayName(page.stack)} (${page.stack.shortDescription})`,
       `Audience: ${page.audience.name} (${page.audience.shortDescription})`,
+      audienceConstraints ? `Audience constraints: ${audienceConstraints}` : "",
+      painPoints ? `Service pain points: ${painPoints}` : "",
+      stackNotes ? `Stack implementation notes: ${stackNotes}` : "",
+      serviceCanonical?.excerpt
+        ? `Canonical service excerpt (tone reference):\n${serviceCanonical.excerpt}`
+        : "",
       "",
       "Return ONLY strict JSON with this schema:",
       "{",
       '  "introMarkdown": string,',
       '  "sections": [{ "id": string, "title": string, "bodyMarkdown": string }],',
+      '  "faqs": [{ "question": string, "answerMarkdown": string }],',
       '  "related": [{ "slug": string, "reasonMarkdown": string }]',
       "}",
       "",
       "Rules:",
       "- Markdown only (no HTML).",
-      "- Keep intro under ~120 words.",
-      "- Create 4 sections: Overview, What you get, Process, FAQ.",
-      "- Use stable ids: overview, deliverables, process, faq.",
-      "- FAQ bodyMarkdown should contain 2-3 Q&A pairs.",
-      "- related must include exactly these slugs (same order), with 1-2 sentence reasons and no links:",
+      "- Intro: 80–120 words, combo-specific, no generic opener.",
+      "- sections: optional overrides for ids playbook, situation, failure-modes only.",
+      "- playbook section: numbered steps with stack-specific tactics (min 150 words).",
+      "- faqs: exactly 3 Q&As referencing this service + stack + audience.",
+      "- Do NOT repeat deliverables checklist or package pricing (rendered from catalog).",
+      serviceCanonical?.bannedPhrases?.length
+        ? `- Never use: ${serviceCanonical.bannedPhrases.join(", ")}`
+        : "",
+      "- related must include exactly these slugs (same order), with specific 'read this if…' reasons:",
       related.map((r) => `  - ${r.slug}`).join("\n"),
-    ].join("\n");
+    ]
+      .filter(Boolean)
+      .join("\n");
 
     let generated: unknown;
     try {
-      const raw = await callOpenAI(prompt);
+      const raw = await callLlm(prompt, llmBackends);
       generated = extractJson(raw);
     } catch (err) {
       console.warn(
         `[pseo] Failed to generate ${page.slug}, retrying once...`,
+        err instanceof Error ? err.message : err,
       );
-      const raw = await callOpenAI(prompt);
+      const raw = await callLlm(prompt, llmBackends);
       generated = extractJson(raw);
     }
 
     const parsed = generated as {
       introMarkdown?: string;
       sections?: PseoCopySection[];
+      faqs?: Array<{ question: string; answerMarkdown: string }>;
       related?: PseoRelatedLinkCopy[];
     };
 
     existingCopy.pages[page.slug] = {
       introMarkdown: parsed.introMarkdown,
       sections: parsed.sections,
+      faqs: parsed.faqs,
       related: parsed.related,
       updatedAt: new Date().toISOString(),
     };
@@ -293,7 +441,7 @@ async function main() {
       await fs.writeFile(copyPath, JSON.stringify(existingCopy, null, 2) + "\n");
     }
 
-    await sleep(250);
+    await sleep(1500);
   }
 
   if (dryRun) {


### PR DESCRIPTION
## Summary
- Rebuild `/pseo` with catalog v2, structured leaf template (situation, failure modes, playbook, proof, package fit, FAQ), and human-language UI ("Design system playbooks")
- Generate and ship copy for 12 pilot pages; all leaves remain `noindex` until added to `indexedLeafSlugs`
- Add `npm run pseo:check-quality`, AI Gateway support in the generator, and PSEO improvement plan docs
- Fix oversized gap between blog/work hero text and content via paired `Section` spacing (`hero` + `follow`)

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `SKIP_STORYBOOK_TESTS=1 npm test -- lib/pseo/catalog.test.ts`
- [x] `npm run pseo:check-quality -- --require-proof-link --require-package-link` (12/12 pilot pages)
- [ ] Spot-check `/blog`, `/work`, and `/pseo/design-system-audit-nextjs-startups` on preview


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Rebranded SEO landing pages from "Design System Guides" to "Design System Playbooks"
  * Added comprehensive playbook content covering design audits, design tokens, component libraries, and AI DesignOps
  * Enhanced structured data with FAQ schema and improved breadcrumb trails
  * Implemented selective page indexing for quality-gated rollout

* **Bug Fixes**
  * Fixed sitemap freshness tracking to use accurate catalog timestamps
  * Corrected product name capitalization (e.g., Next.js, TypeScript) in SEO metadata

* **Documentation**
  * Added detailed improvement strategy and site audit reports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->