### PR TITLE
[codex] Refresh LLM-wiki project snippet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,5 +65,17 @@ rg -n "t\(\"" nextjs-app/ app/ | grep -v ".test.tsx"
 ---
 
 <!-- LLM-WIKI:START -->
-Cross-project wiki: `/Users/petrilahdelma/SAPDevelop/llm-wiki` — query with `qmd-query.sh "digitaltableteur <topic>"` before non-trivial work.
+## Cross-project LLM-wiki
+
+This repo participates in the shared LLM-wiki at `/Users/petrilahdelma/SAPDevelop/llm-wiki`.
+
+Read before non-trivial work:
+- Start with a compact project memory packet: `/Users/petrilahdelma/SAPDevelop/llm-wiki/wiki/tools/llm-wiki-context.mjs --project "digitaltableteur" --query "<task or topic>"`.
+- For broader retrieval, search adjacent concepts with `/Users/petrilahdelma/SAPDevelop/llm-wiki/wiki/tools/qmd-query.sh "digitaltableteur <task or topic>"`.
+- Open relevant pages under `/Users/petrilahdelma/SAPDevelop/llm-wiki/wiki` before deciding.
+
+Write after durable discoveries:
+- Capture decisions, reusable gotchas, cross-project patterns, source summaries, and project-state changes with `/Users/petrilahdelma/SAPDevelop/llm-wiki/wiki/tools/llm-wiki-capture.mjs --project "digitaltableteur" --kind decision --title "<title>" --summary "<what changed and why>"`.
+- Do not capture secrets, raw logs, transient TODOs, or live coordination state.
+- Do not edit compiled wiki pages from this repo. Capture first; the LLM-wiki ingest pass will file it into entities, concepts, patterns, or synthesis.
 <!-- LLM-WIKI:END -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,15 @@ When changing agent workflows: update the relevant area `AGENTS.md`, skill in `.
 <!-- LLM-WIKI:START -->
 ## Cross-project LLM-wiki
 
-Read before non-trivial work: `/Users/petrilahdelma/SAPDevelop/llm-wiki/wiki/tools/qmd-query.sh "digitaltableteur <topic>"`
+This repo participates in the shared LLM-wiki at `/Users/petrilahdelma/SAPDevelop/llm-wiki`.
 
-Capture durable discoveries: `llm-wiki-capture.mjs --project digitaltableteur --kind decision --title "..." --summary "..."`
+Read before non-trivial work:
+- Start with a compact project memory packet: `/Users/petrilahdelma/SAPDevelop/llm-wiki/wiki/tools/llm-wiki-context.mjs --project "digitaltableteur" --query "<task or topic>"`.
+- For broader retrieval, search adjacent concepts with `/Users/petrilahdelma/SAPDevelop/llm-wiki/wiki/tools/qmd-query.sh "digitaltableteur <task or topic>"`.
+- Open relevant pages under `/Users/petrilahdelma/SAPDevelop/llm-wiki/wiki` before deciding.
+
+Write after durable discoveries:
+- Capture decisions, reusable gotchas, cross-project patterns, source summaries, and project-state changes with `/Users/petrilahdelma/SAPDevelop/llm-wiki/wiki/tools/llm-wiki-capture.mjs --project "digitaltableteur" --kind decision --title "<title>" --summary "<what changed and why>"`.
+- Do not capture secrets, raw logs, transient TODOs, or live coordination state.
+- Do not edit compiled wiki pages from this repo. Capture first; the LLM-wiki ingest pass will file it into entities, concepts, patterns, or synthesis.
 <!-- LLM-WIKI:END -->


### PR DESCRIPTION
## What changed

- Refreshed the marker-bounded LLM-wiki block in AGENTS.md and CLAUDE.md.
- Points project agents at the shared context packet, qmd search, and capture script.

## Validation

- git diff --cached --check

## Notes

Created from a clean temporary worktree based on main; unrelated local work was not staged or committed.