### PR TITLE
fix(ds): CI red gates and contact book-call scroll

### DIFF
--- a/app/design-system/agent/page.tsx
+++ b/app/design-system/agent/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+
+import goldenIntentsJson from "../../../scripts/design-system/agent-eval/golden-intents.json";
+import patternRecipesJson from "../../../scripts/design-system/pattern-composition.recipes.json";
 
 export const metadata: Metadata = {
   title: "Design System Agent Demo | Digitaltableteur",
@@ -20,19 +21,10 @@ type PatternRecipe = {
   avoidWhen?: string[];
 };
 
-function loadJson<T>(relativePath: string): T {
-  const path = join(process.cwd(), relativePath);
-  return JSON.parse(readFileSync(path, "utf8")) as T;
-}
-
 /** Read-only agentic DS proof — no layout chrome changes. */
 export default function DesignSystemAgentPage() {
-  const goldenIntents = loadJson<{ cases: GoldenCase[] }>(
-    "scripts/design-system/agent-eval/golden-intents.json",
-  );
-  const patternRecipes = loadJson<{ patterns: PatternRecipe[] }>(
-    "scripts/design-system/pattern-composition.recipes.json",
-  );
+  const goldenIntents = goldenIntentsJson as { cases: GoldenCase[] };
+  const patternRecipes = patternRecipesJson as { patterns: PatternRecipe[] };
 
   return (
     <main className="mx-auto max-w-3xl px-6 py-16 font-body text-foreground">

--- a/nextjs-app/shared/components/Button/Button.contract.json
+++ b/nextjs-app/shared/components/Button/Button.contract.json
@@ -8,7 +8,28 @@
   "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=406-1569",
   "radixPrimitive": null,
   "element": "button",
-  "variants": {},
+  "variants": {
+    "variant": {
+      "values": [
+        "primary",
+        "secondary",
+        "tertiary",
+        "secondaryError",
+        "tertiaryError",
+        "error",
+        "warning",
+        "success",
+        "info"
+      ],
+      "default": "primary",
+      "propSourced": true
+    },
+    "surface": {
+      "values": ["default", "onDark", "onBrand"],
+      "default": "default",
+      "propSourced": true
+    }
+  },
   "slots": [
     "icon",
     "endIcon"

--- a/nextjs-app/shared/components/Button/Button.stories.tsx
+++ b/nextjs-app/shared/components/Button/Button.stories.tsx
@@ -94,6 +94,18 @@ export default {
       table: { category: "Appearance", type: { summary: "boolean" } },
     },
 
+    surface: {
+      control: { type: "select" },
+      options: ["default", "onDark", "onBrand"],
+      description:
+        "Surface behind the button — use onDark/onBrand on tinted bands instead of isInverse on gradients",
+      table: {
+        category: "Appearance",
+        type: { summary: "ButtonSurface" },
+        defaultValue: { summary: "default" },
+      },
+    },
+
     isRounded: {
       control: "boolean",
       description: "Applies rounded corners to the button (v1.1.0+)",

--- a/nextjs-app/shared/lib/mcp/server-card.test.ts
+++ b/nextjs-app/shared/lib/mcp/server-card.test.ts
@@ -31,6 +31,9 @@ describe("MCP server card shape", () => {
     expect(card.serverInfo.version).toMatch(/^\d+\.\d+\.\d+$/);
     expect(card.url).toContain("/mcp");
     expect(card.capabilities.tools).toBe(true);
-    expect(card.tools).toHaveLength(14);
+    expect(card.tools).toEqual([
+      ...CONSULTING_TOOL_NAMES,
+      ...DESIGN_SYSTEM_TOOL_NAMES,
+    ]);
   });
 });

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.module.css
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.module.css
@@ -5,6 +5,10 @@
   gap: var(--space-layout-24);
 }
 
+.contactFormAnchor {
+  scroll-margin-top: 6rem;
+}
+
 .modeSwitch {
   display: inline-flex;
   width: 100%;

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import {
+  forwardRef,
   useCallback,
   useEffect,
+  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -26,12 +28,18 @@ export interface ContactInquiryPanelProps {
   bookingConfig?: SiteBookingConfig;
 }
 
-export function ContactInquiryPanel({
-  initialMode = "message",
-  packageId,
-  messagePanel,
-  bookingConfig,
-}: ContactInquiryPanelProps) {
+export interface ContactInquiryPanelHandle {
+  /** Switch to the message tab and scroll the viewport to the form. */
+  scrollToMessageForm: () => void;
+}
+
+export const ContactInquiryPanel = forwardRef<
+  ContactInquiryPanelHandle,
+  ContactInquiryPanelProps
+>(function ContactInquiryPanel(
+  { initialMode = "message", packageId, messagePanel, bookingConfig },
+  ref,
+) {
   const { t } = useTranslation();
   const [mode, setMode] = useState<ContactInquiryMode>(initialMode);
   const messageTabRef = useRef<HTMLButtonElement>(null);
@@ -53,6 +61,23 @@ export function ContactInquiryPanel({
   const handleSelectMessage = useCallback(() => {
     setMode("message");
   }, []);
+
+  const scrollToMessageForm = useCallback(() => {
+    setMode("message");
+    requestAnimationFrame(() => {
+      const formRoot = document.getElementById("contact-form");
+      if (!formRoot) return;
+
+      formRoot.scrollIntoView({ behavior: "smooth", block: "start" });
+
+      const firstField = formRoot.querySelector<HTMLElement>(
+        'input:not([type="hidden"]):not([disabled]), textarea:not([disabled]), select:not([disabled])',
+      );
+      firstField?.focus({ preventScroll: true });
+    });
+  }, []);
+
+  useImperativeHandle(ref, () => ({ scrollToMessageForm }), [scrollToMessageForm]);
 
   const handleTabKeyDown = useCallback(
     (event: KeyboardEvent<HTMLButtonElement>) => {
@@ -124,7 +149,9 @@ export function ContactInquiryPanel({
           hidden={mode !== "message"}
           data-donny-target="contact.form"
         >
-          <div id="contact-form">{messagePanel}</div>
+          <div id="contact-form" className={styles.contactFormAnchor}>
+            {messagePanel}
+          </div>
         </div>
         <div
           id="contact-panel-book"
@@ -169,7 +196,7 @@ export function ContactInquiryPanel({
       </div>
     </div>
   );
-}
+});
 
 ContactInquiryPanel.displayName = "ContactInquiryPanel";
 

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/index.ts
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/index.ts
@@ -1,6 +1,7 @@
 export {
   ContactInquiryPanel,
   type ContactInquiryMode,
+  type ContactInquiryPanelHandle,
   type ContactInquiryPanelProps,
 } from "./ContactInquiryPanel";
 export { default } from "./ContactInquiryPanel";

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import Image from "next/image";
 import { useTranslation } from "react-i18next";
 import { motion, AnimatePresence } from "framer-motion";
@@ -9,8 +9,11 @@ import { cn } from "@/lib/utils";
 import Text from "@dt/Text";
 import Title from "@dt/Title";
 import Icon from "@dt/Icon";
-import { ContactInquiryPanel } from "../ContactInquiryPanel";
-import type { ContactInquiryMode } from "../ContactInquiryPanel";
+import {
+  ContactInquiryPanel,
+  type ContactInquiryMode,
+  type ContactInquiryPanelHandle,
+} from "../ContactInquiryPanel";
 import type { SiteBookingConfig } from "../../lib/donny-booking";
 import { ContactFormEditorial } from "../../components/ContactFormEditorial";
 import { ContactFormSuccessEditorial } from "../../components/ContactFormSuccessEditorial";
@@ -43,6 +46,7 @@ export function ContactPageContentEditorial({
   bookingConfig,
 }: ContactPageContentEditorialProps) {
   const { t } = useTranslation();
+  const inquiryPanelRef = useRef<ContactInquiryPanelHandle>(null);
   const [showSuccess, setShowSuccess] = useState(false);
   // Skip entrance animations under reduced-motion so axe never samples
   // partial-opacity frames as color-contrast violations.
@@ -55,6 +59,17 @@ export function ContactPageContentEditorial({
   const handleSendAnother = () => {
     setShowSuccess(false);
   };
+
+  const handleScrollToContactForm = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+      inquiryPanelRef.current?.scrollToMessageForm();
+      if (typeof window !== "undefined") {
+        window.history.replaceState(null, "", "#contact-form");
+      }
+    },
+    [],
+  );
 
   return (
     <div className={cn(styles.page, className)}>
@@ -143,6 +158,7 @@ export function ContactPageContentEditorial({
           <div className={styles.rightColumn}>
             <div className={styles.formPanel}>
               <ContactInquiryPanel
+                ref={inquiryPanelRef}
                 initialMode={initialInquiryMode}
                 packageId={bookingPackageId}
                 bookingConfig={bookingConfig}
@@ -249,7 +265,11 @@ export function ContactPageContentEditorial({
                         )}
                       </Text>
                     </div>
-                    <a href="/contact?mode=book" className={styles.newBusinessCta}>
+                    <a
+                      href="#contact-form"
+                      className={styles.newBusinessCta}
+                      onClick={handleScrollToContactForm}
+                    >
                       <span className={styles.email}>
                         {t("contactNewBusinessBookLink", "Book a call")}
                       </span>

--- a/nextjs-app/shared/patterns/ProofBlock/ProofBlock.module.css
+++ b/nextjs-app/shared/patterns/ProofBlock/ProofBlock.module.css
@@ -51,13 +51,6 @@
   box-shadow: 0 12px 36px rgb(0 0 0 / 5%);
 }
 
-.metricCardDark {
-  border-color: rgb(255 255 255 / 8%);
-  background: var(--color-dark);
-  box-shadow: 0 12px 40px rgb(0 0 0 / 12%);
-  color: var(--color-white);
-}
-
 .metricValue {
   margin: 0;
   font-family: var(--primary-bold-font, var(--font-body));
@@ -79,6 +72,26 @@
   margin: 0;
   color: inherit;
   opacity: 0.85;
+}
+
+.metricCardDark {
+  border-color: rgb(255 255 255 / 8%);
+  background: var(--color-dark);
+  box-shadow: 0 12px 40px rgb(0 0 0 / 12%);
+  color: var(--color-white);
+}
+
+.metricCardDark .metricValue {
+  color: var(--color-white);
+}
+
+.metricCardDark .metricLabel {
+  color: rgb(255 255 255 / 92%);
+}
+
+.metricCardDark .metricDetail {
+  color: rgb(255 255 255 / 85%);
+  opacity: 1;
 }
 
 @media (width <= 48rem) {

--- a/scripts/design-system/cva-sync-lib.mjs
+++ b/scripts/design-system/cva-sync-lib.mjs
@@ -9,6 +9,7 @@ function normalizeVariantValue(value) {
 
 const VARIANT_PROP_NAMES = new Set([
   "variant",
+  "surface",
   "size",
   "severity",
   "tone",
@@ -52,6 +53,7 @@ export function cvaAlignsWithProps(cvaVariants, props) {
 
 /** Explicit allowlist: prop-driven styling without root CVA invocation. */
 const PROP_SOURCED_AXES = {
+  Button: ["variant", "surface"],
   Title: ["size", "terminals"],
   Checkbox: ["size"],
   Switch: ["size"],


### PR DESCRIPTION
## Summary
- Fixes stable Button contract/Storybook drift for the new `surface` prop (`propSourced` variant axes).
- Fixes ProofBlock dark metric card WCAG contrast (Storybook a11y gate).
- Replaces contact page “Book a call” link reload with in-page scroll to `#contact-form`.
- Derives MCP server-card tool list from constants; agent proof page uses static JSON imports.

## Test plan
- [x] `npm run validate:components`
- [x] `npm run typecheck`
- [x] `npm run lint` / `npm run lint:css`
- [x] `npm run test:ci`
- [ ] CI PR Validation (expected green)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added surface variant options (default, onDark, onBrand) to Button component.
  * Introduced scroll-to-contact-form capability for improved form navigation and user experience.

* **Bug Fixes**
  * Improved metric card typography and color contrast in dark mode.

* **Style**
  * Enhanced contact form anchor with dedicated scroll positioning styling.

* **Refactor**
  * Optimized design system data loading at build time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->