### PR TITLE
feat(design-system): sync Figma design URLs to DT-Site-stuff library

### DIFF
--- a/.cursor/rules/writing-style.mdc
+++ b/.cursor/rules/writing-style.mdc
@@ -1,0 +1,17 @@
+---
+description: Digitaltableteur blog and long-form prose — load project voice rules before drafting or editing articles
+globs:
+  - content/**/*.mdx
+  - content/**/*.md
+  - docs/WRITING_STYLE.md
+---
+
+# Writing style (this repo only)
+
+Before creating or editing blog posts, drafts, or long-form markdown in this project:
+
+1. Read **`docs/WRITING_STYLE.md`** (authoritative; do not use global llm-wiki or shared skills for voice).
+2. UI microcopy / `t()` strings → `.claude/agents/copywriting-lead.md`, not WRITING_STYLE.
+3. After substantive edits: read aloud; check banned vocabulary and paragraph rhythm (no staccato one-liners).
+
+Do not copy `WRITING_STYLE.md` to other repositories.

--- a/.storybook/lib/resolve-figma-from-contract.ts
+++ b/.storybook/lib/resolve-figma-from-contract.ts
@@ -1,16 +1,47 @@
-import { existsSync, readFileSync, readdirSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+/// <reference types="vite/client" />
 import type { StoryContext } from "@storybook/react";
 
-const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
-const SEARCH_ROOTS = [
-  join(REPO_ROOT, "nextjs-app/shared/components"),
-  join(REPO_ROOT, "nextjs-app/shared/patterns"),
-  join(REPO_ROOT, "nextjs-app/shared/templates"),
-];
+/**
+ * Resolves the Figma design URL for a story from its component contract.
+ *
+ * Storybook preview code runs in the BROWSER, so this module must not touch
+ * `node:fs`. We build the component-name -> Figma-URL map at build time with
+ * Vite's `import.meta.glob` (eager), which inlines the contract JSON into the
+ * bundle. Looking up the map at runtime is then fully browser-safe.
+ */
 
-const cache = new Map<string, string | null>();
+type ContractModule = {
+  name?: unknown;
+  figma?: unknown;
+};
+
+// Vite requires static, literal glob patterns. One call per search root (no
+// brace expansion, for broad Vite-version compatibility). Paths are relative
+// to this file: `.storybook/lib/` -> repo root is two levels up.
+const contractModules: Record<string, ContractModule> = {
+  ...import.meta.glob<ContractModule>(
+    "../../nextjs-app/shared/components/**/*.contract.json",
+    { eager: true, import: "default" },
+  ),
+  ...import.meta.glob<ContractModule>(
+    "../../nextjs-app/shared/patterns/**/*.contract.json",
+    { eager: true, import: "default" },
+  ),
+  ...import.meta.glob<ContractModule>(
+    "../../nextjs-app/shared/templates/**/*.contract.json",
+    { eager: true, import: "default" },
+  ),
+};
+
+const figmaByName = new Map<string, string>();
+for (const contract of Object.values(contractModules)) {
+  const name = typeof contract?.name === "string" ? contract.name : null;
+  const figma =
+    typeof contract?.figma === "string" && contract.figma.startsWith("http")
+      ? contract.figma
+      : null;
+  if (name && figma) figmaByName.set(name, figma);
+}
 
 function componentNameFromContext(context: StoryContext): string | null {
   const fromComponent =
@@ -24,76 +55,21 @@ function componentNameFromContext(context: StoryContext): string | null {
   return segment ?? null;
 }
 
-function findContractPath(name: string): string | null {
-  for (const base of SEARCH_ROOTS) {
-    const direct = join(base, name, `${name}.contract.json`);
-    if (existsSync(direct)) return direct;
-
-    const walk = (dir: string): string | null => {
-      for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        const full = join(dir, entry.name);
-        if (entry.isDirectory()) {
-          const nested = walk(full);
-          if (nested) return nested;
-          continue;
-        }
-        if (entry.name === `${name}.contract.json`) return full;
-      }
-      return null;
-    };
-
-    if (existsSync(base)) {
-      const nested = walk(base);
-      if (nested) return nested;
-    }
-  }
-  return null;
-}
-
-function readFigmaUrl(name: string): string | null {
-  if (cache.has(name)) return cache.get(name) ?? null;
-
-  const contractPath = findContractPath(name);
-  if (contractPath) {
-    try {
-      const contract = JSON.parse(readFileSync(contractPath, "utf8")) as {
-        figma?: unknown;
-      };
-      const figma =
-        typeof contract.figma === "string" && contract.figma.startsWith("http")
-          ? contract.figma
-          : null;
-      cache.set(name, figma);
-      return figma;
-    } catch {
-      cache.set(name, null);
-      return null;
-    }
-  }
-
-  cache.set(name, null);
-  return null;
-}
-
 /** Storybook Design addon parameters sourced from the component contract. */
-export function resolveDesignParameters(context: StoryContext): {
-  type: "figma";
-  url: string;
-} | undefined {
+export function resolveDesignParameters(
+  context: StoryContext,
+): { type: "figma"; url: string } | undefined {
   const explicit = context.parameters?.design as
     | { type?: string; url?: string }
     | undefined;
   if (explicit?.url && typeof explicit.url === "string") {
-    return {
-      type: "figma",
-      url: explicit.url,
-    };
+    return { type: "figma", url: explicit.url };
   }
 
   const name = componentNameFromContext(context);
   if (!name) return undefined;
 
-  const url = readFigmaUrl(name);
+  const url = figmaByName.get(name);
   if (!url) return undefined;
 
   return { type: "figma", url };

--- a/docs/FIGMA_DESIGN_SYSTEM_SYNC.md
+++ b/docs/FIGMA_DESIGN_SYSTEM_SYNC.md
@@ -1,0 +1,47 @@
+# Figma design system sync (code → DT-Site-stuff)
+
+Canonical file: [DT-Site-stuff](https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?m=dev) (`PC2UPdYwm8qGt6ZTg0AakF`).
+
+**Source of truth for tokens:** `nextjs-app/shared/styles/variables.css` (4 themes: light, dark, HCB, HCW).
+
+## Phase order
+
+| Phase | What | Tooling |
+|-------|------|---------|
+| **0** | Discovery — pages, existing variables | `get_metadata` (no `nodeId`), `get_variable_defs` on a small frame |
+| **1** | Variables / tokens | `npm run build:figma-variables` → `use_figma` chunks in `foundations/figma/phases/` |
+| **2** | File structure | `use_figma` — Cover, Foundations, Atoms, Molecules, Organisms, Patterns, Site |
+| **3** | Components | One `use_figma` call per component (atoms → molecules → organisms → patterns) |
+| **4** | Views / routes | `generate_figma_design` + `use_figma` to assemble screens from library components |
+
+In-scope components: `scripts/design-system/in-scope-components.mjs`.
+
+## MCP: avoid hangs
+
+Per [Figma MCP tools](https://developers.figma.com/docs/figma-mcp-server/tools-and-prompts/):
+
+1. **Do not** call `get_metadata` on the whole file with a heavy `nodeId` first — use **no `nodeId`** to list pages only.
+2. **Never** run two `use_figma` calls in parallel.
+3. Prefer **Desktop MCP** (`http://127.0.0.1:3845/mcp`) with DT-Site-stuff open in Dev Mode if remote calls stall.
+4. Smoke test: `whoami` → `get_metadata` (fileKey only) → one small `use_figma` chunk.
+5. Avoid selecting huge frames for `get_design_context` / `get_variable_defs`.
+
+Setup details: [`FIGMA_MCP_SETUP.md`](./FIGMA_MCP_SETUP.md).
+
+## Build Figma variable payloads (local)
+
+```bash
+npm run build:tokens          # refresh token-catalog + DTCG
+npm run build:figma-variables # → foundations/figma/variables-manifest.json + phases/*.js
+```
+
+Then apply each `foundations/figma/phases/phase-1a-color-chunk-*.js` via MCP `use_figma` with `fileKey: PC2UPdYwm8qGt6ZTg0AakF` and `skillNames: "figma-generate-library"`.
+
+## Repo config
+
+- `scripts/design-system/figma-config.mjs` — file key/slug (override with `FIGMA_FILE_KEY` / `FIGMA_FILE_SLUG`).
+- Contracts still use placeholder `node-id=dt-*` until real frames exist; run `npm run sync:figma` after publishing nodes.
+
+## Resume
+
+State ledger pattern: `figma-generate-library` skill — tag nodes with `setSharedPluginData('dsb', …)` and re-run discovery if a session times out.

--- a/nextjs-app/shared/components/Accordion/Accordion.contract.json
+++ b/nextjs-app/shared/components/Accordion/Accordion.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "Expandable sections with keyboard-operable triggers.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-accordion",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=381-17",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/AdaptiveLoadingButton/AdaptiveLoadingButton.contract.json
+++ b/nextjs-app/shared/components/AdaptiveLoadingButton/AdaptiveLoadingButton.contract.json
@@ -5,7 +5,7 @@
   "group": "interaction",
   "status": "beta",
   "description": "AdaptiveLoadingButton — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-adaptive-loading-button",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-adaptive-loading-button",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/AlertBanner/AlertBanner.contract.json
+++ b/nextjs-app/shared/components/AlertBanner/AlertBanner.contract.json
@@ -5,7 +5,7 @@
   "group": "feedback",
   "status": "beta",
   "description": "Inline alert for info, warning, success, and error feedback.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-alert-banner",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=394-41",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/AnimatedDialog/AnimatedDialog.contract.json
+++ b/nextjs-app/shared/components/AnimatedDialog/AnimatedDialog.contract.json
@@ -5,7 +5,7 @@
   "group": "feedback",
   "status": "beta",
   "description": "Dialog (modal) variant with GSAP-driven enter/exit animation. Wraps the shadcn `Dialog` primitive and adds the size axis + severity colour token + animation type axis.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-animated-dialog",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-animated-dialog",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/AnimatedGlyphBackground/AnimatedGlyphBackground.contract.json
+++ b/nextjs-app/shared/components/AnimatedGlyphBackground/AnimatedGlyphBackground.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "AnimatedGlyphBackground — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-animated-glyph-background",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-animated-glyph-background",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/ArticleCard/ArticleCard.contract.json
+++ b/nextjs-app/shared/components/ArticleCard/ArticleCard.contract.json
@@ -5,7 +5,7 @@
   "group": "content",
   "status": "beta",
   "description": "Blog article teaser card with title, lead, and read time.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-article-card",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-article-card",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/AspectRatio/AspectRatio.contract.json
+++ b/nextjs-app/shared/components/AspectRatio/AspectRatio.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "Layout primitive that locks its children to a fixed width/height ratio (1:1, 4:3, 16:9, …) so media-shaped containers reserve space before content loads.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-aspect-ratio",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-aspect-ratio",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Author/Author.contract.json
+++ b/nextjs-app/shared/components/Author/Author.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "Author — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-author",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-author",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/AuthorBio/AuthorBio.contract.json
+++ b/nextjs-app/shared/components/AuthorBio/AuthorBio.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "AuthorBio — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-author-bio",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-author-bio",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Avatar/Avatar.contract.json
+++ b/nextjs-app/shared/components/Avatar/Avatar.contract.json
@@ -5,7 +5,7 @@
   "group": "display",
   "status": "stable",
   "description": "Profile image, initials, link, or menu trigger.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-avatar",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=369-8",
   "radixPrimitive": null,
   "element": "button",
   "variants": {},

--- a/nextjs-app/shared/components/Badge/Badge.contract.json
+++ b/nextjs-app/shared/components/Badge/Badge.contract.json
@@ -5,7 +5,7 @@
   "group": "display",
   "status": "stable",
   "description": "Compact status label with semantic state, size, and optional icon.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-badge",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=400-1249",
   "radixPrimitive": null,
   "element": "span",
   "variants": {},

--- a/nextjs-app/shared/components/Breadcrumb/Breadcrumb.contract.json
+++ b/nextjs-app/shared/components/Breadcrumb/Breadcrumb.contract.json
@@ -5,7 +5,7 @@
   "group": "navigation",
   "status": "beta",
   "description": "Navigation trail with current page indication.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-breadcrumb",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=381-31",
   "radixPrimitive": null,
   "element": "nav",
   "variants": {},

--- a/nextjs-app/shared/components/BusyIndicator/BusyIndicator.contract.json
+++ b/nextjs-app/shared/components/BusyIndicator/BusyIndicator.contract.json
@@ -5,7 +5,7 @@
   "group": "feedback",
   "status": "beta",
   "description": "BusyIndicator — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-busy-indicator",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-busy-indicator",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Button/Button.contract.json
+++ b/nextjs-app/shared/components/Button/Button.contract.json
@@ -5,7 +5,7 @@
   "group": "interaction",
   "status": "beta",
   "description": "Primary interaction control with variant, severity, loading, and link modes.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-button",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=406-1569",
   "radixPrimitive": null,
   "element": "button",
   "variants": {},

--- a/nextjs-app/shared/components/Card/Card.contract.json
+++ b/nextjs-app/shared/components/Card/Card.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "Composable surface for grouped content with header, body, media, and actions.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-card",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=377-26",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/CategoryFilter/CategoryFilter.contract.json
+++ b/nextjs-app/shared/components/CategoryFilter/CategoryFilter.contract.json
@@ -5,7 +5,7 @@
   "group": "navigation",
   "status": "beta",
   "description": "Filter pill row for list pages (blog archive, work index). Multiple visual treatments (pills, underline, minimal) for different surface densities.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-category-filter",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-category-filter",
   "radixPrimitive": null,
   "element": "nav",
   "variants": {},

--- a/nextjs-app/shared/components/Center/Center.contract.json
+++ b/nextjs-app/shared/components/Center/Center.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "Centers its children horizontally and vertically inside a relative container. Single-purpose alternative to ad-hoc `flex items-center justify-center` snippets scattered through the codebase.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-center",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-center",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/ChatWidget/ChatWidget.contract.json
+++ b/nextjs-app/shared/components/ChatWidget/ChatWidget.contract.json
@@ -5,7 +5,7 @@
   "group": "interaction",
   "status": "beta",
   "description": "Collapsible site assistant chat widget with streaming replies.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-chat-widget",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=473-25",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Checkbox/Checkbox.contract.json
+++ b/nextjs-app/shared/components/Checkbox/Checkbox.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Accessible checkbox with label, indeterminate, and size variants.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-checkbox",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=372-14",
   "radixPrimitive": null,
   "element": "input",
   "variants": {},

--- a/nextjs-app/shared/components/CheckboxField/CheckboxField.contract.json
+++ b/nextjs-app/shared/components/CheckboxField/CheckboxField.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Single checkbox wired to a label and optional helper text. Distinct from `Checkbox` (the unwrapped primitive) — `CheckboxField` is the form-row composition with `Label` + `HelperText` already attached.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-checkbox-field",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-checkbox-field",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/CheckboxGroup/CheckboxGroup.contract.json
+++ b/nextjs-app/shared/components/CheckboxGroup/CheckboxGroup.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Grouped checkboxes with optional master checkbox.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-checkbox-group",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=383-24",
   "radixPrimitive": null,
   "element": "fieldset",
   "variants": {},

--- a/nextjs-app/shared/components/ClientLogoMarquee/ClientLogoMarquee.contract.json
+++ b/nextjs-app/shared/components/ClientLogoMarquee/ClientLogoMarquee.contract.json
@@ -5,7 +5,7 @@
   "group": "marketing",
   "status": "beta",
   "description": "Animated client logo marquee on the homepage.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-client-logo-marquee",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-client-logo-marquee",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.contract.json
+++ b/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "CodeBlockWindow — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-code-block-window",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-code-block-window",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/CodeSnippet/CodeSnippet.contract.json
+++ b/nextjs-app/shared/components/CodeSnippet/CodeSnippet.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "CodeSnippet — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-code-snippet",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-code-snippet",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/ComplianceCard/ComplianceCard.contract.json
+++ b/nextjs-app/shared/components/ComplianceCard/ComplianceCard.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "ComplianceCard — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-compliance-card",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-compliance-card",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/ContactForm/ContactForm.contract.json
+++ b/nextjs-app/shared/components/ContactForm/ContactForm.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Full contact form with validation, attachments, and submission flow.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-contact-form",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=470-2",
   "radixPrimitive": null,
   "element": "form",
   "variants": {},

--- a/nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.contract.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Editorial contact form used on the live contact page.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-contact-form-editorial",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-contact-form-editorial",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Container/Container.contract.json
+++ b/nextjs-app/shared/components/Container/Container.contract.json
@@ -5,7 +5,7 @@
   "group": "layout",
   "status": "beta",
   "description": "Max-width content wrapper with responsive horizontal padding.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-container",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-container",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/CookieConsent/CookieConsent.contract.json
+++ b/nextjs-app/shared/components/CookieConsent/CookieConsent.contract.json
@@ -5,7 +5,7 @@
   "group": "chrome",
   "status": "beta",
   "description": "GDPR cookie consent modal and banner wired to site providers.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-cookie-consent",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-cookie-consent",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Designerman/Designerman.contract.json
+++ b/nextjs-app/shared/components/Designerman/Designerman.contract.json
@@ -5,7 +5,7 @@
   "group": "marketing",
   "status": "beta",
   "description": "Designerman — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-designerman",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-designerman",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Display/Display.contract.json
+++ b/nextjs-app/shared/components/Display/Display.contract.json
@@ -5,7 +5,7 @@
   "group": "display",
   "status": "beta",
   "description": "Display-sized heading for marketing hero copy. Larger than the `Title` scale; used sparingly on landing/about/contact heroes where the type itself is the visual.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-display",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-display",
   "radixPrimitive": null,
   "element": "h1",
   "variants": {},

--- a/nextjs-app/shared/components/Divider/Divider.contract.json
+++ b/nextjs-app/shared/components/Divider/Divider.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "Visual separator between sections (horizontal or vertical).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-divider",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=368-6",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/DonnyAvatar/DonnyAvatar.contract.json
+++ b/nextjs-app/shared/components/DonnyAvatar/DonnyAvatar.contract.json
@@ -5,7 +5,7 @@
   "group": "display",
   "status": "beta",
   "description": "DonnyAvatar — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-donny-avatar",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-donny-avatar",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.contract.json
+++ b/nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "EmailSignatureGenerator — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-email-signature-generator",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-email-signature-generator",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/EnhancedProjectCard/EnhancedProjectCard.contract.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/EnhancedProjectCard.contract.json
@@ -5,7 +5,7 @@
   "group": "marketing",
   "status": "beta",
   "description": "Portfolio project card with image, video hover, and metadata.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-enhanced-project-card",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-enhanced-project-card",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/ExpandableSection/ExpandableSection.contract.json
+++ b/nextjs-app/shared/components/ExpandableSection/ExpandableSection.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "Collapsible content region with a trigger header. Lighter than `Accordion` (which manages a group of expandables) — used standalone for a single 'show more' or detail-disclosure section.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-expandable-section",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-expandable-section",
   "radixPrimitive": null,
   "element": "section",
   "variants": {},

--- a/nextjs-app/shared/components/FileUpload/FileUpload.contract.json
+++ b/nextjs-app/shared/components/FileUpload/FileUpload.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "File picker with size validation and clear control.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-file-upload",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=384-26",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/FlexBox/FlexBox.contract.json
+++ b/nextjs-app/shared/components/FlexBox/FlexBox.contract.json
@@ -5,7 +5,7 @@
   "group": "layout",
   "status": "beta",
   "description": "Flexbox layout primitive for stacks and rows.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-flex-box",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-flex-box",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/FormField/FormField.contract.json
+++ b/nextjs-app/shared/components/FormField/FormField.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Wrapper that owns the label + control + helper-text triplet for a single field. Wires `htmlFor`/`id`, `aria-describedby`, and the required-/error-state slots so consumers do not reimplement them per form.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-form-field",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-form-field",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.contract.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Uppercase-label form field for editorial contact flows.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-form-field-editorial",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-form-field-editorial",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/FormGroup/FormGroup.contract.json
+++ b/nextjs-app/shared/components/FormGroup/FormGroup.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Fieldset wrapper for grouped form controls (checkbox set, radio set, named address block). Renders a real `<fieldset>` + `<legend>` so the grouping is announced.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-form-group",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-form-group",
   "radixPrimitive": null,
   "element": "fieldset",
   "variants": {},

--- a/nextjs-app/shared/components/Gallery/Gallery.contract.json
+++ b/nextjs-app/shared/components/Gallery/Gallery.contract.json
@@ -5,7 +5,7 @@
   "group": "display",
   "status": "beta",
   "description": "Image gallery grid with a click-to-expand lightbox and motion on hover. Used on work-detail and editorial pages where the imagery is the primary content.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-gallery",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-gallery",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Grid/Grid.contract.json
+++ b/nextjs-app/shared/components/Grid/Grid.contract.json
@@ -5,7 +5,7 @@
   "group": "layout",
   "status": "beta",
   "description": "CSS grid layout primitive with tokenized gaps.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-grid",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-grid",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/GroupLabel/GroupLabel.contract.json
+++ b/nextjs-app/shared/components/GroupLabel/GroupLabel.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Fieldset/legend-shaped label used by `CheckboxGroup`, `FormGroup`, and other multi-control groupings. Provides the group's accessible name without forcing every child input to repeat it.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-group-label",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-group-label",
   "radixPrimitive": null,
   "element": "label",
   "variants": {},

--- a/nextjs-app/shared/components/Heading/Heading.contract.json
+++ b/nextjs-app/shared/components/Heading/Heading.contract.json
@@ -5,7 +5,7 @@
   "group": "display",
   "status": "beta",
   "description": "Semantic heading primitive (h1–h6) with an explicit visual size axis decoupled from the HTML level so the document outline stays honest.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-heading",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-heading",
   "radixPrimitive": null,
   "element": "h2",
   "variants": {},

--- a/nextjs-app/shared/components/HelperText/HelperText.contract.json
+++ b/nextjs-app/shared/components/HelperText/HelperText.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Semantic helper or validation copy below form controls.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-helper-text",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=371-17",
   "radixPrimitive": null,
   "element": "p",
   "variants": {},

--- a/nextjs-app/shared/components/Icon/Icon.contract.json
+++ b/nextjs-app/shared/components/Icon/Icon.contract.json
@@ -5,7 +5,7 @@
   "group": "display",
   "status": "stable",
   "description": "Phosphor icon wrapper with size, weight, and motion affordances.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-icon",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-icon",
   "radixPrimitive": null,
   "element": "span",
   "variants": {},

--- a/nextjs-app/shared/components/IconButton/IconButton.contract.json
+++ b/nextjs-app/shared/components/IconButton/IconButton.contract.json
@@ -5,7 +5,7 @@
   "group": "actions",
   "status": "beta",
   "description": "Icon-only action button. Wraps the underlying shadcn `Button` with a circular shape, enforced `aria-label`, and the design-system size axis.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-icon-button",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-icon-button",
   "radixPrimitive": null,
   "element": "button",
   "variants": {},

--- a/nextjs-app/shared/components/ImagePlaceholder/ImagePlaceholder.contract.json
+++ b/nextjs-app/shared/components/ImagePlaceholder/ImagePlaceholder.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "ImagePlaceholder — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-image-placeholder",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-image-placeholder",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Inputs/Inputs.contract.json
+++ b/nextjs-app/shared/components/Inputs/Inputs.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Labeled text input with validation, helper text, and size tokens.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-inputs",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=374-10",
   "radixPrimitive": null,
   "element": "input",
   "variants": {

--- a/nextjs-app/shared/components/Label/Label.contract.json
+++ b/nextjs-app/shared/components/Label/Label.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Form field label with required, disabled, and tooltip affordances.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-label",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=371-6",
   "radixPrimitive": null,
   "element": "label",
   "variants": {},

--- a/nextjs-app/shared/components/Layout/Layout.contract.json
+++ b/nextjs-app/shared/components/Layout/Layout.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "Top-level page shell wrapping every Next.js app/* route. Renders the global header, the route's children inside the main landmark, and the global footer. Catalog entry exists so the page structure is documented; the implementation is not parameterised.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-layout",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-layout",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Link/Link.contract.json
+++ b/nextjs-app/shared/components/Link/Link.contract.json
@@ -5,7 +5,7 @@
   "group": "navigation",
   "status": "beta",
   "description": "Accessible inline link with size tokens and optional trailing icon.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-link",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=371-30",
   "radixPrimitive": null,
   "element": "a",
   "variants": {},

--- a/nextjs-app/shared/components/LinkedInQuoteCard/LinkedInQuoteCard.contract.json
+++ b/nextjs-app/shared/components/LinkedInQuoteCard/LinkedInQuoteCard.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "LinkedInQuoteCard — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-linked-in-quote-card",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-linked-in-quote-card",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/List/List.contract.json
+++ b/nextjs-app/shared/components/List/List.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "List — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-list",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-list",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/LocationCard/LocationCard.contract.json
+++ b/nextjs-app/shared/components/LocationCard/LocationCard.contract.json
@@ -5,7 +5,7 @@
   "group": "display",
   "status": "beta",
   "description": "Card variant for displaying a single office or service location (address, hours, map link). Visual sibling of `Card` with the location-specific slot order baked in.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-location-card",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-location-card",
   "radixPrimitive": null,
   "element": "article",
   "variants": {},

--- a/nextjs-app/shared/components/Logo/Logo.contract.json
+++ b/nextjs-app/shared/components/Logo/Logo.contract.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "../../../scripts/design-system/contract.schema.json",
+  "name": "Logo",
+  "tier": "atom",
+  "group": "display",
+  "status": "beta",
+  "description": "Digitaltableteur brand mark — monochrome (currentColor), square footprint, optional hover pulse.",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=480-1588",
+  "radixPrimitive": null,
+  "element": "svg",
+  "variants": {},
+  "slots": [],
+  "asChild": false,
+  "subParts": [],
+  "requiredStories": [
+    "Default",
+    "Playground",
+    "Example",
+    "ForcedColors"
+  ],
+  "argTypesProxyExempt": [
+    "animated",
+    "badge",
+    "className",
+    "decorative",
+    "size",
+    "title"
+  ],
+  "a11y": {
+    "keyboard": [],
+    "ariaRequirements": [
+      "accessible name via title unless decorative",
+      "decorative renders aria-hidden"
+    ],
+    "reducedMotion": true,
+    "reviewed": false,
+    "forcedColorsVerified": false,
+    "reviewedNote": "New atom — WIP badge retained until a11y + visual + translation verification."
+  },
+  "tokens": {
+    "colors": [],
+    "spacing": []
+  },
+  "lightDarkVerified": false,
+  "consumers": []
+}

--- a/nextjs-app/shared/components/Logo/Logo.mdx
+++ b/nextjs-app/shared/components/Logo/Logo.mdx
@@ -1,0 +1,37 @@
+import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
+import * as LogoStories from "./Logo.stories.tsx";
+
+<Meta of={LogoStories} />
+
+# Logo
+
+The Digitaltableteur brand mark. Monochrome (inherits `currentColor`), renders in
+a square `size`×`size` box, and supports an opt-in hover pulse.
+
+<Canvas of={LogoStories.Default} />
+
+## Usage
+
+```tsx
+import Logo from "@dt/Logo";
+
+<Logo size={28} />
+<Logo size={28} animated />        {/* hover pulse, reduced-motion safe */}
+<Logo decorative />                {/* next to a visible wordmark */}
+```
+
+## Sizes
+
+<Canvas of={LogoStories.Sizes} />
+
+## Controls
+
+<Controls />
+
+## Accessibility
+
+- Default exposes `role="img"` with an accessible name from `title`
+  (`"Digitaltableteur"`).
+- Use `decorative` when the brand is already named by adjacent text — the mark is
+  then `aria-hidden`.
+- The pulse only runs on hover and is disabled under `prefers-reduced-motion`.

--- a/nextjs-app/shared/components/Logo/Logo.module.css
+++ b/nextjs-app/shared/components/Logo/Logo.module.css
@@ -1,0 +1,93 @@
+/*
+ * Wrap defaults in @layer components so Tailwind utilities (in @layer utilities)
+ * win over the module's own rules — matches the Divider/Icon pattern and keeps
+ * consumer sizing/spacing utilities authoritative.
+ */
+@layer components {
+  .logo {
+    display: inline-block;
+    flex-shrink: 0;
+
+    /* Mark inherits text color via currentColor — theme- and forced-colors-safe. */
+    color: inherit;
+    vertical-align: middle;
+  }
+
+  /* Brand badge: flip the mark to the contrast token; lime fill on the circle. */
+
+  .badged {
+    color: var(--logo-color, #000);
+  }
+
+  .badgeBg {
+    fill: var(--logo-background, #dfff00);
+  }
+
+  .bar1,
+  .bar2,
+  .bar3 {
+    transition: opacity 0.3s ease;
+  }
+
+  /* Opt-in: pulse the three leading bars on hover. */
+
+  .animated:hover .bar1 {
+    animation: dt-logo-pulse-1 0.9s ease-in-out infinite;
+  }
+
+  .animated:hover .bar2 {
+    animation: dt-logo-pulse-2 0.9s ease-in-out infinite;
+  }
+
+  .animated:hover .bar3 {
+    animation: dt-logo-pulse-3 0.9s ease-in-out infinite;
+  }
+
+  @keyframes dt-logo-pulse-1 {
+    0%,
+    33%,
+    100% {
+      opacity: 1;
+    }
+
+    5%,
+    28% {
+      opacity: 0.5;
+    }
+  }
+
+  @keyframes dt-logo-pulse-2 {
+    0%,
+    5%,
+    66%,
+    100% {
+      opacity: 1;
+    }
+
+    33%,
+    61% {
+      opacity: 0.5;
+    }
+  }
+
+  @keyframes dt-logo-pulse-3 {
+    0%,
+    61%,
+    100% {
+      opacity: 1;
+    }
+
+    66%,
+    95% {
+      opacity: 0.5;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .animated:hover .bar1,
+    .animated:hover .bar2,
+    .animated:hover .bar3 {
+      animation: none;
+    }
+  }
+}

--- a/nextjs-app/shared/components/Logo/Logo.spec.md
+++ b/nextjs-app/shared/components/Logo/Logo.spec.md
@@ -1,0 +1,37 @@
+# Logo — spec
+
+Brand mark for Digitaltableteur. Atom, display group.
+
+## Purpose
+
+Single source of truth for the DT mark. Renders the canonical vector from
+`public/dt-logo.svg` inline so it inherits `currentColor` and scales cleanly.
+Replaces ad-hoc inline SVGs (e.g. the placeholder square previously used in
+`SiteHeader` / `SiteFooter`).
+
+## API
+
+| Prop         | Type      | Default            | Notes                                                  |
+| ------------ | --------- | ------------------ | ------------------------------------------------------ |
+| `size`       | `number`  | `24`               | Square render box in px; mark fits inside (no distort) |
+| `animated`   | `boolean` | `false`            | Three-bar hover pulse; disabled under reduced motion   |
+| `title`      | `string`  | `"Digitaltableteur"` | Accessible name; ignored when `decorative`           |
+| `decorative` | `boolean` | `false`            | `aria-hidden`, no title — for redundant placements      |
+| `className`  | `string`  | —                  | Utility/spacing classes                                |
+
+## Behavior
+
+- Monochrome via `currentColor`; color comes from the consumer's text color, so
+  it is theme- and forced-colors-safe (no hardcoded values).
+- `animated` adds the source SVG's `pulse-1/2/3` keyframes on hover only.
+
+## Accessibility
+
+- Default: `role="img"` + `<title>`/`aria-label` from `title`.
+- `decorative`: removed from the a11y tree (`aria-hidden`), for cases where an
+  adjacent wordmark already names the brand.
+- The accessible name is a brand proper noun and is not translated.
+
+## Out of scope
+
+- Wordmark lockup and the colored badge circle remain composition.

--- a/nextjs-app/shared/components/Logo/Logo.stories.tsx
+++ b/nextjs-app/shared/components/Logo/Logo.stories.tsx
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import Logo from "./Logo";
+import contract from "./Logo.contract.json";
+
+const meta = {
+  title: "Atoms/Logo",
+  component: Logo,
+  tags: ["beta", "!autodocs"],
+  parameters: {
+    layout: "centered",
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+  },
+  argTypes: {
+    size: {
+      control: { type: "number", min: 16, max: 256, step: 4 },
+      description: "Square render box in pixels",
+      table: { category: "Layout", defaultValue: { summary: "24" } },
+    },
+    animated: {
+      control: "boolean",
+      description: "Pulse the leading bars on hover (disabled under reduced motion)",
+      table: { category: "Motion", defaultValue: { summary: "false" } },
+    },
+    badge: {
+      control: "boolean",
+      description: "Wrap the mark in the brand lime circle",
+      table: { category: "Appearance", defaultValue: { summary: "false" } },
+    },
+    title: {
+      control: "text",
+      description: "Accessible name (ignored when decorative)",
+      table: { category: "Accessibility", defaultValue: { summary: "Digitaltableteur" } },
+    },
+    decorative: {
+      control: "boolean",
+      description: "Remove the mark from the accessibility tree",
+      table: { category: "Accessibility", defaultValue: { summary: "false" } },
+    },
+    className: { control: false, table: { category: "Advanced" } },
+  },
+  args: { size: 24, animated: false, badge: false, decorative: false },
+} satisfies Meta<typeof Logo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "none" },
+};
+
+export const Default: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "none" },
+  ...Playground,
+};
+
+export const Example: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "none" },
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "0.5rem",
+        fontFamily: "var(--font-text)",
+        fontWeight: 700,
+      }}
+    >
+      <Logo size={28} />
+      Digitaltableteur
+    </span>
+  ),
+};
+
+export const Sizes: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div
+      style={{
+        display: "flex",
+        gap: "var(--space-layout-16)",
+        alignItems: "flex-end",
+      }}
+    >
+      {[16, 24, 40, 64].map((s) => (
+        <Logo key={s} size={s} />
+      ))}
+    </div>
+  ),
+};
+
+export const Animated: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => <Logo size={64} animated />,
+};
+
+export const Badge: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div
+      style={{
+        display: "flex",
+        gap: "var(--space-layout-16)",
+        alignItems: "center",
+      }}
+    >
+      <Logo size={40} badge />
+      <Logo size={40} badge animated />
+    </div>
+  ),
+};
+
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "active" },
+};

