### PR TITLE
feat(ds): enforce stable consumers and variant axes in CI

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -23,6 +23,7 @@ jobs:
       - run: npm run check:contrast
       - run: npm run check:token-descriptions
       - run: npm run validate:components
+      - run: npm run check:consumers
       - run: npm run validate:agent-docs
       - run: npm run validate:translations
       - run: npm run typecheck

--- a/nextjs-app/shared/components/Avatar/Avatar.contract.json
+++ b/nextjs-app/shared/components/Avatar/Avatar.contract.json
@@ -1,88 +1,62 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "Avatar",
-  "tier": "atom",
-  "group": "display",
-  "status": "stable",
-  "description": "Profile image, initials, link, or menu trigger.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=369-8",
-  "radixPrimitive": null,
-  "element": "button",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [
-      "menu trigger needs accessible name",
-      "image alt from name"
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Avatar",
+    "tier": "atom",
+    "group": "display",
+    "status": "beta",
+    "description": "Profile image, initials, link, or menu trigger.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=369-8",
+    "radixPrimitive": null,
+    "element": "button",
+    "variants": {},
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "2026-05-26 — production behavior, keyboard, and forced-colors verified in Storybook.",
-    "forcedColorsVerified": true,
-    "accessibilityTreeVerified": true,
-    "realBrowserForcedColorsVerified": true
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "clickable",
-    "decoding",
-    "destinationUrl",
-    "id",
-    "imageUrl",
-    "loading",
-    "menuItems",
-    "menuLabel",
-    "name",
-    "placementRefreshKey",
-    "ref",
-    "size",
-    "sizes",
-    "srcSet",
-    "style",
-    "variant"
-  ],
-  "consumers": [
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/stories/KitchenSink.stories.tsx",
-      "since": "2026-05-27"
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [
+            "menu trigger needs accessible name",
+            "image alt from name"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-05-26 — production behavior, keyboard, and forced-colors verified in Storybook.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true
     },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/AuthorBio/AuthorBio.tsx",
-      "since": "2026-05-27"
+    "tokens": {
+        "colors": [],
+        "spacing": []
     },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/Author/Author.tsx",
-      "since": "2026-05-27"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/Avatar/Avatar.test.tsx",
-      "since": "2026-05-27"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/Avatar/Avatar.stories.tsx",
-      "since": "2026-05-27"
-    }
-  ]
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "clickable",
+        "decoding",
+        "destinationUrl",
+        "id",
+        "imageUrl",
+        "loading",
+        "menuItems",
+        "menuLabel",
+        "name",
+        "placementRefreshKey",
+        "ref",
+        "size",
+        "sizes",
+        "srcSet",
+        "style",
+        "variant"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/components/Badge/Badge.contract.json
+++ b/nextjs-app/shared/components/Badge/Badge.contract.json
@@ -70,43 +70,18 @@
     "consumers": [
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/stories/TestHealth.stories.tsx",
-            "since": "2026-05-27"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/Badge/Badge.stories.tsx",
-            "since": "2026-05-27"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/Badge/Badge.test.tsx",
-            "since": "2026-05-27"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/OpenHours/OpenHours.tsx",
-            "since": "2026-05-27"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.stories.tsx",
-            "since": "2026-05-27"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/Card/Card.tsx",
-            "since": "2026-05-27"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/CookieConsent/CookieConsent.tsx",
-            "since": "2026-05-27"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Pseo/PseoClusterBadges.tsx",
-            "since": "2026-05-27"
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Pseo/PseoPillarMetaBadgeLinks.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+            "since": "2026-06-04"
         }
     ]
 }

