### PR TITLE
fix(dev): clear Button deprecation and image warnings in dev

### DIFF
--- a/app/blog/NextBlogNav.tsx
+++ b/app/blog/NextBlogNav.tsx
@@ -45,7 +45,7 @@ export function NextBlogNav() {
             variant="tertiary"
             size="m"
             icon={<Icon name="arrow-left" ariaLabel="Previous article" />}
-            disabled={!isArticleRoute || currentIndex <= 0}
+            isDisabled={!isArticleRoute || currentIndex <= 0}
             onClick={() => {
               if (!isArticleRoute) return;
               if (currentIndex > 0)
@@ -58,7 +58,9 @@ export function NextBlogNav() {
             variant="tertiary"
             size="m"
             endIcon={<Icon name="arrow-right" ariaLabel="Next article" />}
-            disabled={!isArticleRoute || currentIndex === blogPages.length - 1}
+            isDisabled={
+              !isArticleRoute || currentIndex === blogPages.length - 1
+            }
             onClick={() => {
               if (!isArticleRoute) return;
               if (currentIndex < blogPages.length - 1)

--- a/app/blog/[slug]/ServerArticleMain.tsx
+++ b/app/blog/[slug]/ServerArticleMain.tsx
@@ -29,13 +29,15 @@ export function ServerArticleMain({
         <aside className="not-prose mt-12 rounded-lg border border-border bg-muted/30 p-6">
           <div className="flex items-start gap-4">
             {author.imageUrl ? (
-              <Image
-                src={author.imageUrl}
-                alt=""
-                width={64}
-                height={64}
-                className="size-16 rounded-full object-cover"
-              />
+              <div className="relative size-16 shrink-0 overflow-hidden rounded-full bg-muted">
+                <Image
+                  src={author.imageUrl}
+                  alt=""
+                  fill
+                  className="object-cover"
+                  sizes="64px"
+                />
+              </div>
             ) : null}
             <div>
               <p className="font-display text-lg font-semibold text-foreground">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -129,11 +129,13 @@ export default function RootLayout({
             })(window,document,'script','dataLayer','GTM-NJ654G92');
           `}
         </Script>
-        <Script
-          src="https://analytics.ahrefs.com/analytics.js"
-          data-key="iO1vJe+oY/MXihktNC/upw"
-          strategy="afterInteractive"
-        />
+        {process.env.NODE_ENV === "production" ? (
+          <Script
+            src="https://analytics.ahrefs.com/analytics.js"
+            data-key="iO1vJe+oY/MXihktNC/upw"
+            strategy="afterInteractive"
+          />
+        ) : null}
         <Script
           src={`https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`}
           strategy="afterInteractive"

--- a/nextjs-app/app/blog/NextBlogNav.tsx
+++ b/nextjs-app/app/blog/NextBlogNav.tsx
@@ -58,7 +58,7 @@ export function NextBlogNav() {
             variant="tertiary"
             size="m"
             icon={<Icon name="arrow-left" ariaLabel="Previous" />}
-            disabled={!isArticleRoute || currentIndex <= 0}
+            isDisabled={!isArticleRoute || currentIndex <= 0}
             onClick={() => {
               if (!isArticleRoute) return;
               if (currentIndex > 0)
@@ -71,7 +71,9 @@ export function NextBlogNav() {
             variant="tertiary"
             size="m"
             endIcon={<Icon name="arrow-right" ariaLabel="Next" />}
-            disabled={!isArticleRoute || currentIndex === blogPages.length - 1}
+            isDisabled={
+              !isArticleRoute || currentIndex === blogPages.length - 1
+            }
             onClick={() => {
               if (!isArticleRoute) return;
               if (currentIndex < blogPages.length - 1)

--- a/nextjs-app/shared/components/BlogNav/BlogNav.tsx
+++ b/nextjs-app/shared/components/BlogNav/BlogNav.tsx
@@ -65,7 +65,7 @@ const BlogNav: React.FC = () => {
             variant="tertiary"
             size="m"
             icon={<Icon name="arrow-left" ariaLabel={t("blogNavPrev")} />}
-            disabled={!isArticleRoute || currentIndex <= 0}
+            isDisabled={!isArticleRoute || currentIndex <= 0}
             onClick={() => {
               if (!isArticleRoute) return;
               if (currentIndex > 0) navigate(blogPages[currentIndex - 1].path);
@@ -77,7 +77,9 @@ const BlogNav: React.FC = () => {
             variant="tertiary"
             size="m"
             endIcon={<Icon name="arrow-right" ariaLabel={t("blogNavNext")} />}
-            disabled={!isArticleRoute || currentIndex === blogPages.length - 1}
+            isDisabled={
+              !isArticleRoute || currentIndex === blogPages.length - 1
+            }
             onClick={() => {
               if (!isArticleRoute) return;
               if (currentIndex < blogPages.length - 1)

--- a/nextjs-app/shared/components/ContactForm/ContactForm.tsx
+++ b/nextjs-app/shared/components/ContactForm/ContactForm.tsx
@@ -429,7 +429,7 @@ const ContactForm: React.FC<ContactFormProps> = () => {
               type="button"
               variant="tertiary"
               onClick={handleClearForm}
-              disabled={isSubmitting}
+              isDisabled={isSubmitting}
             >
               {t("contactClear")}
             </Button>
@@ -439,7 +439,7 @@ const ContactForm: React.FC<ContactFormProps> = () => {
               variant="primary"
               loading={isSubmitting}
               loadingLabelKey="busyIndicator.loading"
-              disabled={isSubmitting || !isFormValid}
+              isDisabled={isSubmitting || !isFormValid}
             >
               {t("contactSubmit")}
             </AdaptiveLoadingButton>

--- a/nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.tsx
+++ b/nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.tsx
@@ -144,14 +144,14 @@ const NewsletterWaitlist: React.FC<NewsletterWaitlistProps> = ({
             <Button
               type="button"
               onClick={handleCancel}
-              disabled={disabled || isSubmitting}
+              isDisabled={disabled || isSubmitting}
               variant="secondary"
             >
               {t("newsletterWaitlist.cancel")}
             </Button>
             <AdaptiveLoadingButton
               type="submit"
-              disabled={disabled || isSubmitting || !email.trim()}
+              isDisabled={disabled || isSubmitting || !email.trim()}
               variant="primary"
               loading={isSubmitting}
               loadingLabelKey="newsletterWaitlist.submitting"


### PR DESCRIPTION
## Summary

- Migrate `@dt/Button` / `AdaptiveLoadingButton` from deprecated `disabled` to `isDisabled` on blog nav, contact form, and newsletter waitlist (pricing).
- Fix blog article author avatar Next.js `Image` warning by using a sized wrapper with `fill` instead of conflicting `width`/`height` + Tailwind `size-16`.
- Load Ahrefs analytics script only in production so localhost dev no longer logs `Ignoring Event: localhost`.

## Test plan

- [ ] Run `npm run dev`, visit `/contact`, `/blog`, a blog post, and `/pricing` — no Button deprecation warnings in terminal.
- [ ] On a blog post with author aside, confirm avatar renders correctly and no Next.js image aspect-ratio warning.
- [ ] Confirm Ahrefs script absent in dev page source; production deploy still includes analytics (if verified on preview/prod).


Made with [Cursor](https://cursor.com)