--- a/nextjs-app/shared/components/Logo/Logo.test.tsx
+++ b/nextjs-app/shared/components/Logo/Logo.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import Logo from "./Logo";
+
+describe("Logo", () => {
+  it("renders with the default accessible name", () => {
+    render(<Logo />);
+    expect(screen.getByRole("img", { name: "Digitaltableteur" })).toBeTruthy();
+  });
+
+  it("honors a custom title", () => {
+    render(<Logo title="Home" />);
+    expect(screen.getByRole("img", { name: "Home" })).toBeTruthy();
+  });
+
+  it("is removed from the accessibility tree when decorative", () => {
+    const { container } = render(<Logo decorative />);
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(container.querySelector("svg")?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("applies the size to the svg box", () => {
+    const { container } = render(<Logo size={48} />);
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("width")).toBe("48");
+    expect(svg?.getAttribute("height")).toBe("48");
+  });
+
+  it("adds an animation class only when animated", () => {
+    const tokens = (el: Element | null) =>
+      (el?.getAttribute("class") ?? "").split(/\s+/).filter(Boolean);
+    const staticSvg = render(<Logo />).container.querySelector("svg");
+    const animatedSvg = render(<Logo animated />).container.querySelector("svg");
+    expect(tokens(animatedSvg).length).toBeGreaterThan(tokens(staticSvg).length);
+  });
+
+  it("renders a badge circle only when badge is set", () => {
+    expect(
+      render(<Logo />).container.querySelector("circle"),
+    ).toBeNull();
+    expect(
+      render(<Logo badge />).container.querySelector("circle"),
+    ).not.toBeNull();
+  });
+});

--- a/nextjs-app/shared/components/Logo/Logo.tsx
+++ b/nextjs-app/shared/components/Logo/Logo.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import styles from "./Logo.module.css";
+
+export interface LogoProps {
+  /** Square render box in pixels. Default 24. */
+  size?: number;
+  /** Enable the three-bar pulse on hover (respects prefers-reduced-motion). Default false. */
+  animated?: boolean;
+  /** Wrap the mark in the brand lime circle (`--logo-background` / `--logo-color`). Default false. */
+  badge?: boolean;
+  /** Accessible name for the mark. Ignored when `decorative`. Default "Digitaltableteur". */
+  title?: string;
+  /** When true the mark is purely decorative and removed from the accessibility tree. Default false. */
+  decorative?: boolean;
+  /** Optional utility/spacing classes. */
+  className?: string;
+}
+
+/**
+ * Digitaltableteur brand mark. Monochrome (inherits `currentColor`) and renders
+ * inside a square `size`×`size` box. Opt into the hover pulse with `animated`,
+ * or the lime brand badge with `badge` (a filled circle behind a contrast mark).
+ */
+export const Logo = React.forwardRef<SVGSVGElement, LogoProps>(function Logo(
+  {
+    size = 24,
+    animated = false,
+    badge = false,
+    title = "Digitaltableteur",
+    decorative = false,
+    className,
+  },
+  ref,
+) {
+  const classNames = [
+    styles.logo,
+    badge ? styles.badged : "",
+    animated ? styles.animated : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const a11yProps = decorative
+    ? ({ "aria-hidden": true, role: "presentation" } as const)
+    : ({ role: "img", "aria-label": title } as const);
+
+  // Badge mode pads the mark inside a square viewBox so a full-bleed circle can
+  // sit behind it; mark color flips to the contrast token via `.badged`.
+  const viewBox = badge ? "-121 -157 637 637" : "0 0 395 323";
+
+  return (
+    <svg
+      ref={ref}
+      className={classNames}
+      width={size}
+      height={size}
+      viewBox={viewBox}
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      focusable="false"
+      {...a11yProps}
+    >
+      {decorative ? null : <title>{title}</title>}
+      {badge ? (
+        <circle className={styles.badgeBg} cx="197.5" cy="161.5" r="318.5" />
+      ) : null}
+      <rect
+        className={styles.bar1}
+        x="190.742"
+        width="39.0494"
+        height="142.681"
+        fill="currentColor"
+      />
+      <rect
+        className={styles.bar2}
+        x="190.742"
+        y="180.228"
+        width="39.0494"
+        height="142.681"
+        fill="currentColor"
+      />
+      <rect
+        className={styles.bar3}
+        x="267.338"
+        y="181.73"
+        width="39.0494"
+        height="127.662"
+        transform="rotate(-90 267.338 181.73)"
+        fill="currentColor"
+      />
+      <rect y="37.5475" width="39.0494" height="246.312" fill="currentColor" />
+      <rect
+        x="115.646"
+        y="76.597"
+        width="39.0494"
+        height="168.213"
+        fill="currentColor"
+      />
+      <path
+        d="M39.0493 76.597L39.0493 37.5475L118.65 37.5475L154.696 76.5969L39.0493 76.597Z"
+        fill="currentColor"
+      />
+      <path
+        d="M39.0493 244.81L39.0493 283.859L118.65 283.859L154.696 244.81L39.0493 244.81Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+});
+
+Logo.displayName = "Logo";
+export default Logo;

--- a/nextjs-app/shared/components/Logo/index.ts
+++ b/nextjs-app/shared/components/Logo/index.ts
@@ -1,0 +1,2 @@
+export { Logo, default } from "./Logo";
+export type { LogoProps } from "./Logo";

--- a/nextjs-app/shared/components/MCPActionButton/MCPActionButton.contract.json
+++ b/nextjs-app/shared/components/MCPActionButton/MCPActionButton.contract.json
@@ -5,7 +5,7 @@
   "group": "interaction",
   "status": "beta",
   "description": "MCPActionButton — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-mcpaction-button",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-mcpaction-button",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.contract.json
+++ b/nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "MacWindowFrame — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-mac-window-frame",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-mac-window-frame",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.contract.json
+++ b/nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "MarkdownMessage — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-markdown-message",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-markdown-message",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Modal/Modal.contract.json
+++ b/nextjs-app/shared/components/Modal/Modal.contract.json
@@ -5,7 +5,7 @@
   "group": "overlay",
   "status": "beta",
   "description": "Modal dialog for confirmations, forms, and focused tasks.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-modal",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=384-13",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/NavLink/NavLink.contract.json
+++ b/nextjs-app/shared/components/NavLink/NavLink.contract.json
@@ -5,7 +5,7 @@
   "group": "navigation",
   "status": "beta",
   "description": "Navigation anchor primitive used inside `SiteHeader`, `Footer`, and in-page navs. Renders an underlying `next/link` and applies the `aria-current='page'` token when the active route matches.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-nav-link",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-nav-link",
   "radixPrimitive": null,
   "element": "a",
   "variants": {},

--- a/nextjs-app/shared/components/NavMenuList/NavMenuList.contract.json
+++ b/nextjs-app/shared/components/NavMenuList/NavMenuList.contract.json
@@ -5,7 +5,7 @@
   "group": "navigation",
   "status": "beta",
   "description": "NavMenuList — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-nav-menu-list",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-nav-menu-list",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.contract.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Newsletter waitlist signup with inline email capture.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-newsletter-waitlist",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=471-21",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/NextHeader/NextHeader.contract.json
+++ b/nextjs-app/shared/components/NextHeader/NextHeader.contract.json
@@ -5,7 +5,7 @@
   "group": "navigation",
   "status": "beta",
   "description": "Concrete Next.js implementation of the site header pattern. Renders the logo, primary nav, theme switcher, and the mobile-menu trigger. Visually documented at the catalog level via `SiteHeader`; this entry exists so the implementation file is also discoverable.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-next-header",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-next-header",
   "radixPrimitive": null,
   "element": "header",
   "variants": {},

--- a/nextjs-app/shared/components/NextLayout/NextLayout.contract.json
+++ b/nextjs-app/shared/components/NextLayout/NextLayout.contract.json
@@ -5,7 +5,7 @@
   "group": "chrome",
   "status": "beta",
   "description": "Production app shell: header, main landmark, footer, chat, consent.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-next-layout",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-next-layout",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/NextMobileMenu/NextMobileMenu.contract.json
+++ b/nextjs-app/shared/components/NextMobileMenu/NextMobileMenu.contract.json
@@ -5,7 +5,7 @@
   "group": "navigation",
   "status": "beta",
   "description": "Mobile-viewport navigation drawer paired with `NextHeader`. Opens on the header's mobile-menu trigger, traps focus while open, and closes on Esc / outside click.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-next-mobile-menu",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-next-mobile-menu",
   "radixPrimitive": null,
   "element": "dialog",
   "variants": {},

--- a/nextjs-app/shared/components/OpenHours/OpenHours.contract.json
+++ b/nextjs-app/shared/components/OpenHours/OpenHours.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "OpenHours — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-open-hours",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-open-hours",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Pagination/Pagination.contract.json
+++ b/nextjs-app/shared/components/Pagination/Pagination.contract.json
@@ -5,7 +5,7 @@
   "group": "navigation",
   "status": "beta",
   "description": "Pagination controls for paged lists (article archive, search results). Renders a `<nav>` landmark with previous/next buttons and a numbered list; supports ellipsis truncation for long page ranges.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-pagination",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-pagination",
   "radixPrimitive": null,
   "element": "nav",
   "variants": {},

--- a/nextjs-app/shared/components/PersonCard/PersonCard.contract.json
+++ b/nextjs-app/shared/components/PersonCard/PersonCard.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "PersonCard — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-person-card",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-person-card",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/PhoneInput/PhoneInput.contract.json
+++ b/nextjs-app/shared/components/PhoneInput/PhoneInput.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "PhoneInput — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-phone-input",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-phone-input",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Progress/Progress.contract.json
+++ b/nextjs-app/shared/components/Progress/Progress.contract.json
@@ -5,7 +5,7 @@
   "group": "feedback",
   "status": "beta",
   "description": "Determinate linear progress indicator.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-progress",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=369-15",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Radio/Radio.contract.json
+++ b/nextjs-app/shared/components/Radio/Radio.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Single radio option; compose with RadioGroup for sets.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-radio",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=372-27",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/RadioGroup/RadioGroup.contract.json
+++ b/nextjs-app/shared/components/RadioGroup/RadioGroup.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Accessible radio button group with legend and validation.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-radio-group",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=383-36",
   "radixPrimitive": null,
   "element": "div",
   "variants": {

--- a/nextjs-app/shared/components/ReadingProgress/ReadingProgress.contract.json
+++ b/nextjs-app/shared/components/ReadingProgress/ReadingProgress.contract.json
@@ -5,7 +5,7 @@
   "group": "feedback",
   "status": "beta",
   "description": "Scroll-linked reading progress indicator for long content.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-reading-progress",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-reading-progress",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Section/Section.contract.json
+++ b/nextjs-app/shared/components/Section/Section.contract.json
@@ -5,7 +5,7 @@
   "group": "layout",
   "status": "beta",
   "description": "Semantic section wrapper with spacing and background tokens.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-section",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-section",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.contract.json
+++ b/nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "SecureCVDownload — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-secure-cvdownload",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-secure-cvdownload",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Select/Select.contract.json
+++ b/nextjs-app/shared/components/Select/Select.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Native select with label, options, error state, and size tokens.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-select",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=383-23",
   "radixPrimitive": null,
   "element": "select",
   "variants": {

--- a/nextjs-app/shared/components/SentrySummaryCard/SentrySummaryCard.contract.json
+++ b/nextjs-app/shared/components/SentrySummaryCard/SentrySummaryCard.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "SentrySummaryCard — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-sentry-summary-card",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-sentry-summary-card",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/ServiceCard/ServiceCard.contract.json
+++ b/nextjs-app/shared/components/ServiceCard/ServiceCard.contract.json
@@ -5,7 +5,7 @@
   "group": "marketing",
   "status": "beta",
   "description": "Service tile with icon, title, description, and optional link.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-service-card",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-service-card",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/ServicesGrid/ServicesGrid.contract.json
+++ b/nextjs-app/shared/components/ServicesGrid/ServicesGrid.contract.json
@@ -5,7 +5,7 @@
   "group": "marketing",
   "status": "beta",
   "description": "ServicesGrid — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-services-grid",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-services-grid",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Skeleton/Skeleton.contract.json
+++ b/nextjs-app/shared/components/Skeleton/Skeleton.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "Skeleton — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-skeleton",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-skeleton",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/SkillsGrid/SkillsGrid.contract.json
+++ b/nextjs-app/shared/components/SkillsGrid/SkillsGrid.contract.json
@@ -5,7 +5,7 @@
   "group": "display",
   "status": "beta",
   "description": "Grid of skill / tech logos arranged in 4 / 6 / 8 columns. Used on the about page and case studies to show capabilities or tooling at a glance.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-skills-grid",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-skills-grid",
   "radixPrimitive": null,
   "element": "section",
   "variants": {},

--- a/nextjs-app/shared/components/SkipLink/SkipLink.contract.json
+++ b/nextjs-app/shared/components/SkipLink/SkipLink.contract.json
@@ -5,7 +5,7 @@
   "group": "navigation",
   "status": "beta",
   "description": "Skip-to-main link shown on keyboard focus.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-skip-link",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-skip-link",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/SocialShare/SocialShare.contract.json
+++ b/nextjs-app/shared/components/SocialShare/SocialShare.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "SocialShare — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-social-share",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-social-share",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Spacer/Spacer.contract.json
+++ b/nextjs-app/shared/components/Spacer/Spacer.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "Empty layout element that injects a fixed gap on a single axis. Used inside flex/grid containers where adding a token-sized gap as a sibling reads cleaner than the gap utility.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-spacer",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-spacer",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Spinner/Spinner.contract.json
+++ b/nextjs-app/shared/components/Spinner/Spinner.contract.json
@@ -5,7 +5,7 @@
   "group": "feedback",
   "status": "beta",
   "description": "Indeterminate loading spinner for async UI.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-spinner",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=368-16",
   "radixPrimitive": null,
   "element": "span",
   "variants": {

--- a/nextjs-app/shared/components/Stack/Stack.contract.json
+++ b/nextjs-app/shared/components/Stack/Stack.contract.json
@@ -5,7 +5,7 @@
   "group": "layout",
   "status": "beta",
   "description": "Flex stack primitive for vertical and horizontal rhythm.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-stack",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-stack",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Switch/Switch.contract.json
+++ b/nextjs-app/shared/components/Switch/Switch.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Toggle control with label placement, loading, and helper text.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-switch",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=373-14",
   "radixPrimitive": null,
   "element": "button",
   "variants": {},

--- a/nextjs-app/shared/components/Tabs/Tabs.contract.json
+++ b/nextjs-app/shared/components/Tabs/Tabs.contract.json
@@ -5,7 +5,7 @@
   "group": "navigation",
   "status": "beta",
   "description": "Tablist navigation with keyboard support and variant styles.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-tabs",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=381-5",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Tag/Tag.contract.json
+++ b/nextjs-app/shared/components/Tag/Tag.contract.json
@@ -5,7 +5,7 @@
   "group": "display",
   "status": "beta",
   "description": "Small static or removable label for metadata (categories, statuses, filters). Distinct from `Badge` (which is the design-system semantic chip with stable contracts) — `Tag` is the lightweight catalog primitive used by editorial surfaces.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-tag",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-tag",
   "radixPrimitive": null,
   "element": "span",
   "variants": {},

--- a/nextjs-app/shared/components/Testimonial/Testimonial.contract.json
+++ b/nextjs-app/shared/components/Testimonial/Testimonial.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "Testimonial — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-testimonial",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-testimonial",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Text/Text.contract.json
+++ b/nextjs-app/shared/components/Text/Text.contract.json
@@ -5,7 +5,7 @@
   "group": "display",
   "status": "stable",
   "description": "Body and inline typography with size, terminal, and line-height tokens.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-text",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=370-19",
   "radixPrimitive": null,
   "element": "p",
   "variants": {},

--- a/nextjs-app/shared/components/TextArea/TextArea.contract.json
+++ b/nextjs-app/shared/components/TextArea/TextArea.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Multi-line text field with optional label, validation, and character count.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-text-area",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=374-17",
   "radixPrimitive": null,
   "element": "textarea",
   "variants": {

--- a/nextjs-app/shared/components/TextInput/TextInput.contract.json
+++ b/nextjs-app/shared/components/TextInput/TextInput.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "Single-line text input primitive with optional start/end icon slots, an inline clear button, and an error state. Wraps a native `<input>` so HTML attributes pass through.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-text-input",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-text-input",
   "radixPrimitive": null,
   "element": "input",
   "variants": {},

--- a/nextjs-app/shared/components/TextLink/TextLink.contract.json
+++ b/nextjs-app/shared/components/TextLink/TextLink.contract.json
@@ -5,7 +5,7 @@
   "group": "navigation",
   "status": "beta",
   "description": "Inline text link primitive with a stable focus ring + underline contract. Distinct from `Link` (the design-system Link wrapping `next/link`) — `TextLink` is the unwrapped underline-on-hover token used inside prose.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-text-link",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-text-link",
   "radixPrimitive": null,
   "element": "a",
   "variants": {},

--- a/nextjs-app/shared/components/ThemeProvider/ThemeProvider.contract.json
+++ b/nextjs-app/shared/components/ThemeProvider/ThemeProvider.contract.json
@@ -5,7 +5,7 @@
   "group": "foundation",
   "status": "beta",
   "description": "Theme context for light, dark, and high-contrast modes.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-theme-provider",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-theme-provider",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/Title/Title.contract.json
+++ b/nextjs-app/shared/components/Title/Title.contract.json
@@ -5,7 +5,7 @@
   "group": "display",
   "status": "stable",
   "description": "Semantic heading with size and terminal (serif/sans) variants.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-title",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=370-12",
   "radixPrimitive": null,
   "element": "h1",
   "variants": {},

--- a/nextjs-app/shared/components/Toast/Toast.contract.json
+++ b/nextjs-app/shared/components/Toast/Toast.contract.json
@@ -5,7 +5,7 @@
   "group": "feedback",
   "status": "beta",
   "description": "Transient status message with severity, position, and auto-dismiss.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-toast",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=393-35",
   "radixPrimitive": null,
   "element": "div",
   "variants": {

--- a/nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.contract.json
+++ b/nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.contract.json
@@ -5,7 +5,7 @@
   "group": "form",
   "status": "beta",
   "description": "TransformingActionInput — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-transforming-action-input",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-transforming-action-input",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/ValueCard/ValueCard.contract.json
+++ b/nextjs-app/shared/components/ValueCard/ValueCard.contract.json
@@ -5,7 +5,7 @@
   "group": "display",
   "status": "beta",
   "description": "Card variant for values / principles grids — icon + title + short description, with the same three visual treatments as `LocationCard`.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-value-card",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-value-card",
   "radixPrimitive": null,
   "element": "article",
   "variants": {},

--- a/nextjs-app/shared/components/VisuallyHidden/VisuallyHidden.contract.json
+++ b/nextjs-app/shared/components/VisuallyHidden/VisuallyHidden.contract.json
@@ -5,7 +5,7 @@
   "group": "accessibility",
   "status": "beta",
   "description": "Screen-reader-only text; not visible until focused in context.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-visually-hidden",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=371-31",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/components/WipBadge/WipBadge.contract.json
+++ b/nextjs-app/shared/components/WipBadge/WipBadge.contract.json
@@ -5,7 +5,7 @@
   "group": "feedback",
   "status": "beta",
   "description": "Storybook-only maturity badge for non-stable components.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-wip-badge",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-wip-badge",
   "radixPrimitive": null,
   "element": "span",
   "variants": {},

--- a/nextjs-app/shared/components/WipBadge/WipBadge.module.css
+++ b/nextjs-app/shared/components/WipBadge/WipBadge.module.css
@@ -37,6 +37,17 @@
 .wipBadgeDocs .badge {
   padding-block: var(--space-internal-4);
   padding-inline: var(--space-internal-8);
+  border-radius: var(--radius-sm, 4px);
+
+  /* Must be opaque: the badge is position:fixed over scrolling docs content,
+     so a transparent fill lets page content (e.g. transparent SVG marks) bleed
+     through the label. Mirrors the canvas variant's surface fill. */
+  background: var(
+    --color-surface-elevated,
+    var(--main-body-background-color, #fff)
+  );
   box-shadow: 0 0 0 1px rgb(0 0 0 / 8%), 0 8px 24px rgb(15 23 42 / 12%);
+  font-size: var(--font-size-sm, 0.875rem);
+  color: var(--color-text, #111);
   pointer-events: auto;
 }

--- a/nextjs-app/shared/components/animations/FadeIn/FadeIn.contract.json
+++ b/nextjs-app/shared/components/animations/FadeIn/FadeIn.contract.json
@@ -5,7 +5,7 @@
   "group": "motion",
   "status": "beta",
   "description": "Scroll-triggered fade-in animation wrapper (GSAP).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-fade-in",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-fade-in",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/foundations/figma/COMPONENT_GAPS.md
+++ b/nextjs-app/shared/foundations/figma/COMPONENT_GAPS.md
@@ -1,0 +1,128 @@
+# Figma library — component rebuild Gaps report
+
+Running log of fidelity gaps between code (source of truth) and the Figma library
+(`PC2UPdYwm8qGt6ZTg0AakF`). Rule: build 100% from the design system, flag gaps, never invent.
+
+## Button (406:1569) — icon wiring complete
+
+Matrix: `Variant(9) × Size(3) × State(3) × Inverse(2)` = 108. Verified, 0 anomalies.
+
+Icon model:
+- Status variants (Error/Warning/Success/Info/SecondaryError/TertiaryError, 54): semantic
+  glyph stays **baked per-variant** and visible (XCircle / Warning / CheckCircle / Info).
+- Visual variants (Primary/Secondary/Tertiary incl. inverse, 54): shared optional leading
+  `Icon` (INSTANCE_SWAP) + `Has Icon` (BOOL), default off.
+- All 108: shared optional trailing `End Icon` + `Has End Icon`, default off.
+- Default swap placeholder = ArrowRight, recolored per-child to the label color variable.
+
+Gaps (flagged, not invented):
+1. **Status leading icon is not swappable or hideable.** Figma's non-variant component
+   properties carry a single global default with no per-variant default; linking the baked
+   glyph to a shared INSTANCE_SWAP destroys the per-variant glyph (verified). So the
+   code behavior `lookupIcon(icon) ?? getSemanticIcon(...)` is honored only for the
+   default branch (semantic glyph shown); the override branch is not expressible on status
+   variants without either a variant-axis explosion or per-family swap properties.
+2. **`isRounded` not modeled.** `componentPropertyReferences` accepts only
+   `visible | characters | mainComponent`; a BOOLEAN cannot drive `cornerRadius`. Faithful
+   options: a Rounded variant axis (108→216) or a separate pill component. Deferred.
+3. **Icon Only** deferred (user decision); code supports it via `!children && icon` → square.
+4. **Error background `#b91c1c` untokenized** (pre-existing; recolor when a token exists).
+
+## Avatar (369:8) — variant axis added
+
+Added `Variant=Initials|Image` (was Size-only). Image variant = tokenized circle with a
+centered Phosphor **User** placeholder glyph (swap for a real image fill in use).
+
+Gaps:
+1. **Image variant is a User-glyph placeholder**, not a real photo fill (Figma image fills
+   need an uploaded hash). Designers replace with a photo. Faithful to the "image slot".
+2. **Dropdown menu not modeled as a Figma sub-component.** Code's `menuItems` render a
+   floating menu with per-item icons (`.avatarMenuIcon`). No caret on the trigger in code,
+   so none added (would be invented). The menu molecule (with real Phosphor item icons) is
+   a separate build, not done here.
+
+## Form atoms — Checkbox / Radio / Switch
+
+Icons here were already real (Checkbox Check glyph, Radio dot, Switch thumb). Work + gaps:
+
+- **Checkbox (372:14)**: added **Indeterminate** state (Minus glyph `390:28558`) across SM/MD/LG;
+  now Unchecked/Checked/Indeterminate/Disabled × 3 = 12. Matches code's `isIndeterminate`.
+- **Radio (372:27)**: real Ellipse dot, no glyph needed. GAP: State is a single axis
+  (Unchecked/Checked/Disabled) so disabled-checked can't be expressed; flagged, low priority.
+- **Switch (373:14)**: real Ellipse thumb. GAPS: no **Disabled** and no **Loading** states
+  (code has `isLoading` spinner + disabled). Loading needs a spinner glyph in the thumb;
+  state expansion deferred/flagged.
+
+## Inputs / TextArea / Select
+
+- **Select (383:23)**: added baked **CaretDown** chevron to all 4 states, recolored per state.
+  GAP: only a State axis; code has `size` (sm/md/lg) — Size axis missing.
+- **Inputs (374:10)**: no icon props in code (type/size/error only), so no icons added.
+  GAP: only State axis; code `size` (sm/md/lg) missing. password/search show no glyph in code.
+- **TextArea (374:17)**: no inherent icons. Disabled state RESOLVED (cloned Default, bound
+  bg `322:832` + text `322:844`, real disabled tokens) → 4 states. Resize affordance not modeled.
+
+## Tabs / Accordion / FileUpload
+
+- **Accordion (381:17)**: added expand/collapse carets — CaretDown (expanded) + CaretRight
+  (collapsed) in the section headers, matching code's `<span className={styles.icon}>`.
+- **Tabs (381:5)**: text tabs with underline indicator; code has no per-tab icons, none added.
+  GAP: single static component — variants `default|pills|underline`, `size`, and disabled
+  tab state not modeled as a component set.
+- **FileUpload (384:26)**: REBUILT dropzone → **field + button** to match code: label +
+  display field ('No file selected', real field tokens) + a composed **Button** instance
+  (Secondary/MD) carrying the **UploadSimple** glyph + 'Browse'. Hidden-input/clear are behavioral.
+
+## Toast / AlertBanner — semantic icons
+
+- **Toast (393:35)**: fixed Success glyph plain `Check` → **CheckCircle**. All 5 intents now
+  correct (Default none, Success CheckCircle, Warning, Error XCircle, Info), white on fill.
+- **AlertBanner (394:41)**: added the 3 missing semantic icons — Success (CheckCircle),
+  Warning, Error (XCircle); Info already present. Removed 3 orphan stray `Vector` nodes left
+  in the icon frames from an earlier build. Bound each icon to its semantic color variable
+  (color/info, color/success, color/warning, color/error).
+  RESOLVED: added `Dismissible` BOOLEAN (default off) + a muted Phosphor **X** close glyph
+  (top-right, `color/muted`) linked across all 4 variants. Verified on the Error variant.
+
+> Note: live node ids for Toast/AlertBanner differed from the stale ledger ids
+> (Toast 393:35 not 378:38; AlertBanner 394:41 not 378:25). Ledger ids refreshed.
+
+
+## Discretionary follow-up pass (states + FileUpload)
+
+- TextArea **Disabled** added (real disabled tokens). FileUpload **rebuilt** to field+button.
+- Switch **Disabled** added per size (opacity-dimmed — no track-disabled token exists in the
+  system; flagged as opacity-based rather than tokenized).
+
+Still open (genuinely token/spec-blocked, not invented):
+- **Switch Loading** (spinner-in-thumb) — niche; deferred.
+- **Tabs** `default|pills|underline` + size + disabled — needs design direction on pill/default
+  styling (current component is the underline treatment only).
+- **Size axes** (Inputs/Select/TextArea) — BLOCKED: no control-height-per-size tokens exist
+  (only `size/width/*`, `radius/*`, `space/*`); would require inventing heights.
+- **Button** `isRounded` (variant-axis only) + Icon Only (user-deferred).
+- **Avatar** dropdown menu molecule unbuilt.
+
+## Organisms (page 331:825) — built (were empty)
+
+All composed from real component instances + Phosphor glyphs + tokens.
+
+- **ContactForm (470:2)**: heading + labeled Inputs (Full name, Email) + Message TextArea +
+  FileUpload instance + full-width Submit Button. GAP: honeypot + per-field validation/error
+  states are behavioral, not modeled; copy is illustrative (real copy is i18n).
+- **NewsletterWaitlist (471:21)**: expanded state — title + subtitle + email Input + Notify
+  Button. GAP: collapsed trigger/expand animation is behavioral, not modeled.
+- **ChatWidget (473:25)**: panel with shadow, dark header (ChatCircleDots + title + close X),
+  bot/user message bubbles, input row + PaperPlaneTilt send button. GAPs: message bubbles are
+  bespoke (no Bubble component); launcher FAB, streaming/typing/error states not modeled.
+
+## Patterns (page 331:826) — built (were empty)
+
+- **SiteHeader (476:2)**: logo + brand + nav (Home/Work/About/Pricing/Blog/Contact) +
+  Get-in-touch Button + List hamburger, bottom border. GAPs: theme/language controls
+  (behavioral) not modeled; mobile drawer is just the hamburger affordance; logo is a DT
+  placeholder mark, not the animated logo-bar.
+- **SiteFooter (477:6)**: brand/tagline/address column + Company/Resources nav columns +
+  divider + copyright + social glyphs (Instagram/LinkedIn/X/GitHub). GAPs: social set is a
+  subset (Facebook/Medium/Substack/Dribbble omitted); neutral-light footer treatment chosen;
+  nav columns illustrative.

--- a/nextjs-app/shared/foundations/figma/phases/README.md
+++ b/nextjs-app/shared/foundations/figma/phases/README.md
@@ -1,0 +1,18 @@
+# Figma `use_figma` phase scripts
+
+Generated from `variables-manifest.json`. **Run sequentially** via Figma MCP `use_figma` (remote) — never in parallel.
+
+File: [`DT-Site-stuff`](https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff) (`PC2UPdYwm8qGt6ZTg0AakF`)
+
+## Phase 1 — variables
+
+1. `whoami` — confirm MCP auth
+2. `get_metadata` with **fileKey only** (no nodeId) — list pages
+3. For each `phase-1a-color-chunk-*.js`: pass file contents to `use_figma` with `skillNames: "figma-generate-library"`
+4. Then each `phase-1b-dimension-string-chunk-*.js`
+
+## Phase 2+ 
+
+See `docs/FIGMA_DESIGN_SYSTEM_SYNC.md`.
+
+Run ID: `dt-dsb-2026-06-01`

--- a/nextjs-app/shared/foundations/figma/phases/phase-1a-color-chunk-01.js
+++ b/nextjs-app/shared/foundations/figma/phases/phase-1a-color-chunk-01.js
@@ -1,0 +1,71 @@
+
+function hexToFigmaColor(hex) {
+  let h = String(hex).replace('#', '');
+  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+  return {
+    r: parseInt(h.substring(0, 2), 16) / 255,
+    g: parseInt(h.substring(2, 4), 16) / 255,
+    b: parseInt(h.substring(4, 6), 16) / 255,
+    a: h.length === 8 ? parseInt(h.substring(6, 8), 16) / 255 : 1,
+  };
+}
+
+// Variables/collections do NOT support setSharedPluginData (that mixin is
+// nodes/styles only). Idempotency is by name, per the figma-generate-library
+// skill's state table.
+async function upsertCollection(name, modeLabels, _key, _runId) {
+  const cols = await figma.variables.getLocalVariableCollectionsAsync();
+  let coll = cols.find((c) => c.name === name) || null;
+  if (!coll) coll = figma.variables.createVariableCollection(name);
+  const modeIds = {};
+  const existing = coll.modes.map((m) => m.name);
+  if (existing.length === 1 && existing[0] === 'Mode 1' && modeLabels.length) {
+    coll.renameMode(coll.modes[0].modeId, modeLabels[0]);
+  }
+  for (const label of modeLabels) {
+    let mode = coll.modes.find((m) => m.name === label);
+    if (!mode) {
+      const id = coll.addMode(label);
+      mode = coll.modes.find((m) => m.modeId === id);
+    }
+    if (mode) modeIds[label] = mode.modeId;
+  }
+  return { collection: coll, modeIds };
+}
+
+async function upsertVariable(coll, modeIds, def, _runId) {
+  const vars = await figma.variables.getLocalVariablesAsync();
+  let variable = vars.find(
+    (v) => v.variableCollectionId === coll.id && v.name === def.name,
+  );
+  if (!variable) variable = figma.variables.createVariable(def.name, coll, def.type);
+  for (const [modeLabel, raw] of Object.entries(def.values)) {
+    const modeId = modeIds[modeLabel];
+    if (!modeId) continue;
+    let value = raw;
+    if (def.type === 'COLOR' && typeof raw === 'string' && raw.startsWith('#')) {
+      value = hexToFigmaColor(raw);
+    }
+    variable.setValueForMode(modeId, value);
+  }
+  variable.scopes = def.scopes || [];
+  if (def.codeSyntax?.WEB) variable.setVariableCodeSyntax('WEB', def.codeSyntax.WEB);
+  return variable.id;
+}
+
+const RUN_ID = "dt-dsb-2026-06-01";
+
+const { collection, modeIds } = await upsertCollection(
+  "DT / Color",
+  ["Light","Dark","HCB","HCW"],
+  'collection/dt-color',
+  RUN_ID,
+);
+const created = [];
+const defs = [{"name":"accent/cyan","cssVar":"--accent-cyan","type":"COLOR","values":{"Light":"#71efff","Dark":"#71efff","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--accent-cyan)"}},{"name":"accent/pink","cssVar":"--accent-pink","type":"COLOR","values":{"Light":"#f205c5","Dark":"#f205c5","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--accent-pink)"}},{"name":"accent/purple","cssVar":"--accent-purple","type":"COLOR","values":{"Light":"#812eff","Dark":"#812eff","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--accent-purple)"}},{"name":"accent/teal","cssVar":"--accent-teal","type":"COLOR","values":{"Light":"#85b5bd","Dark":"#85b5bd","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--accent-teal)"}},{"name":"accent/violet","cssVar":"--accent-violet","type":"COLOR","values":{"Light":"#bc6dff","Dark":"#bc6dff","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--accent-violet)"}},{"name":"accent/yellow","cssVar":"--accent-yellow","type":"COLOR","values":{"Light":"#f2e274","Dark":"#f2e274","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--accent-yellow)"}},{"name":"color/black","cssVar":"--color-black","type":"COLOR","values":{"Light":"#000","Dark":"#fff","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-black)"}},{"name":"color/border","cssVar":"--color-border","type":"COLOR","values":{"Light":"#c0c0c0","Dark":"#333","HCB":"#333","HCW":"#333"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-border)"}},{"name":"color/border/light","cssVar":"--color-border-light","type":"COLOR","values":{"Light":"#ccc","Dark":"#444","HCB":"#444","HCW":"#444"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-border-light)"}},{"name":"color/dark","cssVar":"--color-dark","type":"COLOR","values":{"Light":"#222","Dark":"#e0e0e0","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-dark)"}},{"name":"color/disabled/bg","cssVar":"--color-disabled-bg","type":"COLOR","values":{"Light":"#e0e0e0","Dark":"#23272a","HCB":"#313131","HCW":"#313131"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-disabled-bg)"}},{"name":"color/disabled/bg/light","cssVar":"--color-disabled-bg-light","type":"COLOR","values":{"Light":"#d8d8d8","Dark":"#23272a","HCB":"#7b7b7b","HCW":"#7b7b7b"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-disabled-bg-light)"}},{"name":"color/disabled/placeholder","cssVar":"--color-disabled-placeholder","type":"COLOR","values":{"Light":"#858585","Dark":"#555","HCB":"#555","HCW":"#555"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-disabled-placeholder)"}},{"name":"color/error","cssVar":"--color-error","type":"COLOR","values":{"Light":"#dc3545","Dark":"#ff6b6b","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-error)"}},{"name":"color/error/bg","cssVar":"--color-error-bg","type":"COLOR","values":{"Light":"#dfbdbc","Dark":"#2d2323","HCB":"#000","HCW":"#fff"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-error-bg)"}},{"name":"color/error/text","cssVar":"--color-error-text","type":"COLOR","values":{"Light":"#7a1f1f","Dark":"#ffb3b3","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-error-text)"}},{"name":"color/gray","cssVar":"--color-gray","type":"COLOR","values":{"Light":"#5e5e5e","Dark":"#aaa","HCB":"#aaa","HCW":"#aaa"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-gray)"}},{"name":"color/gray/dark","cssVar":"--color-gray-dark","type":"COLOR","values":{"Light":"#333","Dark":"#bbb","HCB":"#1f1f1f","HCW":"#e6e6e6"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-gray-dark)"}},{"name":"color/gray/medium","cssVar":"--color-gray-medium","type":"COLOR","values":{"Light":"#666","Dark":"#888","HCB":"#888","HCW":"#888"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-gray-medium)"}},{"name":"color/header/bg","cssVar":"--color-header-bg","type":"COLOR","values":{"Light":"#282c34","Dark":"#181a1b","HCB":"#000","HCW":"#fff"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-header-bg)"}},{"name":"color/info","cssVar":"--color-info","type":"COLOR","values":{"Light":"#0c7a8b","Dark":"#71efff","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-info)"}},{"name":"color/light/bg","cssVar":"--color-light-bg","type":"COLOR","values":{"Light":"#f9f9f9","Dark":"#23272a","HCB":"#101010","HCW":"#f1f1f1"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-light-bg)"}},{"name":"color/muted","cssVar":"--color-muted","type":"COLOR","values":{"Light":"#6c757d","Dark":"#888","HCB":"#888","HCW":"#888"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-muted)"}},{"name":"color/muted/light","cssVar":"--color-muted-light","type":"COLOR","values":{"Light":"#4949a7","Dark":"#555","HCB":"#555","HCW":"#555"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-muted-light)"}},{"name":"color/neutral/bg","cssVar":"--color-neutral-bg","type":"COLOR","values":{"Light":"#e2e8f0","Dark":"#3b3f5c","HCB":"#000","HCW":"#fff"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-neutral-bg)"}},{"name":"color/neutral/text","cssVar":"--color-neutral-text","type":"COLOR","values":{"Light":"#1a1d26","Dark":"#f5f7ff","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-neutral-text)"}},{"name":"color/primary","cssVar":"--color-primary","type":"COLOR","values":{"Light":"#041b23","Dark":"#6fa8ff","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-primary)"}},{"name":"color/react","cssVar":"--color-react","type":"COLOR","values":{"Light":"#61dafb","Dark":"#61dafb","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-react)"}},{"name":"color/success","cssVar":"--color-success","type":"COLOR","values":{"Light":"#068338","Dark":"#4fd18b","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-success)"}},{"name":"color/surface","cssVar":"--color-surface","type":"COLOR","values":{"Light":"#fff","Dark":"#181a1b","HCB":"#000","HCW":"#fff"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-surface)"}},{"name":"color/text","cssVar":"--color-text","type":"COLOR","values":{"Light":"#041b23","Dark":"#e0e0e0","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-text)"}},{"name":"color/title","cssVar":"--color-title","type":"COLOR","values":{"Light":"#041b23","Dark":"#6fa8ff","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-title)"}},{"name":"color/warning","cssVar":"--color-warning","type":"COLOR","values":{"Light":"#ffc107","Dark":"#ffb366","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-warning)"}},{"name":"color/warning/contrast","cssVar":"--color-warning-contrast","type":"COLOR","values":{"Light":"#8d5a00","Dark":"#ffb366","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-warning-contrast)"}},{"name":"color/warning/text","cssVar":"--color-warning-text","type":"COLOR","values":{"Light":"#041b23","Dark":"#181a1b","HCB":"#000","HCW":"#041b23"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-warning-text)"}}];
+for (const def of defs) {
+  created.push(await upsertVariable(collection, modeIds, def, RUN_ID));
+}
+return { collectionId: collection.id, variableIds: created, chunk: 1, total: 2 };
+
+return { ok: true, RUN_ID };

--- a/nextjs-app/shared/foundations/figma/phases/phase-1a-color-chunk-02.js
+++ b/nextjs-app/shared/foundations/figma/phases/phase-1a-color-chunk-02.js
@@ -1,0 +1,71 @@
+
+function hexToFigmaColor(hex) {
+  let h = String(hex).replace('#', '');
+  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+  return {
+    r: parseInt(h.substring(0, 2), 16) / 255,
+    g: parseInt(h.substring(2, 4), 16) / 255,
+    b: parseInt(h.substring(4, 6), 16) / 255,
+    a: h.length === 8 ? parseInt(h.substring(6, 8), 16) / 255 : 1,
+  };
+}
+
+// Variables/collections do NOT support setSharedPluginData (that mixin is
+// nodes/styles only). Idempotency is by name, per the figma-generate-library
+// skill's state table.
+async function upsertCollection(name, modeLabels, _key, _runId) {
+  const cols = await figma.variables.getLocalVariableCollectionsAsync();
+  let coll = cols.find((c) => c.name === name) || null;
+  if (!coll) coll = figma.variables.createVariableCollection(name);
+  const modeIds = {};
+  const existing = coll.modes.map((m) => m.name);
+  if (existing.length === 1 && existing[0] === 'Mode 1' && modeLabels.length) {
+    coll.renameMode(coll.modes[0].modeId, modeLabels[0]);
+  }
+  for (const label of modeLabels) {
+    let mode = coll.modes.find((m) => m.name === label);
+    if (!mode) {
+      const id = coll.addMode(label);
+      mode = coll.modes.find((m) => m.modeId === id);
+    }
+    if (mode) modeIds[label] = mode.modeId;
+  }
+  return { collection: coll, modeIds };
+}
+
+async function upsertVariable(coll, modeIds, def, _runId) {
+  const vars = await figma.variables.getLocalVariablesAsync();
+  let variable = vars.find(
+    (v) => v.variableCollectionId === coll.id && v.name === def.name,
+  );
+  if (!variable) variable = figma.variables.createVariable(def.name, coll, def.type);
+  for (const [modeLabel, raw] of Object.entries(def.values)) {
+    const modeId = modeIds[modeLabel];
+    if (!modeId) continue;
+    let value = raw;
+    if (def.type === 'COLOR' && typeof raw === 'string' && raw.startsWith('#')) {
+      value = hexToFigmaColor(raw);
+    }
+    variable.setValueForMode(modeId, value);
+  }
+  variable.scopes = def.scopes || [];
+  if (def.codeSyntax?.WEB) variable.setVariableCodeSyntax('WEB', def.codeSyntax.WEB);
+  return variable.id;
+}
+
+const RUN_ID = "dt-dsb-2026-06-01";
+
+const { collection, modeIds } = await upsertCollection(
+  "DT / Color",
+  ["Light","Dark","HCB","HCW"],
+  'collection/dt-color',
+  RUN_ID,
+);
+const created = [];
+const defs = [{"name":"color/white","cssVar":"--color-white","type":"COLOR","values":{"Light":"#fff","Dark":"#181a1b","HCB":"#000","HCW":"#fff"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--color-white)"}},{"name":"link/color","cssVar":"--link-color","type":"COLOR","values":{"Light":"#041b23","Dark":"#71efff","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--link-color)"}},{"name":"logo/background","cssVar":"--logo-background","type":"COLOR","values":{"Light":"#dfff00","Dark":"#812eff","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--logo-background)"}},{"name":"logo/color","cssVar":"--logo-color","type":"COLOR","values":{"Light":"#000","Dark":"#fff","HCB":"#000","HCW":"#fff"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--logo-color)"}},{"name":"logo/text/color","cssVar":"--logo-text-color","type":"COLOR","values":{"Light":"#041b23","Dark":"#e0e0e0","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--logo-text-color)"}},{"name":"main/body/background/color","cssVar":"--main-body-background-color","type":"COLOR","values":{"Light":"#fff","Dark":"#181a1b","HCB":"#000","HCW":"#fff"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--main-body-background-color)"}},{"name":"main/body/copy/color","cssVar":"--main-body-copy-color","type":"COLOR","values":{"Light":"#041b23","Dark":"#6fa8ff","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--main-body-copy-color)"}},{"name":"selection/background","cssVar":"--selection-background","type":"COLOR","values":{"Light":"#041b23","Dark":"#6fa8ff","HCB":"#fff","HCW":"#000"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--selection-background)"}},{"name":"selection/color","cssVar":"--selection-color","type":"COLOR","values":{"Light":"#fff","Dark":"#181a1b","HCB":"#000","HCW":"#fff"},"scopes":["FRAME_FILL","SHAPE_FILL","STROKE_COLOR","TEXT_FILL"],"codeSyntax":{"WEB":"var(--selection-color)"}}];
+for (const def of defs) {
+  created.push(await upsertVariable(collection, modeIds, def, RUN_ID));
+}
+return { collectionId: collection.id, variableIds: created, chunk: 2, total: 2 };
+
+return { ok: true, RUN_ID };

--- a/nextjs-app/shared/foundations/figma/phases/phase-1b-dimension-string-chunk-01.js
+++ b/nextjs-app/shared/foundations/figma/phases/phase-1b-dimension-string-chunk-01.js
@@ -1,0 +1,81 @@
+
+function hexToFigmaColor(hex) {
+  let h = String(hex).replace('#', '');
+  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+  return {
+    r: parseInt(h.substring(0, 2), 16) / 255,
+    g: parseInt(h.substring(2, 4), 16) / 255,
+    b: parseInt(h.substring(4, 6), 16) / 255,
+    a: h.length === 8 ? parseInt(h.substring(6, 8), 16) / 255 : 1,
+  };
+}
+
+// Variables/collections do NOT support setSharedPluginData (that mixin is
+// nodes/styles only). Idempotency is by name, per the figma-generate-library
+// skill's state table.
+async function upsertCollection(name, modeLabels, _key, _runId) {
+  const cols = await figma.variables.getLocalVariableCollectionsAsync();
+  let coll = cols.find((c) => c.name === name) || null;
+  if (!coll) coll = figma.variables.createVariableCollection(name);
+  const modeIds = {};
+  const existing = coll.modes.map((m) => m.name);
+  if (existing.length === 1 && existing[0] === 'Mode 1' && modeLabels.length) {
+    coll.renameMode(coll.modes[0].modeId, modeLabels[0]);
+  }
+  for (const label of modeLabels) {
+    let mode = coll.modes.find((m) => m.name === label);
+    if (!mode) {
+      const id = coll.addMode(label);
+      mode = coll.modes.find((m) => m.modeId === id);
+    }
+    if (mode) modeIds[label] = mode.modeId;
+  }
+  return { collection: coll, modeIds };
+}
+
+async function upsertVariable(coll, modeIds, def, _runId) {
+  const vars = await figma.variables.getLocalVariablesAsync();
+  let variable = vars.find(
+    (v) => v.variableCollectionId === coll.id && v.name === def.name,
+  );
+  if (!variable) variable = figma.variables.createVariable(def.name, coll, def.type);
+  for (const [modeLabel, raw] of Object.entries(def.values)) {
+    const modeId = modeIds[modeLabel];
+    if (!modeId) continue;
+    let value = raw;
+    if (def.type === 'COLOR' && typeof raw === 'string' && raw.startsWith('#')) {
+      value = hexToFigmaColor(raw);
+    }
+    variable.setValueForMode(modeId, value);
+  }
+  variable.scopes = def.scopes || [];
+  if (def.codeSyntax?.WEB) variable.setVariableCodeSyntax('WEB', def.codeSyntax.WEB);
+  return variable.id;
+}
+
+const RUN_ID = "dt-dsb-2026-06-01";
+
+const dim = [{"name":"radius/lg","cssVar":"--radius-lg","type":"FLOAT","values":{"Value":8},"scopes":["CORNER_RADIUS"],"codeSyntax":{"WEB":"var(--radius-lg)"}},{"name":"radius/md","cssVar":"--radius-md","type":"FLOAT","values":{"Value":4},"scopes":["CORNER_RADIUS"],"codeSyntax":{"WEB":"var(--radius-md)"}},{"name":"radius/sm","cssVar":"--radius-sm","type":"FLOAT","values":{"Value":2},"scopes":["CORNER_RADIUS"],"codeSyntax":{"WEB":"var(--radius-sm)"}},{"name":"size/width/form","cssVar":"--size-width-form","type":"FLOAT","values":{"Value":600},"scopes":[],"codeSyntax":{"WEB":"var(--size-width-form)"}},{"name":"size/width/lg","cssVar":"--size-width-lg","type":"FLOAT","values":{"Value":900},"scopes":[],"codeSyntax":{"WEB":"var(--size-width-lg)"}},{"name":"size/width/md","cssVar":"--size-width-md","type":"FLOAT","values":{"Value":320},"scopes":[],"codeSyntax":{"WEB":"var(--size-width-md)"}},{"name":"space/internal/0","cssVar":"--space-internal-0","type":"FLOAT","values":{"Value":0},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-internal-0)"}},{"name":"space/internal/12","cssVar":"--space-internal-12","type":"FLOAT","values":{"Value":12},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-internal-12)"}},{"name":"space/internal/16","cssVar":"--space-internal-16","type":"FLOAT","values":{"Value":16},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-internal-16)"}},{"name":"space/internal/2","cssVar":"--space-internal-2","type":"FLOAT","values":{"Value":2},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-internal-2)"}},{"name":"space/internal/24","cssVar":"--space-internal-24","type":"FLOAT","values":{"Value":24},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-internal-24)"}},{"name":"space/internal/32","cssVar":"--space-internal-32","type":"FLOAT","values":{"Value":32},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-internal-32)"}},{"name":"space/internal/4","cssVar":"--space-internal-4","type":"FLOAT","values":{"Value":4},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-internal-4)"}},{"name":"space/internal/6","cssVar":"--space-internal-6","type":"FLOAT","values":{"Value":6},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-internal-6)"}},{"name":"space/internal/8","cssVar":"--space-internal-8","type":"FLOAT","values":{"Value":8},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-internal-8)"}},{"name":"space/layout/0","cssVar":"--space-layout-0","type":"FLOAT","values":{"Value":0},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-layout-0)"}},{"name":"space/layout/120","cssVar":"--space-layout-120","type":"FLOAT","values":{"Value":120},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-layout-120)"}},{"name":"space/layout/16","cssVar":"--space-layout-16","type":"FLOAT","values":{"Value":16},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-layout-16)"}},{"name":"space/layout/160","cssVar":"--space-layout-160","type":"FLOAT","values":{"Value":160},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-layout-160)"}},{"name":"space/layout/24","cssVar":"--space-layout-24","type":"FLOAT","values":{"Value":24},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-layout-24)"}},{"name":"space/layout/32","cssVar":"--space-layout-32","type":"FLOAT","values":{"Value":32},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-layout-32)"}},{"name":"space/layout/4","cssVar":"--space-layout-4","type":"FLOAT","values":{"Value":4},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-layout-4)"}},{"name":"space/layout/40","cssVar":"--space-layout-40","type":"FLOAT","values":{"Value":40},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-layout-40)"}},{"name":"space/layout/48","cssVar":"--space-layout-48","type":"FLOAT","values":{"Value":48},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-layout-48)"}},{"name":"space/layout/6","cssVar":"--space-layout-6","type":"FLOAT","values":{"Value":6},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-layout-6)"}},{"name":"space/layout/64","cssVar":"--space-layout-64","type":"FLOAT","values":{"Value":64},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-layout-64)"}},{"name":"space/layout/8","cssVar":"--space-layout-8","type":"FLOAT","values":{"Value":8},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-layout-8)"}},{"name":"space/layout/80","cssVar":"--space-layout-80","type":"FLOAT","values":{"Value":80},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-layout-80)"}},{"name":"space/layout/96","cssVar":"--space-layout-96","type":"FLOAT","values":{"Value":96},"scopes":["GAP","WIDTH_HEIGHT"],"codeSyntax":{"WEB":"var(--space-layout-96)"}}];
+const str = [{"name":"font/text","cssVar":"--font-text","type":"STRING","values":{"Value":"var(--font-body), system-ui, sans-serif"},"scopes":[],"codeSyntax":{"WEB":"var(--font-text)"}},{"name":"font/title","cssVar":"--font-title","type":"STRING","values":{"Value":"var(--font-heading), system-ui, sans-serif"},"scopes":[],"codeSyntax":{"WEB":"var(--font-title)"}},{"name":"font/weight/text","cssVar":"--font-weight-text","type":"STRING","values":{"Value":"400"},"scopes":[],"codeSyntax":{"WEB":"var(--font-weight-text)"}},{"name":"font/weight/title","cssVar":"--font-weight-title","type":"STRING","values":{"Value":"700"},"scopes":[],"codeSyntax":{"WEB":"var(--font-weight-title)"}}];
+let created = [];
+if (dim.length) {
+  const { collection, modeIds } = await upsertCollection(
+    "DT / Dimension",
+    ["Value"],
+    'collection/dt-dimension',
+    RUN_ID,
+  );
+  for (const def of dim) created.push(await upsertVariable(collection, modeIds, def, RUN_ID));
+}
+if (str.length) {
+  const { collection, modeIds } = await upsertCollection(
+    "DT / String",
+    ["Value"],
+    'collection/dt-string',
+    RUN_ID,
+  );
+  for (const def of str) created.push(await upsertVariable(collection, modeIds, def, RUN_ID));
+}
+return { variableIds: created, chunk: 1, total: 1 };
+
+return { ok: true, RUN_ID };