--- a/nextjs-app/shared/components/Button/Button.contract.json
+++ b/nextjs-app/shared/components/Button/Button.contract.json
@@ -1,136 +1,184 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "Button",
-  "tier": "molecule",
-  "group": "interaction",
-  "status": "stable",
-  "description": "Primary interaction control with variant, severity, loading, and link modes.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=406-1569",
-  "radixPrimitive": null,
-  "element": "button",
-  "variants": {
-    "variant": {
-      "values": [
-        "primary",
-        "secondary",
-        "tertiary",
-        "secondaryError",
-        "tertiaryError",
-        "error",
-        "warning",
-        "success",
-        "info"
-      ],
-      "default": "primary",
-      "propSourced": true
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Button",
+    "tier": "molecule",
+    "group": "interaction",
+    "status": "stable",
+    "description": "Primary interaction control with variant, severity, loading, and link modes.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=406-1569",
+    "radixPrimitive": null,
+    "element": "button",
+    "variants": {
+        "variant": {
+            "values": [
+                "primary",
+                "secondary",
+                "tertiary",
+                "secondaryError",
+                "tertiaryError",
+                "error",
+                "warning",
+                "success",
+                "info"
+            ],
+            "default": "primary",
+            "propSourced": true
+        },
+        "surface": {
+            "values": [
+                "default",
+                "onDark",
+                "onBrand"
+            ],
+            "default": "default",
+            "propSourced": true
+        },
+        "severity": {
+            "values": ["error", "warning", "success", "info"],
+            "default": "error",
+            "propSourced": true
+        },
+        "size": {
+            "values": ["sm", "md", "lg", "s", "m", "l"],
+            "default": "md",
+            "propSourced": true
+        }
     },
-    "surface": {
-      "values": ["default", "onDark", "onBrand"],
-      "default": "default",
-      "propSourced": true
-    }
-  },
-  "slots": [
-    "icon",
-    "endIcon"
-  ],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [
-      "Enter",
-      "Space"
+    "slots": [
+        "icon",
+        "endIcon"
     ],
-    "ariaRequirements": [
-      "accessible name",
-      "aria-busy when loading",
-      "disabled state"
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "2026-05-26 — keyboard, loading, forced-colors verified in Storybook.",
-    "forcedColorsVerified": true,
-    "accessibilityTreeVerified": true,
-    "realBrowserForcedColorsVerified": true,
-    "axeTestExempt": "Interaction atom; axe on Default/Primary and compliance stories."
-  },
-  "tokens": {
-    "colors": [
-      "--color-warning-text",
-      "--color-white"
+    "a11y": {
+        "keyboard": [
+            "Enter",
+            "Space"
+        ],
+        "ariaRequirements": [
+            "accessible name",
+            "aria-busy when loading",
+            "disabled state"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-05-26 — keyboard, loading, forced-colors verified in Storybook.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true,
+        "axeTestExempt": "Interaction atom; axe on Default/Primary and compliance stories."
+    },
+    "tokens": {
+        "colors": [
+            "--color-warning-text",
+            "--color-white"
+        ],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "ariaDescribedBy",
+        "ariaLabel",
+        "ariaLabelledBy",
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "disabled",
+        "download",
+        "form",
+        "href",
+        "icon",
+        "iconEnd",
+        "id",
+        "inverse",
+        "isDisabled",
+        "isInverse",
+        "isLoading",
+        "isRounded",
+        "loading",
+        "name",
+        "onClick",
+        "ref",
+        "rel",
+        "role",
+        "rounded",
+        "severity",
+        "size",
+        "style",
+        "submit",
+        "target",
+        "tooltip",
+        "type",
+        "value",
+        "variant"
     ],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "ariaDescribedBy",
-    "ariaLabel",
-    "ariaLabelledBy",
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "disabled",
-    "download",
-    "form",
-    "href",
-    "icon",
-    "iconEnd",
-    "id",
-    "inverse",
-    "isDisabled",
-    "isInverse",
-    "isLoading",
-    "isRounded",
-    "loading",
-    "name",
-    "onClick",
-    "ref",
-    "rel",
-    "role",
-    "rounded",
-    "severity",
-    "size",
-    "style",
-    "submit",
-    "target",
-    "tooltip",
-    "type",
-    "value",
-    "variant"
-  ],
-  "consumers": [
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "app/not-found.tsx",
-      "since": "2026-06-03",
-      "note": "App Router error surface"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "app/error.tsx",
-      "since": "2026-06-03"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/CookieConsent/CookieConsentBanner.tsx",
-      "since": "2026-06-03"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/ContactForm/ContactForm.tsx",
-      "since": "2026-06-03"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/ChatWidget/ChatToggle.tsx",
-      "since": "2026-06-03"
-    }
-  ]
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/NextBlogNav.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/error.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/not-found.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/work/NextWorkNav.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullEnPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullFiPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullSvPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx",
+            "since": "2026-06-04"
+        }
+    ]
 }

