### PR TITLE
chore: isolate npm config from DSharp Azure feed

### DIFF
--- a/.npm-userconfig
+++ b/.npm-userconfig
@@ -1,0 +1,2 @@
+; Intentionally empty. digitaltableteur installs only from the public npm registry.
+; Do not add DSharp/Azure feed settings here.

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,8 @@
+; Isolate this repo from machine-wide ~/.npmrc (e.g. DSharp Azure Artifacts + always-auth).
+; userconfig is redirected to a project-local file so global registry auth does not apply here.
+userconfig=.npm-userconfig
+
+registry=https://registry.npmjs.org/
+@dsharp:registry=https://registry.npmjs.org/
+
 legacy-peer-deps=true


### PR DESCRIPTION
## Summary

- Redirect `userconfig` to committed `.npm-userconfig` (empty) so global `~/.npmrc` DSharp/Azure settings do not apply in this repo.
- Pin `registry` and `@dsharp:registry` to the public npm registry (no `@dsharp` deps in this project).

## Test plan

- [ ] From repo root: `npm --version` shows no `always-auth` warning
- [ ] `npm config get registry` → `https://registry.npmjs.org/`
- [ ] `npm install` succeeds on a clean machine without Azure Artifacts auth


Made with [Cursor](https://cursor.com)