--- a/nextjs-app/shared/foundations/figma/variables-manifest.json
+++ b/nextjs-app/shared/foundations/figma/variables-manifest.json
@@ -1,0 +1,1958 @@
+{
+  "fileKey": "PC2UPdYwm8qGt6ZTg0AakF",
+  "fileSlug": "DT-Site-stuff",
+  "fileUrl": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff",
+  "generatedAt": "2026-06-01T18:09:23.409Z",
+  "source": "nextjs-app/shared/styles/variables.css",
+  "runId": "dt-dsb-2026-06-01",
+  "modes": [
+    {
+      "id": "light",
+      "label": "Light",
+      "marker": null
+    },
+    {
+      "id": "dark",
+      "label": "Dark",
+      "marker": ".themeDark,"
+    },
+    {
+      "id": "hcb",
+      "label": "HCB",
+      "marker": ".themeHCB,"
+    },
+    {
+      "id": "hcw",
+      "label": "HCW",
+      "marker": ".themeHCW,"
+    }
+  ],
+  "collections": {
+    "color": {
+      "name": "DT / Color",
+      "modes": [
+        "Light",
+        "Dark",
+        "HCB",
+        "HCW"
+      ],
+      "tokens": [
+        {
+          "name": "accent/cyan",
+          "cssVar": "--accent-cyan",
+          "type": "COLOR",
+          "values": {
+            "Light": "#71efff",
+            "Dark": "#71efff",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--accent-cyan)"
+          }
+        },
+        {
+          "name": "accent/pink",
+          "cssVar": "--accent-pink",
+          "type": "COLOR",
+          "values": {
+            "Light": "#f205c5",
+            "Dark": "#f205c5",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--accent-pink)"
+          }
+        },
+        {
+          "name": "accent/purple",
+          "cssVar": "--accent-purple",
+          "type": "COLOR",
+          "values": {
+            "Light": "#812eff",
+            "Dark": "#812eff",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--accent-purple)"
+          }
+        },
+        {
+          "name": "accent/teal",
+          "cssVar": "--accent-teal",
+          "type": "COLOR",
+          "values": {
+            "Light": "#85b5bd",
+            "Dark": "#85b5bd",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--accent-teal)"
+          }
+        },
+        {
+          "name": "accent/violet",
+          "cssVar": "--accent-violet",
+          "type": "COLOR",
+          "values": {
+            "Light": "#bc6dff",
+            "Dark": "#bc6dff",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--accent-violet)"
+          }
+        },
+        {
+          "name": "accent/yellow",
+          "cssVar": "--accent-yellow",
+          "type": "COLOR",
+          "values": {
+            "Light": "#f2e274",
+            "Dark": "#f2e274",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--accent-yellow)"
+          }
+        },
+        {
+          "name": "color/black",
+          "cssVar": "--color-black",
+          "type": "COLOR",
+          "values": {
+            "Light": "#000",
+            "Dark": "#fff",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-black)"
+          }
+        },
+        {
+          "name": "color/border",
+          "cssVar": "--color-border",
+          "type": "COLOR",
+          "values": {
+            "Light": "#c0c0c0",
+            "Dark": "#333",
+            "HCB": "#333",
+            "HCW": "#333"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-border)"
+          }
+        },
+        {
+          "name": "color/border/light",
+          "cssVar": "--color-border-light",
+          "type": "COLOR",
+          "values": {
+            "Light": "#ccc",
+            "Dark": "#444",
+            "HCB": "#444",
+            "HCW": "#444"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-border-light)"
+          }
+        },
+        {
+          "name": "color/dark",
+          "cssVar": "--color-dark",
+          "type": "COLOR",
+          "values": {
+            "Light": "#222",
+            "Dark": "#e0e0e0",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-dark)"
+          }
+        },
+        {
+          "name": "color/disabled/bg",
+          "cssVar": "--color-disabled-bg",
+          "type": "COLOR",
+          "values": {
+            "Light": "#e0e0e0",
+            "Dark": "#23272a",
+            "HCB": "#313131",
+            "HCW": "#313131"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-disabled-bg)"
+          }
+        },
+        {
+          "name": "color/disabled/bg/light",
+          "cssVar": "--color-disabled-bg-light",
+          "type": "COLOR",
+          "values": {
+            "Light": "#d8d8d8",
+            "Dark": "#23272a",
+            "HCB": "#7b7b7b",
+            "HCW": "#7b7b7b"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-disabled-bg-light)"
+          }
+        },
+        {
+          "name": "color/disabled/placeholder",
+          "cssVar": "--color-disabled-placeholder",
+          "type": "COLOR",
+          "values": {
+            "Light": "#858585",
+            "Dark": "#555",
+            "HCB": "#555",
+            "HCW": "#555"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-disabled-placeholder)"
+          }
+        },
+        {
+          "name": "color/error",
+          "cssVar": "--color-error",
+          "type": "COLOR",
+          "values": {
+            "Light": "#dc3545",
+            "Dark": "#ff6b6b",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-error)"
+          }
+        },
+        {
+          "name": "color/error/bg",
+          "cssVar": "--color-error-bg",
+          "type": "COLOR",
+          "values": {
+            "Light": "#dfbdbc",
+            "Dark": "#2d2323",
+            "HCB": "#000",
+            "HCW": "#fff"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-error-bg)"
+          }
+        },
+        {
+          "name": "color/error/text",
+          "cssVar": "--color-error-text",
+          "type": "COLOR",
+          "values": {
+            "Light": "#7a1f1f",
+            "Dark": "#ffb3b3",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-error-text)"
+          }
+        },
+        {
+          "name": "color/gray",
+          "cssVar": "--color-gray",
+          "type": "COLOR",
+          "values": {
+            "Light": "#5e5e5e",
+            "Dark": "#aaa",
+            "HCB": "#aaa",
+            "HCW": "#aaa"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-gray)"
+          }
+        },
+        {
+          "name": "color/gray/dark",
+          "cssVar": "--color-gray-dark",
+          "type": "COLOR",
+          "values": {
+            "Light": "#333",
+            "Dark": "#bbb",
+            "HCB": "#1f1f1f",
+            "HCW": "#e6e6e6"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-gray-dark)"
+          }
+        },
+        {
+          "name": "color/gray/medium",
+          "cssVar": "--color-gray-medium",
+          "type": "COLOR",
+          "values": {
+            "Light": "#666",
+            "Dark": "#888",
+            "HCB": "#888",
+            "HCW": "#888"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-gray-medium)"
+          }
+        },
+        {
+          "name": "color/header/bg",
+          "cssVar": "--color-header-bg",
+          "type": "COLOR",
+          "values": {
+            "Light": "#282c34",
+            "Dark": "#181a1b",
+            "HCB": "#000",
+            "HCW": "#fff"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-header-bg)"
+          }
+        },
+        {
+          "name": "color/info",
+          "cssVar": "--color-info",
+          "type": "COLOR",
+          "values": {
+            "Light": "#0c7a8b",
+            "Dark": "#71efff",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-info)"
+          }
+        },
+        {
+          "name": "color/light/bg",
+          "cssVar": "--color-light-bg",
+          "type": "COLOR",
+          "values": {
+            "Light": "#f9f9f9",
+            "Dark": "#23272a",
+            "HCB": "#101010",
+            "HCW": "#f1f1f1"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-light-bg)"
+          }
+        },
+        {
+          "name": "color/muted",
+          "cssVar": "--color-muted",
+          "type": "COLOR",
+          "values": {
+            "Light": "#6c757d",
+            "Dark": "#888",
+            "HCB": "#888",
+            "HCW": "#888"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-muted)"
+          }
+        },
+        {
+          "name": "color/muted/light",
+          "cssVar": "--color-muted-light",
+          "type": "COLOR",
+          "values": {
+            "Light": "#4949a7",
+            "Dark": "#555",
+            "HCB": "#555",
+            "HCW": "#555"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-muted-light)"
+          }
+        },
+        {
+          "name": "color/neutral/bg",
+          "cssVar": "--color-neutral-bg",
+          "type": "COLOR",
+          "values": {
+            "Light": "#e2e8f0",
+            "Dark": "#3b3f5c",
+            "HCB": "#000",
+            "HCW": "#fff"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-neutral-bg)"
+          }
+        },
+        {
+          "name": "color/neutral/text",
+          "cssVar": "--color-neutral-text",
+          "type": "COLOR",
+          "values": {
+            "Light": "#1a1d26",
+            "Dark": "#f5f7ff",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-neutral-text)"
+          }
+        },
+        {
+          "name": "color/primary",
+          "cssVar": "--color-primary",
+          "type": "COLOR",
+          "values": {
+            "Light": "#041b23",
+            "Dark": "#6fa8ff",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-primary)"
+          }
+        },
+        {
+          "name": "color/react",
+          "cssVar": "--color-react",
+          "type": "COLOR",
+          "values": {
+            "Light": "#61dafb",
+            "Dark": "#61dafb",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-react)"
+          }
+        },
+        {
+          "name": "color/success",
+          "cssVar": "--color-success",
+          "type": "COLOR",
+          "values": {
+            "Light": "#068338",
+            "Dark": "#4fd18b",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-success)"
+          }
+        },
+        {
+          "name": "color/surface",
+          "cssVar": "--color-surface",
+          "type": "COLOR",
+          "values": {
+            "Light": "#fff",
+            "Dark": "#181a1b",
+            "HCB": "#000",
+            "HCW": "#fff"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-surface)"
+          }
+        },
+        {
+          "name": "color/text",
+          "cssVar": "--color-text",
+          "type": "COLOR",
+          "values": {
+            "Light": "#041b23",
+            "Dark": "#e0e0e0",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-text)"
+          }
+        },
+        {
+          "name": "color/title",
+          "cssVar": "--color-title",
+          "type": "COLOR",
+          "values": {
+            "Light": "#041b23",
+            "Dark": "#6fa8ff",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-title)"
+          }
+        },
+        {
+          "name": "color/warning",
+          "cssVar": "--color-warning",
+          "type": "COLOR",
+          "values": {
+            "Light": "#ffc107",
+            "Dark": "#ffb366",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-warning)"
+          }
+        },
+        {
+          "name": "color/warning/contrast",
+          "cssVar": "--color-warning-contrast",
+          "type": "COLOR",
+          "values": {
+            "Light": "#8d5a00",
+            "Dark": "#ffb366",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-warning-contrast)"
+          }
+        },
+        {
+          "name": "color/warning/text",
+          "cssVar": "--color-warning-text",
+          "type": "COLOR",
+          "values": {
+            "Light": "#041b23",
+            "Dark": "#181a1b",
+            "HCB": "#000",
+            "HCW": "#041b23"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-warning-text)"
+          }
+        },
+        {
+          "name": "color/white",
+          "cssVar": "--color-white",
+          "type": "COLOR",
+          "values": {
+            "Light": "#fff",
+            "Dark": "#181a1b",
+            "HCB": "#000",
+            "HCW": "#fff"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--color-white)"
+          }
+        },
+        {
+          "name": "link/color",
+          "cssVar": "--link-color",
+          "type": "COLOR",
+          "values": {
+            "Light": "#041b23",
+            "Dark": "#71efff",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--link-color)"
+          }
+        },
+        {
+          "name": "logo/background",
+          "cssVar": "--logo-background",
+          "type": "COLOR",
+          "values": {
+            "Light": "#dfff00",
+            "Dark": "#812eff",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--logo-background)"
+          }
+        },
+        {
+          "name": "logo/color",
+          "cssVar": "--logo-color",
+          "type": "COLOR",
+          "values": {
+            "Light": "#000",
+            "Dark": "#fff",
+            "HCB": "#000",
+            "HCW": "#fff"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--logo-color)"
+          }
+        },
+        {
+          "name": "logo/text/color",
+          "cssVar": "--logo-text-color",
+          "type": "COLOR",
+          "values": {
+            "Light": "#041b23",
+            "Dark": "#e0e0e0",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--logo-text-color)"
+          }
+        },
+        {
+          "name": "main/body/background/color",
+          "cssVar": "--main-body-background-color",
+          "type": "COLOR",
+          "values": {
+            "Light": "#fff",
+            "Dark": "#181a1b",
+            "HCB": "#000",
+            "HCW": "#fff"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--main-body-background-color)"
+          }
+        },
+        {
+          "name": "main/body/copy/color",
+          "cssVar": "--main-body-copy-color",
+          "type": "COLOR",
+          "values": {
+            "Light": "#041b23",
+            "Dark": "#6fa8ff",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--main-body-copy-color)"
+          }
+        },
+        {
+          "name": "selection/background",
+          "cssVar": "--selection-background",
+          "type": "COLOR",
+          "values": {
+            "Light": "#041b23",
+            "Dark": "#6fa8ff",
+            "HCB": "#fff",
+            "HCW": "#000"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--selection-background)"
+          }
+        },
+        {
+          "name": "selection/color",
+          "cssVar": "--selection-color",
+          "type": "COLOR",
+          "values": {
+            "Light": "#fff",
+            "Dark": "#181a1b",
+            "HCB": "#000",
+            "HCW": "#fff"
+          },
+          "scopes": [
+            "FRAME_FILL",
+            "SHAPE_FILL",
+            "STROKE_COLOR",
+            "TEXT_FILL"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--selection-color)"
+          }
+        }
+      ]
+    },
+    "dimension": {
+      "name": "DT / Dimension",
+      "modes": [
+        "Value"
+      ],
+      "tokens": [
+        {
+          "name": "radius/lg",
+          "cssVar": "--radius-lg",
+          "type": "FLOAT",
+          "values": {
+            "Value": 8
+          },
+          "scopes": [
+            "CORNER_RADIUS"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--radius-lg)"
+          }
+        },
+        {
+          "name": "radius/md",
+          "cssVar": "--radius-md",
+          "type": "FLOAT",
+          "values": {
+            "Value": 4
+          },
+          "scopes": [
+            "CORNER_RADIUS"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--radius-md)"
+          }
+        },
+        {
+          "name": "radius/sm",
+          "cssVar": "--radius-sm",
+          "type": "FLOAT",
+          "values": {
+            "Value": 2
+          },
+          "scopes": [
+            "CORNER_RADIUS"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--radius-sm)"
+          }
+        },
+        {
+          "name": "size/width/form",
+          "cssVar": "--size-width-form",
+          "type": "FLOAT",
+          "values": {
+            "Value": 600
+          },
+          "scopes": [],
+          "codeSyntax": {
+            "WEB": "var(--size-width-form)"
+          }
+        },
+        {
+          "name": "size/width/lg",
+          "cssVar": "--size-width-lg",
+          "type": "FLOAT",
+          "values": {
+            "Value": 900
+          },
+          "scopes": [],
+          "codeSyntax": {
+            "WEB": "var(--size-width-lg)"
+          }
+        },
+        {
+          "name": "size/width/md",
+          "cssVar": "--size-width-md",
+          "type": "FLOAT",
+          "values": {
+            "Value": 320
+          },
+          "scopes": [],
+          "codeSyntax": {
+            "WEB": "var(--size-width-md)"
+          }
+        },
+        {
+          "name": "space/internal/0",
+          "cssVar": "--space-internal-0",
+          "type": "FLOAT",
+          "values": {
+            "Value": 0
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-internal-0)"
+          }
+        },
+        {
+          "name": "space/internal/12",
+          "cssVar": "--space-internal-12",
+          "type": "FLOAT",
+          "values": {
+            "Value": 12
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-internal-12)"
+          }
+        },
+        {
+          "name": "space/internal/16",
+          "cssVar": "--space-internal-16",
+          "type": "FLOAT",
+          "values": {
+            "Value": 16
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-internal-16)"
+          }
+        },
+        {
+          "name": "space/internal/2",
+          "cssVar": "--space-internal-2",
+          "type": "FLOAT",
+          "values": {
+            "Value": 2
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-internal-2)"
+          }
+        },
+        {
+          "name": "space/internal/24",
+          "cssVar": "--space-internal-24",
+          "type": "FLOAT",
+          "values": {
+            "Value": 24
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-internal-24)"
+          }
+        },
+        {
+          "name": "space/internal/32",
+          "cssVar": "--space-internal-32",
+          "type": "FLOAT",
+          "values": {
+            "Value": 32
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-internal-32)"
+          }
+        },
+        {
+          "name": "space/internal/4",
+          "cssVar": "--space-internal-4",
+          "type": "FLOAT",
+          "values": {
+            "Value": 4
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-internal-4)"
+          }
+        },
+        {
+          "name": "space/internal/6",
+          "cssVar": "--space-internal-6",
+          "type": "FLOAT",
+          "values": {
+            "Value": 6
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-internal-6)"
+          }
+        },
+        {
+          "name": "space/internal/8",
+          "cssVar": "--space-internal-8",
+          "type": "FLOAT",
+          "values": {
+            "Value": 8
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-internal-8)"
+          }
+        },
+        {
+          "name": "space/layout/0",
+          "cssVar": "--space-layout-0",
+          "type": "FLOAT",
+          "values": {
+            "Value": 0
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-layout-0)"
+          }
+        },
+        {
+          "name": "space/layout/120",
+          "cssVar": "--space-layout-120",
+          "type": "FLOAT",
+          "values": {
+            "Value": 120
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-layout-120)"
+          }
+        },
+        {
+          "name": "space/layout/16",
+          "cssVar": "--space-layout-16",
+          "type": "FLOAT",
+          "values": {
+            "Value": 16
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-layout-16)"
+          }
+        },
+        {
+          "name": "space/layout/160",
+          "cssVar": "--space-layout-160",
+          "type": "FLOAT",
+          "values": {
+            "Value": 160
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-layout-160)"
+          }
+        },
+        {
+          "name": "space/layout/24",
+          "cssVar": "--space-layout-24",
+          "type": "FLOAT",
+          "values": {
+            "Value": 24
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-layout-24)"
+          }
+        },
+        {
+          "name": "space/layout/32",
+          "cssVar": "--space-layout-32",
+          "type": "FLOAT",
+          "values": {
+            "Value": 32
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-layout-32)"
+          }
+        },
+        {
+          "name": "space/layout/4",
+          "cssVar": "--space-layout-4",
+          "type": "FLOAT",
+          "values": {
+            "Value": 4
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-layout-4)"
+          }
+        },
+        {
+          "name": "space/layout/40",
+          "cssVar": "--space-layout-40",
+          "type": "FLOAT",
+          "values": {
+            "Value": 40
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-layout-40)"
+          }
+        },
+        {
+          "name": "space/layout/48",
+          "cssVar": "--space-layout-48",
+          "type": "FLOAT",
+          "values": {
+            "Value": 48
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-layout-48)"
+          }
+        },
+        {
+          "name": "space/layout/6",
+          "cssVar": "--space-layout-6",
+          "type": "FLOAT",
+          "values": {
+            "Value": 6
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-layout-6)"
+          }
+        },
+        {
+          "name": "space/layout/64",
+          "cssVar": "--space-layout-64",
+          "type": "FLOAT",
+          "values": {
+            "Value": 64
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-layout-64)"
+          }
+        },
+        {
+          "name": "space/layout/8",
+          "cssVar": "--space-layout-8",
+          "type": "FLOAT",
+          "values": {
+            "Value": 8
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-layout-8)"
+          }
+        },
+        {
+          "name": "space/layout/80",
+          "cssVar": "--space-layout-80",
+          "type": "FLOAT",
+          "values": {
+            "Value": 80
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-layout-80)"
+          }
+        },
+        {
+          "name": "space/layout/96",
+          "cssVar": "--space-layout-96",
+          "type": "FLOAT",
+          "values": {
+            "Value": 96
+          },
+          "scopes": [
+            "GAP",
+            "WIDTH_HEIGHT"
+          ],
+          "codeSyntax": {
+            "WEB": "var(--space-layout-96)"
+          }
+        }
+      ]
+    },
+    "string": {
+      "name": "DT / String",
+      "modes": [
+        "Value"
+      ],
+      "tokens": [
+        {
+          "name": "font/text",
+          "cssVar": "--font-text",
+          "type": "STRING",
+          "values": {
+            "Value": "var(--font-body), system-ui, sans-serif"
+          },
+          "scopes": [],
+          "codeSyntax": {
+            "WEB": "var(--font-text)"
+          }
+        },
+        {
+          "name": "font/title",
+          "cssVar": "--font-title",
+          "type": "STRING",
+          "values": {
+            "Value": "var(--font-heading), system-ui, sans-serif"
+          },
+          "scopes": [],
+          "codeSyntax": {
+            "WEB": "var(--font-title)"
+          }
+        },
+        {
+          "name": "font/weight/text",
+          "cssVar": "--font-weight-text",
+          "type": "STRING",
+          "values": {
+            "Value": "400"
+          },
+          "scopes": [],
+          "codeSyntax": {
+            "WEB": "var(--font-weight-text)"
+          }
+        },
+        {
+          "name": "font/weight/title",
+          "cssVar": "--font-weight-title",
+          "type": "STRING",
+          "values": {
+            "Value": "700"
+          },
+          "scopes": [],
+          "codeSyntax": {
+            "WEB": "var(--font-weight-title)"
+          }
+        }
+      ]
+    }
+  },
+  "stats": {
+    "color": 44,
+    "dimension": 29,
+    "string": 4,
+    "skipped": 86
+  },
+  "skipped": [
+    {
+      "name": "--breakpoint-desktop",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "1024px"
+    },
+    {
+      "name": "--breakpoint-mobile",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "480px"
+    },
+    {
+      "name": "--breakpoint-tablet",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "768px"
+    },
+    {
+      "name": "--breakpoint-ultra",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "1920px"
+    },
+    {
+      "name": "--breakpoint-wide",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "1440px"
+    },
+    {
+      "name": "--checkbox-background-color",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "#fff"
+    },
+    {
+      "name": "--checkbox-checkmark-color",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "#fff"
+    },
+    {
+      "name": "--color-primary-disabled",
+      "category": "color",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "#0000ff50"
+    },
+    {
+      "name": "--container-full",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "100%"
+    },
+    {
+      "name": "--container-lg",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "1200px"
+    },
+    {
+      "name": "--container-md",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "960px"
+    },
+    {
+      "name": "--container-sm",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "640px"
+    },
+    {
+      "name": "--container-xl",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "1440px"
+    },
+    {
+      "name": "--duration-fast",
+      "category": "motion",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "200ms"
+    },
+    {
+      "name": "--duration-instant",
+      "category": "motion",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "100ms"
+    },
+    {
+      "name": "--duration-normal",
+      "category": "motion",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "350ms"
+    },
+    {
+      "name": "--duration-slow",
+      "category": "motion",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "500ms"
+    },
+    {
+      "name": "--duration-slower",
+      "category": "motion",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "800ms"
+    },
+    {
+      "name": "--duration-slowest",
+      "category": "motion",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "1200ms"
+    },
+    {
+      "name": "--focus-ring-color",
+      "category": "focus",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "#041b23"
+    },
+    {
+      "name": "--focus-ring-offset",
+      "category": "focus",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "2px"
+    },
+    {
+      "name": "--focus-ring-width",
+      "category": "focus",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "2px"
+    },
+    {
+      "name": "--font-size-button-l",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "clamp(1.125rem, 0.45vw + 1rem, 1.25rem)"
+    },
+    {
+      "name": "--font-size-button-m",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "clamp(1rem, 0.35vw + 0.9rem, 1.125rem)"
+    },
+    {
+      "name": "--font-size-button-s",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "clamp(0.875rem, 0.3vw + 0.8rem, 1rem)"
+    },
+    {
+      "name": "--font-size-text",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "clamp(1rem, 0.6vw + 0.9rem, 1.25rem)"
+    },
+    {
+      "name": "--font-size-text-l",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "clamp(1.125rem, 0.8vw + 1rem, 1.5rem)"
+    },
+    {
+      "name": "--font-size-text-m",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "clamp(1rem, 0.6vw + 0.9rem, 1.25rem)"
+    },
+    {
+      "name": "--font-size-text-s",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "clamp(0.75rem, 0.4vw + 0.8rem, 1.05rem)"
+    },
+    {
+      "name": "--font-size-title",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "clamp(2.25rem, 3.5vw + 1.5rem, 3.75rem)"
+    },
+    {
+      "name": "--font-size-title-l",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "clamp(2.75rem, 4vw + 1.75rem, 4.25rem)"
+    },
+    {
+      "name": "--font-size-title-m",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "clamp(2rem, 2.8vw + 1.3rem, 3rem)"
+    },
+    {
+      "name": "--font-size-title-s",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "clamp(1.5rem, 2vw + 1.1rem, 2.25rem)"
+    },
+    {
+      "name": "--font-size-title-xl",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "clamp(3.5rem, 6vw + 2.5rem, 5.5rem)"
+    },
+    {
+      "name": "--gallery-caption-bg",
+      "category": "elevation",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "rgb(0 0 0 / 55%)"
+    },
+    {
+      "name": "--grid-columns-desktop",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "12"
+    },
+    {
+      "name": "--grid-columns-mobile",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "4"
+    },
+    {
+      "name": "--grid-columns-tablet",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "8"
+    },
+    {
+      "name": "--grid-gap-desktop",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "2rem"
+    },
+    {
+      "name": "--grid-gap-mobile",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "1rem"
+    },
+    {
+      "name": "--grid-gap-tablet",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "1.5rem"
+    },
+    {
+      "name": "--inverted-text-color",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "#fff"
+    },
+    {
+      "name": "--line-height-loose",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "1.75"
+    },
+    {
+      "name": "--line-height-normal",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "1.5"
+    },
+    {
+      "name": "--line-height-relaxed",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "1.625"
+    },
+    {
+      "name": "--line-height-snug",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "1.375"
+    },
+    {
+      "name": "--line-height-tight",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "1.2"
+    },
+    {
+      "name": "--modal-overlay-bg",
+      "category": "elevation",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "rgb(0 0 0 / 50%)"
+    },
+    {
+      "name": "--modal-shadow",
+      "category": "elevation",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "0 4px 8px rgb(0 0 0 / 20%)"
+    },
+    {
+      "name": "--motion-distance-lg",
+      "category": "motion",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "48px"
+    },
+    {
+      "name": "--motion-distance-md",
+      "category": "motion",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "24px"
+    },
+    {
+      "name": "--motion-distance-sm",
+      "category": "motion",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "12px"
+    },
+    {
+      "name": "--motion-distance-xl",
+      "category": "motion",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "80px"
+    },
+    {
+      "name": "--page-margin-desktop",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "3rem"
+    },
+    {
+      "name": "--page-margin-mobile",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "1rem"
+    },
+    {
+      "name": "--page-margin-tablet",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "2rem"
+    },
+    {
+      "name": "--page-margin-wide",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "4rem"
+    },
+    {
+      "name": "--primary-body-font",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "var(--font-body), system-ui, sans-serif"
+    },
+    {
+      "name": "--primary-bold-font",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "var(--font-body), system-ui, sans-serif"
+    },
+    {
+      "name": "--primary-heading-font",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "var(--font-heading), system-ui, sans-serif"
+    },
+    {
+      "name": "--primary-text-color",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "#041b23"
+    },
+    {
+      "name": "--rhythm-base",
+      "category": "layout",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "0.5rem"
+    },
+    {
+      "name": "--secondary-body-font",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "var(--font-heading), system-ui, sans-serif"
+    },
+    {
+      "name": "--secondary-bold-font",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "var(--font-heading), system-ui, sans-serif"
+    },
+    {
+      "name": "--secondary-heading-font",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "var(--font-body), system-ui, sans-serif"
+    },
+    {
+      "name": "--secondary-text-color",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "#041b23"
+    },
+    {
+      "name": "--stagger-fast",
+      "category": "motion",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "0.03s"
+    },
+    {
+      "name": "--stagger-normal",
+      "category": "motion",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "0.08s"
+    },
+    {
+      "name": "--stagger-slow",
+      "category": "motion",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "0.15s"
+    },
+    {
+      "name": "--storybook-bg",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "#f9f9f9"
+    },
+    {
+      "name": "--storybook-blue",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "#041b23"
+    },
+    {
+      "name": "--storybook-cyan",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "#71efff"
+    },
+    {
+      "name": "--storybook-dark",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "#222"
+    },
+    {
+      "name": "--storybook-gray",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "#707070"
+    },
+    {
+      "name": "--storybook-pink",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "#f0f"
+    },
+    {
+      "name": "--storybook-purple",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "#812eff"
+    },
+    {
+      "name": "--storybook-violet",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "#bc6dff"
+    },
+    {
+      "name": "--storybook-white",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "#fff"
+    },
+    {
+      "name": "--storybook-yellow",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "#ff0"
+    },
+    {
+      "name": "--tracking-normal",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "0"
+    },
+    {
+      "name": "--tracking-tight",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "-0.025em"
+    },
+    {
+      "name": "--tracking-tighter",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "-0.05em"
+    },
+    {
+      "name": "--tracking-wide",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "0.025em"
+    },
+    {
+      "name": "--tracking-wider",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "0.05em"
+    },
+    {
+      "name": "--tracking-widest",
+      "category": "typography",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "0.1em"
+    },
+    {
+      "name": "--wavy-underline-mask",
+      "category": "other",
+      "reason": "non-figma-value (clamp, color-mix, or unresolved var)",
+      "sample": "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='6' viewBox='0 0 16 6'%3E%3Cpath d='M0 3 Q4 0 8 3 T16 3' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E\")"
+    }
+  ],
+  "phases": [
+    {
+      "id": "phase-0",
+      "label": "Discovery (get_metadata pages only, no nodeId)"
+    },
+    {
+      "id": "phase-1a",
+      "label": "Create DT / Color collection + variables",
+      "script": "phase-1a-color.js"
+    },
+    {
+      "id": "phase-1b",
+      "label": "Create DT / Dimension + DT / String",
+      "script": "phase-1b-dimension-string.js"
+    },
+    {
+      "id": "phase-2",
+      "label": "Page skeleton (Foundations, Atoms, …)"
+    },
+    {
+      "id": "phase-3-atoms",
+      "label": "Atoms one-by-one (Button first)"
+    }
+  ]
+}