--- a/nextjs-app/shared/components/Button/Button.stories.tsx
+++ b/nextjs-app/shared/components/Button/Button.stories.tsx
@@ -72,7 +72,11 @@ export default {
       control: { type: "select" },
       options: ["error", "warning", "success", "info"],
       description: "Semantic severity for status-based styling (v1.1.0+)",
-      table: { category: "Appearance", type: { summary: "ButtonSeverity" } },
+      table: {
+        category: "Appearance",
+        type: { summary: "ButtonSeverity" },
+        defaultValue: { summary: "error" },
+      },
     },
 
     size: {

--- a/nextjs-app/shared/components/Card/Card.contract.json
+++ b/nextjs-app/shared/components/Card/Card.contract.json
@@ -1,110 +1,121 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "Card",
-  "tier": "molecule",
-  "group": "structure",
-  "status": "stable",
-  "description": "Composable surface for grouped content with header, body, media, and actions.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=377-26",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [
-    "extra",
-    "cover",
-    "icon",
-    "badge",
-    "footer"
-  ],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [
-      "semantic heading for title",
-      "link/button actions need accessible names"
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Card",
+    "tier": "molecule",
+    "group": "structure",
+    "status": "stable",
+    "description": "Composable surface for grouped content with header, body, media, and actions.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=377-26",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "variant": {
+            "values": ["elevated", "filled", "outlined"],
+            "default": "elevated",
+            "propSourced": true
+        },
+        "size": {
+            "values": ["S", "M", "L", "full"],
+            "default": "M",
+            "propSourced": true
+        }
+    },
+    "slots": [
+        "extra",
+        "cover",
+        "icon",
+        "badge",
+        "footer"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "2026-05-26 — structure, hover/focus, forced-colors verified in Storybook.",
-    "forcedColorsVerified": true,
-    "accessibilityTreeVerified": true,
-    "realBrowserForcedColorsVerified": true,
-    "axeTestExempt": "Complex molecule; axe on representative Default/Example stories."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "actions",
-    "activeTabKey",
-    "as",
-    "asChild",
-    "badge",
-    "badgeProps",
-    "body",
-    "bodyProps",
-    "bodyStyle",
-    "bordered",
-    "children",
-    "className",
-    "cover",
-    "defaultActiveTabKey",
-    "description",
-    "descriptionProps",
-    "design",
-    "extra",
-    "footer",
-    "headStyle",
-    "hoverable",
-    "icon",
-    "iconProps",
-    "id",
-    "interactive",
-    "level",
-    "link",
-    "linkLabel",
-    "loading",
-    "onClick",
-    "onTabChange",
-    "position",
-    "ref",
-    "size",
-    "state",
-    "statusMessage",
-    "statusMessageProps",
-    "style",
-    "subTitle",
-    "subTitleProps",
-    "tabs",
-    "terminals",
-    "title",
-    "titleProps",
-    "variant"
-  ],
-  "consumers": [
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
-      "since": "2026-06-03"
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [
+            "semantic heading for title",
+            "link/button actions need accessible names"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-05-26 — structure, hover/focus, forced-colors verified in Storybook.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true,
+        "axeTestExempt": "Complex molecule; axe on representative Default/Example stories."
     },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/ComplianceCard/ComplianceCard.tsx",
-      "since": "2026-06-03"
+    "tokens": {
+        "colors": [],
+        "spacing": []
     },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/SentrySummaryCard/SentrySummaryCard.tsx",
-      "since": "2026-06-03"
-    }
-  ]
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "actions",
+        "activeTabKey",
+        "as",
+        "asChild",
+        "badge",
+        "badgeProps",
+        "body",
+        "bodyProps",
+        "bodyStyle",
+        "bordered",
+        "children",
+        "className",
+        "cover",
+        "defaultActiveTabKey",
+        "description",
+        "descriptionProps",
+        "design",
+        "extra",
+        "footer",
+        "headStyle",
+        "hoverable",
+        "icon",
+        "iconProps",
+        "id",
+        "interactive",
+        "level",
+        "link",
+        "linkLabel",
+        "loading",
+        "onClick",
+        "onTabChange",
+        "position",
+        "ref",
+        "size",
+        "state",
+        "statusMessage",
+        "statusMessageProps",
+        "style",
+        "subTitle",
+        "subTitleProps",
+        "tabs",
+        "terminals",
+        "title",
+        "titleProps",
+        "variant"
+    ],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx",
+            "since": "2026-06-04"
+        }
+    ]
 }

