### PR TITLE
feat(ds): verify Figma library sync and tighten agentic DS gates

### DIFF
--- a/.planning/milestones/agentic-ds-v2/STATE.md
+++ b/.planning/milestones/agentic-ds-v2/STATE.md
@@ -4,20 +4,23 @@
 
 ## Shipped
 
-- [x] Phase 7: Intent golden eval (20 cases, 85% gate)
+- [x] Phase 7: Intent golden eval (20 cases, 90% gate — currently 100%)
 - [x] Phase 8: Operating model + audit playbook
-- [x] Phase 10 (partial): Pattern recipes + `suggest_pattern_for_layout` MCP + golden patterns eval
-- [x] Phase 11 (partial): `/design-system/agent` proof page
+- [x] Phase 9: Figma variables verified in DT-Site-stuff (78 vars: Color 45, Dimension 29, String 4)
+- [x] Phase 2–3: Page skeleton + 277 components verified; `dsb-state.json` + `npm run verify:figma-in-scope`
+- [x] Code Connect: **skipped** (Figma Pro — use contract URLs + Storybook Design panel)
+- [x] Phase 10 (expanded): SiteHeader, SiteFooter, ArticleHero recipes + golden patterns
+- [x] Phase 11: `/design-system/agent` proof page + sitemap + Colophon link
 - [x] Phase 12 (partial): `npm run agentic-ds-audit` + audit playbook doc
 - [x] CI quota rule in `AGENTS.md` — verify locally, admin merge
 
-## Figma (phase 9 — manual MCP)
+## Figma (phase 9 — verified)
 
-Local payloads ready:
+Variables synced to [DT-Site-stuff](https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff) (`runId: dt-dsb-2026-06-03`). Re-apply after token changes:
 
 ```bash
 npm run build:figma-variables
-# Apply nextjs-app/shared/foundations/figma/phases/*.js via Figma MCP (DT-Site-stuff)
+npm run figma:apply-variables   # Desktop MCP; sequential phase scripts
 ```
 
 See [docs/FIGMA_DESIGN_SYSTEM_SYNC.md](../../../docs/FIGMA_DESIGN_SYSTEM_SYNC.md).

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -33,6 +33,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     "/accessibility",
     "/blog",
     "/colophon",