--- a/nextjs-app/shared/foundations/token-catalog.json
+++ b/nextjs-app/shared/foundations/token-catalog.json
@@ -1,6 +1,6 @@
 {
   "source": "nextjs-app/shared/styles/variables.css",
-  "generatedAt": "2026-05-28T15:58:57.705Z",
+  "generatedAt": "2026-06-01T17:51:20.212Z",
   "tokenCount": 163,
   "usageCoverage": 131,
   "themes": [

--- a/nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.contract.json
+++ b/nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.contract.json
@@ -5,7 +5,7 @@
   "group": "marketing",
   "status": "beta",
   "description": "About page narrative sections and team highlights.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-about-page-content",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-about-page-content",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/CTASection/CTASection.contract.json
+++ b/nextjs-app/shared/patterns/CTASection/CTASection.contract.json
@@ -5,7 +5,7 @@
   "group": "marketing",
   "status": "beta",
   "description": "Call-to-action band used on marketing pages.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-ctasection",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=502-20",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/ContactHero/ContactHero.contract.json
+++ b/nextjs-app/shared/patterns/ContactHero/ContactHero.contract.json
@@ -5,7 +5,7 @@
   "group": "marketing",
   "status": "beta",
   "description": "Contact page hero with headline and supporting copy.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-contact-hero",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-contact-hero",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.contract.json
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.contract.json
@@ -5,7 +5,7 @@
   "group": "marketing",
   "status": "beta",
   "description": "Editorial contact page layout with form and success state.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-contact-page-content-editorial",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-contact-page-content-editorial",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.contract.json
+++ b/nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.contract.json
@@ -5,7 +5,7 @@
   "group": "marketing",
   "status": "beta",
   "description": "Homepage design-sprints band with animated CTA pills.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-design-sprints-section",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-design-sprints-section",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/Footer/Footer.contract.json
+++ b/nextjs-app/shared/patterns/Footer/Footer.contract.json
@@ -5,7 +5,7 @@
   "group": "navigation",
   "status": "beta",
   "description": "Footer — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-footer",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-footer",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/GridBlock/GridBlock.contract.json
+++ b/nextjs-app/shared/patterns/GridBlock/GridBlock.contract.json
@@ -5,7 +5,7 @@
   "group": "layout",
   "status": "beta",
   "description": "GridBlock — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-grid-block",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-grid-block",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/Header/Header.contract.json
+++ b/nextjs-app/shared/patterns/Header/Header.contract.json
@@ -5,7 +5,7 @@
   "group": "navigation",
   "status": "beta",
   "description": "Header — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-header",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-header",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/Hero/Hero.contract.json
+++ b/nextjs-app/shared/patterns/Hero/Hero.contract.json
@@ -5,7 +5,7 @@
   "group": "marketing",
   "status": "beta",
   "description": "Hero — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-hero",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-hero",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/HeroSection/HeroSection.contract.json
+++ b/nextjs-app/shared/patterns/HeroSection/HeroSection.contract.json
@@ -5,7 +5,7 @@
   "group": "marketing",
   "status": "beta",
   "description": "Full-bleed hero shell with min-height, alignment, and background variants.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-hero-section",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-hero-section",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/HighlightSection/HighlightSection.contract.json
+++ b/nextjs-app/shared/patterns/HighlightSection/HighlightSection.contract.json
@@ -5,7 +5,7 @@
   "group": "marketing",
   "status": "beta",
   "description": "Highlight band with variant backgrounds and CTA slots.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-highlight-section",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-highlight-section",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/HomeHero/HomeHero.contract.json
+++ b/nextjs-app/shared/patterns/HomeHero/HomeHero.contract.json
@@ -5,7 +5,7 @@
   "group": "marketing",
   "status": "beta",
   "description": "Homepage hero with kinetic title, background, and primary CTA.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-home-hero",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-home-hero",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.stories.tsx
+++ b/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof NewsBulletin> = {
     layout: "fullscreen",
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=310-899",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=503-20",
     },
   },
 };

