### PR TITLE
fix(ds): finish Button isDisabled migration

### DIFF
--- a/app/work/NextWorkNav.tsx
+++ b/app/work/NextWorkNav.tsx
@@ -57,7 +57,7 @@ export function NextWorkNav() {
           variant="tertiary"
           size="m"
           icon={<Icon name="briefcase" ariaLabel="Back to work" />}
-          disabled={isPending}
+          isDisabled={isPending}
           onClick={() => navigate("/work")}
         >
           <span className={styles.buttonLabel}>Back to work</span>
@@ -67,7 +67,7 @@ export function NextWorkNav() {
             variant="tertiary"
             size="m"
             icon={<Icon name="arrow-left" ariaLabel="Previous" />}
-            disabled={navDisabled || currentIndex <= 0}
+            isDisabled={navDisabled || currentIndex <= 0}
             onClick={() => {
               if (prevPath) navigate(prevPath);
             }}
@@ -78,7 +78,7 @@ export function NextWorkNav() {
             variant="tertiary"
             size="m"
             endIcon={<Icon name="arrow-right" ariaLabel="Next" />}
-            disabled={navDisabled || currentIndex === workPages.length - 1}
+            isDisabled={navDisabled || currentIndex === workPages.length - 1}
             onClick={() => {
               if (nextPath) navigate(nextPath);
             }}

--- a/nextjs-app/shared/components/AdaptiveLoadingButton/AdaptiveLoadingButton.tsx
+++ b/nextjs-app/shared/components/AdaptiveLoadingButton/AdaptiveLoadingButton.tsx
@@ -71,8 +71,10 @@ export const AdaptiveLoadingButton = React.forwardRef<
       idleLabelKey = "adaptiveLoadingButton.idle",
       children,
       disabled,
+      isDisabled,
       className = "",
     } = props;
+    const effectiveDisabled = isDisabled ?? disabled;
     const derivedLabel = children ?? t(idleLabelKey);
     const content = loading ? (
       <span className={styles.loadingContent}>
@@ -94,7 +96,7 @@ export const AdaptiveLoadingButton = React.forwardRef<
 
     const commonProps = {
       ref,
-      disabled: disabled || loading,
+      isDisabled: effectiveDisabled || loading,
       "aria-busy": loading,
       accessibleDescription,
       className: `${styles.button} ${className}`.trim(),
@@ -110,6 +112,7 @@ export const AdaptiveLoadingButton = React.forwardRef<
         idleLabelKey: _idleLabelKey,
         children: _children,
         disabled: _disabled,
+        isDisabled: _isDisabled,
         className: _className,
         ...rest
       } = props;
@@ -128,6 +131,7 @@ export const AdaptiveLoadingButton = React.forwardRef<
       idleLabelKey: _idleLabelKey,
       children: _children,
       disabled: _disabled,
+      isDisabled: _isDisabled,
       className: _className,
       ...rest
     } = props;

--- a/nextjs-app/shared/components/Button/SplitButton.tsx
+++ b/nextjs-app/shared/components/Button/SplitButton.tsx
@@ -448,7 +448,7 @@ const SplitButton = React.forwardRef<HTMLDivElement, SplitButtonProps>(
           tooltip={tooltip}
           accessibleName={accessibleName}
           onClick={onPrimaryClick}
-          disabled={disabled}
+          isDisabled={disabled}
           className={[
             buttonStyles.splitMain,
             isTertiary ? buttonStyles.splitTertiaryMain : "",
@@ -494,7 +494,7 @@ const SplitButton = React.forwardRef<HTMLDivElement, SplitButtonProps>(
               });
             }
           }}
-          disabled={disabled || !hasOptions}
+          isDisabled={disabled || !hasOptions}
           className={[
             buttonStyles.splitToggle,
             isTertiary ? buttonStyles.splitTertiaryToggle : "",

--- a/nextjs-app/shared/components/Card/Card.tsx
+++ b/nextjs-app/shared/components/Card/Card.tsx
@@ -202,7 +202,7 @@ const Card: React.FC<CardProps> = ({
         <Button
           key={action.key}
           variant={action.variant || "secondary"}
-          disabled={action.disabled}
+          isDisabled={action.disabled}
           onClick={() => action.onClick?.(action.key)}
           size={size === "L" ? "l" : size === "S" ? "s" : "m"}
         >

--- a/nextjs-app/shared/components/ChatWidget/ChatComposer.tsx
+++ b/nextjs-app/shared/components/ChatWidget/ChatComposer.tsx
@@ -124,7 +124,7 @@ const ChatComposer = React.forwardRef<ChatComposerHandle, ChatComposerProps>(
             type="submit"
             className={styles.sendButton}
             aria-label={resolvedSendLabel}
-            disabled={isSending || !(value ?? "").trim()}
+            isDisabled={isSending || !(value ?? "").trim()}
             icon={<Icon name="paper-plane-tilt" />}
             variant="primary"
             size="m"

--- a/nextjs-app/shared/components/ChatWidget/ChatHeader.tsx
+++ b/nextjs-app/shared/components/ChatWidget/ChatHeader.tsx
@@ -158,7 +158,7 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({
         <Button
           type="button"
           onClick={onReset}
-          disabled={isSending}
+          isDisabled={isSending}
           aria-label={resetAriaLabel}
           variant="tertiary"
           size="m"

--- a/nextjs-app/shared/components/FileUpload/FileUpload.tsx
+++ b/nextjs-app/shared/components/FileUpload/FileUpload.tsx
@@ -225,7 +225,7 @@ const FileUpload: React.FC<FileUploadProps> = ({
           variant="secondary"
           size="m"
           onClick={handleBrowseClick}
-          disabled={disabled}
+          isDisabled={disabled}
         >
           {uploadButtonLabel}
         </Button>
@@ -235,7 +235,7 @@ const FileUpload: React.FC<FileUploadProps> = ({
             variant="tertiary"
             size="s"
             onClick={handleClear}
-            disabled={disabled}
+            isDisabled={disabled}
           >
             {clearButtonLabel}
           </Button>

--- a/nextjs-app/shared/components/MCPActionButton/MCPActionButton.tsx
+++ b/nextjs-app/shared/components/MCPActionButton/MCPActionButton.tsx
@@ -82,10 +82,12 @@ export const MCPActionButton: React.FC<MCPActionButtonProps> = (props) => {
     onError,
     children,
     disabled,
+    isDisabled,
     className = "",
   } = props;
+  const effectiveDisabled = isDisabled ?? disabled;
 
-  const statusKey = disabled
+  const statusKey = effectiveDisabled
     ? "mcpActionButton.status.notReady"
     : STATUS_TO_KEY[status];
   const mergedClassName = useMemo(
@@ -94,7 +96,7 @@ export const MCPActionButton: React.FC<MCPActionButtonProps> = (props) => {
   );
 
   const handleClick = async () => {
-    if (!onExecute || disabled) return;
+    if (!onExecute || effectiveDisabled) return;
     setStatus("loading");
     try {
       const result = await onExecute({ toolId, payload });
@@ -108,7 +110,7 @@ export const MCPActionButton: React.FC<MCPActionButtonProps> = (props) => {
 
   const commonProps = {
     className: mergedClassName,
-    disabled: disabled || status === "loading",
+    isDisabled: effectiveDisabled || status === "loading",
     onClick: handleClick,
     accessibleDescription: t("mcpActionButton.actionDescription"),
   };
@@ -125,6 +127,7 @@ export const MCPActionButton: React.FC<MCPActionButtonProps> = (props) => {
         onError: _onError,
         children: _children,
         disabled: _disabled,
+        isDisabled: _isDisabled,
         className: _className,
         ...rest
       } = props;
@@ -145,6 +148,7 @@ export const MCPActionButton: React.FC<MCPActionButtonProps> = (props) => {
       onError: _onError,
       children: _children,
       disabled: _disabled,
+      isDisabled: _isDisabled,
       className: _className,
       ...rest
     } = props;
@@ -168,7 +172,7 @@ export const MCPActionButton: React.FC<MCPActionButtonProps> = (props) => {
         size="S"
         role="status"
         aria-live="polite"
-        className={`${styles.status} ${disabled ? styles.disabled : ""}`}
+        className={`${styles.status} ${effectiveDisabled ? styles.disabled : ""}`}
       >
         {t(statusKey)}
       </Text>

--- a/nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.tsx
+++ b/nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.tsx
@@ -103,7 +103,7 @@ const NewsletterWaitlist: React.FC<NewsletterWaitlistProps> = ({
       <div className={`${styles.container} ${className || ""}`}>
         <Button
           onClick={handleTransform}
-          disabled={disabled}
+          isDisabled={disabled}
           variant="primary"
           size="l"
           className={styles.triggerButton}

--- a/nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.tsx
+++ b/nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.tsx
@@ -181,14 +181,14 @@ export const SecureCVDownload: React.FC<SecureCVDownloadProps> = ({
             <Button
               variant="secondary"
               onClick={handleClose}
-              disabled={loading}
+              isDisabled={loading}
             >
               {t("downloadResumeCancel")}
             </Button>
             <Button
               variant="primary"
               onClick={handleDownload}
-              disabled={loading || !isValidPassword}
+              isDisabled={loading || !isValidPassword}
             >
               {loading
                 ? t("downloadResumeDownloading")

--- a/nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.tsx
+++ b/nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.tsx
@@ -133,7 +133,7 @@ export const TransformingActionInput: React.FC<TransformingActionInputProps> = (
         <Button
           variant="primary"
           onClick={handleTransform}
-          disabled={disabled}
+          isDisabled={disabled}
           accessibleName={t(actionLabelKey)}
           className={styles.trigger}
         >
@@ -167,14 +167,14 @@ export const TransformingActionInput: React.FC<TransformingActionInputProps> = (
               variant="secondary"
               type="button"
               onClick={() => setMode("button")}
-              disabled={disabled}
+              isDisabled={disabled}
             >
               {t("transformingActionInput.cancel")}
             </Button>
             <Button
               variant="primary"
               type="submit"
-              disabled={disabled}
+              isDisabled={disabled}
               accessibleDescription={t(
                 "transformingActionInput.submitDescription",
               )}

--- a/nextjs-app/shared/components/WorkNav/WorkNav.tsx
+++ b/nextjs-app/shared/components/WorkNav/WorkNav.tsx
@@ -36,7 +36,7 @@ const WorkNav: React.FC = () => {
             variant="tertiary"
             size="m"
             icon={<Icon name="arrow-left" ariaLabel={t("workNavPrev")} />}
-            disabled={currentIndex <= 0}
+            isDisabled={currentIndex <= 0}
             onClick={() => {
               if (currentIndex > 0) navigate(workPages[currentIndex - 1].path);
             }}
@@ -47,7 +47,7 @@ const WorkNav: React.FC = () => {
             variant="tertiary"
             size="m"
             endIcon={<Icon name="arrow-right" ariaLabel={t("workNavNext")} />}
-            disabled={currentIndex === workPages.length - 1}
+            isDisabled={currentIndex === workPages.length - 1}
             onClick={() => {
               if (currentIndex < workPages.length - 1)
                 navigate(workPages[currentIndex + 1].path);


### PR DESCRIPTION
## Summary

- Forward `isDisabled` (not deprecated `disabled`) from `AdaptiveLoadingButton` and `MCPActionButton` into `@dt/Button`.
- Migrate remaining `@dt/Button` call sites: chat widget, newsletter trigger, work nav, split button, card actions, file upload, transforming action input, secure CV download.

Follow-up to #674 — removes persistent `[Button] Prop "disabled" is deprecated` console warnings in dev.

## Test plan

- [ ] `npm run typecheck && npm run lint`
- [ ] Dev: load home, `/contact`, `/pricing`, open chat — no Button deprecation warnings in terminal
- [ ] Submit contact form / newsletter — buttons still disable while submitting


Made with [Cursor](https://cursor.com)