### PR TITLE
fix(mobile): news bulletin arrow scrolls on first click + ProcessBlock a11y test

### DIFF
--- a/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.tsx
+++ b/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.tsx
@@ -128,25 +128,36 @@ export function NewsBulletin({
       "(prefers-reduced-motion: reduce)",
     ).matches;
     const behavior: ScrollBehavior = prefersReducedMotion ? "auto" : "smooth";
-    const trackLeft = track.scrollLeft;
-    const trackRight = trackLeft + track.clientWidth;
+
+    // Measure card vs track in the same (viewport) coordinate space via
+    // getBoundingClientRect, then scroll by the delta. offsetLeft is relative
+    // to the offset parent (here <body>, since no ancestor is positioned), so
+    // it was inflated by the track's left gutter — comparing it against
+    // scroll-space trackRight made the first "next" click pick the already-
+    // visible first card and nudge only ~the gutter width (looked like nothing).
+    const trackRect = track.getBoundingClientRect();
+    const epsilon = 1;
+    const scrollToCard = (card: HTMLElement) => {
+      const delta = card.getBoundingClientRect().left - trackRect.left;
+      track.scrollTo({ left: track.scrollLeft + delta, behavior });
+    };
 
     if (direction === 1) {
       for (const card of cards) {
-        const cardRight = card.offsetLeft + card.offsetWidth;
-        if (cardRight > trackRight + 1) {
-          track.scrollTo({ left: card.offsetLeft, behavior });
+        if (card.getBoundingClientRect().right > trackRect.right + epsilon) {
+          scrollToCard(card);
           return;
         }
       }
+      track.scrollTo({ left: track.scrollWidth, behavior });
       return;
     }
 
     for (let index = cards.length - 1; index >= 0; index -= 1) {
       const card = cards[index];
       if (!card) continue;
-      if (card.offsetLeft < trackLeft - 1) {
-        track.scrollTo({ left: card.offsetLeft, behavior });
+      if (card.getBoundingClientRect().left < trackRect.left - epsilon) {
+        scrollToCard(card);
         return;
       }
     }

--- a/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.test.tsx
+++ b/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.test.tsx
@@ -214,8 +214,11 @@ describe("ProcessBlock", () => {
       const mainHeading = screen.getByText("Process");
       expect(mainHeading.tagName).toBe("H2");
 
+      // Phase titles sit directly under the section title (H2), so they are
+      // H3 — sequential, no skipped level. Asserting H4 here would itself be a
+      // heading-hierarchy violation (H2 → H4).
       const phaseHeading = screen.getByText("Discover");
-      expect(phaseHeading.tagName).toBe("H4");
+      expect(phaseHeading.tagName).toBe("H3");
     });
 
     it("has data attribute for title", () => {


### PR DESCRIPTION
## NewsBulletin: right arrow does nothing on first click (mobile)
**Symptom:** on mobile the right arrow did nothing when clicked; only after the user had already scrolled horizontally past a point did it start working. Reproduced on production (iPhone) and local dev at mobile width.

**Root cause:** the arrow handler used `card.offsetLeft` as the `scrollTo` target. `offsetLeft` is relative to the nearest *positioned* ancestor — and none of `.section`/`.viewport`/`.track`/`.card` are positioned, so it resolves to `<body>`. That inflated every card position by the track's left gutter (left nav button + page margin ≈ 50px), and it was compared against scroll-space coordinates. Confirmed live: at `scrollLeft: 0`, `card0.offsetLeft(50) + width(401) = 451 > trackRight(401)`, so the loop picked the already-visible first card and scrolled to `offsetLeft = 50` — a 50px nudge that looks like nothing. Only after a manual scroll did the geometry line up enough to advance.

**Fix:** measure card vs track with `getBoundingClientRect()` (same viewport coordinate space) and scroll by the delta (`scrollLeft + (cardRect.left - trackRect.left)`) — correct at any scroll position and independent of the offset parent. Verified: next `0 → 428 → 856`, prev `856 → 428 → 0` (one card per click).

## ProcessBlock: fix pre-existing failing a11y test
`ProcessBlock` renders the section title as **H2** and phase titles as **H3** — proper sequential heading hierarchy, no skipped level. The test asserted the phase was **H4** (which would be an H2 → H4 skip, the very thing "uses proper heading hierarchy" forbids), so it failed on `main`. Corrected the assertion to H3; no component change needed.

## Verification
- `typecheck` PASS, `lint` PASS (0 errors)
- `test:ci`: **1774/1774 pass** (previously 1773/1774 — this PR makes the suite fully green)
- NewsBulletin arrow behavior verified live at mobile width (both directions cycle one card per click)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