--- a/nextjs-app/shared/patterns/PageLayout/PageLayout.contract.json
+++ b/nextjs-app/shared/patterns/PageLayout/PageLayout.contract.json
@@ -5,7 +5,7 @@
   "group": "layout",
   "status": "beta",
   "description": "PageLayout — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-page-layout",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-page-layout",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.contract.json
+++ b/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "ProcessBlock — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-process-block",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-process-block",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/ProofBlock/ProofBlock.contract.json
+++ b/nextjs-app/shared/patterns/ProofBlock/ProofBlock.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "ProofBlock — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-proof-block",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-proof-block",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.contract.json
+++ b/nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.contract.json
@@ -5,7 +5,7 @@
   "group": "marketing",
   "status": "beta",
   "description": "ServicesBlock — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-services-block",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-services-block",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/ServicesSection/ServicesSection.contract.json
+++ b/nextjs-app/shared/patterns/ServicesSection/ServicesSection.contract.json
@@ -5,7 +5,7 @@
   "group": "marketing",
   "status": "beta",
   "description": "Homepage services grid with icons and copy.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-services-section",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-services-section",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/SiteFooter/SiteFooter.contract.json
+++ b/nextjs-app/shared/patterns/SiteFooter/SiteFooter.contract.json
@@ -5,7 +5,7 @@
   "group": "navigation",
   "status": "beta",
   "description": "Production site footer with links and social icons.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-site-footer",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=477-6",
   "radixPrimitive": null,
   "element": "footer",
   "variants": {},

