### PR TITLE
test(design-system): close review follow-ups #4/#5 (CodeBlockWindow dark, MultiCombobox play)

### DIFF
--- a/nextjs-app/shared/components/MultiCombobox/MultiCombobox.mdx
+++ b/nextjs-app/shared/components/MultiCombobox/MultiCombobox.mdx
@@ -75,7 +75,7 @@ Controlled with a `string[]`; selections render as removable chips.
 ## Promotion notes
 
 Promoted to **beta** with documented argTypes, Example/ForcedColors stories, a
-`KeyboardMultiSelect` play function (open, arrow-navigate, toggle by keyboard;
+`KeyboardMultiSelect` play function (type-to-filter then select by keyboard;
 portaled listbox queried via `screen`), and Carbon MDX. Shares `Combobox`'s
 field CSS, inheriting the placeholder contrast fix. Default/Playground/Example
 pass axe with `test: "error"`; light + dark verified in Storybook. In production

--- a/nextjs-app/shared/components/MultiCombobox/MultiCombobox.stories.tsx
+++ b/nextjs-app/shared/components/MultiCombobox/MultiCombobox.stories.tsx
@@ -123,22 +123,28 @@ export const Example: Story = {
   ),
 };
 
-/** Opens with ArrowDown, toggles an option with Enter — keyboard-only. */
+/** Type-to-filter to a single match, then select it with Enter — keyboard-only. */
 export const KeyboardMultiSelect: Story = {
   tags: ["beta-matrix"],
   render: () => <MultiComboboxDemo />,
   play: async ({ canvasElement }) => {
     const input = within(canvasElement).getByRole("combobox");
-    input.focus(); // onFocus opens the list (highlight starts at index 0)
-    await waitFor(() => expect(screen.getByRole("listbox")).toBeVisible());
-    await userEvent.keyboard("{ArrowDown}{Enter}"); // move to 2nd option, toggle
-    // Multi-select keeps the list open; the moved-to option is now aria-selected
-    // and a chip is added to the field.
+    // Type-to-filter narrows to a single option and resets the highlight to it,
+    // so Enter selects it deterministically — no dependence on auto-open
+    // behavior or arrow-key index math.
+    await userEvent.type(input, "acc");
     await waitFor(() =>
-      expect(screen.getByRole("option", { name: /design/i })).toHaveAttribute(
-        "aria-selected",
-        "true",
-      ),
+      expect(
+        screen.getByRole("option", { name: /accessibility/i }),
+      ).toBeVisible(),
+    );
+    await userEvent.keyboard("{Enter}");
+    // Multi-select keeps the list open; the option is now aria-selected and a
+    // chip is added to the field.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("option", { name: /accessibility/i }),
+      ).toHaveAttribute("aria-selected", "true"),
     );
   },
 };


### PR DESCRIPTION
Closes the two low-severity review notes from PR #667.

- **#4 CodeBlockWindow dark theme** — no code change needed. Verified the `github-dark` syntax palette renders with strong contrast on the dark code surface, and confirmed the `DarkPreview` story already renders in `.themeDark` and runs axe with `test: "error"` (so it is durably gated, not a one-off check).
- **#5 MultiCombobox play coupling** — replaced the `onFocus`-auto-open + arrow-index-math play with a deterministic type-to-filter flow (type narrows to one option and resets the highlight; Enter selects it). No coupling to incidental open/index behavior.

Test/doc-only; no production code change. typecheck + validate:components green; MultiCombobox 5/5 with axe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)