+    "/design-system/agent",
     "/sitemap",
   ].map((path) => ({
     url: toUrl(path),

--- a/docs/AGENTIC_DS_AUDIT_PLAYBOOK.md
+++ b/docs/AGENTIC_DS_AUDIT_PLAYBOOK.md
@@ -24,7 +24,10 @@ Runs, in order:
 | Step | What it proves |
 |------|----------------|
 | `build:tokens` | Manifest, agent blocks, relationship graph regenerate |
-| `agent:eval` | Schema, MCP tools, intent + pattern golden sets |
+| `agent:eval` | Schema, MCP tools, intent (≥90%) + pattern golden sets |
+| `check:storybook-figma` | Contract `figma` URLs use DT file + real node ids |
+| `verify:figma-in-scope` | In-scope components mapped in `FIGMA_NODE_IDS` |
+| `sync:figma` | Contracts aligned with `figma-config.mjs` |
 | `lint:dt-usage` | Import policy in `app/` |
 | `check:contract-drift --strict` | TS ↔ contract parity |
 
@@ -65,10 +68,14 @@ Call:
 
 ```bash
 npm run build:figma-variables
+npm run verify:figma-in-scope
+npm run sync:figma
 npm run check:figma
 ```
 
-**Pass:** Variable payloads generated; contracts link to real Figma nodes for promoted components.
+**Pass:** Variable payloads generated; 33/34 in-scope components deep-link to Figma (Icon = Phosphor library exception).
+
+**Code Connect:** not used on Figma Pro — Storybook Design panel + contract URLs instead.
 
 ### 5. Agent discovery
 
@@ -83,9 +90,9 @@ npm run check:figma
 | Dimension | Weak | Strong |
 |-----------|------|--------|
 | Manifest + contracts | Hand-written README only | Generated agent blocks + drift CI |
-| Retrieval | Generic component list | Intent + pattern golden evals ≥85% |
+| Retrieval | Generic component list | Intent + pattern golden evals ≥90% |
 | Enforcement | Ad hoc review | `lint:dt-usage` + validate commands |
-| Figma loop | Drift accepted | Variables + node-id sync |
+| Figma loop | Drift accepted | Variables + node-id sync (no Code Connect on Pro) |
 | Operating model | Undocumented | Public workflow + guardrails |
 
 ---

--- a/docs/FIGMA_DESIGN_SYSTEM_SYNC.md
+++ b/docs/FIGMA_DESIGN_SYSTEM_SYNC.md
@@ -10,9 +10,11 @@ Canonical file: [DT-Site-stuff](https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0A
 |-------|------|---------|
 | **0** | Discovery — pages, existing variables | `get_metadata` (no `nodeId`), `get_variable_defs` on a small frame |
 | **1** | Variables / tokens | `npm run build:figma-variables` → `use_figma` chunks in `foundations/figma/phases/` |
-| **2** | File structure | `use_figma` — Cover, Foundations, Atoms, Molecules, Organisms, Patterns, Site |
-| **3** | Components | One `use_figma` call per component (atoms → molecules → organisms → patterns) |
+| **2** | File structure | Verified — 9 pages, Getting Started doc, dsb-state.json |
+| **3** | Components | 277 nodes in file; 33/34 in-scope mapped in `FIGMA_NODE_IDS` (Icon = Phosphor library) |
 | **4** | Views / routes | `generate_figma_design` + `use_figma` to assemble screens from library components |
+
+**Code Connect:** skipped on Figma Pro (requires Organization). Use contract `figma` URLs + Storybook Design panel instead.
 
 In-scope components: `scripts/design-system/in-scope-components.mjs`.
 
@@ -35,7 +37,13 @@ npm run build:tokens          # refresh token-catalog + DTCG
 npm run build:figma-variables # → foundations/figma/variables-manifest.json + phases/*.js
 ```
 
-Then apply each `foundations/figma/phases/phase-1a-color-chunk-*.js` via MCP `use_figma` with `fileKey: PC2UPdYwm8qGt6ZTg0AakF` and `skillNames: "figma-generate-library"`.
+Then apply each `foundations/figma/phases/phase-*.js` via MCP `use_figma` with `fileKey: PC2UPdYwm8qGt6ZTg0AakF` and `skillNames: "figma-generate-library"` (Cursor Figma plugin or remote MCP — **not** Desktop selection MCP, which lacks `use_figma`).
+
+Optional CLI wrapper when your MCP endpoint exposes `use_figma`:
+
+```bash
+FIGMA_DESKTOP_MCP_URL=https://your-mcp-endpoint/mcp npm run figma:apply-variables
+```
 
 ## Repo config
 

--- a/nextjs-app/shared/components/pages/Colophon/ColophonPage.tsx
+++ b/nextjs-app/shared/components/pages/Colophon/ColophonPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import React from "react";
 
 import Text from "@dt/Text";
@@ -306,7 +307,12 @@ export function ColophonPage() {
               Fourteen Model Context Protocol configurations for development and
               operations: Figma, GitHub, Sentry, Vercel, Sanity, Context7,
               TypeScript LSP, Akaunting, Docker, Next.js devtools, and more. The
-              repo and CMS workflows are agent-native by design.
+              repo and CMS workflows are agent-native by design. The{" "}
+              <Link href="/design-system/agent" className={styles.inlineLink}>
+                design system agent demo
+              </Link>{" "}
+              shows MCP tools, golden evals, and pattern recipes without
+              changing production chrome.
             </p>
           </div>
         </div>

--- a/nextjs-app/shared/components/pages/Colophon/colophon.module.css
+++ b/nextjs-app/shared/components/pages/Colophon/colophon.module.css
@@ -38,6 +38,12 @@
   font-size: 0.9em;
 }
 
+.inlineLink {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
 .section {
   margin-block-end: var(--space-layout-64);
 }

--- a/nextjs-app/shared/foundations/figma/dsb-state.json
+++ b/nextjs-app/shared/foundations/figma/dsb-state.json
@@ -1,0 +1,49 @@
+{
+  "runId": "dt-dsb-2026-06-03",
+  "fileKey": "PC2UPdYwm8qGt6ZTg0AakF",
+  "fileSlug": "DT-Site-stuff",
+  "updatedAt": "2026-06-03T18:00:00.000Z",
+  "phase": "phase3-complete",
+  "pages": [
+    "✦ DT · Design System",
+    "▸ Getting Started",
+    "◆ Foundations",
+    "──────  Components",
+    "Atoms",
+    "Molecules",
+    "Organisms",
+    "Patterns",
+    "Design WIP"
+  ],
+  "variables": {
+    "DT / Color": 45,
+    "DT / Dimension": 29,
+    "DT / String": 4,
+    "total": 78
+  },
+  "components": {
+    "totalComponentNodes": 277,
+    "byPage": {
+      "Atoms": 201,
+      "Molecules": 64,
+      "Organisms": 3,
+      "Patterns": 8
+    }
+  },
+  "inScopeCoverage": {
+    "mappedInFigmaConfig": 33,
+    "documentedExceptions": ["Icon"],
+    "totalInScope": 34
+  },
+  "codeConnect": {
+    "status": "skipped",
+    "reason": "Figma Pro plan — Code Connect requires Organization. Use contract figma URLs + Storybook Design panel."
+  },
+  "completedSteps": [
+    "phase0-discovery",
+    "phase1-variables",
+    "phase2-file-structure",
+    "phase3-in-scope-components"
+  ],
+  "pendingSteps": ["phase4-route-views"]
+}

--- a/nextjs-app/shared/foundations/figma/phases/README.md
+++ b/nextjs-app/shared/foundations/figma/phases/README.md
@@ -16,3 +16,14 @@ File: [`DT-Site-stuff`](https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-S
 See `docs/FIGMA_DESIGN_SYSTEM_SYNC.md`.
 
 Run ID: `dt-dsb-2026-06-03`
+
+## Phase 2–3 — library (verified)
+
+State ledger: `../dsb-state.json`. Verify in-scope node ids:
+
+```bash
+npm run verify:figma-in-scope
+npm run sync:figma
+```
+
+Code Connect is **not** used (Figma Pro). Storybook Design panel + contract `figma` URLs instead.

--- a/nextjs-app/shared/foundations/figma/variables-manifest.json
+++ b/nextjs-app/shared/foundations/figma/variables-manifest.json
@@ -2,9 +2,19 @@
   "fileKey": "PC2UPdYwm8qGt6ZTg0AakF",
   "fileSlug": "DT-Site-stuff",
   "fileUrl": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff",
-  "generatedAt": "2026-06-03T15:23:17.082Z",
+  "generatedAt": "2026-06-03T15:58:03.846Z",
   "source": "nextjs-app/shared/styles/variables.css",
   "runId": "dt-dsb-2026-06-03",
+  "figmaApplied": {
+    "appliedAt": "2026-06-03T16:00:00.000Z",
+    "verifiedAt": "2026-06-03T18:00:00.000Z",
+    "variableCounts": {
+      "DT / Color": 45,
+      "DT / Dimension": 29,
+      "DT / String": 4
+    },
+    "total": 78
+  },
   "modes": [
     {
       "id": "light",

--- a/nextjs-app/shared/foundations/token-catalog.json
+++ b/nextjs-app/shared/foundations/token-catalog.json
@@ -1,6 +1,6 @@
 {
   "source": "nextjs-app/shared/styles/variables.css",
-  "generatedAt": "2026-06-03T11:42:54.320Z",
+  "generatedAt": "2026-06-03T15:58:04.125Z",
   "tokenCount": 163,
   "usageCoverage": 131,
   "themes": [

--- a/package.json
+++ b/package.json
@@ -93,6 +93,8 @@
     "build:agent-blocks": "tsx scripts/design-system/build-component-agent-blocks.ts",
     "build:relationship-graph": "node scripts/design-system/generate-relationship-graph.mjs",
     "build:figma-variables": "node scripts/design-system/build-figma-variables-payload.mjs && node scripts/design-system/generate-figma-phase-scripts.mjs",
+    "figma:apply-variables": "node scripts/design-system/apply-figma-variables-local.mjs",
+    "verify:figma-in-scope": "node scripts/design-system/verify-figma-in-scope.mjs",
     "check:contrast": "node scripts/design-system/check-contrast.mjs",
     "check:token-descriptions": "tsx scripts/design-system/check-token-descriptions.ts",
     "check:drift": "tsx scripts/design-system/check-drift.ts",

--- a/scripts/design-system/agent-eval/golden-patterns.json
+++ b/scripts/design-system/agent-eval/golden-patterns.json
@@ -10,12 +10,32 @@
     {
       "id": "site-header",
       "query": "site header navigation pattern",
+      "expectedTop1": "SiteHeader"
+    },
+    {
+      "id": "legacy-header",
+      "query": "legacy storybook header pattern language switcher",
       "expectedTop1": "Header"
     },
     {
       "id": "hero-landing",
       "query": "full bleed homepage hero",
       "expectedTop1": "HeroSection"
+    },
+    {
+      "id": "app-header",
+      "query": "Next.js app shell sticky header navigation",
+      "expectedTop1": "SiteHeader"
+    },
+    {
+      "id": "site-footer",
+      "query": "site wide footer link columns",
+      "expectedTop1": "SiteFooter"
+    },
+    {
+      "id": "article-hero",
+      "query": "blog article hero title metadata",
+      "expectedTop1": "ArticleHero"
     }
   ]
 }

--- a/scripts/design-system/agent-eval/intent-retrieval-eval.mjs
+++ b/scripts/design-system/agent-eval/intent-retrieval-eval.mjs
@@ -12,7 +12,7 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 const MANIFEST = join(ROOT, "nextjs-app/shared/foundations/dist/agent-manifest.json");
 const GOLDEN = join(dirname(fileURLToPath(import.meta.url)), "golden-intents.json");
 
-const MIN_PASS_RATE = 0.85;
+const MIN_PASS_RATE = 0.9;
 
 /**
  * @param {import('./golden-intents.json')} spec

--- a/scripts/design-system/agentic-ds-audit.mjs
+++ b/scripts/design-system/agentic-ds-audit.mjs
@@ -12,6 +12,9 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const steps = [
   { name: "build:tokens", cmd: "npm", args: ["run", "build:tokens"] },
   { name: "agent:eval", cmd: "npm", args: ["run", "agent:eval"] },
+  { name: "check:storybook-figma", cmd: "npm", args: ["run", "check:storybook-figma"] },
+  { name: "verify:figma-in-scope", cmd: "npm", args: ["run", "verify:figma-in-scope"] },
+  { name: "sync:figma", cmd: "npm", args: ["run", "sync:figma"] },
   { name: "lint:dt-usage", cmd: "npm", args: ["run", "lint:dt-usage"] },
   {
     name: "contract-drift",
@@ -27,6 +30,10 @@ const manifestPath = join(
 const figmaPhasesDir = join(
   ROOT,
   "nextjs-app/shared/foundations/figma/phases",
+);
+const dsbStatePath = join(
+  ROOT,
+  "nextjs-app/shared/foundations/figma/dsb-state.json",
 );
 
 console.log("# Agentic DS audit (local)\n");
@@ -72,6 +79,15 @@ const figmaPhaseCount = existsSync(figmaPhasesDir)
 console.log(
   `- Figma variable phases (local payloads): ${figmaPhaseCount} script(s) — apply via MCP per docs/FIGMA_DESIGN_SYSTEM_SYNC.md`,
 );
+if (existsSync(dsbStatePath)) {
+  const dsb = JSON.parse(readFileSync(dsbStatePath, "utf8"));
+  console.log(
+    `- Figma library state: ${dsb.components?.totalComponentNodes ?? "?"} components, ${dsb.variables?.total ?? "?"} tokens (runId ${dsb.runId})`,
+  );
+  if (dsb.codeConnect?.status === "skipped") {
+    console.log(`- Code Connect: skipped (${dsb.codeConnect.reason})`);
+  }
+}
 console.log("\nPlaybook: docs/AGENTIC_DS_AUDIT_PLAYBOOK.md\n");
 
 process.exit(failed ? 1 : 0);

--- a/scripts/design-system/apply-figma-variables-local.mjs
+++ b/scripts/design-system/apply-figma-variables-local.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Apply generated Figma variable phase scripts via an MCP server that exposes
+ * the `use_figma` tool (Cursor Figma plugin / remote MCP — not Desktop selection MCP).
+ *
+ * Usage: node scripts/design-system/apply-figma-variables-local.mjs [phase-file.js ...]
+ * Default: all phase-*.js in foundations/figma/phases/ (sorted, sequential).
+ */
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+import { FIGMA_FILE_KEY } from "./figma-config.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const PHASES_DIR = join(
+  ROOT,
+  "nextjs-app/shared/foundations/figma/phases",
+);
+const MCP_URL = process.env.FIGMA_DESKTOP_MCP_URL ?? "http://127.0.0.1:3845/mcp";
+const RUN_ID =
+  JSON.parse(
+    readFileSync(
+      join(ROOT, "nextjs-app/shared/foundations/figma/variables-manifest.json"),
+      "utf8",
+    ),
+  ).runId ?? "unknown";
+
+function listPhases() {
+  const argPhases = process.argv.slice(2).filter((a) => a.endsWith(".js"));
+  if (argPhases.length) {
+    return argPhases.map((p) =>
+      p.includes("/") ? p : join(PHASES_DIR, p),
+    );
+  }
+  return readdirSync(PHASES_DIR)
+    .filter((f) => f.startsWith("phase-") && f.endsWith(".js"))
+    .sort()
+    .map((f) => join(PHASES_DIR, f));
+}
+
+/** @param {Client} client @param {string} code @param {string} description */
+async function applyPhase(client, code, description) {
+  const result = await client.callTool({
+    name: "use_figma",
+    arguments: {
+      fileKey: FIGMA_FILE_KEY,
+      code,
+      description,
+      skillNames: "figma-generate-library",
+    },
+  });
+  const text =
+    result.content
+      ?.map((part) => ("text" in part ? part.text : JSON.stringify(part)))
+      .join("\n") ?? JSON.stringify(result);
+  return text;
+}
+
+async function main() {
+  const phasePaths = listPhases();
+  if (!phasePaths.length) {
+    console.error("No phase scripts found in", PHASES_DIR);
+    process.exit(1);
+  }
+
+  console.log(`Figma MCP: ${MCP_URL}`);
+  console.log(`fileKey: ${FIGMA_FILE_KEY}, runId: ${RUN_ID}`);
+  console.log(`Phases: ${phasePaths.length} (sequential)\n`);
+
+  const client = new Client({
+    name: "dt-apply-figma-variables",
+    version: "1.0.0",
+  });
+  const transport = new StreamableHTTPClientTransport(new URL(MCP_URL));
+  await client.connect(transport);
+
+  try {
+    for (const phasePath of phasePaths) {
+      if (!existsSync(phasePath)) {
+        throw new Error(`Missing phase script: ${phasePath}`);
+      }
+      const base = phasePath.split("/").pop();
+      const code = readFileSync(phasePath, "utf8");
+      console.log(`→ ${base} (${code.length} bytes)`);
+      const summary = await applyPhase(
+        client,
+        code,
+        `Apply ${base} (${RUN_ID})`,
+      );
+      console.log(`  ✓ ${summary.slice(0, 200)}\n`);
+    }
+    console.log("Done.");
+  } finally {
+    await transport.close();
+  }
+}
+
+main().catch((err) => {
+  console.error("FAIL:", err.message ?? err);
+  process.exit(1);
+});

--- a/scripts/design-system/build-figma-variables-payload.mjs
+++ b/scripts/design-system/build-figma-variables-payload.mjs
@@ -3,7 +3,7 @@
  * Build Figma variable manifest from variables.css (all 4 themes).
  * Output: nextjs-app/shared/foundations/figma/variables-manifest.json
  */
-import { writeFileSync, mkdirSync } from "node:fs";
+import { writeFileSync, mkdirSync, readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { FIGMA_FILE_KEY, FIGMA_FILE_SLUG } from "./figma-config.mjs";
@@ -103,6 +103,17 @@ function main() {
     }
   }
 
+  const manifestPath = resolve(
+    __dirname,
+    "../../nextjs-app/shared/foundations/figma/variables-manifest.json",
+  );
+  let figmaApplied;
+  try {
+    figmaApplied = JSON.parse(readFileSync(manifestPath, "utf8")).figmaApplied;
+  } catch {
+    /* first run */
+  }
+
   const manifest = {
     fileKey: FIGMA_FILE_KEY,
     fileSlug: FIGMA_FILE_SLUG,
@@ -110,6 +121,7 @@ function main() {
     generatedAt: new Date().toISOString(),
     source: "nextjs-app/shared/styles/variables.css",
     runId: `dt-dsb-${new Date().toISOString().slice(0, 10)}`,
+    ...(figmaApplied ? { figmaApplied } : {}),
     modes: FIGMA_MODES,
     collections,
     stats: {

--- a/scripts/design-system/generate-figma-phase-scripts.mjs
+++ b/scripts/design-system/generate-figma-phase-scripts.mjs
@@ -162,6 +162,17 @@ File: [\`${manifest.fileSlug}\`](${manifest.fileUrl}) (\`${manifest.fileKey}\`)
 See \`docs/FIGMA_DESIGN_SYSTEM_SYNC.md\`.
 
 Run ID: \`${manifest.runId}\`
+
+## Phase 2–3 — library (verified)
+
+State ledger: \`../dsb-state.json\`. Verify in-scope node ids:
+
+\`\`\`bash
+npm run verify:figma-in-scope
+npm run sync:figma
+\`\`\`
+
+Code Connect is **not** used (Figma Pro). Storybook Design panel + contract \`figma\` URLs instead.
 `;
 
   writeFileSync(resolve(OUT_DIR, "README.md"), readme);

--- a/scripts/design-system/pattern-composition.recipes.json
+++ b/scripts/design-system/pattern-composition.recipes.json
@@ -60,6 +60,66 @@
         "background": "Supports backgroundImage and tokenized min-height; compose children rather than hardcoding layout."
       },
       "storybookId": "patterns-herosection--default"
+    },
+    {
+      "name": "SiteHeader",
+      "publicImport": "@dt/SiteHeader",
+      "tier": "pattern",
+      "status": "beta",
+      "useWhen": [
+        "Next.js app shell sticky header with brand and nav",
+        "production site header with theme and language controls",
+        "global navigation shell on marketing routes"
+      ],
+      "avoidWhen": [
+        "Storybook-only legacy Header pattern",
+        "embedded header inside a card or modal",
+        "replacing native header buttons without design sign-off"
+      ],
+      "composesWith": ["Link", "MobileDrawer", "Icon"],
+      "variantNotes": {
+        "chrome": "Production SiteHeader owns theme/language controls — do not swap to @dt/Button without explicit header redesign."
+      },
+      "storybookId": "patterns-siteheader--default"
+    },
+    {
+      "name": "SiteFooter",
+      "publicImport": "@dt/SiteFooter",
+      "tier": "pattern",
+      "status": "beta",
+      "useWhen": [
+        "site-wide footer with link columns and social links",
+        "global footer shell on marketing routes"
+      ],
+      "avoidWhen": [
+        "legacy Footer pattern with different IA",
+        "inline footer inside a card or modal",
+        "admin or app-specific footer fork"
+      ],
+      "composesWith": ["Link", "Text"],
+      "variantNotes": {
+        "singleton": "Mount exactly one SiteFooter per page via app layout."
+      },
+      "storybookId": "patterns-sitefooter--default"
+    },
+    {
+      "name": "ArticleHero",
+      "publicImport": "@dt/ArticleHero",
+      "tier": "pattern",
+      "status": "beta",
+      "useWhen": [
+        "blog article hero with title metadata and optional image",
+        "editorial article header block"
+      ],
+      "avoidWhen": [
+        "marketing homepage hero — prefer HeroSection",
+        "compact page title without article metadata"
+      ],
+      "composesWith": ["Title", "Text", "Link"],
+      "variantNotes": {
+        "metadata": "Expects article fields (date, author, tags) — compose rather than hardcoding."
+      },
+      "storybookId": null
     }
   ]
 }

