### PR TITLE
fix: restore chat toggle layout after a11y change

### DIFF
--- a/nextjs-app/shared/components/ChatWidget/ChatToggle.tsx
+++ b/nextjs-app/shared/components/ChatWidget/ChatToggle.tsx
@@ -95,19 +95,18 @@ const ChatToggle = React.forwardRef<HTMLButtonElement, ChatToggleProps>(
           isOpen ? (
             <Icon name="caret-down" ariaLabel={ariaLabel} />
           ) : (
-            <span aria-hidden="true">
-              <DonnyAvatar
-                state={donnyState}
-                size="sm"
-                trackMouse={!isOpen}
-                proximitySelectors={CURIOSITY_SELECTORS}
-                onProximityChange={handleProximityChange}
-                enableIdleExpressions={!isOpen}
-                idleExpressionInterval={8000}
-                enableSleepDetection={!isOpen}
-                className={styles.toggleAvatar}
-              />
-            </span>
+            <DonnyAvatar
+              decorative
+              state={donnyState}
+              size="sm"
+              trackMouse={!isOpen}
+              proximitySelectors={CURIOSITY_SELECTORS}
+              onProximityChange={handleProximityChange}
+              enableIdleExpressions={!isOpen}
+              idleExpressionInterval={8000}
+              enableSleepDetection={!isOpen}
+              className={styles.toggleAvatar}
+            />
           )
         }
         aria-expanded={isOpen}

--- a/nextjs-app/shared/components/DonnyAvatar/DonnyAvatar.test.tsx
+++ b/nextjs-app/shared/components/DonnyAvatar/DonnyAvatar.test.tsx
@@ -79,6 +79,12 @@ describe("DonnyAvatar", () => {
       expect(avatar).toHaveAttribute("aria-label", "Donny is thinking");
     });
 
+    it("is decorative when used inside a labeled control", () => {
+      const { container } = render(<DonnyAvatar decorative state="idle" />);
+      expect(screen.queryByRole("img")).not.toBeInTheDocument();
+      expect(container.firstChild).toHaveAttribute("aria-hidden", "true");
+    });
+
     it("updates aria-label when state changes", async () => {
       vi.useFakeTimers();
       const { rerender } = render(<DonnyAvatar state="idle" />);

--- a/nextjs-app/shared/components/DonnyAvatar/DonnyAvatar.tsx
+++ b/nextjs-app/shared/components/DonnyAvatar/DonnyAvatar.tsx
@@ -64,6 +64,8 @@ export interface DonnyAvatarProps {
   sleepyDelay?: number;
   /** Time in ms before Donny falls asleep (default 150000 = 2.5 min) */
   sleepDelay?: number;
+  /** When true, omit role/label so a parent control owns the accessible name (e.g. chat toggle) */
+  decorative?: boolean;
 }
 
 /**
@@ -301,6 +303,7 @@ export function DonnyAvatar({
   enableSleepDetection = false,
   sleepyDelay = 120000,  // 2 minutes
   sleepDelay = 150000,   // 2.5 minutes
+  decorative = false,
 }: DonnyAvatarProps) {
   const [currentState, setCurrentState] = useState<DonnyState>(state);
   const [isTransitioning, setIsTransitioning] = useState(false);
@@ -613,8 +616,9 @@ export function DonnyAvatar({
       data-transitioning={isTransitioning}
       data-tracking={trackMouse}
       data-near-target={isNearTarget}
-      aria-label={`Donny is ${currentState}`}
-      role="img"
+      aria-hidden={decorative ? true : undefined}
+      aria-label={decorative ? undefined : `Donny is ${currentState}`}
+      role={decorative ? undefined : "img"}
     >
       <svg
         viewBox="0 0 40 32"


### PR DESCRIPTION
## Summary

- Fixes visual regression on the closed chat pill introduced in #638
- Replaces the extra `aria-hidden` wrapper with `DonnyAvatar` `decorative` mode so icon/text flex alignment matches the previous design
- Keeps WCAG 2.5.3 label-in-name (`Chat — Chat with Donny`)

## Test plan

- [x] `npx playwright test tests/a11y/operable/label-in-name.spec.ts`
- [x] `SKIP_STORYBOOK_TESTS=1 npx vitest run DonnyAvatar.test`
- [ ] Visual check: closed chat toggle on home (icon + label centered on lime pill)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility for the avatar component in the chat widget to better support screen readers and assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->