### PR TITLE
feat(design-system): Figma design URLs in Storybook + SkipLink contrast fix

### DIFF
--- a/nextjs-app/shared/components/Accordion/Accordion.stories.tsx
+++ b/nextjs-app/shared/components/Accordion/Accordion.stories.tsx
@@ -10,6 +10,10 @@ const meta: Meta<typeof Accordion> = {
   component: Accordion,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=381-17",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/AdaptiveLoadingButton/AdaptiveLoadingButton.stories.tsx
+++ b/nextjs-app/shared/components/AdaptiveLoadingButton/AdaptiveLoadingButton.stories.tsx
@@ -8,6 +8,10 @@ const meta: Meta<typeof AdaptiveLoadingButton> = {
   title: "Molecules/AdaptiveLoadingButton",
   component: AdaptiveLoadingButton,
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-adaptive-loading-button",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "centered",

--- a/nextjs-app/shared/components/AlertBanner/AlertBanner.stories.tsx
+++ b/nextjs-app/shared/components/AlertBanner/AlertBanner.stories.tsx
@@ -7,7 +7,14 @@ const meta: Meta<typeof AlertBanner> = {
   title: "Molecules/AlertBanner",
   component: AlertBanner,
   tags: ["beta", "!autodocs"],
-  parameters: { contractStatus: contract.status, a11y: { test: "error" } },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=394-41",
+    },
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+  },
   argTypes: {
     tone: {
       control: { type: "select" },

--- a/nextjs-app/shared/components/AnimatedDialog/AnimatedDialog.stories.tsx
+++ b/nextjs-app/shared/components/AnimatedDialog/AnimatedDialog.stories.tsx
@@ -61,6 +61,10 @@ const meta = {
   component: AnimatedDialog,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-animated-dialog",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/AnimatedGlyphBackground/AnimatedGlyphBackground.stories.tsx
+++ b/nextjs-app/shared/components/AnimatedGlyphBackground/AnimatedGlyphBackground.stories.tsx
@@ -13,6 +13,10 @@ const meta: Meta<typeof AnimatedGlyphBackground> = {
   component: AnimatedGlyphBackground,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-animated-glyph-background",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "fullscreen",

--- a/nextjs-app/shared/components/ArticleCard/ArticleCard.stories.tsx
+++ b/nextjs-app/shared/components/ArticleCard/ArticleCard.stories.tsx
@@ -15,6 +15,10 @@ const meta = {
   component: ArticleCard,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-article-card",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/AspectRatio/AspectRatio.stories.tsx
+++ b/nextjs-app/shared/components/AspectRatio/AspectRatio.stories.tsx
@@ -16,6 +16,10 @@ const meta = {
   component: AspectRatio,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-aspect-ratio",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Author/Author.stories.tsx
+++ b/nextjs-app/shared/components/Author/Author.stories.tsx
@@ -19,6 +19,10 @@ const meta: Meta<typeof Author> = {
   component: Author,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-author",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "centered",

--- a/nextjs-app/shared/components/AuthorBio/AuthorBio.stories.tsx
+++ b/nextjs-app/shared/components/AuthorBio/AuthorBio.stories.tsx
@@ -13,6 +13,10 @@ const meta: Meta<typeof AuthorBio> = {
   component: AuthorBio,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-author-bio",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "centered",

--- a/nextjs-app/shared/components/Avatar/Avatar.stories.tsx
+++ b/nextjs-app/shared/components/Avatar/Avatar.stories.tsx
@@ -16,6 +16,10 @@ export default {
   component: Avatar,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=369-8",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/Badge/Badge.stories.tsx
+++ b/nextjs-app/shared/components/Badge/Badge.stories.tsx
@@ -23,6 +23,10 @@ const meta: Meta<typeof Badge> = {
   component: Badge,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=400-1249",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     // Disable global WIP badge to prevent duplicate 'Badge' text collision in tests

--- a/nextjs-app/shared/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/nextjs-app/shared/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -10,6 +10,10 @@ const meta: Meta<typeof Breadcrumb> = {
   component: Breadcrumb,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=381-31",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/BusyIndicator/BusyIndicator.stories.tsx
+++ b/nextjs-app/shared/components/BusyIndicator/BusyIndicator.stories.tsx
@@ -25,7 +25,14 @@ const meta: Meta<typeof BusyIndicator> = {
   title: "Atoms/BusyIndicator",
   component: BusyIndicator,
   tags: ["beta", "!autodocs"],
-  parameters: { contractStatus: contract.status, a11y: { test: "error" } },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-busy-indicator",
+    },
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+  },
 };
 export default meta;
 

--- a/nextjs-app/shared/components/Button/Button.stories.tsx
+++ b/nextjs-app/shared/components/Button/Button.stories.tsx
@@ -15,6 +15,10 @@ export default {
   component: Button,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=406-1569",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/Button/SplitButton.stories.tsx
+++ b/nextjs-app/shared/components/Button/SplitButton.stories.tsx
@@ -22,6 +22,10 @@ const meta: Meta<typeof SplitButton> = {
   component: SplitButton,
   tags: ["autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=406-1569",
+    },
     layout: "padded",
     llm: { schema },
     docs: {

--- a/nextjs-app/shared/components/Card/Card.stories.tsx
+++ b/nextjs-app/shared/components/Card/Card.stories.tsx
@@ -13,6 +13,10 @@ const CardStoryMeta = {
   component: Card,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=377-26",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/CategoryFilter/CategoryFilter.stories.tsx
+++ b/nextjs-app/shared/components/CategoryFilter/CategoryFilter.stories.tsx
@@ -45,6 +45,10 @@ const meta = {
   component: CategoryFilter,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-category-filter",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Center/Center.stories.tsx
+++ b/nextjs-app/shared/components/Center/Center.stories.tsx
@@ -13,6 +13,10 @@ const meta = {
   component: Center,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-center",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/ChatWidget/AIProcessingState.stories.tsx
+++ b/nextjs-app/shared/components/ChatWidget/AIProcessingState.stories.tsx
@@ -40,6 +40,10 @@ const meta = {
   component: AIProcessingState,
   tags: ["autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=473-25",
+    },
     layout: "centered",
     docs: {
       description: {

--- a/nextjs-app/shared/components/ChatWidget/ChatComposer.stories.tsx
+++ b/nextjs-app/shared/components/ChatWidget/ChatComposer.stories.tsx
@@ -18,7 +18,13 @@ const meta: Meta<typeof ChatComposer> = {
     onSubmit: noop,
     maxLength: 1_000,
   },
-  parameters: { layout: "padded" },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=473-25",
+    },
+    layout: "padded",
+  },
 };
 
 export default meta;

--- a/nextjs-app/shared/components/ChatWidget/ChatHeader.stories.tsx
+++ b/nextjs-app/shared/components/ChatWidget/ChatHeader.stories.tsx
@@ -25,7 +25,12 @@ type Story = StoryObj<typeof ChatHeader>;
 
 export const Default: Story = {
   tags: ["beta-matrix"],
-  parameters: {},
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=473-25",
+    },
+  },
 };
 
 export const Sending: Story = { args: { isSending: true } };

--- a/nextjs-app/shared/components/ChatWidget/ChatMessageBubble.stories.tsx
+++ b/nextjs-app/shared/components/ChatWidget/ChatMessageBubble.stories.tsx
@@ -48,7 +48,13 @@ const meta: Meta<typeof ChatMessageBubble> = {
   title: "Molecules/Chat/ChatMessageBubble",
   component: ChatMessageBubble,
   tags: ["autodocs"],
-  parameters: { layout: "padded" },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=473-25",
+    },
+    layout: "padded",
+  },
   args: { isStreaming: false },
 };
 

--- a/nextjs-app/shared/components/ChatWidget/ChatMessages.stories.tsx
+++ b/nextjs-app/shared/components/ChatWidget/ChatMessages.stories.tsx
@@ -140,7 +140,12 @@ const meta: Meta<typeof ChatMessages> = {
   component: ChatMessages,
   tags: ["autodocs"],
   args: { messages: SAMPLE_MESSAGES },
-  parameters: {},
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=473-25",
+    },
+  },
 };
 
 export default meta;

--- a/nextjs-app/shared/components/ChatWidget/ChatToggle.stories.tsx
+++ b/nextjs-app/shared/components/ChatWidget/ChatToggle.stories.tsx
@@ -3,6 +3,12 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import ChatToggle from "./ChatToggle";
 
 const meta: Meta<typeof ChatToggle> = {
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=473-25",
+    },
+  },
   title: "Molecules/Chat/ChatToggle",
   component: ChatToggle,
   tags: ["autodocs"],

--- a/nextjs-app/shared/components/ChatWidget/ChatWidget.stories.tsx
+++ b/nextjs-app/shared/components/ChatWidget/ChatWidget.stories.tsx
@@ -132,6 +132,10 @@ const meta: Meta<typeof ChatWidget> = {
   component: ChatWidget,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=473-25",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Checkbox/Checkbox.stories.tsx
+++ b/nextjs-app/shared/components/Checkbox/Checkbox.stories.tsx
@@ -78,6 +78,10 @@ export default {
   component: Checkbox,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=372-14",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/CheckboxField/CheckboxField.stories.tsx
+++ b/nextjs-app/shared/components/CheckboxField/CheckboxField.stories.tsx
@@ -14,6 +14,10 @@ const meta = {
   component: CheckboxField,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-checkbox-field",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/nextjs-app/shared/components/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -78,6 +78,10 @@ export default {
   component: CheckboxGroup,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=383-24",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/ClientLogoMarquee/ClientLogoMarquee.stories.tsx
+++ b/nextjs-app/shared/components/ClientLogoMarquee/ClientLogoMarquee.stories.tsx
@@ -11,6 +11,10 @@ const meta = {
   component: ClientLogoMarquee,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-client-logo-marquee",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.stories.tsx
+++ b/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.stories.tsx
@@ -17,6 +17,10 @@ const meta: Meta<typeof CodeBlockWindow> = {
   title: "Organisms/CodeBlockWindow",
   component: CodeBlockWindow,
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-code-block-window",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "padded",

--- a/nextjs-app/shared/components/CodeSnippet/CodeSnippet.stories.tsx
+++ b/nextjs-app/shared/components/CodeSnippet/CodeSnippet.stories.tsx
@@ -60,6 +60,10 @@ const meta: Meta<typeof CodeSnippet> = {
   component: CodeSnippet,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-code-snippet",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/ComplianceCard/ComplianceCard.stories.tsx
+++ b/nextjs-app/shared/components/ComplianceCard/ComplianceCard.stories.tsx
@@ -9,6 +9,10 @@ const meta = {
   title: "Molecules/ComplianceCard",
   component: ComplianceCard,
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-compliance-card",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "padded",

--- a/nextjs-app/shared/components/ContactForm/ContactForm.stories.tsx
+++ b/nextjs-app/shared/components/ContactForm/ContactForm.stories.tsx
@@ -81,6 +81,10 @@ const meta: Meta<typeof ContactForm> = {
   component: ContactForm,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=470-2",
+    },
     layout: "padded",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.stories.tsx
+++ b/nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.stories.tsx
@@ -10,6 +10,10 @@ const meta = {
   component: ContactFormEditorial,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-contact-form-editorial",
+    },
     layout: "padded",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Container/Container.stories.tsx
+++ b/nextjs-app/shared/components/Container/Container.stories.tsx
@@ -18,6 +18,10 @@ const meta = {
   component: Container,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-container",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/CookieConsent/CookieConsent.stories.tsx
+++ b/nextjs-app/shared/components/CookieConsent/CookieConsent.stories.tsx
@@ -8,6 +8,10 @@ const meta = {
   component: CookieConsent,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-cookie-consent",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Designerman/Designerman.stories.tsx
+++ b/nextjs-app/shared/components/Designerman/Designerman.stories.tsx
@@ -9,6 +9,10 @@ const meta: Meta<typeof Designerman> = {
   component: Designerman,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-designerman",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "fullscreen",

--- a/nextjs-app/shared/components/Display/Display.stories.tsx
+++ b/nextjs-app/shared/components/Display/Display.stories.tsx
@@ -12,6 +12,10 @@ const meta = {
   component: Display,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-display",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Divider/Divider.stories.tsx
+++ b/nextjs-app/shared/components/Divider/Divider.stories.tsx
@@ -7,6 +7,10 @@ const meta = {
   component: Divider,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=368-6",
+    },
     layout: "padded",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/DonnyActionProvider/DonnyActionProvider.stories.tsx
+++ b/nextjs-app/shared/components/DonnyActionProvider/DonnyActionProvider.stories.tsx
@@ -29,7 +29,7 @@ function DemoPanel() {
       <Button
         variant="secondary"
         onClick={() => {
-          // eslint-disable-next-line no-console
+           
           console.log(capturePageContext());
         }}
       >

--- a/nextjs-app/shared/components/DonnyAvatar/DonnyAvatar.stories.tsx
+++ b/nextjs-app/shared/components/DonnyAvatar/DonnyAvatar.stories.tsx
@@ -8,6 +8,10 @@ const meta: Meta<typeof DonnyAvatar> = {
   component: DonnyAvatar,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-donny-avatar",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "centered",

--- a/nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.stories.tsx
+++ b/nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.stories.tsx
@@ -10,6 +10,10 @@ const meta: Meta<typeof EmailSignatureGenerator> = {
   component: EmailSignatureGenerator,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-email-signature-generator",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "fullscreen",

--- a/nextjs-app/shared/components/EnhancedProjectCard/EnhancedProjectCard.stories.tsx
+++ b/nextjs-app/shared/components/EnhancedProjectCard/EnhancedProjectCard.stories.tsx
@@ -19,6 +19,10 @@ const meta = {
   component: EnhancedProjectCard,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-enhanced-project-card",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/ExpandableSection/ExpandableSection.stories.tsx
+++ b/nextjs-app/shared/components/ExpandableSection/ExpandableSection.stories.tsx
@@ -29,6 +29,10 @@ const meta = {
   component: ExpandableSection,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-expandable-section",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/FileUpload/FileUpload.stories.tsx
+++ b/nextjs-app/shared/components/FileUpload/FileUpload.stories.tsx
@@ -77,6 +77,10 @@ export default {
   component: FileUpload,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=384-26",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },
@@ -122,7 +126,8 @@ export default {
     appearance: {
       control: "select",
       options: ["default", "editorial"],
-      description: "Visual variant — editorial matches FormFieldEditorial / Combobox",
+      description:
+        "Visual variant — editorial matches FormFieldEditorial / Combobox",
     },
     value: {
       table: { disable: true },

--- a/nextjs-app/shared/components/FlexBox/FlexBox.stories.tsx
+++ b/nextjs-app/shared/components/FlexBox/FlexBox.stories.tsx
@@ -27,6 +27,10 @@ const meta = {
   component: FlexBox,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-flex-box",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/FormField/FormField.stories.tsx
+++ b/nextjs-app/shared/components/FormField/FormField.stories.tsx
@@ -15,6 +15,10 @@ const meta = {
   component: FormField,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-form-field",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.stories.tsx
+++ b/nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.stories.tsx
@@ -15,6 +15,10 @@ const meta = {
   component: FormFieldEditorial,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-form-field-editorial",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/FormGroup/FormGroup.stories.tsx
+++ b/nextjs-app/shared/components/FormGroup/FormGroup.stories.tsx
@@ -19,6 +19,10 @@ const meta = {
   component: FormGroup,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-form-group",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Gallery/Gallery.stories.tsx
+++ b/nextjs-app/shared/components/Gallery/Gallery.stories.tsx
@@ -29,6 +29,10 @@ const meta = {
   component: Gallery,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-gallery",
+    },
     layout: "padded",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Grid/Grid.stories.tsx
+++ b/nextjs-app/shared/components/Grid/Grid.stories.tsx
@@ -37,6 +37,10 @@ const meta = {
   component: Grid,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-grid",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/GroupLabel/GroupLabel.stories.tsx
+++ b/nextjs-app/shared/components/GroupLabel/GroupLabel.stories.tsx
@@ -14,6 +14,10 @@ const meta = {
   component: GroupLabel,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-group-label",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Heading/Heading.stories.tsx
+++ b/nextjs-app/shared/components/Heading/Heading.stories.tsx
@@ -13,6 +13,10 @@ const meta = {
   component: Heading,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-heading",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/HelperText/HelperText.stories.tsx
+++ b/nextjs-app/shared/components/HelperText/HelperText.stories.tsx
@@ -10,6 +10,10 @@ const meta: Meta<typeof HelperText> = {
   component: HelperText,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=371-17",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/Icon/Icon.stories.tsx
+++ b/nextjs-app/shared/components/Icon/Icon.stories.tsx
@@ -4,7 +4,14 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import Icon from "@dt/Icon";
 
 const meta: Meta<typeof Icon> = {
-  parameters: { contractStatus: contract.status, a11y: { test: "error" } },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-icon",
+    },
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+  },
   title: "Atoms/Icon",
   component: Icon,
   tags: ["beta", "!autodocs"],

--- a/nextjs-app/shared/components/IconButton/IconButton.stories.tsx
+++ b/nextjs-app/shared/components/IconButton/IconButton.stories.tsx
@@ -17,6 +17,10 @@ const meta = {
   component: IconButton,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-icon-button",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/ImagePlaceholder/ImagePlaceholder.stories.tsx
+++ b/nextjs-app/shared/components/ImagePlaceholder/ImagePlaceholder.stories.tsx
@@ -19,6 +19,10 @@ const meta: Meta<typeof ImagePlaceholder> = {
   component: ImagePlaceholder,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-image-placeholder",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "centered",

--- a/nextjs-app/shared/components/Inputs/Inputs.stories.tsx
+++ b/nextjs-app/shared/components/Inputs/Inputs.stories.tsx
@@ -12,6 +12,10 @@ const meta = {
   component: Inputs,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=374-10",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/Label/Label.stories.tsx
+++ b/nextjs-app/shared/components/Label/Label.stories.tsx
@@ -78,6 +78,10 @@ export default {
   component: Label,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=371-6",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/Layout/Layout.stories.tsx
+++ b/nextjs-app/shared/components/Layout/Layout.stories.tsx
@@ -17,6 +17,10 @@ const meta = {
   component: Layout,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-layout",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Link/Link.stories.tsx
+++ b/nextjs-app/shared/components/Link/Link.stories.tsx
@@ -83,6 +83,10 @@ export default {
   component: Link,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=371-30",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     test: { disable: true },

--- a/nextjs-app/shared/components/LinkedInQuoteCard/LinkedInQuoteCard.stories.tsx
+++ b/nextjs-app/shared/components/LinkedInQuoteCard/LinkedInQuoteCard.stories.tsx
@@ -192,6 +192,10 @@ export default {
   title: "Molecules/LinkedInQuoteCard",
   component: LinkedInQuoteCard,
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-linked-in-quote-card",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "fullscreen",

--- a/nextjs-app/shared/components/List/List.stories.tsx
+++ b/nextjs-app/shared/components/List/List.stories.tsx
@@ -88,6 +88,10 @@ const meta: Meta<typeof List> = {
   component: List,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-list",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/LocationCard/LocationCard.stories.tsx
+++ b/nextjs-app/shared/components/LocationCard/LocationCard.stories.tsx
@@ -14,6 +14,10 @@ const meta = {
   component: LocationCard,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-location-card",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Logo/Logo.stories.tsx
+++ b/nextjs-app/shared/components/Logo/Logo.stories.tsx
@@ -7,6 +7,10 @@ const meta = {
   component: Logo,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=480-1588",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },
@@ -19,7 +23,8 @@ const meta = {
     },
     animated: {
       control: "boolean",
-      description: "Pulse the leading bars on hover (disabled under reduced motion)",
+      description:
+        "Pulse the leading bars on hover (disabled under reduced motion)",
       table: { category: "Motion", defaultValue: { summary: "false" } },
     },
     badge: {
@@ -30,7 +35,10 @@ const meta = {
     title: {
       control: "text",
       description: "Accessible name (ignored when decorative)",
-      table: { category: "Accessibility", defaultValue: { summary: "Digitaltableteur" } },
+      table: {
+        category: "Accessibility",
+        defaultValue: { summary: "Digitaltableteur" },
+      },
     },
     decorative: {
       control: "boolean",

--- a/nextjs-app/shared/components/MCPActionButton/MCPActionButton.stories.tsx
+++ b/nextjs-app/shared/components/MCPActionButton/MCPActionButton.stories.tsx
@@ -7,6 +7,10 @@ const meta: Meta<typeof MCPActionButton> = {
   title: "Molecules/MCPActionButton",
   component: MCPActionButton,
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-mcpaction-button",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "padded",

--- a/nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.stories.tsx
+++ b/nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.stories.tsx
@@ -7,6 +7,10 @@ const meta: Meta<typeof MacWindowFrame> = {
   title: "Molecules/MacWindowFrame",
   component: MacWindowFrame,
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-mac-window-frame",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "padded",

--- a/nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.stories.tsx
+++ b/nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.stories.tsx
@@ -8,14 +8,22 @@ const meta: Meta<typeof MarkdownMessage> = {
     density: {
       control: "select",
       options: ["default", "chat"],
-      description: "Typography density for chat bubbles vs default markdown blocks",
+      description:
+        "Typography density for chat bubbles vs default markdown blocks",
       table: { defaultValue: { summary: "default" } },
     },
   },
   title: "Molecules/Chat/MarkdownMessage",
   component: MarkdownMessage,
   tags: ["beta", "!autodocs"],
-  parameters: { contractStatus: contract.status, a11y: { test: "error" } },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-markdown-message",
+    },
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+  },
   args: {
     content:
       "# Heading\n\nSome **bold** text, _italics_, and a list:\n\n- Item one\n- Item two\n\n`inline code`\n\n```js\nconsole.log('block code');\n```\n\n> Blockquote example\n\nA table:\n\n| Col A | Col B |\n|-------|-------|\n| 1     | 2     |\n| 3     | 4     |\n",

--- a/nextjs-app/shared/components/Modal/Modal.stories.tsx
+++ b/nextjs-app/shared/components/Modal/Modal.stories.tsx
@@ -79,6 +79,10 @@ export default {
   component: Modal,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=384-13",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },
@@ -233,11 +237,9 @@ const Template: StoryFn<ModalProps> = (args: ModalProps) => {
         isOpen={open}
         onClose={() => setOpen(false)}
         title={t(args.title as string)}
-         
         children={
           typeof args.children === "string" ? t(args.children) : args.children
         }
-         
       />
     </>
   );

--- a/nextjs-app/shared/components/NavLink/NavLink.stories.tsx
+++ b/nextjs-app/shared/components/NavLink/NavLink.stories.tsx
@@ -14,6 +14,10 @@ const meta = {
   component: NavLink,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-nav-link",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/NavMenuList/NavMenuList.stories.tsx
+++ b/nextjs-app/shared/components/NavMenuList/NavMenuList.stories.tsx
@@ -26,7 +26,14 @@ const meta: Meta<typeof NavMenuList> = {
   title: "Molecules/NavMenuList",
   component: NavMenuList,
   tags: ["beta", "!autodocs"],
-  parameters: { contractStatus: contract.status, a11y: { test: "error" } },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-nav-menu-list",
+    },
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+  },
   decorators: [
     (Story) => {
       // If a parent preview already provides a router, don't nest another

--- a/nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.stories.tsx
+++ b/nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.stories.tsx
@@ -8,6 +8,10 @@ const meta: Meta<typeof NewsletterWaitlist> = {
   component: NewsletterWaitlist,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=471-21",
+    },
     layout: "padded",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/NextHeader/NextHeader.stories.tsx
+++ b/nextjs-app/shared/components/NextHeader/NextHeader.stories.tsx
@@ -8,6 +8,10 @@ const meta = {
   component: NextHeader,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-next-header",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/NextLayout/NextLayout.stories.tsx
+++ b/nextjs-app/shared/components/NextLayout/NextLayout.stories.tsx
@@ -21,6 +21,10 @@ const meta = {
   component: NextLayout,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-next-layout",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/NextMobileMenu/NextMobileMenu.stories.tsx
+++ b/nextjs-app/shared/components/NextMobileMenu/NextMobileMenu.stories.tsx
@@ -47,6 +47,10 @@ const meta = {
   component: NextMobileMenu,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-next-mobile-menu",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/OpenHours/OpenHours.stories.tsx
+++ b/nextjs-app/shared/components/OpenHours/OpenHours.stories.tsx
@@ -83,6 +83,10 @@ type Story = StoryObj<typeof OpenHours>;
 
 export const Z_OpenHoursCompliance: Story = {
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-open-hours",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     docs: { disable: true },

--- a/nextjs-app/shared/components/Pagination/Pagination.stories.tsx
+++ b/nextjs-app/shared/components/Pagination/Pagination.stories.tsx
@@ -30,6 +30,10 @@ const meta = {
   component: Pagination,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-pagination",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/PersonCard/PersonCard.stories.tsx
+++ b/nextjs-app/shared/components/PersonCard/PersonCard.stories.tsx
@@ -353,6 +353,10 @@ export const Playground = Default;
 export const Example = {
   tags: ["beta-matrix"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-person-card",
+    },
     a11y: { test: "error" },
     contractStatus: contract.status,
     controls: { disable: true },

--- a/nextjs-app/shared/components/PhoneInput/PhoneInput.stories.tsx
+++ b/nextjs-app/shared/components/PhoneInput/PhoneInput.stories.tsx
@@ -89,6 +89,10 @@ const meta: Meta<typeof PhoneInput> = {
   component: PhoneInput,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-phone-input",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/Progress/Progress.stories.tsx
+++ b/nextjs-app/shared/components/Progress/Progress.stories.tsx
@@ -7,6 +7,10 @@ const meta = {
   component: Progress,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=369-15",
+    },
     layout: "padded",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Radio/Radio.stories.tsx
+++ b/nextjs-app/shared/components/Radio/Radio.stories.tsx
@@ -7,6 +7,10 @@ const meta = {
   component: Radio,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=372-27",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/RadioGroup/RadioGroup.stories.tsx
+++ b/nextjs-app/shared/components/RadioGroup/RadioGroup.stories.tsx
@@ -13,6 +13,10 @@ const meta = {
   component: RadioGroup,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=383-36",
+    },
     layout: "padded",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/ReadingProgress/ReadingProgress.stories.tsx
+++ b/nextjs-app/shared/components/ReadingProgress/ReadingProgress.stories.tsx
@@ -8,6 +8,10 @@ const meta = {
   component: ReadingProgress,
   tags: ["!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-reading-progress",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Section/Section.stories.tsx
+++ b/nextjs-app/shared/components/Section/Section.stories.tsx
@@ -18,6 +18,10 @@ const meta = {
   component: Section,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-section",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.stories.tsx
+++ b/nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.stories.tsx
@@ -74,7 +74,14 @@ const meta: Meta<typeof SecureCVDownload> = {
   title: "Molecules/SecureCVDownload",
   component: SecureCVDownload,
   tags: ["beta", "!autodocs"],
-  parameters: { contractStatus: contract.status, a11y: { test: "error" } },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-secure-cvdownload",
+    },
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+  },
   argTypes: {
     buttonText: {
       control: "text",

--- a/nextjs-app/shared/components/Select/Select.stories.tsx
+++ b/nextjs-app/shared/components/Select/Select.stories.tsx
@@ -80,6 +80,10 @@ export default {
   component: Select,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=383-23",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/Select/SelectOption.stories.tsx
+++ b/nextjs-app/shared/components/Select/SelectOption.stories.tsx
@@ -3,7 +3,16 @@ import SelectOption from "./SelectOption";
 import Select from "@dt/Select";
 import { userEvent, within } from "storybook/test";
 import { useTranslation } from "react-i18next";
-export default { title: "Atoms/SelectOption", component: SelectOption };
+export default {
+  title: "Atoms/SelectOption",
+  component: SelectOption,
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=383-23",
+    },
+  },
+};
 
 export const Default = () => {
   const { t } = useTranslation();

--- a/nextjs-app/shared/components/SentrySummaryCard/SentrySummaryCard.stories.tsx
+++ b/nextjs-app/shared/components/SentrySummaryCard/SentrySummaryCard.stories.tsx
@@ -25,7 +25,14 @@ const meta: Meta<typeof SentrySummaryCard> = {
   title: "Molecules/SentrySummaryCard",
   component: SentrySummaryCard,
   tags: ["beta", "!autodocs"],
-  parameters: { contractStatus: contract.status, a11y: { test: "error" } },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-sentry-summary-card",
+    },
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+  },
 };
 export default meta;
 

--- a/nextjs-app/shared/components/ServiceCard/ServiceCard.stories.tsx
+++ b/nextjs-app/shared/components/ServiceCard/ServiceCard.stories.tsx
@@ -19,6 +19,10 @@ const meta = {
   component: ServiceCard,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-service-card",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/ServicesGrid/ServicesGrid.stories.tsx
+++ b/nextjs-app/shared/components/ServicesGrid/ServicesGrid.stories.tsx
@@ -77,6 +77,10 @@ const meta: Meta<typeof ServicesGrid> = {
   component: ServicesGrid,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-services-grid",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "centered",

--- a/nextjs-app/shared/components/Skeleton/Skeleton.stories.tsx
+++ b/nextjs-app/shared/components/Skeleton/Skeleton.stories.tsx
@@ -75,7 +75,14 @@ const meta: Meta<typeof Skeleton> = {
   title: "Atoms/Skeleton",
   component: Skeleton,
   tags: ["beta", "!autodocs"],
-  parameters: { contractStatus: contract.status, a11y: { test: "error" } },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-skeleton",
+    },
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+  },
 };
 export default meta;
 

--- a/nextjs-app/shared/components/SkillsGrid/SkillsGrid.stories.tsx
+++ b/nextjs-app/shared/components/SkillsGrid/SkillsGrid.stories.tsx
@@ -32,6 +32,10 @@ const meta = {
   component: SkillsGrid,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-skills-grid",
+    },
     layout: "padded",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/SkipLink/SkipLink.module.css
+++ b/nextjs-app/shared/components/SkipLink/SkipLink.module.css
@@ -1,0 +1,37 @@
+/*
+ * Skip link: visually hidden until focused, then a high-contrast pill in the
+ * top-left. Uses theme-aware tokens (--color-primary / --color-white), which
+ * are paired for guaranteed contrast across all four themes (light, dark,
+ * HCB, HCW) — the same pairing proven in Layout.module.css.
+ */
+
+.skipLink {
+  position: absolute;
+  z-index: 100;
+  padding-block: var(--space-internal-8, 0.5rem);
+  padding-inline: var(--space-internal-16, 1rem);
+  border-radius: var(--radius-md, 0.375rem);
+  background: var(--color-primary);
+  font-family: var(--font-body, system-ui, sans-serif);
+  font-size: var(--font-size-text-m, 1rem);
+  font-weight: 500;
+  line-height: var(--line-height-snug, 1.3);
+  text-decoration: none;
+  color: var(--color-white);
+  transition: inset-block-start 0.2s ease;
+  inset-block-start: -4rem;
+  inset-inline-start: var(--space-internal-12, 0.75rem);
+}
+
+.skipLink:focus,
+.skipLink:focus-visible {
+  outline: 2px solid var(--focus-ring-color, var(--color-primary));
+  outline-offset: 2px;
+  inset-block-start: var(--space-internal-12, 0.75rem);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skipLink {
+    transition: none;
+  }
+}

--- a/nextjs-app/shared/components/SkipLink/SkipLink.stories.tsx
+++ b/nextjs-app/shared/components/SkipLink/SkipLink.stories.tsx
@@ -13,6 +13,10 @@ const meta = {
   component: SkipLink,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-skip-link",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/SkipLink/SkipLink.tsx
+++ b/nextjs-app/shared/components/SkipLink/SkipLink.tsx
@@ -2,6 +2,8 @@
 
 import { cn } from "@/lib/utils";
 
+import styles from "./SkipLink.module.css";
+
 export interface SkipLinkProps {
   href?: string;
   children?: React.ReactNode;
@@ -10,6 +12,9 @@ export interface SkipLinkProps {
 
 /**
  * SkipLink component.
+ *
+ * Visually hidden until focused, then surfaces as a high-contrast pill so
+ * keyboard users can jump straight to the main content.
  */
 export function SkipLink({
   href = "#main-content",
@@ -17,18 +22,7 @@ export function SkipLink({
   className,
 }: SkipLinkProps) {
   return (
-    <a
-      href={href}
-      className={cn(
-        "sr-only focus:not-sr-only",
-        "focus:absolute focus:top-4 focus:left-4 focus:z-50",
-        "focus:px-4 focus:py-2 focus:rounded-md",
-        "focus:bg-foreground focus:text-background",
-        "focus:font-body focus:text-text-m focus:font-medium",
-        "focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ring",
-        className
-      )}
-    >
+    <a href={href} className={cn(styles.skipLink, className)}>
       {children}
     </a>
   );

--- a/nextjs-app/shared/components/SocialShare/SocialShare.stories.tsx
+++ b/nextjs-app/shared/components/SocialShare/SocialShare.stories.tsx
@@ -80,6 +80,10 @@ const meta = {
   title: "Molecules/SocialShare",
   component: SocialShare,
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-social-share",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "centered",

--- a/nextjs-app/shared/components/Spacer/Spacer.stories.tsx
+++ b/nextjs-app/shared/components/Spacer/Spacer.stories.tsx
@@ -12,6 +12,10 @@ const meta = {
   component: Spacer,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-spacer",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Spinner/Spinner.stories.tsx
+++ b/nextjs-app/shared/components/Spinner/Spinner.stories.tsx
@@ -7,6 +7,10 @@ const meta = {
   component: Spinner,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=368-16",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Stack/Stack.stories.tsx
+++ b/nextjs-app/shared/components/Stack/Stack.stories.tsx
@@ -23,6 +23,10 @@ const meta = {
   component: Stack,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-stack",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Switch/Switch.stories.tsx
+++ b/nextjs-app/shared/components/Switch/Switch.stories.tsx
@@ -78,6 +78,10 @@ const meta: Meta<typeof Switch> = {
   component: Switch,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=373-14",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/Tabs/Tabs.stories.tsx
+++ b/nextjs-app/shared/components/Tabs/Tabs.stories.tsx
@@ -114,6 +114,10 @@ const meta: Meta<typeof Tabs> = {
   component: Tabs,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=381-5",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/Tag/Tag.stories.tsx
+++ b/nextjs-app/shared/components/Tag/Tag.stories.tsx
@@ -14,6 +14,10 @@ const meta = {
   component: Tag,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-tag",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Testimonial/Testimonial.stories.tsx
+++ b/nextjs-app/shared/components/Testimonial/Testimonial.stories.tsx
@@ -75,6 +75,10 @@ export default {
   title: "Molecules/Testimonial",
   component: Testimonial,
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-testimonial",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "padded",

--- a/nextjs-app/shared/components/Text/Text.stories.tsx
+++ b/nextjs-app/shared/components/Text/Text.stories.tsx
@@ -90,6 +90,10 @@ export default {
   component: Text,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=370-19",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/TextArea/TextArea.stories.tsx
+++ b/nextjs-app/shared/components/TextArea/TextArea.stories.tsx
@@ -8,6 +8,10 @@ const meta = {
   component: TextArea,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=374-17",
+    },
     layout: "padded",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/TextInput/TextInput.stories.tsx
+++ b/nextjs-app/shared/components/TextInput/TextInput.stories.tsx
@@ -16,6 +16,10 @@ const meta = {
   component: TextInput,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-text-input",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/TextLink/TextLink.stories.tsx
+++ b/nextjs-app/shared/components/TextLink/TextLink.stories.tsx
@@ -16,6 +16,10 @@ const meta = {
   component: TextLink,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-text-link",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/ThemeProvider/ThemeProvider.stories.tsx
+++ b/nextjs-app/shared/components/ThemeProvider/ThemeProvider.stories.tsx
@@ -24,6 +24,10 @@ const meta = {
   component: ThemeProvider,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-theme-provider",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Title/Title.stories.tsx
+++ b/nextjs-app/shared/components/Title/Title.stories.tsx
@@ -93,6 +93,10 @@ export default {
   component: Title,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=370-12",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/Toast/Toast.stories.tsx
+++ b/nextjs-app/shared/components/Toast/Toast.stories.tsx
@@ -79,6 +79,10 @@ const meta: Meta<typeof Toast> = {
   component: Toast,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=393-35",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },

--- a/nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.stories.tsx
+++ b/nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.stories.tsx
@@ -8,6 +8,10 @@ const meta: Meta<typeof TransformingActionInput> = {
   title: "Molecules/TransformingActionInput",
   component: TransformingActionInput,
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-transforming-action-input",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "padded",

--- a/nextjs-app/shared/components/ValueCard/ValueCard.stories.tsx
+++ b/nextjs-app/shared/components/ValueCard/ValueCard.stories.tsx
@@ -17,6 +17,10 @@ const meta = {
   component: ValueCard,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-value-card",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/nextjs-app/shared/components/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -7,6 +7,10 @@ const meta = {
   component: VisuallyHidden,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=371-31",
+    },
     layout: "centered",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/WipBadge/WipBadge.stories.tsx
+++ b/nextjs-app/shared/components/WipBadge/WipBadge.stories.tsx
@@ -5,6 +5,10 @@ const meta: Meta<typeof WipBadge> = {
   title: "Atoms/WipBadge",
   component: WipBadge,
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-wip-badge",
+    },
     layout: "centered",
     docs: {
       description: {

--- a/nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.stories.tsx
+++ b/nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.stories.tsx
@@ -11,6 +11,10 @@ const meta = {
   component: AboutPageContent,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-about-page-content",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/patterns/CTASection/CTASection.stories.tsx
+++ b/nextjs-app/shared/patterns/CTASection/CTASection.stories.tsx
@@ -17,6 +17,10 @@ const meta = {
   component: CTASection,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=502-20",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/patterns/ContactHero/ContactHero.stories.tsx
+++ b/nextjs-app/shared/patterns/ContactHero/ContactHero.stories.tsx
@@ -14,6 +14,10 @@ const meta = {
   component: ContactHero,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-contact-hero",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.stories.tsx
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.stories.tsx
@@ -9,6 +9,10 @@ const meta = {
   component: ContactPageContentEditorial,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-contact-page-content-editorial",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.stories.tsx
+++ b/nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.stories.tsx
@@ -11,6 +11,10 @@ const meta = {
   component: DesignSprintsSection,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-design-sprints-section",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/patterns/Footer/Footer.stories.tsx
+++ b/nextjs-app/shared/patterns/Footer/Footer.stories.tsx
@@ -10,6 +10,10 @@ const meta: Meta<typeof Footer> = {
   component: Footer,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-footer",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "fullscreen", // Keep WIP badge until visual + a11y verified

--- a/nextjs-app/shared/patterns/GridBlock/GridBlock.stories.tsx
+++ b/nextjs-app/shared/patterns/GridBlock/GridBlock.stories.tsx
@@ -9,6 +9,10 @@ const meta: Meta<typeof GridBlock> = {
   component: GridBlock,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-grid-block",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "fullscreen",

--- a/nextjs-app/shared/patterns/Header/Header.stories.tsx
+++ b/nextjs-app/shared/patterns/Header/Header.stories.tsx
@@ -13,6 +13,10 @@ const meta: Meta<typeof Header> = {
   component: Header,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-header",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "fullscreen", // Keep WIP badge until visual + a11y verified

--- a/nextjs-app/shared/patterns/Header/MobileMenu.stories.tsx
+++ b/nextjs-app/shared/patterns/Header/MobileMenu.stories.tsx
@@ -8,6 +8,10 @@ const meta: Meta<typeof MobileMenu> = {
   component: MobileMenu,
   tags: ["autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-header",
+    },
     layout: "fullscreen",
     docs: {
       description: {

--- a/nextjs-app/shared/patterns/Hero/Hero.stories.tsx
+++ b/nextjs-app/shared/patterns/Hero/Hero.stories.tsx
@@ -10,6 +10,10 @@ const meta: Meta<typeof Hero> = {
   component: Hero,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-hero",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "fullscreen",

--- a/nextjs-app/shared/patterns/HeroSection/HeroSection.stories.tsx
+++ b/nextjs-app/shared/patterns/HeroSection/HeroSection.stories.tsx
@@ -27,6 +27,10 @@ const meta = {
   component: HeroSection,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-hero-section",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/patterns/HighlightSection/HighlightSection.stories.tsx
+++ b/nextjs-app/shared/patterns/HighlightSection/HighlightSection.stories.tsx
@@ -19,6 +19,10 @@ const meta = {
   component: HighlightSection,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-highlight-section",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/patterns/HomeHero/HomeHero.stories.tsx
+++ b/nextjs-app/shared/patterns/HomeHero/HomeHero.stories.tsx
@@ -12,6 +12,10 @@ const meta = {
   component: HomeHero,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-home-hero",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/patterns/PageLayout/PageLayout.stories.tsx
+++ b/nextjs-app/shared/patterns/PageLayout/PageLayout.stories.tsx
@@ -11,6 +11,10 @@ const meta: Meta<typeof PageLayout> = {
   component: PageLayout,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-page-layout",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "fullscreen",

--- a/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.stories.tsx
+++ b/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.stories.tsx
@@ -7,6 +7,10 @@ const meta: Meta<typeof ProcessBlock> = {
   component: ProcessBlock,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-process-block",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "fullscreen",

--- a/nextjs-app/shared/patterns/ProofBlock/ProofBlock.stories.tsx
+++ b/nextjs-app/shared/patterns/ProofBlock/ProofBlock.stories.tsx
@@ -9,6 +9,10 @@ const meta: Meta<typeof ProofBlock> = {
   component: ProofBlock,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-proof-block",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     wip: { disabled: false },

--- a/nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.stories.tsx
+++ b/nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.stories.tsx
@@ -31,6 +31,10 @@ const meta: Meta<typeof ServicesBlock> = {
   component: ServicesBlock,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-services-block",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "fullscreen",

--- a/nextjs-app/shared/patterns/ServicesSection/ServicesSection.stories.tsx
+++ b/nextjs-app/shared/patterns/ServicesSection/ServicesSection.stories.tsx
@@ -38,6 +38,10 @@ const meta = {
   component: ServicesSection,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-services-section",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/patterns/SiteFooter/SiteFooter.stories.tsx
+++ b/nextjs-app/shared/patterns/SiteFooter/SiteFooter.stories.tsx
@@ -7,6 +7,10 @@ const meta: Meta<typeof SiteFooter> = {
   component: SiteFooter,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=477-6",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/patterns/SiteHeader/SiteHeader.stories.tsx
+++ b/nextjs-app/shared/patterns/SiteHeader/SiteHeader.stories.tsx
@@ -7,6 +7,10 @@ const meta: Meta<typeof SiteHeader> = {
   component: SiteHeader,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=476-2",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/patterns/StoryBlock/StoryBlock.stories.tsx
+++ b/nextjs-app/shared/patterns/StoryBlock/StoryBlock.stories.tsx
@@ -9,6 +9,10 @@ const meta: Meta<typeof StoryBlock> = {
   component: StoryBlock,
   tags: ["!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-story-block",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "fullscreen",

--- a/nextjs-app/shared/patterns/TeamBlock/TeamBlock.stories.tsx
+++ b/nextjs-app/shared/patterns/TeamBlock/TeamBlock.stories.tsx
@@ -123,6 +123,10 @@ const meta: Meta<typeof TeamBlockForStorybook> = {
   // Exclude from Vitest tests
   tags: ["beta", "!autodocs", "!test"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-team-block",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "fullscreen",

--- a/nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.stories.tsx
+++ b/nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.stories.tsx
@@ -37,6 +37,10 @@ const meta = {
   component: WorkMagneticField,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-work-magnetic-field",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.stories.tsx
+++ b/nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.stories.tsx
@@ -31,6 +31,10 @@ const meta = {
   component: WorkPreviewSection,
   tags: ["beta", "!autodocs"],
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-work-preview-section",
+    },
     layout: "fullscreen",
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/templates/NextLayoutShell/NextLayoutShell.stories.tsx
+++ b/nextjs-app/shared/templates/NextLayoutShell/NextLayoutShell.stories.tsx
@@ -9,6 +9,10 @@ const meta: Meta = {
   tags: ["beta", "!autodocs"],
   title: "Templates/NextLayoutShell",
   parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-next-layout-shell",
+    },
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "fullscreen",

--- a/scripts/design-system/inject-story-design-urls.mjs
+++ b/scripts/design-system/inject-story-design-urls.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Inject the Storybook Design addon `design` parameter into each component's
+ * `.stories.tsx`, sourcing the Figma URL from the colocated `.contract.json`.
+ *
+ * Adds, as the first key of the meta `parameters` block:
+ *   design: { type: "figma", url: "<contract.figma>" },
+ *
+ * Handles both multiline and inline `parameters: { ... }` blocks by inserting
+ * directly after the opening brace; run Prettier afterwards to reflow.
+ * If no `parameters` block exists, one is created at the top of the meta.
+ *
+ * Idempotent: skips files that already declare a `type: "figma"` design param.
+ * (A `design` *prop* / argType — e.g. Badge — does NOT count.)
+ *
+ * Run: node scripts/design-system/inject-story-design-urls.mjs
+ */
+import { readFileSync, writeFileSync, readdirSync, existsSync } from "node:fs";
+import { join, resolve, dirname, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const roots = [
+  join(ROOT, "nextjs-app/shared/components"),
+  join(ROOT, "nextjs-app/shared/patterns"),
+  join(ROOT, "nextjs-app/shared/templates"),
+];
+
+function findContractFigma(dir) {
+  const files = readdirSync(dir).filter((f) => f.endsWith(".contract.json"));
+  for (const f of files) {
+    try {
+      const json = JSON.parse(readFileSync(join(dir, f), "utf8"));
+      if (typeof json.figma === "string" && json.figma.startsWith("http")) {
+        return json.figma;
+      }
+    } catch {
+      /* ignore unparseable */
+    }
+  }
+  return null;
+}
+
+let injected = 0;
+let skippedHas = 0;
+let skippedNoUrl = 0;
+const unhandled = [];
+
+for (const root of roots) {
+  if (!existsSync(root)) continue;
+  for (const dir of readdirSync(root)) {
+    const compDir = join(root, dir);
+    let storyFiles;
+    try {
+      storyFiles = readdirSync(compDir).filter((f) =>
+        f.endsWith(".stories.tsx"),
+      );
+    } catch {
+      continue;
+    }
+    if (storyFiles.length === 0) continue;
+
+    const figma = findContractFigma(compDir);
+    if (!figma) {
+      skippedNoUrl += storyFiles.length;
+      continue;
+    }
+
+    const designProp = `design: { type: "figma", url: "${figma}" },`;
+
+    for (const storyFile of storyFiles) {
+      const path = join(compDir, storyFile);
+      let src = readFileSync(path, "utf8");
+
+      // Already has a Figma design param — leave it alone.
+      if (/design:\s*\{\s*type:\s*["']figma["']/.test(src)) {
+        skippedHas += 1;
+        continue;
+      }
+
+      // Insert right after the first `parameters: {` brace (meta block — it
+      // precedes any story). Works for both inline and multiline blocks.
+      const params = src.match(/(^[ \t]*)parameters:\s*\{/m);
+      if (params) {
+        const childIndent = `${params[1]}  `;
+        src = src.replace(
+          params[0],
+          `${params[0]}\n${childIndent}${designProp}`,
+        );
+        writeFileSync(path, src);
+        injected += 1;
+        continue;
+      }
+
+      // No parameters block: create one at the top of the meta object.
+      const metaOpen = src.match(
+        /^([ \t]*)(?:const meta[^=]*=\s*\{|export default \{)[ \t]*\r?\n/m,
+      );
+      if (!metaOpen) {
+        unhandled.push(basename(path));
+        continue;
+      }
+      const childIndent = `${metaOpen[1]}  `;
+      const block = `${childIndent}parameters: { ${designProp} },\n`;
+      src = src.replace(metaOpen[0], `${metaOpen[0]}${block}`);
+      writeFileSync(path, src);
+      injected += 1;
+    }
+  }
+}
+
+console.log(
+  `✓ inject-story-design-urls: injected ${injected}, already-had ${skippedHas}, no-figma-url ${skippedNoUrl}, unhandled ${unhandled.length}`,
+);
+if (unhandled.length) {
+  console.log(`  unhandled (edit manually): ${unhandled.join(", ")}`);
+}


### PR DESCRIPTION
## Summary
- Inject the addon-designs `parameters.design` (`type: "figma"`) into every beta/stable story meta, sourced from each component's contract `figma` URL — 137 stories now deep-link to **DT-Site-stuff** (44 real node-ids, 93 honest `dt-*` placeholders for unbuilt frames). Adds idempotent `scripts/design-system/inject-story-design-urls.mjs`.
- Fix SkipLink rendering dark-on-dark: replaced the fragile Tailwind `bg-foreground`/`text-background` inversion with a CSS Module using theme-aware `--color-primary` / `--color-white` (the contrast-paired tokens proven in Layout), readable across all four themes.

## Verification
- `npm run check:storybook-figma` — 128 contracts valid
- ESLint on all story files — 0 errors
- `npm run typecheck` — pass
- stylelint `SkipLink.module.css` — pass
- SkipLink confirmed rendering with contrast in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Chores**
  * Integrated Figma design links throughout Storybook documentation for improved designer-developer collaboration and reference.
  * Added automation script to streamline design URL integration into component stories.

* **Style**
  * Refined SkipLink component styling for improved accessibility and focus behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->