--- a/scripts/design-system/verify-figma-in-scope.mjs
+++ b/scripts/design-system/verify-figma-in-scope.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * Verify in-scope DS components have Figma node ids (or documented exceptions).
+ */
+import { IN_SCOPE_COMPONENTS } from "./in-scope-components.mjs";
+import { FIGMA_NODE_IDS, FIGMA_FILE_KEY } from "./figma-config.mjs";
+
+/** Components intentionally without a single Figma node (library / composite). */
+const FIGMA_EXCEPTIONS = {
+  Icon: "Phosphor icon library on-page — not a single component node",
+};
+
+let failed = 0;
+
+console.log(`# Figma in-scope coverage (${FIGMA_FILE_KEY})\n`);
+
+for (const { name, tier } of IN_SCOPE_COMPONENTS) {
+  const nodeId = FIGMA_NODE_IDS[name];
+  const exception = FIGMA_EXCEPTIONS[name];
+  if (nodeId) {
+    console.log(`✓ ${name} (${tier}) → ${nodeId}`);
+  } else if (exception) {
+    console.log(`○ ${name} (${tier}) — ${exception}`);
+  } else {
+    console.error(`✗ ${name} (${tier}) — missing FIGMA_NODE_IDS entry`);
+    failed += 1;
+  }
+}
+
+const mapped = IN_SCOPE_COMPONENTS.filter((c) => FIGMA_NODE_IDS[c.name]).length;
+const excepted = Object.keys(FIGMA_EXCEPTIONS).length;
+console.log(
+  `\n${mapped}/${IN_SCOPE_COMPONENTS.length} mapped, ${excepted} documented exception(s)`,
+);
+
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## Summary
- Verifies DT-Site-stuff Figma library state (78 tokens, 277 components) with `dsb-state.json` and `npm run verify:figma-in-scope`
- Expands `agentic-ds-audit` with Storybook/Figma contract checks; raises intent eval gate to 90%
- Adds SiteHeader, SiteFooter, and ArticleHero pattern recipes plus golden eval cases
- Surfaces `/design-system/agent` in sitemap and Colophon; documents Code Connect skip on Figma Pro

## Test plan
- [x] `npm run agentic-ds-audit`
- [x] `npm run agent:eval` (intent 20/20, patterns 7/7)
- [x] `npm run verify:figma-in-scope`
- [x] `npm run sync:figma`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added design system agent demo route and link in Colophon page
  * Added new pattern recipes (SiteHeader, SiteFooter, ArticleHero) to design system

* **Documentation**
  * Updated design system audit playbook with enhanced Figma verification steps
  * Added Phase 2–3 library verification and sync procedures

* **Chores**
  * Added npm scripts for Figma variable application and scope verification
  * Increased intent retrieval evaluation threshold to 90%
  * Enhanced design system audit pipeline with Figma synchronization checks
  * Updated design system state tracking and metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->