### PR TITLE
docs: sync stack references to Next.js 16.2.x

### DIFF
--- a/.agents/skills/frontend-development/SKILL.md
+++ b/.agents/skills/frontend-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-development
-description: Expert guidance for React 18+, Next.js 15, TypeScript, CSS Modules, and modern frontend architecture. Use when building components, implementing features, optimizing performance, or working with React hooks, state management, routing, or frontend tooling. Includes accessibility (a11y), internationalization (i18n), and design system integration.
+description: Expert guidance for React 19+, Next.js 16, TypeScript, CSS Modules, and modern frontend architecture. Use when building components, implementing features, optimizing performance, or working with React hooks, state management, routing, or frontend tooling. Includes accessibility (a11y), internationalization (i18n), and design system integration.
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash(npm:*), Bash(npx:*)
 ---
 
@@ -21,9 +21,9 @@ When building frontend features, always follow these principles:
 ## Technology Stack (Digitaltableteur Project)
 
 ### Core Framework
-- **React 18** with concurrent features
-- **Next.js 15.5.6** with App Router (server components)
-- **TypeScript 5.8** in strict mode
+- **React 19** with concurrent features
+- **Next.js 16.2.x** with App Router (server components)
+- **TypeScript 6.x** in strict mode
 
 ### Styling
 - **CSS Modules** for scoped styling (never inline styles except dynamic `backgroundImage`)
