### PR TITLE
fix(ci): clear stylelint errors blocking validate (unblocks dependabot PRs)

### DIFF
--- a/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css
+++ b/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css
@@ -9,12 +9,13 @@
   --bulletin-card-min-height: 5rem;
   --bulletin-nav-size: 2.75rem;
 
+  margin-inline: calc(50% - 50vw);
   box-sizing: border-box;
   width: 100vw;
   max-width: 100vw;
-  margin-inline: calc(50% - 50vw);
   background-color: var(--bulletin-card-bg);
   color: var(--bulletin-copy);
+
   --bulletin-mark-color: var(--color-white);
 }
 
@@ -24,11 +25,11 @@
 
 .viewport {
   display: grid;
-  align-items: center;
   box-sizing: border-box;
   grid-template-columns: var(--bulletin-nav-size) minmax(0, 1fr) var(
       --bulletin-nav-size
     );
+  align-items: center;
 }
 
 .viewportCentered {
@@ -38,18 +39,18 @@
 
 .navSpacer {
   display: block;
-  inline-size: var(--bulletin-nav-size);
   block-size: var(--bulletin-nav-size);
+  inline-size: var(--bulletin-nav-size);
   flex-shrink: 0;
 }
 
 .navButton {
   display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  inline-size: var(--bulletin-nav-size);
-  block-size: var(--bulletin-nav-size);
   padding: 0;
+  block-size: var(--bulletin-nav-size);
+  inline-size: var(--bulletin-nav-size);
+  justify-content: center;
+  align-items: center;
   border: 0;
   border-radius: 0;
   background-color: color-mix(in srgb, var(--bulletin-card-bg) 72%, white);
@@ -69,18 +70,19 @@
 
 .track {
   display: flex;
-  align-items: stretch;
-  gap: var(--bulletin-card-gap);
-  box-sizing: border-box;
-  inline-size: 100%;
+
   /* Room for descenders — overflow-x:auto otherwise clips overflow-y */
   padding-block: 0.125rem;
+  box-sizing: border-box;
+  inline-size: 100%;
+  align-items: stretch;
+  gap: var(--bulletin-card-gap);
+  -ms-overflow-style: none;
   overflow-x: auto;
   overscroll-behavior-x: contain;
   scroll-behavior: smooth;
   scroll-snap-type: x proximity;
   scrollbar-width: none;
-  -ms-overflow-style: none;
 }
 
 .trackCentered {
@@ -102,24 +104,24 @@
 
 .card {
   display: flex;
-  flex: 0 0 auto;
-  align-items: center;
-  box-sizing: border-box;
-  inline-size: max-content;
-  max-inline-size: 100%;
-  min-block-size: var(--bulletin-card-min-height);
   padding-block: 1rem; /* Figma vertical inset (16px) */
   padding-inline: var(--bulletin-card-padding-inline);
+  box-sizing: border-box;
+  inline-size: max-content;
+  min-block-size: var(--bulletin-card-min-height);
+  max-inline-size: 100%;
+  flex: 0 0 auto;
+  align-items: center;
   background-color: var(--bulletin-card-bg);
-  scroll-snap-align: start;
   transition: background-color 0.2s ease;
+  scroll-snap-align: start;
 }
 
 .cardContent {
   display: flex;
+  min-block-size: 3rem;
   align-items: center;
   gap: var(--bulletin-content-gap);
-  min-block-size: 3rem;
 }
 
 .cardInteractive {
@@ -139,15 +141,15 @@
 .badge {
   display: flex;
   flex-shrink: 0;
-  align-items: center;
   justify-content: center;
+  align-items: center;
 }
 
 .badgeImage {
-  inline-size: auto;
   block-size: auto;
-  max-inline-size: 100%;
+  inline-size: auto;
   max-block-size: 3rem;
+  max-inline-size: 100%;
   object-fit: contain;
 }
 
@@ -158,82 +160,78 @@
   mask-repeat: no-repeat;
   mask-position: center;
   mask-size: contain;
-  -webkit-mask-repeat: no-repeat;
-  -webkit-mask-position: center;
-  -webkit-mask-size: contain;
 }
 
 .percentBadge {
   display: inline-flex;
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: center;
-  inline-size: 3rem;
   block-size: 3rem;
+  inline-size: 3rem;
+  flex-shrink: 0;
+  justify-content: center;
+  align-items: center;
   border-radius: 999px;
   background-color: var(--logo-background, #dfff00);
-  color: var(--color-primary, #041b23);
   font-family: var(--font-heading);
   font-size: 1rem;
   font-weight: 700;
-  letter-spacing: -0.05em;
   line-height: 1;
+  letter-spacing: -0.05em;
+  color: var(--color-primary, #041b23);
 }
 
 .npmBadge {
   display: inline-flex;
   flex-shrink: 0;
-  overflow: hidden;
   border-radius: 0.2rem;
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: 0.803rem;
   font-weight: 500;
   line-height: 1;
-  text-shadow: 0 0.05rem 0 rgb(0 0 0 / 0.55);
+  overflow: hidden;
+  text-shadow: 0 0.05rem 0 rgb(0 0 0 / 55%);
 }
 
 .npmBadgeLabel {
   display: inline-flex;
-  align-items: center;
-  justify-content: center;
   padding-inline: 0.45rem;
   min-block-size: 1.506rem;
+  justify-content: center;
+  align-items: center;
   background-color: #5c5c5c;
   color: #fff;
 }
 
 .npmBadgeVersion {
   display: inline-flex;
-  align-items: center;
-  justify-content: center;
   padding-inline: 0.45rem;
   min-block-size: 1.506rem;
+  justify-content: center;
+  align-items: center;
   background-color: #0085ca;
-  color: #fff;
   letter-spacing: -0.06em;
+  color: #fff;
 }
 
 .placeholderBadge {
   display: block;
-  flex-shrink: 0;
-  inline-size: 3rem;
   block-size: 3rem;
+  inline-size: 3rem;
+  flex-shrink: 0;
   background-color: #d9d9d9;
 }
 
 .body {
   margin: 0;
+  max-inline-size: 100%;
   flex-shrink: 0;
   font-family: var(--font-sans, var(--primary-body-font));
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.375; /* Figma 16px / 22px — avoids clipping g, p, y */
-  color: var(--bulletin-copy);
-  white-space: nowrap;
-  overflow-x: hidden;
-  overflow-y: visible;
   text-overflow: ellipsis;
-  max-inline-size: 100%;
+  white-space: nowrap;
+  color: var(--bulletin-copy);
+  overflow: hidden visible;
 }
 
 @media (forced-colors: active) {


### PR DESCRIPTION
Fixes the 7 stylelint errors in `NewsBulletin.module.css` that fail the `validate` job on main and block all 14 open dependabot PRs (#648–#661). Repo CSS now lints with 0 errors (warnings unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)