--- a/nextjs-app/shared/patterns/SiteHeader/SiteHeader.contract.json
+++ b/nextjs-app/shared/patterns/SiteHeader/SiteHeader.contract.json
@@ -5,7 +5,7 @@
   "group": "navigation",
   "status": "beta",
   "description": "Production site header with nav, theme toggle, and mobile drawer.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-site-header",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=476-2",
   "radixPrimitive": null,
   "element": "header",
   "variants": {},

--- a/nextjs-app/shared/patterns/StoryBlock/StoryBlock.contract.json
+++ b/nextjs-app/shared/patterns/StoryBlock/StoryBlock.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "StoryBlock — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-story-block",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-story-block",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/TeamBlock/TeamBlock.contract.json
+++ b/nextjs-app/shared/patterns/TeamBlock/TeamBlock.contract.json
@@ -5,7 +5,7 @@
   "group": "structure",
   "status": "beta",
   "description": "TeamBlock — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-team-block",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-team-block",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.contract.json
+++ b/nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.contract.json
@@ -5,7 +5,7 @@
   "group": "marketing",
   "status": "beta",
   "description": "Homepage work grid with magnetic hover on project cards.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-work-magnetic-field",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-work-magnetic-field",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.contract.json
+++ b/nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.contract.json
@@ -5,7 +5,7 @@
   "group": "marketing",
   "status": "beta",
   "description": "Work index preview grid of project cards.",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-work-preview-section",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-work-preview-section",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/nextjs-app/shared/templates/NextLayoutShell/NextLayoutShell.contract.json
