### PR TITLE
fix(home): stop news bulletin descender clipping

### DIFF
--- a/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css
+++ b/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css
@@ -73,6 +73,8 @@
   gap: var(--bulletin-card-gap);
   box-sizing: border-box;
   inline-size: 100%;
+  /* Room for descenders — overflow-x:auto otherwise clips overflow-y */
+  padding-block: 0.125rem;
   overflow-x: auto;
   overscroll-behavior-x: contain;
   scroll-behavior: smooth;
@@ -106,6 +108,7 @@
   inline-size: max-content;
   max-inline-size: 100%;
   min-block-size: var(--bulletin-card-min-height);
+  padding-block: 1rem; /* Figma vertical inset (16px) */
   padding-inline: var(--bulletin-card-padding-inline);
   background-color: var(--bulletin-card-bg);
   scroll-snap-align: start;
@@ -224,10 +227,11 @@
   font-family: var(--font-sans, var(--primary-body-font));
   font-size: 1rem;
   font-weight: 400;
-  line-height: 1;
+  line-height: 1.375; /* Figma 16px / 22px — avoids clipping g, p, y */
   color: var(--bulletin-copy);
   white-space: nowrap;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: visible;
   text-overflow: ellipsis;
   max-inline-size: 100%;
 }


### PR DESCRIPTION
## Summary
Fixes clipped descenders (g, p, y) in the homepage news bulletin copy.

## Changes
- Restore `line-height: 1.375` on bulletin body text (Figma 16/22)
- Add card `padding-block: 1rem` and track padding so horizontal scroll does not clip vertical glyphs
- Use `overflow-x: hidden` only for ellipsis

## Test plan
- [ ] Homepage bulletin: verify "during", "Rhythmguard", "DSharp" render full descenders

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined News Bulletin component with improved spacing and text rendering to prevent character clipping during scrolling and enhance overall visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->