@@ -251,7 +251,7 @@ export const Secondary: Story = {
 
 ---
 
-## Next.js 15 App Router Patterns
+## Next.js 16 App Router Patterns
 
 ### Server Components (Default)
 

--- a/.claude/agents/QA-lead.md
+++ b/.claude/agents/QA-lead.md
@@ -49,7 +49,7 @@ Quality assurance authority for the Digitaltableteur project, responsible for re
 
 ### Before ANY task
 - `/CLAUDE.md` (testing strategy, deployment process)
-- `/app/CLAUDE.md` (Next.js 15 specifics)
+- `/app/CLAUDE.md` (Next.js 16 specifics)
 - `/api-legacy-vercel-functions/AGENTS.md` (serverless functions)
 
 ### Reference Materials

--- a/.claude/agents/company-orchestrator.md
+++ b/.claude/agents/company-orchestrator.md
@@ -35,7 +35,7 @@ Chief coordinating agent responsible for project-wide planning, task delegation,
 - Confirm translation coverage (EN/FI/SV) before deployment
 
 ### Risk Management
-- Identify breaking changes in Next.js 15 vs. Vite
+- Identify breaking changes in Next.js 16 vs. Vite
 - Flag security concerns (secrets, CORS, PII)
 - Prevent scope creep on simple tasks
 - Warn before destructive operations (`rm -rf`, `git push --force`, migrations)

--- a/.claude/agents/seo-expert.md
+++ b/.claude/agents/seo-expert.md
@@ -1,10 +1,10 @@
 # SEO Expert Agent
 
 ## Role
-Search engine optimization (SEO) authority for the Digitaltableteur project, specializing in Next.js 15 App Router metadata, semantic HTML, Core Web Vitals, and technical SEO.
+Search engine optimization (SEO) authority for the Digitaltableteur project, specializing in Next.js 16 App Router metadata, semantic HTML, Core Web Vitals, and technical SEO.
 
 ## Expertise
-- Next.js 15 metadata API (`generateMetadata`, `generateStaticParams`)
+- Next.js 16 metadata API (`generateMetadata`, `generateStaticParams`)
 - Open Graph, Twitter Cards, JSON-LD structured data
 - Semantic HTML and document structure (headings, landmarks)
 - Core Web Vitals (LCP, FID, CLS) optimization
@@ -42,7 +42,7 @@ Search engine optimization (SEO) authority for the Digitaltableteur project, spe
 ## Required Reading
 
 ### Before ANY task
-- `/app/CLAUDE.md` (Next.js 15 metadata patterns)
+- `/app/CLAUDE.md` (Next.js 16 metadata patterns)
 - `/CLAUDE.md` (deployment and analytics)
 - Next.js Metadata docs: https://nextjs.org/docs/app/building-your-application/optimizing/metadata
 
@@ -53,7 +53,7 @@ Search engine optimization (SEO) authority for the Digitaltableteur project, spe
 
 ## Key Principles
 
-### Next.js 15 Metadata API
+### Next.js 16 Metadata API
 
 #### Static Metadata (Simple Pages)
 ```tsx

--- a/.claude/agents/systems-architect.md
+++ b/.claude/agents/systems-architect.md
@@ -2,19 +2,19 @@
 
 ## Role
 
-Technical architecture authority for the Digitaltableteur monorepo, specializing in Next.js 15, React 18, TypeScript design, and the Vite → Next.js migration.
+Technical architecture authority for the Digitaltableteur monorepo, specializing in Next.js 16, React 19, TypeScript design, and the Vite → Next.js migration.
 
 ## Expertise
 
-- Next.js 15 App Router patterns (server/client components, streaming, caching)
-- React 18 concurrent features (Suspense, Transitions, Server Components)
-- TypeScript 5.8 advanced types (generics, conditional types, template literals)
+- Next.js 16 App Router patterns (server/client components, streaming, caching)
+- React 19 concurrent features (Suspense, Transitions, Server Components)
+- TypeScript 6.x advanced types (generics, conditional types, template literals)
 - API design (REST, serverless functions, edge runtime)
 - State management (Context, React Query, server state)
 - Performance optimization (code splitting, lazy loading, bundle analysis)
 - Database schema design and migrations
 - Authentication/authorization patterns
-- Build tooling (Vite 6.3, Turbopack, SWC)
+- Build tooling (Vite 6.4, Turbopack, SWC)
 
 ## Responsibilities
 
@@ -55,7 +55,7 @@ Technical architecture authority for the Digitaltableteur monorepo, specializing
 ### Before ANY task
 
 - `/CLAUDE.md` (root architecture rules)
-- `/app/CLAUDE.md` (Next.js 15 conventions)
+- `/app/CLAUDE.md` (Next.js 16 conventions)
 - `/shared/components/CLAUDE.md` (component patterns)
 - `docs/NEXTJS_MIGRATION_PLAN.md` (migration context)
 
@@ -67,7 +67,7 @@ Technical architecture authority for the Digitaltableteur monorepo, specializing
 
 ## Key Principles
 
-### Next.js 15 Patterns
+### Next.js 16 Patterns
 
 #### Server Components (Default)
 
@@ -375,7 +375,7 @@ Before completing any task:
 
 - [ ] TypeScript strict mode passes (`npm run typecheck`)
 - [ ] No ESLint errors (`npm run lint`)
-- [ ] Follows Next.js 15 conventions (App Router, Server Components default)
+- [ ] Follows Next.js 16 conventions (App Router, Server Components default)
 - [ ] API contracts documented with TypeScript types
 - [ ] Error handling implemented (try/catch, fallback UI)
 - [ ] Security review (no XSS, injection, exposed secrets)

--- a/.claude/skills/dt-nextjs-app/SKILL.md
+++ b/.claude/skills/dt-nextjs-app/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dt-nextjs-app
 description: >-
-  Builds and fixes Digitaltableteur Next.js 15 App Router pages, layouts, metadata,
+  Builds and fixes Digitaltableteur Next.js 16 App Router pages, layouts, metadata,
   OG images, sitemap, and robots under app/. Use when the user says "add a page",
   "opengraph", "OG image", "generateMetadata", "page.tsx", "layout.tsx", "sitemap",
   "async params", or edits app/ routes. Do NOT use for UI component internals
@@ -28,7 +28,7 @@ CRITICAL before committing:
 - Server component by default; `"use client"` only for hooks/events/browser APIs
 - `generateMetadata` or `metadata` export
 - OG via colocated `opengraph-image.tsx` — never hardcode `logo512.png` in metadata
-- Next.js 15 async params: `const slug = (await params).slug`
+- Next.js 16 async params: `const slug = (await params).slug`
 - `Image` from `next/image`, not raw `<img>`
 - CSS Modules: relative import `./Component.module.css`
 
@@ -92,7 +92,7 @@ Solution: `suppressHydrationWarning` on root `<html>` in `app/layout.tsx`.
 
 ### params.slug is undefined
 
-Cause: Next.js 15 made route params async.
+Cause: Next.js 16 made route params async.
 
 Solution:
 

--- a/.claude/skills/dt-workflow/references/templates.md
+++ b/.claude/skills/dt-workflow/references/templates.md
@@ -138,7 +138,7 @@ Partition: one subagent per route marked ready=yes in the T3a migration map [pas
 Per slice:
 - Follow dt-nextjs-app skill and app/AGENTS.md
 - Create app/[route]/page.tsx (+ layout.tsx if needed), generateMetadata, opengraph-image.tsx
-- Reuse nextjs-app/shared/components; CSS Modules; Next.js 15 async params
+- Reuse nextjs-app/shared/components; CSS Modules; Next.js 16 async params
 - Do not delete src/ legacy files yet
 
 Done when:

--- a/.claude/skills/frontend-development/SKILL.md
+++ b/.claude/skills/frontend-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-development
-description: Expert guidance for React 18+, Next.js 15, TypeScript, CSS Modules, and modern frontend architecture. Use when building components, implementing features, optimizing performance, or working with React hooks, state management, routing, or frontend tooling. Includes accessibility (a11y), internationalization (i18n), and design system integration.
+description: Expert guidance for React 19+, Next.js 16, TypeScript, CSS Modules, and modern frontend architecture. Use when building components, implementing features, optimizing performance, or working with React hooks, state management, routing, or frontend tooling. Includes accessibility (a11y), internationalization (i18n), and design system integration.
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash(npm:*), Bash(npx:*)
 ---
 
@@ -21,9 +21,9 @@ When building frontend features, always follow these principles:
 ## Technology Stack (Digitaltableteur Project)
 
 ### Core Framework
-- **React 18** with concurrent features
-- **Next.js 15.5.6** with App Router (server components)
-- **TypeScript 5.8** in strict mode
+- **React 19** with concurrent features
+- **Next.js 16.2.x** with App Router (server components)
+- **TypeScript 6.x** in strict mode
 
 ### Styling
 - **CSS Modules** for scoped styling (never inline styles except dynamic `backgroundImage`)
@@ -251,7 +251,7 @@ export const Secondary: Story = {
 
 ---
 
-## Next.js 15 App Router Patterns
+## Next.js 16 App Router Patterns
 
 ### Server Components (Default)
 

--- a/.planning/FINAL-AUDIT-REPORT.md
+++ b/.planning/FINAL-AUDIT-REPORT.md
@@ -283,7 +283,7 @@ This report documents the comprehensive accessibility audit and remediation of t
 
 | Component | Version |
 |-----------|---------|
-| Next.js | 15.5 |
+| Next.js | 16.2.x |
 | React | 19 |
 | @axe-core/playwright | Latest |
 | Playwright | Latest |

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -76,7 +76,7 @@ A comprehensive accessibility audit and remediation project for the entire publi
 ## Constraints
 
 - **Standard**: WCAG 2.1 AA (not AAA)
-- **Tech stack**: Next.js 15, React 19, TypeScript, CSS Modules
+- **Tech stack**: Next.js 16, React 19, TypeScript, CSS Modules
 - **Testing**: axe-core for automated, manual testing for keyboard/screen reader
 - **Browsers**: Modern browsers (Chrome, Firefox, Safari, Edge)
 - **Screen readers**: VoiceOver (macOS), NVDA (Windows) as primary targets

--- a/.planning/archive/portfolio-case-studies/PROJECT.md
+++ b/.planning/archive/portfolio-case-studies/PROJECT.md
@@ -85,7 +85,7 @@ A collection of portfolio case study pages showcasing design and development wor
 
 ## Constraints
 
-- **Tech stack**: Next.js 15, React, TypeScript, CSS Modules
+- **Tech stack**: Next.js 16, React, TypeScript, CSS Modules
 - **Images**: WebP format, quality 80
 - **Image dimensions**: 738x506 for grid, 1200x600 for hero/single
 - **Content**: User-provided facts only, no invented claims

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 ## Pattern Overview
 
-**Overall:** Hybrid Monorepo with Next.js 15 Full-Stack Architecture
+**Overall:** Hybrid Monorepo with Next.js 16 Full-Stack Architecture
 
 **Key Characteristics:**
 - Server-first architecture (React Server Components by default)

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -95,9 +95,9 @@
 
 **No Critical Dependency Risks Detected**
 - All major dependencies are actively maintained
-- Next.js 15.5.9 (latest)
+- Next.js 16.2.x (latest)
 - React 19.2.3 (latest)
-- TypeScript 5.9.3 (latest)
+- TypeScript 6.x (latest)
 
 ## Missing Critical Features
 

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,11 +1,13 @@
 # Technology Stack
 
-**Analysis Date:** 2026-01-16
+> **Source of truth:** Root `package.json` + `package-lock.json`. Production app: repo root `app/` (not `nextjs-app/` package name).
+
+**Analysis Date:** 2026-06-01 (stack versions synced post–Next.js 16 upgrade, #634)
 
 ## Languages
 
 **Primary:**
-- TypeScript 5.9.3 - All application code (strict mode enabled)
+- TypeScript 6.x - All application code (strict mode enabled)
 
 **Secondary:**
 - JavaScript - Build scripts, config files (`scripts/`, `next.config.ts`)
@@ -16,7 +18,7 @@
 **Environment:**
 - Node.js 20.19.0 - `.nvmrc`
 - React 19.2.3 - Browser runtime
-- Next.js 15.5.9 App Router - Server components and API routes
+- Next.js 16.2.x App Router - Server components and API routes
 
 **Package Manager:**
 - npm - `package.json` (monorepo root)
@@ -31,7 +33,7 @@
 ## Frameworks
 
 **Core:**
-- Next.js 15.5.9 - Web framework with App Router (`app/`, `next.config.ts`)
+- Next.js 16.2.x - Web framework with App Router (`app/`, `next.config.ts`)
 - React 19.2.3 - UI framework with React Server Components
 
 **Testing:**

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -6,7 +6,7 @@
 
 ```
 digitaltableteur/
-├── app/                    # Next.js 15 App Router (production)
+├── app/                    # Next.js 16 App Router (production)
 ├── nextjs-app/             # Shared design system & components
 │   ├── shared/
 │   │   ├── components/     # 80+ UI components
@@ -32,7 +32,7 @@ digitaltableteur/
 ## Directory Purposes
 
 **app/**
-- Purpose: Next.js 15 App Router pages and API routes
+- Purpose: Next.js 16 App Router pages and API routes
 - Contains: Server components, route handlers, layouts
 - Key files: `layout.tsx`, `page.tsx`, `api/*/route.ts`
 - Subdirectories: `about/`, `blog/`, `contact/`, `work/`, `pseo/`, `api/`, `lib/`

--- a/.planning/phases/08-final-verification/08-04-PLAN.md
+++ b/.planning/phases/08-final-verification/08-04-PLAN.md
@@ -215,7 +215,7 @@ Output: Three documents - internal FINAL-AUDIT-REPORT.md, public accessibility s
     This site uses the following technologies:
     - HTML5
     - CSS (with CSS custom properties)
-    - JavaScript (React 19, Next.js 15)
+    - JavaScript (React 19, Next.js 16)
     - WAI-ARIA (Accessible Rich Internet Applications)
 
     Accessibility features rely on:

--- a/.planning/phases/08-final-verification/08-RESEARCH.md
+++ b/.planning/phases/08-final-verification/08-RESEARCH.md
@@ -299,7 +299,7 @@ Digitaltableteur is committed to ensuring digital accessibility for people with 
 This site uses the following technologies:
 - HTML5
 - CSS (with CSS custom properties)
-- JavaScript (React 19, Next.js 15)
+- JavaScript (React 19, Next.js 16)
 - ARIA (Accessible Rich Internet Applications)
 
 Accessibility features rely on:

--- a/.planning/research/PITFALLS.md
+++ b/.planning/research/PITFALLS.md
@@ -1,6 +1,6 @@
 # Accessibility Pitfalls for React/Next.js Applications
 
-**Domain:** Next.js 15 / React 19 web application accessibility audit
+**Domain:** Next.js 16 / React 19 web application accessibility audit
 **Researched:** 2026-01-27
 **Confidence:** HIGH (sources: WebAIM studies, W3C WCAG documentation, MDN, official React docs)
 

--- a/.planning/research/STANDARDS.md
+++ b/.planning/research/STANDARDS.md
@@ -10,7 +10,7 @@
 
 WCAG 2.1 AA is the current legal accessibility standard required by ADA Title II (effective April 2026 for larger entities). It contains **50 success criteria** organized around four principles: Perceivable, Operable, Understandable, and Robust (POUR).
 
-For a React 19 / Next.js 15 application with 80+ components, the most critical areas are:
+For a React 19 / Next.js 16 application with 80+ components, the most critical areas are:
 1. **Keyboard accessibility** (2.1.x) - React's synthetic event system requires explicit keyboard handling
 2. **Focus management** (2.4.x) - SPA navigation breaks native focus behavior
 3. **Name, Role, Value** (4.1.2) - Custom components need ARIA attributes
@@ -183,7 +183,7 @@ User interface components and navigation must be operable.
 | **2.4.6 Headings and Labels** | AA | Headings/labels describe content | `<Title>` components are descriptive | **Manual:** Review heading hierarchy |
 | **2.4.7 Focus Visible** | AA | Focus indicator is visible | CSS focus styles; no `outline: none` | **Automated:** axe partial. **Manual:** Visual inspection |
 
-**Next.js 15 specific - Focus management for SPA navigation:**
+**Next.js 16 specific - Focus management for SPA navigation:**
 ```tsx
 // After route change, move focus to main content
 import { usePathname } from 'next/navigation';

--- a/.planning/research/TOOLS.md
+++ b/.planning/research/TOOLS.md
@@ -1,6 +1,6 @@
 # Accessibility Testing Tools and Methodology
 
-**Domain:** Accessibility Audit for Next.js 15 / React 19 Site
+**Domain:** Accessibility Audit for Next.js 16 / React 19 Site
 **Researched:** 2026-01-27
 **Overall Confidence:** HIGH (well-established domain, verified sources)
 
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-This document provides a comprehensive guide to accessibility testing tools and methodologies for auditing a production Next.js 15 / React 19 website. The project already has axe-core integrated via `jest-axe` in the test suite. This research covers how to maximize that investment while adding complementary manual testing.
+This document provides a comprehensive guide to accessibility testing tools and methodologies for auditing a production Next.js 16 / React 19 website. The project already has axe-core integrated via `jest-axe` in the test suite. This research covers how to maximize that investment while adding complementary manual testing.
 
 **Key insight:** Automated tools catch 30-40% of WCAG violations. A robust audit requires combining automation with manual keyboard testing, screen reader testing, and visual inspection.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@
 
 ## Snapshot
 
-**Type:** Hybrid monorepo (Next.js 15 production + Vite legacy)  
-**Stack:** React 19, TypeScript 5.9, Next.js 15.5, Storybook 10  
+**Type:** Hybrid monorepo (Next.js 16 production + Vite legacy)  
+**Stack:** React 19, TypeScript 6.x, Next.js 16.2, Storybook 10  
 **Production app:** `app/` · **Design system:** `nextjs-app/shared/components/`
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Type** | Hybrid monorepo (Next.js 15 production + Vite legacy) |
-| **Stack** | React 19, TypeScript 5.9, Next.js 15.5, Storybook 10 |
+| **Type** | Hybrid monorepo (Next.js 16 production + Vite legacy) |
+| **Stack** | React 19, TypeScript 6.x, Next.js 16.2, Storybook 10 |
 | **Architecture** | Component-driven design system, CSS Modules, i18next (EN/FI/SV) |
 | **Hosting** | Vercel serverless |
 
@@ -66,7 +66,7 @@ npm run sanity:publish   # Publish blog → refreshes manifest
 
 ## Gotchas (agents miss these)
 
-**Next.js 15 async params**
+**Next.js 16 async params**
 
 ```tsx
 export default async function Page({ params }: Props) {

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@
 
 > "Iteration beats perfection—ship today, learn tomorrow, refine forever."
 
-Digitaltableteur is a hybrid monorepo portfolio website featuring both Next.js 15 (production) and Vite (legacy) applications. Built with React 18 and TypeScript 5.8, it showcases a comprehensive design system, multi-language support (EN/FI/SV), AI-powered chat interface, and enterprise-grade tooling including Sentry observability, Linear issue management, and MCP (Model Context Protocol) integrations.
+Digitaltableteur is a hybrid monorepo portfolio website featuring both Next.js 16 (production) and Vite (legacy) applications. Built with React 19 and TypeScript 6.x, it showcases a comprehensive design system, multi-language support (EN/FI/SV), AI-powered chat interface, and enterprise-grade tooling including Sentry observability, Linear issue management, and MCP (Model Context Protocol) integrations.
 
 ## 🚀 Features
 
 ### Core Architecture
 
-- **Hybrid Monorepo**: Next.js 15 App Router (production) + Vite 6.3 (legacy) in parallel migration
+- **Hybrid Monorepo**: Next.js 16 App Router (production) + Vite 6.4 (legacy) in parallel migration
 - **AI Documentation System**: Hierarchical CLAUDE.md/AGENTS.md structure optimized for AI assistants
 - **Design System**: 50+ components with CSS Modules, design tokens, Storybook, and visual regression testing
-- **Type Safety**: TypeScript 5.8 strict mode with comprehensive interfaces and JSDoc documentation
+- **Type Safety**: TypeScript 6.x strict mode with comprehensive interfaces and JSDoc documentation
 
 ### User Experience
 
@@ -361,7 +361,7 @@ npm run sanity:publish
 
 ```
 digitaltableteur/
-├── app/                       # Next.js 15 App Router (production)
+├── app/                       # Next.js 16 App Router (production)
 │   ├── layout.tsx             # Root layout with providers
 │   ├── page.tsx               # Home page (server component)
 │   ├── about/page.tsx         # Route pages
@@ -405,10 +405,10 @@ digitaltableteur/
 
 **Frontend**
 
-- React 18: Concurrent features, Suspense, automatic batching
-- TypeScript 5.8: Strict mode, decorators, import attributes
-- Next.js 15.5.6: App Router, Server Components, Streaming SSR
-- Vite 6.3: Lightning-fast HMR, optimized production builds
+- React 19: Concurrent features, Suspense, automatic batching
+- TypeScript 6.x: Strict mode, decorators, import attributes
+- Next.js 16.2.x: App Router, Server Components, Streaming SSR
+- Vite 6.4: Lightning-fast HMR, optimized production builds
 - React Router 7: Client-side routing with lazy loading (Vite app)
 
 **Styling & Design**
@@ -782,8 +782,8 @@ Before creating a PR:
 
 **Frontend**:
 
-- [React 18](https://react.dev/) - UI framework
-- [Next.js 15](https://nextjs.org/) - React framework with App Router
+- [React 19](https://react.dev/) - UI framework
+- [Next.js 16](https://nextjs.org/) - React framework with App Router
 - [Vite](https://vitejs.dev/) - Build tool and development server
 - [TypeScript](https://www.typescriptlang.org/) - Type safety
 - [React Router](https://reactrouter.com/) - Client-side routing (Vite app)

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -2,8 +2,8 @@
 
 ## Package Identity
 
-**Purpose**: Next.js 15 App Router (production app)  
-**Framework**: Next.js 15.5.6 with App Router
+**Purpose**: Next.js 16 App Router (production app)  
+**Framework**: Next.js 16.2.x with App Router
 
 ---
 

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -2,8 +2,8 @@
 
 ## Package Identity
 
-**Purpose**: Next.js 15 App Router (production application)  
-**Technology**: Next.js 15.5.6, React Server Components, App Router  
+**Purpose**: Next.js 16 App Router (production application)  
+**Technology**: Next.js 16.2.x, React Server Components, App Router  
 **Entry Point**: `app/layout.tsx` (root layout)  
 **Parent Context**: Extends [../CLAUDE.md](../CLAUDE.md)
 

--- a/app/api/donny-context.js
+++ b/app/api/donny-context.js
@@ -49,7 +49,7 @@ IMPORTANT: When asked about ANY project, case study, or portfolio work, ALWAYS u
 - Illustrations: Editorial illustrations and character designs
 
 Technology Stack:
-- Frontend: React 19, Next.js 15, TypeScript, CSS Modules, Radix UI
+- Frontend: React 19, Next.js 16, TypeScript, CSS Modules, Radix UI
 - Design: Figma, design tokens (CSS custom properties), Storybook 10
 - Animation: GSAP, Framer Motion, Lenis smooth scroll
 - AI/LLM: Vercel AI SDK, MCP integrations

--- a/docs/2026_PRD.md
+++ b/docs/2026_PRD.md
@@ -209,7 +209,7 @@ CMS integration for:
 
 ### Tech Stack Recommendations
 
-- Frontend: Next.js 15, React 19, TypeScript, TailwindCSS
+- Frontend: Next.js 16, React 19, TypeScript, TailwindCSS
 - CMS: Sanity.io or Contentlayer (MDX)
 - Hosting: Vercel (Edge runtime)
 - Analytics: PostHog / Plausible

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -47,8 +47,8 @@
   - Critical gotchas and solutions
 
 - **`NEXTJS_16_UPGRADE_PLAN.md`**
-  - Next.js 15.5 → 16 upgrade (Turbopack, proxy, async APIs)
-  - Phased checklist, verification matrix, rollback — **start here for the 16 bump**
+  - Next.js 15.5 → 16 upgrade (**done**, #634): Turbopack, proxy, async APIs
+  - Phased checklist, verification matrix, rollback — **historical; production is on 16.2.x**
 
 - **`2026_PRD.md`**
   - Product requirements document

--- a/docs/AGENT_WORKFLOW.md
+++ b/docs/AGENT_WORKFLOW.md
@@ -9,7 +9,7 @@ How Digitaltableteur structures AI agent context — inspired by Apple's leaked 
 General-purpose models do not know:
 
 - Our component contract system and WIP lifecycle
-- Next.js 15 async params and OG image conventions
+- Next.js 16 async params and OG image conventions
 - Which npm scripts gate merges
 - That `react-icons` must stay at 5.5.0
 

--- a/docs/CLAUDE_AUTOMATION_RECOMMENDATIONS.md
+++ b/docs/CLAUDE_AUTOMATION_RECOMMENDATIONS.md
@@ -16,8 +16,8 @@ recommend automations for this project
 
 | Signal | Detected |
 |--------|----------|
-| **Type** | Hybrid monorepo — Next.js 15 production + Vite legacy + Storybook |
-| **Stack** | React 19, TypeScript 5.9, Vitest, Playwright, Sanity CMS |
+| **Type** | Hybrid monorepo — Next.js 16 production + Vite legacy + Storybook |
+| **Stack** | React 19, TypeScript 6.x, Vitest, Playwright, Sanity CMS |
 | **Backend** | Next.js API routes, MongoDB, Vercel AI SDK (chat) |
 | **Design system** | 80+ contracted components, CSS Modules, agent-manifest |
 | **CI** | GitHub Actions PR validation (typecheck, lint, visual, security) |

--- a/docs/COMPREHENSIVE_SECURITY_AUDIT_2025-12-03.md
+++ b/docs/COMPREHENSIVE_SECURITY_AUDIT_2025-12-03.md
@@ -1,5 +1,7 @@
 # Comprehensive Security Audit Report
 
+> **Superseded dependency snapshot:** Production now runs **Next.js 16.2.x** and **React 19** (see root `package.json`, merged in #634). Version tables below reflect **December 2025** audit time, not current installs.
+
 **Date**: December 3, 2025  
 **Last Updated**: January 19, 2026 (OpenAI Spending Limits)  
 **Scope**: Full codebase lint, security checks, vulnerability scan  

--- a/docs/GEMINI_SEO_REVIEW_ACTION_PLAN.md
+++ b/docs/GEMINI_SEO_REVIEW_ACTION_PLAN.md
@@ -25,7 +25,7 @@
 
 **Gemini Claimed**: "Your site is a CSR SPA that is not serving static HTML to crawlers"
 
-**Reality**: Site is Next.js 15 with **full SSR/SSG**. Verification:
+**Reality**: Site is Next.js 16 with **full SSR/SSG**. Verification:
 
 ```bash
 curl -s https://www.digitaltableteur.com/about | grep -o '<meta name="description" content="[^"]*"'
@@ -42,7 +42,7 @@ curl -s https://www.digitaltableteur.com/about | grep -o '<meta name="descriptio
 
 ✅ **Static HTML with unique meta tags per route**  
 ✅ **Pre-rendered content visible to crawlers**  
-✅ **Next.js 15 App Router with SSG**
+✅ **Next.js 16 App Router with SSG**
 
 ### 2. Robots.txt ✅ **WORKING**
 

--- a/docs/LLM_COMPONENT_GENERATION_RULES.md
+++ b/docs/LLM_COMPONENT_GENERATION_RULES.md
@@ -38,10 +38,10 @@
 
 **Next.js Migration Context (November 2025):**
 
-- **Primary platform:** Next.js 15.5.6 App Router (`nextjs-app/`)
-- **Legacy platform:** Vite-based SPA (maintained for Storybook/testing)
-- **Shared components:** Located in `shared/components/` - accessible to both platforms via symlinks
-- **Platform-specific code:** Use `nextjs-app/app/` for Next.js routes, `src/` for Vite-only code
+- **Primary platform:** Next.js 16.2.x App Router (repo root `app/`, `next.config.ts`)
+- **Legacy platform:** Vite-based SPA in `vite-app/` (parallel; not production)
+- **Shared components:** `nextjs-app/shared/components/` (import via `@dt/*`)
+- **Platform-specific code:** Root `app/` for routes/API; `vite-app/` for Vite-only surfaces
 
 **Example:**
 

--- a/docs/NEXTJS_16_UPGRADE_PLAN.md
+++ b/docs/NEXTJS_16_UPGRADE_PLAN.md
@@ -31,7 +31,7 @@
 | **Bundler (dev)** | **Turbopack (default)** | `next dev -p 3001` — MDX plugins use string names; `dev:webpack` fallback retained |
 | **Bundler (build)** | **Turbopack (default)** | `next build` — ~22s local vs ~90s webpack; `analyze` uses Turbopack too |
 | **Lint** | Custom `scripts/lint-banner.mjs` → local ESLint | Already off `next lint` |
-| **MDX** | `@next/mdx` + `next.config.ts` wrapper | Root has `@next/mdx@16.0.10` while `next@15.5.18` — **align on upgrade** |
+| **MDX** | `@next/mdx` + `next.config.ts` wrapper | Align `@next/mdx` peer with `next@16.2.x` (done in #634) |
 
 ### Recent stability context (do not repeat mistakes)
 
@@ -262,7 +262,7 @@ Compare route first-load JS sizes if Turbopack build is used on Vercel. Roll bac
 
 ## Rollback plan
 
-1. Revert PR / branch — production stays on 15.5.x
+1. Revert PR / branch — production would roll back to 15.5.x (pre-#634)
 2. If merged and broken: revert commit on `main`, redeploy Vercel
 3. `.next` local corruption: `npm run dev:reset`
 4. Keep `--webpack` flags in scripts for 1 release if Turbopack blocks ship

--- a/docs/NEXTJS_MIGRATION_PLAN.md
+++ b/docs/NEXTJS_MIGRATION_PLAN.md
@@ -1,6 +1,8 @@
 # Next.js Migration Plan: Parallel Hybrid Approach
 
-**Status:** Planning  
+> **Current truth (2026):** Production runs **Next.js 16.2.x** at the **repo root** (`app/`, `next.config.ts`). Vite remains in `vite-app/` for legacy/Storybook-adjacent workflows. This document describes the **historical** Vite → Next migration; for the 15 → 16 bump see [`NEXTJS_16_UPGRADE_PLAN.md`](NEXTJS_16_UPGRADE_PLAN.md).
+
+**Status:** Largely complete (production on root App Router)  
 **Start Date:** November 2025  
 **Strategy:** Zero-downtime incremental migration  
 **Risk Level:** Minimal (instant rollback capability)
@@ -9,7 +11,7 @@
 
 ## Executive Summary
 
-This document outlines a **parallel migration strategy** from Vite SPA to Next.js 15 App Router. The core principle: **keep the existing Vite app running in production while gradually introducing Next.js routes alongside it**. This approach eliminates migration risk and enables instant rollback.
+This document outlines a **parallel migration strategy** from Vite SPA to Next.js 16 App Router. The core principle: **keep the existing Vite app running in production while gradually introducing Next.js routes alongside it**. This approach eliminates migration risk and enables instant rollback.
 
 ### Why Parallel Migration?
 
@@ -28,7 +30,7 @@ This document outlines a **parallel migration strategy** from Vite SPA to Next.j
 ```
 digitaltableteur/
 ├── src/                    # Existing Vite app (untouched during migration)
-├── nextjs-app/            # New Next.js 15 app
+├── nextjs-app/            # New Next.js 16 app
 │   ├── app/               # App router
 │   ├── providers/         # Next.js-specific providers
 │   ├── components/        # Next.js-specific wrappers
@@ -1007,7 +1009,7 @@ npx lighthouse "$NEXT_BASE$ROUTE" --quiet --only-categories=accessibility
 
 ### Documentation
 
-- [Next.js 15 App Router](https://nextjs.org/docs/app)
+- [Next.js 16 App Router](https://nextjs.org/docs/app)
 - [Next.js Metadata API](https://nextjs.org/docs/app/building-your-application/optimizing/metadata)
 - [Vercel Rewrites](https://vercel.com/docs/projects/project-configuration#rewrites)
 - [i18next React](https://react.i18next.com/)

--- a/docs/SECURITY_HARDENING_IMPLEMENTATION.md
+++ b/docs/SECURITY_HARDENING_IMPLEMENTATION.md
@@ -502,7 +502,7 @@ done
   - **Verification**:
     - Searched `public/` and entire codebase for service worker files
     - No `sw.js`, `service-worker.js`, or `navigator.serviceWorker.register()` calls found
-    - Next.js 15 doesn't include service workers by default
+    - Next.js 16 doesn't include service workers by default
   - **Conclusion**: No action needed, security risk eliminated by absence
 
 - [ ] **AI Output Sanitization in DB Storage**

--- a/docs/SERVICE_WORKER_CACHE_SECURITY.md
+++ b/docs/SERVICE_WORKER_CACHE_SECURITY.md
@@ -2,11 +2,11 @@
 
 **Date:** December 3, 2025  
 **Status:** ✅ Verified Secure  
-**Next.js Version:** 15.5.6
+**Next.js Version:** 16.2.x (production root `package.json`)
 
 ## Executive Summary
 
-Next.js 15 does not include service workers by default. All API routes have been reviewed and configured with appropriate cache headers to prevent sensitive data caching.
+Next.js does not include service workers by default. All API routes have been reviewed and configured with appropriate cache headers to prevent sensitive data caching.
 
 ## Service Worker Review
 
@@ -23,7 +23,7 @@ grep -r "navigator.serviceWorker" src/ app/
 # Result: Only documentation examples, no actual implementation
 ```
 
-**Conclusion:** ✅ No service worker to harden. Next.js 15 handles caching through HTTP headers and Next.js cache configuration.
+**Conclusion:** ✅ No service worker to harden. Next.js 16 handles caching through HTTP headers and Next.js cache configuration.
 
 ### Next.js Built-in Caching
 

--- a/docs/TECHNICAL_PERFORMANCE_OPTIMIZATION.md
+++ b/docs/TECHNICAL_PERFORMANCE_OPTIMIZATION.md
@@ -10,7 +10,7 @@ Beyond the SEO fundamentals already implemented, these technical optimizations w
 
 ### Current Implementation (Good Foundation ✅):
 
-- Next.js 15 with App Router
+- Next.js 16 with App Router
 - Dynamic imports with React.lazy()
 - Image optimization
 - Aggressive cache busting

--- a/nextjs-app/shared/components/pages/Colophon/ColophonPage.tsx
+++ b/nextjs-app/shared/components/pages/Colophon/ColophonPage.tsx
@@ -71,7 +71,7 @@ export function ColophonPage() {
           <div className={styles.card}>
             <p className={styles.cardLabel}>Framework</p>
             <p className={styles.cardValue}>
-              Next.js 15 App Router with React 19 and TypeScript 6. Server
+              Next.js 16 App Router with React 19 and TypeScript 6. Server
               components by default; client components where interactivity,
               i18n, or animation require them. ISR revalidation on marketing and
               content routes.

--- a/nextjs-app/shared/stories/Docs/DesignSystemOverview.stories.tsx
+++ b/nextjs-app/shared/stories/Docs/DesignSystemOverview.stories.tsx
@@ -79,7 +79,7 @@ const DesignSystemOverviewContent = () => {
 
         <div className={styles.techStack}>
           <div className={styles.techItem}>
-            <h3>React 18+</h3>
+            <h3>React 19+</h3>
             <p>
               Functional components with TypeScript strict mode, hooks-based
               state management, and forwardRef support for ref forwarding.

--- a/scripts/linear/create-roadmap-issues.ts
+++ b/scripts/linear/create-roadmap-issues.ts
@@ -42,7 +42,7 @@ const tasks: TicketSeed[] = [
     summary:
       "Build the 2026-ready web surface with Next.js SSR/ISR, structured metadata, and hardened security baselines per PRD section 4.1 + roadmap Q1 foundation.",
     scope: [
-      "Create Next.js 15 app router codebase with SSR/ISR for all current pages",
+      "Create Next.js 16 app router codebase with SSR/ISR for all current pages",
       "Implement head-manager with Organization, Article, and Service schema",
       "Add security headers (CSP, HSTS, Referrer-Policy) + SRI for third-party scripts",
       "Set up GitHub Actions pipeline with OWASP ZAP + Lighthouse gates",

--- a/test-results-summary.md
+++ b/test-results-summary.md
@@ -1,5 +1,7 @@
 # Test & Lint Results Summary - December 3, 2025
 
+> **Historical run.** Dependency advisories (e.g. Next.js 15.5.x RCE) were addressed by upgrading to **Next.js 16.2.x** (#634). Do not treat version callouts below as current production state.
+
 ## ✅ Successfully Completed Checks
 
 ### 1. ESLint


### PR DESCRIPTION
## Summary

- Updates **canonical** agent/docs (`CLAUDE.md`, `AGENTS.md`, `README.md`, `app/*`, skills, `.planning/codebase/*`) to match root `package.json`: **Next.js 16.2.x**, **React 19**, **TypeScript 6.x**.
- Fixes **LLM_COMPONENT_GENERATION_RULES.md** production path: root `app/` (not `nextjs-app/` as the live app).
- Adds **historical banners** on dated audits (`COMPREHENSIVE_SECURITY_AUDIT_2025-12-03.md`, `test-results-summary.md`) and **completion note** on `NEXTJS_MIGRATION_PLAN.md`.
- Leaves **`.planning-archive-*`** unchanged (intentional snapshots).

## Source of truth

| Item | Value |
|------|--------|
| Production app | Repo root `app/`, `next.config.ts` |
| `next` | `^16.2.6` (#634) |
| `react` | `^19.2.6` |

## Test plan

- [ ] Grep: no stale `Next.js 15` in `CLAUDE.md` / `README.md` / `app/CLAUDE.md`
- [ ] Agents read `docs/NEXTJS_16_UPGRADE_PLAN.md` for upgrade context


Made with [Cursor](https://cursor.com)