+++ b/nextjs-app/shared/templates/NextLayoutShell/NextLayoutShell.contract.json
@@ -5,7 +5,7 @@
   "group": "layout",
   "status": "beta",
   "description": "NextLayoutShell — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/d8nFs8A5KcjbFr6KkwZV4H5K/Digitaltableteur-Design-System?node-id=dt-next-layout-shell",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-next-layout-shell",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "bootstrap:breadth": "node scripts/design-system/bootstrap-breadth.mjs",
     "migrate:contracts:v2": "node scripts/design-system/migrate-contracts-v2.mjs",
     "build:tokens": "node scripts/design-system/extract-variables-catalog.mjs && node scripts/design-system/export-dtcg-from-css.mjs && node scripts/design-system/build-tokens.mjs && node scripts/design-system/sync-tailwind-theme.mjs && node scripts/design-system/generate-agent-manifest.mjs",
+    "build:figma-variables": "node scripts/design-system/build-figma-variables-payload.mjs && node scripts/design-system/generate-figma-phase-scripts.mjs",
     "check:contrast": "node scripts/design-system/check-contrast.mjs",
     "check:token-descriptions": "tsx scripts/design-system/check-token-descriptions.ts",
     "check:drift": "tsx scripts/design-system/check-drift.ts",

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-121 -157 637 637" width="64" height="64" role="img" aria-label="Digitaltableteur">
+  <circle cx="197.5" cy="161.5" r="318.5" fill="#dfff00"/>
+  <g fill="#000">
+    <rect x="190.742" width="39.0494" height="142.681"/>
+    <rect x="190.742" y="180.228" width="39.0494" height="142.681"/>
+    <rect x="267.338" y="181.73" width="39.0494" height="127.662" transform="rotate(-90 267.338 181.73)"/>
+    <rect y="37.5475" width="39.0494" height="246.312"/>
+    <rect x="115.646" y="76.597" width="39.0494" height="168.213"/>
+    <path d="M39.0493 76.597L39.0493 37.5475L118.65 37.5475L154.696 76.5969L39.0493 76.597Z"/>
+    <path d="M39.0493 244.81L39.0493 283.859L118.65 283.859L154.696 244.81L39.0493 244.81Z"/>
+  </g>
+</svg>

--- a/scripts/design-system/build-figma-variables-payload.mjs
+++ b/scripts/design-system/build-figma-variables-payload.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Build Figma variable manifest from variables.css (all 4 themes).
+ * Output: nextjs-app/shared/foundations/figma/variables-manifest.json
+ */
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { FIGMA_FILE_KEY, FIGMA_FILE_SLUG } from "./figma-config.mjs";
+import {
+  buildThemeMaps,
+  categorizeToken,
+  cssVarToFigmaName,
+  figmaTypeForToken,
+  FIGMA_MODES,
+  isResolvableColor,
+  parseDimensionPx,
+  resolveToken,
+  scopesForCategory,
+} from "./figma-variables-lib.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = resolve(__dirname, "../../nextjs-app/shared/foundations/figma");
+const OUT_JSON = resolve(OUT_DIR, "variables-manifest.json");
+
+function main() {
+  const { rootProps, themes } = buildThemeMaps();
+  const collections = {
+    color: { name: "DT / Color", modes: FIGMA_MODES.map((m) => m.label), tokens: [] },
+    dimension: {
+      name: "DT / Dimension",
+      modes: ["Value"],
+      tokens: [],
+    },
+    string: { name: "DT / String", modes: ["Value"], tokens: [] },
+  };
+  const skipped = [];
+
+  for (const name of Object.keys(rootProps).sort()) {
+    const category = categorizeToken(name);
+    const resolvedByMode = {};
+    for (const mode of FIGMA_MODES) {
+      resolvedByMode[mode.id] = resolveToken(themes[mode.id], themes[mode.id][name] ?? "");
+    }
+
+    const figmaType = figmaTypeForToken(name, category, resolvedByMode);
+    if (!figmaType) {
+      skipped.push({
+        name,
+        category,
+        reason: "non-figma-value (clamp, color-mix, or unresolved var)",
+        sample: resolvedByMode.light,
+      });
+      continue;
+    }
+
+    const figmaName = cssVarToFigmaName(name);
+    const codeSyntax = { WEB: `var(${name})` };
+    const scopes = scopesForCategory(category);
+
+    if (figmaType === "COLOR") {
+      const values = {};
+      for (const mode of FIGMA_MODES) {
+        const raw = resolvedByMode[mode.id];
+        if (!isResolvableColor(raw)) {
+          skipped.push({ name, category, reason: `unresolved color in ${mode.id}`, sample: raw });
+          continue;
+        }
+        values[mode.label] = raw;
+      }
+      if (Object.keys(values).length === FIGMA_MODES.length) {
+        collections.color.tokens.push({ name: figmaName, cssVar: name, type: "COLOR", values, scopes, codeSyntax });
+      }
+      continue;
+    }
+
+    if (figmaType === "FLOAT") {
+      const px = parseDimensionPx(resolvedByMode.light);
+      if (px == null) {
+        skipped.push({ name, category, reason: "dimension parse failed", sample: resolvedByMode.light });
+        continue;
+      }
+      collections.dimension.tokens.push({
+        name: figmaName,
+        cssVar: name,
+        type: "FLOAT",
+        values: { Value: px },
+        scopes,
+        codeSyntax,
+      });
+      continue;
+    }
+
+    if (figmaType === "STRING") {
+      collections.string.tokens.push({
+        name: figmaName,
+        cssVar: name,
+        type: "STRING",
+        values: { Value: resolvedByMode.light },
+        scopes: [],
+        codeSyntax,
+      });
+    }
+  }
+
+  const manifest = {
+    fileKey: FIGMA_FILE_KEY,
+    fileSlug: FIGMA_FILE_SLUG,
+    fileUrl: `https://www.figma.com/design/${FIGMA_FILE_KEY}/${FIGMA_FILE_SLUG}`,
+    generatedAt: new Date().toISOString(),
+    source: "nextjs-app/shared/styles/variables.css",
+    runId: `dt-dsb-${new Date().toISOString().slice(0, 10)}`,
+    modes: FIGMA_MODES,
+    collections,
+    stats: {
+      color: collections.color.tokens.length,
+      dimension: collections.dimension.tokens.length,
+      string: collections.string.tokens.length,
+      skipped: skipped.length,
+    },
+    skipped,
+    phases: [
+      { id: "phase-0", label: "Discovery (get_metadata pages only, no nodeId)" },
+      { id: "phase-1a", label: "Create DT / Color collection + variables", script: "phase-1a-color.js" },
+      { id: "phase-1b", label: "Create DT / Dimension + DT / String", script: "phase-1b-dimension-string.js" },
+      { id: "phase-2", label: "Page skeleton (Foundations, Atoms, …)" },
+      { id: "phase-3-atoms", label: "Atoms one-by-one (Button first)" },
+    ],
+  };
+
+  mkdirSync(OUT_DIR, { recursive: true });
+  writeFileSync(OUT_JSON, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  console.log(`✓ Figma variables manifest → ${OUT_JSON}`);
+  console.log(
+    `  color=${manifest.stats.color} dimension=${manifest.stats.dimension} string=${manifest.stats.string} skipped=${manifest.stats.skipped}`,
+  );
+}
+
+main();

--- a/scripts/design-system/check-storybook-figma-contract.mjs
+++ b/scripts/design-system/check-storybook-figma-contract.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   FIGMA_FILE_KEY,
+  FIGMA_LIBRARY_EXISTS,
   isDtPlaceholderNodeId,
   isRealFigmaNodeId,
 } from "./figma-config.mjs";
@@ -38,9 +39,16 @@ for (const { name, contract } of iterBetaStableContracts(roots)) {
   }
   const nodeMatch = figma.match(/[?&]node-id=([^&]+)/);
   const nodeId = nodeMatch?.[1] ?? "";
