### PR TITLE
fix(dev): allowlist LAN device origins for next dev asset pipeline

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -150,6 +150,14 @@ const nextConfig: NextConfig = {
       "lenis",
     ],
   },
+  // Allow physical devices on the LAN (e.g. a phone reaching `next dev` via the
+  // Mac's LAN IP) to load /_next/* dev resources. Next 16 blocks cross-origin
+  // dev-asset requests by default, which strips CSS, client JS, and optimized
+  // images on any non-localhost origin — the device renders an unstyled,
+  // non-interactive page (dead hamburger, no nav background, broken images)
+  // while desktop localhost looks fine. Production is unaffected: this gate is
+  // dev-server-only. The subnet wildcard tolerates DHCP reassigning the IP.
+  allowedDevOrigins: ["192.168.1.119", "192.168.1.*"],
   outputFileTracingRoot: __dirname,
   pageExtensions: ["ts", "tsx", "md", "mdx"],
   transpilePackages: ["react-phone-number-input", "libphonenumber-js"],


### PR DESCRIPTION
## What
Add `allowedDevOrigins` to `next.config.ts` so physical devices on the LAN (e.g. a phone reaching `next dev` via the Mac's LAN IP) can load `/_next/*` dev resources.

## Why
Next.js 16 blocks cross-origin requests to its dev-asset pipeline by default. A phone hitting the dev server over the LAN was an un-allowlisted origin, so its requests for CSS, client JS, and optimized images were all blocked — presenting on-device as no nav background, a dead hamburger menu, and missing images, while desktop `localhost` (same-origin) looked fine.

## Scope
Dev-server-only. Production builds don't use this gate and are unaffected.

## Verification
Confirmed on-device: after the change, reloading the dev server via the LAN IP on a phone renders the nav background, hamburger, and images correctly, and the `Blocked cross-origin request to Next.js dev resource` warning is gone from the terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development server configuration to enable testing on devices within the local network during development.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PetriLahdelma/digitaltableteur/pull/671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->