--- a/nextjs-app/shared/components/Card/Card.stories.tsx
+++ b/nextjs-app/shared/components/Card/Card.stories.tsx
@@ -27,12 +27,14 @@ const CardStoryMeta = {
       options: ["S", "M", "L", "full"],
       description:
         "Card size with max-width constraints: S(320px), M(480px), L(600px), full(100%)",
+      table: { defaultValue: { summary: "M" } },
     },
 
     variant: {
       control: { type: "select" },
       options: ["outlined", "filled", "elevated"],
       description: "Card visual variant",
+      table: { defaultValue: { summary: "elevated" } },
     },
 
     badge: {

--- a/nextjs-app/shared/components/Combobox/Combobox.contract.json
+++ b/nextjs-app/shared/components/Combobox/Combobox.contract.json
@@ -1,43 +1,53 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "Combobox",
-  "tier": "molecule",
-  "group": "form",
-  "status": "beta",
-  "description": "Single-select combobox with portaled dropdown, shared with MultiCombobox.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-combobox",
-  "radixPrimitive": null,
-  "element": "button",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": ["Default", "Playground", "Example", "ForcedColors"],
-  "a11y": {
-    "keyboard": ["Tab", "Enter", "Space", "Escape", "ArrowDown", "ArrowUp"],
-    "ariaRequirements": [
-      "trigger role=combobox with aria-expanded/aria-controls/aria-activedescendant",
-      "labelled via aria-labelledby",
-      "listbox with role=listbox + aria-label",
-      "options role=option with aria-selected",
-      "error sets aria-invalid + aria-describedby"
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Combobox",
+    "tier": "molecule",
+    "group": "form",
+    "status": "beta",
+    "description": "Single-select combobox with portaled dropdown, shared with MultiCombobox.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-combobox",
+    "radixPrimitive": null,
+    "element": "button",
+    "variants": {},
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "Verified 2026-06-02: ARIA APG combobox — role=combobox trigger with aria-expanded/aria-controls/aria-activedescendant, aria-labelledby; portaled role=listbox with role=option/aria-selected. Full keyboard (ArrowUp/Down, Enter/Space, Escape) driven and asserted by the KeyboardSelection play function. Fixed a real contrast bug surfaced by enabling axe: the placeholder had opacity:0.7 dropping --color-muted to 2.7:1; removed it (now AA). Default/Playground/Example/KeyboardSelection pass axe with test:error; light + dark verified in Storybook.",
-    "forcedColorsVerified": true
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": ["className", "id", "options"],
-  "consumers": [
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.tsx",
-      "since": "2026-05-28"
-    }
-  ]
+    "a11y": {
+        "keyboard": [
+            "Tab",
+            "Enter",
+            "Space",
+            "Escape",
+            "ArrowDown",
+            "ArrowUp"
+        ],
+        "ariaRequirements": [
+            "trigger role=combobox with aria-expanded/aria-controls/aria-activedescendant",
+            "labelled via aria-labelledby",
+            "listbox with role=listbox + aria-label",
+            "options role=option with aria-selected",
+            "error sets aria-invalid + aria-describedby"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "Verified 2026-06-02: ARIA APG combobox — role=combobox trigger with aria-expanded/aria-controls/aria-activedescendant, aria-labelledby; portaled role=listbox with role=option/aria-selected. Full keyboard (ArrowUp/Down, Enter/Space, Escape) driven and asserted by the KeyboardSelection play function. Fixed a real contrast bug surfaced by enabling axe: the placeholder had opacity:0.7 dropping --color-muted to 2.7:1; removed it (now AA). Default/Playground/Example/KeyboardSelection pass axe with test:error; light + dark verified in Storybook.",
+        "forcedColorsVerified": true
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "className",
+        "id",
+        "options"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/components/Icon/Icon.contract.json
+++ b/nextjs-app/shared/components/Icon/Icon.contract.json
@@ -70,63 +70,63 @@
     "consumers": [
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/not-found.tsx",
-            "since": "2026-05-27"
+            "path": "app/blog/NextBlogNav.tsx",
+            "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "app/error.tsx",
-            "since": "2026-05-27"
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/not-found.tsx",
+            "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "app/work/NextWorkNav.tsx",
-            "since": "2026-05-27"
+            "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/blog/NextBlogNav.tsx",
-            "since": "2026-05-27"
+            "path": "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
+            "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/app/work/NextWorkNav.tsx",
-            "since": "2026-05-27"
+            "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+            "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/utils/semanticIcons.tsx",
-            "since": "2026-05-27"
+            "path": "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullEnPage.tsx",
+            "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/stories/Docs/Icons.stories.tsx",
-            "since": "2026-05-27"
+            "path": "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullFiPage.tsx",
+            "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/stories/TestHealth.stories.tsx",
-            "since": "2026-05-27"
+            "path": "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullSvPage.tsx",
+            "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/foundations/stories/Icons.stories.tsx",
-            "since": "2026-05-27"
+            "path": "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
+            "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/Badge/Badge.stories.tsx",
-            "since": "2026-05-27"
+            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+            "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/Title/Title.stories.tsx",
-            "since": "2026-05-27"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/Badge/Badge.tsx",
-            "since": "2026-05-27"
+            "path": "nextjs-app/shared/patterns/Footer/Footer.tsx",
+            "since": "2026-06-04"
         }
     ]
 }

--- a/nextjs-app/shared/components/MultiCombobox/MultiCombobox.contract.json
+++ b/nextjs-app/shared/components/MultiCombobox/MultiCombobox.contract.json
@@ -1,44 +1,54 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "MultiCombobox",
-  "tier": "molecule",
-  "group": "form",
-  "status": "beta",
-  "description": "Multi-select combobox with inline chips, type-to-filter dropdown, label, error, and helper text.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-multi-combobox",
-  "radixPrimitive": null,
-  "element": "input",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": ["Default", "Playground", "Example", "ForcedColors"],
-  "a11y": {
-    "keyboard": ["Tab", "Enter", "Escape", "ArrowDown", "ArrowUp", "Backspace"],
-    "ariaRequirements": [
-      "input role=combobox with aria-autocomplete=list, aria-expanded, aria-controls, aria-activedescendant",
-      "labelled via aria-labelledby",
-      "listbox role=listbox + aria-multiselectable + aria-label",
-      "options role=option with aria-selected",
-      "selected values are removable Badge chips; Backspace removes the last",
-      "error sets aria-invalid + aria-describedby"
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "MultiCombobox",
+    "tier": "molecule",
+    "group": "form",
+    "status": "beta",
+    "description": "Multi-select combobox with inline chips, type-to-filter dropdown, label, error, and helper text.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-multi-combobox",
+    "radixPrimitive": null,
+    "element": "input",
+    "variants": {},
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "Verified 2026-06-02: type-to-filter combobox — input role=combobox with aria-autocomplete=list/aria-expanded/aria-controls/aria-activedescendant, aria-labelledby; portaled role=listbox aria-multiselectable with role=option/aria-selected; chips are removable Badges, Backspace removes the last. Keyboard (ArrowUp/Down, Enter toggle, Escape, Backspace) driven and asserted by the KeyboardMultiSelect play function. Shares ComboboxField CSS (inherits the placeholder contrast fix). Default/Playground/Example/KeyboardMultiSelect pass axe with test:error; light + dark verified in Storybook.",
-    "forcedColorsVerified": true
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": ["className", "id", "options"],
-  "consumers": [
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx",
-      "since": "2026-05-28"
-    }
-  ]
+    "a11y": {
+        "keyboard": [
+            "Tab",
+            "Enter",
+            "Escape",
+            "ArrowDown",
+            "ArrowUp",
+            "Backspace"
+        ],
+        "ariaRequirements": [
+            "input role=combobox with aria-autocomplete=list, aria-expanded, aria-controls, aria-activedescendant",
+            "labelled via aria-labelledby",
+            "listbox role=listbox + aria-multiselectable + aria-label",
+            "options role=option with aria-selected",
+            "selected values are removable Badge chips; Backspace removes the last",
+            "error sets aria-invalid + aria-describedby"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "Verified 2026-06-02: type-to-filter combobox — input role=combobox with aria-autocomplete=list/aria-expanded/aria-controls/aria-activedescendant, aria-labelledby; portaled role=listbox aria-multiselectable with role=option/aria-selected; chips are removable Badges, Backspace removes the last. Keyboard (ArrowUp/Down, Enter toggle, Escape, Backspace) driven and asserted by the KeyboardMultiSelect play function. Shares ComboboxField CSS (inherits the placeholder contrast fix). Default/Playground/Example/KeyboardMultiSelect pass axe with test:error; light + dark verified in Storybook.",
+        "forcedColorsVerified": true
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "className",
+        "id",
+        "options"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/components/Text/Text.contract.json
+++ b/nextjs-app/shared/components/Text/Text.contract.json
@@ -1,98 +1,124 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "Text",
-  "tier": "atom",
-  "group": "display",
-  "status": "stable",
-  "description": "Body and inline typography with size, terminal, and line-height tokens.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=370-19",
-  "radixPrimitive": null,
-  "element": "p",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [
-      "semantic element via as prop"
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Text",
+    "tier": "atom",
+    "group": "display",
+    "status": "stable",
+    "description": "Body and inline typography with size, terminal, and line-height tokens.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=370-19",
+    "radixPrimitive": null,
+    "element": "p",
+    "variants": {
+        "size": {
+            "values": ["XXS", "XS", "S", "M", "L", "XL", "XXL"],
+            "default": "M",
+            "propSourced": true
+        },
+        "terminals": {
+            "values": ["sans", "serif"],
+            "default": "sans",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "2026-05-26 — typography contrast and forced-colors verified in Storybook.",
-    "forcedColorsVerified": true,
-    "axeTestExempt": "Typography display; axe in colocated tests.",
-    "accessibilityTreeVerified": true,
-    "realBrowserForcedColorsVerified": true
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "id",
-    "lineHeight",
-    "ref",
-    "size",
-    "style",
-    "terminals"
-  ],
-  "consumers": [
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "app/dev/code-window/page.tsx",
-      "since": "2026-05-27"
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [
+            "semantic element via as prop"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-05-26 — typography contrast and forced-colors verified in Storybook.",
+        "forcedColorsVerified": true,
+        "axeTestExempt": "Typography display; axe in colocated tests.",
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true
     },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/templates/NextLayoutShell/NextLayoutShell.stories.tsx",
-      "since": "2026-05-27"
+    "tokens": {
+        "colors": [],
+        "spacing": []
     },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/patterns/ProofBlock/ProofBlock.tsx",
-      "since": "2026-05-27"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/patterns/GridBlock/GridBlock.stories.tsx",
-      "since": "2026-05-27"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/patterns/GridBlock/GridBlock.tsx",
-      "since": "2026-05-27"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/patterns/HighlightSection/HighlightSection.tsx",
-      "since": "2026-05-27"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/patterns/GridBlock/GridBlock.test.tsx",
-      "since": "2026-05-27"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.stories.tsx",
-      "since": "2026-05-27"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.tsx",
-      "since": "2026-05-27"
-    }
-  ]
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "id",
+        "lineHeight",
+        "ref",
+        "size",
+        "style",
+        "terminals"
+    ],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/dev/code-window/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Colophon/ColophonPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/SitemapPage/SitemapPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx",
+            "since": "2026-06-04"
+        }
+    ]
 }

--- a/nextjs-app/shared/components/Text/Text.stories.tsx
+++ b/nextjs-app/shared/components/Text/Text.stories.tsx
@@ -109,12 +109,14 @@ export default {
       control: { type: "radio" },
       options: ["S", "M", "L"],
       description: "Text size variant",
+      table: { defaultValue: { summary: "M" } },
     },
 
     terminals: {
       control: { type: "radio" },
       options: ["sans", "serif"],
       description: "Font family (sans or serif)",
+      table: { defaultValue: { summary: "sans" } },
     },
 
     lineHeight: {

--- a/nextjs-app/shared/components/Title/Title.contract.json
+++ b/nextjs-app/shared/components/Title/Title.contract.json
@@ -71,47 +71,62 @@
         {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "app/dev/code-window/page.tsx",
-            "since": "2026-05-27"
+            "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/HighlightSection/HighlightSection.tsx",
-            "since": "2026-05-27"
+            "path": "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
+            "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/ProofBlock/ProofBlock.tsx",
-            "since": "2026-05-27"
+            "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+            "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.tsx",
-            "since": "2026-05-27"
+            "path": "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+            "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx",
-            "since": "2026-05-27"
+            "path": "nextjs-app/shared/components/pages/Colophon/ColophonPage.tsx",
+            "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/Hero/Hero.tsx",
-            "since": "2026-05-27"
+            "path": "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullEnPage.tsx",
+            "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/templates/NextLayoutShell/NextLayoutShell.stories.tsx",
-            "since": "2026-05-27"
+            "path": "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullFiPage.tsx",
+            "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/NextLayout/NextLayout.stories.tsx",
-            "since": "2026-05-27"
+            "path": "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullSvPage.tsx",
+            "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/HeroSection/HeroSection.stories.tsx",
-            "since": "2026-05-27"
+            "path": "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/ImprintPage/ImprintPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
+            "since": "2026-06-04"
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "check:storybook-figma": "node scripts/design-system/check-storybook-figma-contract.mjs",
     "sync:figma-contracts": "node scripts/design-system/sync-figma-contract-urls.mjs",
     "audit:consumers": "node scripts/design-system/audit-consumers.mjs",
+    "check:consumers": "node scripts/design-system/check-consumers.mjs",
     "audit:usage": "node scripts/design-system/audit-usage.mjs",
     "find-component": "node scripts/design-system/find-component.mjs",
     "lint:dt-usage": "node scripts/design-system/lint-dt-usage.mjs --strict",

--- a/scripts/design-system/audit-consumers.mjs
+++ b/scripts/design-system/audit-consumers.mjs
@@ -2,18 +2,19 @@
 /**
  * Populate contract.consumers[] from @dt/<Component> imports in app/ and nextjs-app/.
  */
-import { execSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  consumersEqual,
+  expectedConsumers,
+} from "./consumers-lib.mjs";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
-const REPO = "digitaltableteur/digitaltableteur";
 const roots = [
   join(ROOT, "nextjs-app/shared/components"),
   join(ROOT, "nextjs-app/shared/patterns"),
 ];
-const scanDirs = ["app", "nextjs-app"].map((d) => join(ROOT, d));
 
 let updated = 0;
 for (const base of roots) {
@@ -33,31 +34,17 @@ for (const base of roots) {
       continue;
     }
 
-    const hits = [];
-    for (const scan of scanDirs) {
-      if (!existsSync(scan)) continue;
-      try {
-        const out = execSync(
-          `rg -l "@dt/${name}[^a-zA-Z]" "${scan}" --glob '*.{tsx,ts,jsx,js}' 2>/dev/null || true`,
-          { encoding: "utf8" },
-        ).trim();
-        if (out) {
-          for (const file of out.split("\n").filter(Boolean).slice(0, 8)) {
-            hits.push({
-              repo: REPO,
-              path: file.replace(`${ROOT}/`, ""),
-              since: "2026-05-27",
-            });
-          }
-        }
-      } catch {
-        // ignore
+    const expected = expectedConsumers(contract, name);
+    if (!expected.length) {
+      if (Array.isArray(contract.consumers) && contract.consumers.length > 0) {
+        contract.consumers = [];
+        writeFileSync(contractPath, `${JSON.stringify(contract, null, 4)}\n`);
+        updated += 1;
       }
+      continue;
     }
-    const unique = [...new Map(hits.map((h) => [h.path, h])).values()];
-    if (!unique.length) continue;
-    if (JSON.stringify(contract.consumers) === JSON.stringify(unique)) continue;
-    contract.consumers = unique;
+    if (consumersEqual(contract.consumers, expected)) continue;
+    contract.consumers = expected;
     writeFileSync(contractPath, `${JSON.stringify(contract, null, 4)}\n`);
     updated += 1;
   }

--- a/scripts/design-system/check-consumers.mjs
+++ b/scripts/design-system/check-consumers.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * CI gate: stable contract consumers[] must match @dt import scan in app/ + nextjs-app/.
+ *
+ *   npm run check:consumers
+ *   npm run audit:consumers   # rewrite contracts to match scan
+ */
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  consumersEqual,
+  expectedConsumers,
+} from "./consumers-lib.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const roots = [
+  join(ROOT, "nextjs-app/shared/components"),
+  join(ROOT, "nextjs-app/shared/patterns"),
+];
+
+const mismatches = [];
+
+for (const base of roots) {
+  for (const name of readdirSync(base, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)) {
+    const contractPath = join(base, name, `${name}.contract.json`);
+    if (!existsSync(contractPath)) continue;
+    const contract = JSON.parse(readFileSync(contractPath, "utf8"));
+
+    if (contract.status !== "stable") {
+      if (Array.isArray(contract.consumers) && contract.consumers.length > 0) {
+        mismatches.push({
+          name,
+          kind: "non-stable-has-consumers",
+          detail: "stable-only field must be empty",
+        });
+      }
+      continue;
+    }
+
+    const expected = expectedConsumers(contract, name);
+    if (!expected.length) {
+      if (Array.isArray(contract.consumers) && contract.consumers.length > 0) {
+        mismatches.push({
+          name,
+          kind: "stable-stale-manual-consumers",
+          detail:
+            "no production imports found — run audit:consumers after adding app/pattern usage, or demote status",
+        });
+      } else {
+        mismatches.push({
+          name,
+          kind: "stable-missing-consumers",
+          detail:
+            "no @dt imports in app/, patterns/, or pages/ — add a production consumer or demote status",
+        });
+      }
+      continue;
+    }
+
+    if (!consumersEqual(contract.consumers, expected)) {
+      mismatches.push({
+        name,
+        kind: "consumers-drift",
+        detail: `run npm run audit:consumers (expected ${expected.length} path(s))`,
+      });
+    }
+  }
+}
+
+if (!mismatches.length) {
+  console.log("✓ Stable component consumers[] match import scan");
+  process.exit(0);
+}
+
+console.error(`Consumers check: ${mismatches.length} issue(s)\n`);
+for (const m of mismatches) {
+  console.error(`  ✗ ${m.name}: ${m.kind} — ${m.detail}`);
+}
+console.error("\nFix: npm run audit:consumers");
+process.exit(1);

--- a/scripts/design-system/consumers-lib.mjs
+++ b/scripts/design-system/consumers-lib.mjs
@@ -1,0 +1,95 @@
+/**
+ * Compute production consumers[] for stable component contracts from @dt imports.
+ */
+import { execSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+export const CONSUMER_REPO = "digitaltableteur/digitaltableteur";
+const COMPONENT_ROOTS = [
+  join(ROOT, "nextjs-app/shared/components"),
+  join(ROOT, "nextjs-app/shared/patterns"),
+];
+/** Production surfaces — app routes, patterns, and page modules (not atom cross-imports). */
+const SCAN_DIRS = [
+  join(ROOT, "app"),
+  join(ROOT, "nextjs-app/shared/patterns"),
+  join(ROOT, "nextjs-app/shared/components/pages"),
+].filter((d) => existsSync(d));
+const MAX_CONSUMERS_PER_COMPONENT = 12;
+
+/**
+ * @param {string} componentName
+ * @returns {Array<{ repo: string, path: string, since: string }>}
+ */
+export function computeConsumersForComponent(componentName) {
+  const hits = [];
+  for (const scan of SCAN_DIRS) {
+    if (!existsSync(scan)) continue;
+    try {
+      const out = execSync(
+        `rg -l "@dt/${componentName}[^a-zA-Z]" "${scan}" --glob '*.{tsx,ts,jsx,js}' --glob '!**/*.test.*' --glob '!**/*.stories.*' 2>/dev/null || true`,
+        { encoding: "utf8" },
+      ).trim();
+      if (!out) continue;
+      for (const file of out.split("\n").filter(Boolean)) {
+        hits.push({
+          repo: CONSUMER_REPO,
+          path: file.replace(`${ROOT}/`, ""),
+          since: "2026-06-04",
+        });
+      }
+    } catch {
+      // ignore rg failures
+    }
+  }
+  const unique = [...new Map(hits.map((h) => [h.path, h])).values()];
+  unique.sort((a, b) => a.path.localeCompare(b.path));
+  return unique.slice(0, MAX_CONSUMERS_PER_COMPONENT);
+}
+
+/**
+ * @returns {Generator<{ name: string, contractPath: string, expected: object[], status: string }>}
+ */
+export function* iterStableContracts() {
+  for (const base of COMPONENT_ROOTS) {
+    if (!existsSync(base)) continue;
+    for (const name of readdirSync(base, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)) {
+      const contractPath = join(base, name, `${name}.contract.json`);
+      if (!existsSync(contractPath)) continue;
+      yield {
+        name,
+        contractPath,
+        status: "pending",
+        expected: [],
+      };
+    }
+  }
+}
+
+/**
+ * @param {object} contract
+ * @param {string} componentName
+ */
+export function expectedConsumers(contract, componentName) {
+  if (contract.status !== "stable") return [];
+  return computeConsumersForComponent(componentName);
+}
+
+/**
+ * @param {unknown} a
+ * @param {unknown} b
+ */
+export function consumersEqual(a, b) {
+  const paths = (arr) =>
+    [...new Set((arr ?? []).map((entry) => entry.path))].sort();
+  const left = paths(a);
+  const right = paths(b);
+  return (
+    left.length === right.length && left.every((path, i) => path === right[i])
+  );
+}

--- a/scripts/design-system/cva-sync-lib.mjs
+++ b/scripts/design-system/cva-sync-lib.mjs
@@ -7,7 +7,7 @@ function normalizeVariantValue(value) {
   return String(value).replace(/^["']+|["']+$/g, "");
 }
 
-const VARIANT_PROP_NAMES = new Set([
+export const VARIANT_PROP_NAMES = new Set([
   "variant",
   "surface",
   "size",
@@ -53,7 +53,9 @@ export function cvaAlignsWithProps(cvaVariants, props) {
 
 /** Explicit allowlist: prop-driven styling without root CVA invocation. */
 const PROP_SOURCED_AXES = {
-  Button: ["variant", "surface"],
+  Button: ["variant", "surface", "severity", "size"],
+  Text: ["size", "terminals"],
+  Card: ["variant", "size"],
   Title: ["size", "terminals"],
   Checkbox: ["size"],
   Switch: ["size"],

--- a/scripts/design-system/validate-components.ts
+++ b/scripts/design-system/validate-components.ts
@@ -12,6 +12,7 @@ import {
     type ObjectLiteralExpression,
     type PropertyAssignment,
 } from 'ts-morph'
+import { VARIANT_PROP_NAMES } from './cva-sync-lib.mjs'
 
 type VariantMap = Record<string, { values: string[]; default: string | null }>
 
@@ -833,6 +834,17 @@ export function validateComponentsDir(root: string): ValidationResult {
                     errors.push(
                         `${name}.tsx: default mismatch for "${axis}": CVA has "${extractedAxis.default ?? '(none)'}", manifest has "${def.default}"`,
                     )
+                }
+            }
+
+            // Stable only: styling axes on Props must be declared in contract.variants (Button.surface drift).
+            if (manifest.status === 'stable') {
+                for (const propName of extracted.declaredPropNames) {
+                    if (VARIANT_PROP_NAMES.has(propName) && !(propName in manifestVariants)) {
+                        errors.push(
+                            `${name}.contract.json: stable requires contract.variants.${propName} (${name}Props exposes styling axis "${propName}"; set propSourced:true when not backed by root CVA)`,
+                        )
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Adds `npm run check:consumers` to PR validation (production import scan: `app/`, `patterns/`, `pages/`).
- Refactors `audit:consumers` to share `consumers-lib.mjs` with stable path-set comparison.
- Stable components must declare `contract.variants` for styling props on `*Props` (closes Button-style drift).
- Syncs stable `consumers[]` and documents Button/Text/Card variant axes; demotes Avatar to beta (no direct production `@dt/Avatar` import yet).

## Test plan
- [x] `npm run validate:components`
- [x] `npm run check:consumers`
- [ ] CI PR Validation


Made with [Cursor](https://cursor.com)