+  // When the DT library exists, a real numeric node-id is valid (and deep-links
+  // from Storybook's Design panel); foreign files are blocked by the file-key
+  // guard above. Otherwise contracts must use the dt-<slug> placeholder.
   if (isRealFigmaNodeId(nodeId)) {
-    console.error(`FAIL ${name}: contract figma must not use foreign numeric node-id`);
-    failed += 1;
+    if (!FIGMA_LIBRARY_EXISTS) {
+      console.error(
+        `FAIL ${name}: contract figma must not use a numeric node-id until the DT library exists`,
+      );
+      failed += 1;
+    }
     continue;
   }
   if (!isDtPlaceholderNodeId(nodeId)) {

--- a/scripts/design-system/figma-config.mjs
+++ b/scripts/design-system/figma-config.mjs
@@ -7,10 +7,24 @@
  */
 import { componentNameToSlug } from "./figma-contract-utils.mjs";
 
+/** DT-Site-stuff — site + design system library (tokens, components, routes). */
 export const FIGMA_FILE_KEY =
-  process.env.FIGMA_FILE_KEY || "d8nFs8A5KcjbFr6KkwZV4H5K";
+  process.env.FIGMA_FILE_KEY || "PC2UPdYwm8qGt6ZTg0AakF";
 export const FIGMA_FILE_SLUG =
-  process.env.FIGMA_FILE_SLUG || "Digitaltableteur-Design-System";
+  process.env.FIGMA_FILE_SLUG || "DT-Site-stuff";
+
+/**
+ * Whether the DT design-system library now exists in the canonical Figma file.
+ *
+ * Built + verified 2026-06: the in-scope components are real, deep-linkable
+ * nodes in the file (see `FIGMA_NODE_IDS`) — though the file is not yet a
+ * *published* Figma library. When true, contracts may carry real numeric
+ * node-ids and the gates accept them; when false they require honest
+ * `dt-<slug>` placeholders (the original "HONEST_FIGMA_DEBT" stance).
+ * Override: `FIGMA_LIBRARY_EXISTS=false`.
+ */
+export const FIGMA_LIBRARY_EXISTS =
+  (process.env.FIGMA_LIBRARY_EXISTS ?? "true") === "true";
 
 /** Dev-mode file URL (no component node until Figma library exists). */
 export const FIGMA_TIER_FILE_URL = `https://www.figma.com/design/${FIGMA_FILE_KEY}/${FIGMA_FILE_SLUG}`;
@@ -29,6 +43,64 @@ export const FIGMA_TIER_PAGES = {
 export function buildFigmaPlaceholderUrl(name) {
   const slug = componentNameToSlug(name);
   return `https://www.figma.com/design/${FIGMA_FILE_KEY}/${FIGMA_FILE_SLUG}?node-id=dt-${slug}`;
+}
+
+/**
+ * Verified Figma node ids in the canonical file (PC2UPdYwm8qGt6ZTg0AakF /
+ * DT-Site-stuff). Each was resolved live against the named component/set.
+ * Components without an entry fall back to the honest `dt-<slug>` placeholder
+ * (e.g. Icon — the real "Icon" is the on-page Phosphor library, not a single
+ * component node).
+ */
+export const FIGMA_NODE_IDS = {
+  Button: "406:1569",
+  Logo: "480:1588",
+  Avatar: "369:8",
+  Checkbox: "372:14",
+  Radio: "372:27",
+  Switch: "373:14",
+  Inputs: "374:10",
+  TextArea: "374:17",
+  Badge: "400:1249",
+  Title: "370:12",
+  Text: "370:19",
+  Label: "371:6",
+  HelperText: "371:17",
+  Link: "371:30",
+  Progress: "369:15",
+  Spinner: "368:16",
+  Divider: "368:6",
+  VisuallyHidden: "371:31",
+  Card: "377:26",
+  Modal: "384:13",
+  AlertBanner: "394:41",
+  Toast: "393:35",
+  Tabs: "381:5",
+  Accordion: "381:17",
+  Breadcrumb: "381:31",
+  Select: "383:23",
+  CheckboxGroup: "383:24",
+  RadioGroup: "383:36",
+  FileUpload: "384:26",
+  ContactForm: "470:2",
+  NewsletterWaitlist: "471:21",
+  ChatWidget: "473:25",
+  SiteHeader: "476:2",
+  SiteFooter: "477:6",
+  CTASection: "502:20",
+  NewsBulletin: "503:20",
+};
+
+/**
+ * Figma URL for a contract: a real Dev-mode node link when the component has a
+ * verified node id, otherwise the honest `dt-<slug>` placeholder.
+ */
+export function buildFigmaUrl(name) {
+  const nodeId = FIGMA_NODE_IDS[name];
+  if (FIGMA_LIBRARY_EXISTS && nodeId) {
+    return `${FIGMA_TIER_FILE_URL}?node-id=${nodeId.replace(":", "-")}`;
+  }
+  return buildFigmaPlaceholderUrl(name);
 }
 
 export function isRealFigmaNodeId(nodeId) {

--- a/scripts/design-system/figma-link.mjs
+++ b/scripts/design-system/figma-link.mjs
@@ -12,6 +12,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   FIGMA_FILE_KEY,
+  FIGMA_LIBRARY_EXISTS,
   isDtPlaceholderNodeId,
   isRealFigmaNodeId,
 } from "./figma-config.mjs";
@@ -67,11 +68,15 @@ for (const { name, contract } of iterBetaStableContracts(roots)) {
   const nodeMatch = figma.match(/[?&]node-id=([^&]+)/);
   const nodeId = nodeMatch?.[1] ?? "";
   if (isRealFigmaNodeId(nodeId)) {
-    console.error(
-      `FAIL ${name}: numeric Figma node-id without DT library (${figma})`,
-    );
-    foreignRealIds += 1;
-    failed += 1;
+    // Numeric node-ids are valid once the DT library exists (file-key guard
+    // above already blocks foreign files). Until then they are forbidden.
+    if (!FIGMA_LIBRARY_EXISTS) {
+      console.error(
+        `FAIL ${name}: numeric Figma node-id without DT library (${figma})`,
+      );
+      foreignRealIds += 1;
+      failed += 1;
+    }
     continue;
   }
   if (!isDtPlaceholderNodeId(nodeId)) {
@@ -88,7 +93,9 @@ if (failed) {
   process.exit(1);
 }
 
-console.log("✓ figma-link: beta/stable contracts have honest DT scaffold figma URLs");
+console.log("✓ figma-link: beta/stable contracts have valid DT figma URLs");
 console.log(
-  "  (HONEST_FIGMA_DEBT: real Figma frames pending — dt-* slugs are expected until the DT file ships)",
+  FIGMA_LIBRARY_EXISTS
+    ? "  (DT library exists — verified components use real node-ids; unbuilt ones keep dt-* slugs)"
+    : "  (HONEST_FIGMA_DEBT: real Figma frames pending — dt-* slugs are expected until the DT file ships)",
 );

--- a/scripts/design-system/figma-variables-lib.mjs
+++ b/scripts/design-system/figma-variables-lib.mjs
@@ -1,0 +1,176 @@
+/**
+ * Parse production CSS themes for Figma variable sync.
+ * Source of truth: nextjs-app/shared/styles/variables.css
+ */
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const VARIABLES_CSS = resolve(
+  __dirname,
+  "../../nextjs-app/shared/styles/variables.css",
+);
+
+export const FIGMA_MODES = [
+  { id: "light", label: "Light", marker: null },
+  { id: "dark", label: "Dark", marker: ".themeDark," },
+  { id: "hcb", label: "HCB", marker: ".themeHCB," },
+  { id: "hcw", label: "HCW", marker: ".themeHCW," },
+];
+
+function parseProps(block) {
+  const props = {};
+  for (const line of block.split("\n")) {
+    const m = line.match(/^\s*(--[\w-]+)\s*:\s*([^;]+);/);
+    if (m) props[m[1]] = m[2].trim();
+  }
+  return props;
+}
+
+function extractBlock(css, marker) {
+  const i = css.indexOf(marker);
+  if (i < 0) return "";
+  const brace = css.indexOf("{", i);
+  if (brace < 0) return "";
+  let depth = 0;
+  for (let j = brace; j < css.length; j++) {
+    const c = css[j];
+    if (c === "{") depth++;
+    else if (c === "}") {
+      depth--;
+      if (depth === 0) return css.slice(brace + 1, j);
+    }
+  }
+  return "";
+}
+
+function parseRootTokens(css) {
+  const chunks = css.split(":root {");
+  const body = (chunks.length >= 3 ? chunks[2] : chunks[1]).split("\n}")[0];
+  return parseProps(body);
+}
+
+export function resolveToken(map, value, depth = 0) {
+  if (depth > 12 || value == null) return value;
+  const v = String(value).trim();
+  const varMatch = v.match(/^var\(\s*(--[^),\s]+)(?:\s*,\s*([^)]+))?\s*\)$/);
+  if (varMatch) {
+    const resolved = map[varMatch[1]] ?? varMatch[2];
+    if (resolved != null) return resolveToken(map, resolved, depth + 1);
+  }
+  return v;
+}
+
+export function buildThemeMaps(css = readFileSync(VARIABLES_CSS, "utf8")) {
+  const rootProps = parseRootTokens(css);
+  const themes = {};
+  for (const mode of FIGMA_MODES) {
+    const overrides = mode.marker ? parseProps(extractBlock(css, mode.marker)) : {};
+    themes[mode.id] = { ...rootProps, ...overrides };
+  }
+  return { rootProps, themes };
+}
+
+const HEX_RE = /^#([0-9a-f]{3,8})$/i;
+const RGB_RE = /^rgba?\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+/i;
+
+export function isResolvableColor(raw) {
+  if (!raw || typeof raw !== "string") return false;
+  const v = raw.trim();
+  if (HEX_RE.test(v)) return true;
+  if (RGB_RE.test(v)) return true;
+  return false;
+}
+
+export function categorizeToken(name) {
+  if (
+    name.startsWith("--color-") ||
+    name.startsWith("--accent-") ||
+    name.startsWith("--main-body") ||
+    name.startsWith("--link-") ||
+    name.startsWith("--logo-") ||
+    name.startsWith("--selection-")
+  ) {
+    return "color";
+  }
+  if (name.startsWith("--space-")) return "space";
+  if (name.startsWith("--radius-")) return "radius";
+  if (
+    name.startsWith("--font-") ||
+    name.startsWith("--line-height") ||
+    name.startsWith("--tracking-") ||
+    name.startsWith("--font-weight")
+  ) {
+    return "typography";
+  }
+  if (
+    name.startsWith("--duration-") ||
+    name.startsWith("--ease-") ||
+    name.startsWith("--stagger-") ||
+    name.startsWith("--motion-")
+  ) {
+    return "motion";
+  }
+  if (
+    name.startsWith("--breakpoint-") ||
+    name.startsWith("--container-") ||
+    name.startsWith("--grid-") ||
+    name.startsWith("--page-margin") ||
+    name.startsWith("--rhythm-")
+  ) {
+    return "layout";
+  }
+  if (name.startsWith("--modal-") || name.startsWith("--gallery-")) return "elevation";
+  if (name.startsWith("--focus-")) return "focus";
+  if (name.startsWith("--size-")) return "size";
+  return "other";
+}
+
+/** CSS var name → Figma slash path (strip leading --, keep semantic segments). */
+export function cssVarToFigmaName(cssVar) {
+  return cssVar.replace(/^--/, "").replace(/-/g, "/");
+}
+
+export function scopesForCategory(category) {
+  switch (category) {
+    case "color":
+      return ["FRAME_FILL", "SHAPE_FILL", "STROKE_COLOR", "TEXT_FILL"];
+    case "space":
+      return ["GAP", "WIDTH_HEIGHT"];
+    case "radius":
+      return ["CORNER_RADIUS"];
+    default:
+      return [];
+  }
+}
+
+export function figmaTypeForToken(name, category, resolvedByMode) {
+  if (category === "color") {
+    const allColor = Object.values(resolvedByMode).every(isResolvableColor);
+    return allColor ? "COLOR" : null;
+  }
+  if (category === "space" || category === "radius" || category === "size") {
+    const allPx = Object.values(resolvedByMode).every((v) => {
+      const n = parseDimensionPx(v);
+      return n != null;
+    });
+    return allPx ? "FLOAT" : null;
+  }
+  if (category === "typography" && name.startsWith("--font-") && !name.includes("size")) {
+    return "STRING";
+  }
+  return null;
+}
+
+export function parseDimensionPx(value) {
+  if (value == null) return null;
+  const v = String(value).trim();
+  const rem = v.match(/^([\d.]+)rem$/);
+  if (rem) return Number(rem[1]) * 16;
+  const px = v.match(/^([\d.]+)px$/);
+  if (px) return Number(px[1]);
+  const num = v.match(/^([\d.]+)$/);
+  if (num) return Number(num[1]);
+  return null;
+}

--- a/scripts/design-system/generate-figma-phase-scripts.mjs
+++ b/scripts/design-system/generate-figma-phase-scripts.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * Generate use_figma plugin scripts from variables-manifest.json (chunked).
+ */
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MANIFEST = resolve(__dirname, "../../nextjs-app/shared/foundations/figma/variables-manifest.json");
+const OUT_DIR = resolve(__dirname, "../../nextjs-app/shared/foundations/figma/phases");
+
+const RUNTIME_HELPERS = `
+function hexToFigmaColor(hex) {
+  let h = String(hex).replace('#', '');
+  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+  return {
+    r: parseInt(h.substring(0, 2), 16) / 255,
+    g: parseInt(h.substring(2, 4), 16) / 255,
+    b: parseInt(h.substring(4, 6), 16) / 255,
+    a: h.length === 8 ? parseInt(h.substring(6, 8), 16) / 255 : 1,
+  };
+}
+
+// Variables/collections do NOT support setSharedPluginData (that mixin is
+// nodes/styles only). Idempotency is by name, per the figma-generate-library
+// skill's state table.
+async function upsertCollection(name, modeLabels, _key, _runId) {
+  const cols = await figma.variables.getLocalVariableCollectionsAsync();
+  let coll = cols.find((c) => c.name === name) || null;
+  if (!coll) coll = figma.variables.createVariableCollection(name);
+  const modeIds = {};
+  const existing = coll.modes.map((m) => m.name);
+  if (existing.length === 1 && existing[0] === 'Mode 1' && modeLabels.length) {
+    coll.renameMode(coll.modes[0].modeId, modeLabels[0]);
+  }
+  for (const label of modeLabels) {
+    let mode = coll.modes.find((m) => m.name === label);
+    if (!mode) {
+      const id = coll.addMode(label);
+      mode = coll.modes.find((m) => m.modeId === id);
+    }
+    if (mode) modeIds[label] = mode.modeId;
+  }
+  return { collection: coll, modeIds };
+}
+
+async function upsertVariable(coll, modeIds, def, _runId) {
+  const vars = await figma.variables.getLocalVariablesAsync();
+  let variable = vars.find(
+    (v) => v.variableCollectionId === coll.id && v.name === def.name,
+  );
+  if (!variable) variable = figma.variables.createVariable(def.name, coll, def.type);
+  for (const [modeLabel, raw] of Object.entries(def.values)) {
+    const modeId = modeIds[modeLabel];
+    if (!modeId) continue;
+    let value = raw;
+    if (def.type === 'COLOR' && typeof raw === 'string' && raw.startsWith('#')) {
+      value = hexToFigmaColor(raw);
+    }
+    variable.setValueForMode(modeId, value);
+  }
+  variable.scopes = def.scopes || [];
+  if (def.codeSyntax?.WEB) variable.setVariableCodeSyntax('WEB', def.codeSyntax.WEB);
+  return variable.id;
+}
+`;
+
+function wrapPluginBody(runId, body) {
+  return `${RUNTIME_HELPERS}
+const RUN_ID = ${JSON.stringify(runId)};
+${body}
+return { ok: true, RUN_ID };
+`;
+}
+
+function chunk(arr, size) {
+  const out = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+function main() {
+  const manifest = JSON.parse(readFileSync(MANIFEST, "utf8"));
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  const colorTokens = manifest.collections.color.tokens;
+  const colorChunks = chunk(colorTokens, 35);
+
+  colorChunks.forEach((tokens, i) => {
+    const body = `
+const { collection, modeIds } = await upsertCollection(
+  ${JSON.stringify(manifest.collections.color.name)},
+  ${JSON.stringify(manifest.collections.color.modes)},
+  'collection/dt-color',
+  RUN_ID,
+);
+const created = [];
+const defs = ${JSON.stringify(tokens)};
+for (const def of defs) {
+  created.push(await upsertVariable(collection, modeIds, def, RUN_ID));
+}
+return { collectionId: collection.id, variableIds: created, chunk: ${i + 1}, total: ${colorChunks.length} };
+`;
+    writeFileSync(
+      resolve(OUT_DIR, `phase-1a-color-chunk-${String(i + 1).padStart(2, "0")}.js`),
+      wrapPluginBody(manifest.runId, body),
+    );
+  });
+
+  const dimString = [
+    ...manifest.collections.dimension.tokens,
+    ...manifest.collections.string.tokens,
+  ];
+  const dimChunks = chunk(dimString, 40);
+  dimChunks.forEach((tokens, i) => {
+    const body = `
+const dim = ${JSON.stringify(manifest.collections.dimension.tokens.filter((t) => tokens.find((x) => x.name === t.name)))};
+const str = ${JSON.stringify(manifest.collections.string.tokens.filter((t) => tokens.find((x) => x.name === t.name)))};
+let created = [];
+if (dim.length) {
+  const { collection, modeIds } = await upsertCollection(
+    ${JSON.stringify(manifest.collections.dimension.name)},
+    ${JSON.stringify(manifest.collections.dimension.modes)},
+    'collection/dt-dimension',
+    RUN_ID,
+  );
+  for (const def of dim) created.push(await upsertVariable(collection, modeIds, def, RUN_ID));
+}
+if (str.length) {
+  const { collection, modeIds } = await upsertCollection(
+    ${JSON.stringify(manifest.collections.string.name)},
+    ${JSON.stringify(manifest.collections.string.modes)},
+    'collection/dt-string',
+    RUN_ID,
+  );
+  for (const def of str) created.push(await upsertVariable(collection, modeIds, def, RUN_ID));
+}
+return { variableIds: created, chunk: ${i + 1}, total: ${dimChunks.length} };
+`;
+    writeFileSync(
+      resolve(OUT_DIR, `phase-1b-dimension-string-chunk-${String(i + 1).padStart(2, "0")}.js`),
+      wrapPluginBody(manifest.runId, body),
+    );
+  });
+
+  const readme = `# Figma \`use_figma\` phase scripts
+
+Generated from \`variables-manifest.json\`. **Run sequentially** via Figma MCP \`use_figma\` (remote) — never in parallel.
+
+File: [\`${manifest.fileSlug}\`](${manifest.fileUrl}) (\`${manifest.fileKey}\`)
+
+## Phase 1 — variables
+
+1. \`whoami\` — confirm MCP auth
+2. \`get_metadata\` with **fileKey only** (no nodeId) — list pages
+3. For each \`phase-1a-color-chunk-*.js\`: pass file contents to \`use_figma\` with \`skillNames: "figma-generate-library"\`
+4. Then each \`phase-1b-dimension-string-chunk-*.js\`
+
+## Phase 2+ 
+
+See \`docs/FIGMA_DESIGN_SYSTEM_SYNC.md\`.
+
+Run ID: \`${manifest.runId}\`
+`;
+
+  writeFileSync(resolve(OUT_DIR, "README.md"), readme);
+  console.log(`✓ ${colorChunks.length} color chunks + ${dimChunks.length} dimension/string chunks → ${OUT_DIR}`);
+}
+
+main();

--- a/scripts/design-system/sync-figma-contract-urls.mjs
+++ b/scripts/design-system/sync-figma-contract-urls.mjs
@@ -9,7 +9,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { buildFigmaPlaceholderUrl, FIGMA_FILE_KEY } from "./figma-config.mjs";
+import { buildFigmaUrl, FIGMA_FILE_KEY } from "./figma-config.mjs";
 import { iterBetaStableContracts } from "./figma-contract-utils.mjs";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
@@ -23,7 +23,7 @@ let updated = 0;
 let skipped = 0;
 
 for (const { name, contract, contractPath } of iterBetaStableContracts(roots)) {
-  const nextUrl = buildFigmaPlaceholderUrl(name);
+  const nextUrl = buildFigmaUrl(name);
   if (contract.figma === nextUrl) {
     skipped += 1;
     continue;


### PR DESCRIPTION
## Summary
Repoints the design-system contracts from the old `Digitaltableteur-Design-System` Figma file to the canonical **DT-Site-stuff** file (`PC2UPdYwm8qGt6ZTg0AakF`), and ships the supporting tooling. The Storybook Design panel now deep-links each component to its real Figma node.

- **Contracts repointed** (~120 `*.contract.json`): the 35 built design-system components carry verified real node-ids (`FIGMA_NODE_IDS`, spot-checked live against the file); unbuilt components keep honest `dt-<slug>` placeholders.
- **Browser-safe resolver**: the Storybook name → Figma-URL map is now built at build time via Vite `import.meta.glob` instead of `node:fs`, so preview code no longer touches the filesystem.
- **Figma variables tooling**: `build:figma-variables` script, payload/lib generators, `foundations/figma/` manifest, and design-system docs.
- **New `Logo` component** (node `480:1588`) + branding favicon.
- **WipBadge** docs badge: opaque surface so the fixed badge doesn't let page content bleed through.
- **Fix**: NewsBulletin story's stale Figma node-id (`310-899`, an off-canvas scratch group) → `503-20`, the real component node.

The `.cursor/rules/writing-style.mdc` addition rides along as a separate `docs(cursor)` commit (unrelated to the Figma work, kept distinct for review).

## Verification
- `npm run check:figma` ✓
- `npm run check:storybook-figma` ✓ (128 contracts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)