### PR TITLE
feat(ds): expand @dt lint and auto-sync variant axes

### DIFF
--- a/docs/DS_AUTOMATION_STRATEGY.md
+++ b/docs/DS_AUTOMATION_STRATEGY.md
@@ -133,7 +133,7 @@ npm run test:stories:matrix:ci
 
 - [ ] “Site baseline” script: run a11y + visual matrix against staging URL → stored report
 - [ ] One-pager for proposals using matrix screenshots
-- [ ] Expand `lint:dt-usage` to `shared/patterns` when shadcn baseline is zero (with exempt list)
+- [x] Expand `lint:dt-usage` to `shared/patterns` and `shared/components/pages` (import policy only)
 
 ### Month 3 — Scale decision
 

--- a/nextjs-app/shared/components/AnimatedDialog/AnimatedDialog.contract.json
+++ b/nextjs-app/shared/components/AnimatedDialog/AnimatedDialog.contract.json
@@ -1,59 +1,82 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "AnimatedDialog",
-  "tier": "molecule",
-  "group": "feedback",
-  "status": "beta",
-  "description": "Dialog (modal) variant with GSAP-driven enter/exit animation. Wraps the shadcn `Dialog` primitive and adds the size axis + severity colour token + animation type axis.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-animated-dialog",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [
-    "trigger"
-  ],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [
-      "Tab — cycles through focusable elements inside the dialog.",
-      "Shift+Tab — reverse cycle.",
-      "Esc — closes the dialog."
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "AnimatedDialog",
+    "tier": "molecule",
+    "group": "feedback",
+    "status": "beta",
+    "description": "Dialog (modal) variant with GSAP-driven enter/exit animation. Wraps the shadcn `Dialog` primitive and adds the size axis + severity colour token + animation type axis.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-animated-dialog",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg",
+                "xl",
+                "full"
+            ],
+            "default": "sm",
+            "propSourced": true
+        },
+        "severity": {
+            "values": [
+                "info",
+                "success",
+                "warning",
+                "error",
+                "default"
+            ],
+            "default": "info",
+            "propSourced": true
+        }
+    },
+    "slots": [
+        "trigger"
     ],
-    "ariaRequirements": [
-      "Renders a real `role='dialog'` with `aria-modal='true'` (via the shadcn primitive).",
-      "Focus moves to the dialog body on open and returns to the trigger on close.",
-      "When `severity` is success/warning/error/info, the icon is decorative and the visible text owns the announcement; the dialog itself does not become a live region."
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "motion": true,
-    "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [
-      "--color-text",
-      "--color-surface-elevated",
-      "--color-accent",
-      "--color-warning",
-      "--color-error",
-      "--color-success"
-    ],
-    "spacing": [
-      "--space-internal-12",
-      "--space-internal-16"
-    ],
-    "radii": [
-      "--radius-md"
-    ]
-  },
-  "lightDarkVerified": true,
-  "consumers": []
+    "a11y": {
+        "keyboard": [
+            "Tab — cycles through focusable elements inside the dialog.",
+            "Shift+Tab — reverse cycle.",
+            "Esc — closes the dialog."
+        ],
+        "ariaRequirements": [
+            "Renders a real `role='dialog'` with `aria-modal='true'` (via the shadcn primitive).",
+            "Focus moves to the dialog body on open and returns to the trigger on close.",
+            "When `severity` is success/warning/error/info, the icon is decorative and the visible text owns the announcement; the dialog itself does not become a live region."
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "motion": true,
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [
+            "--color-text",
+            "--color-surface-elevated",
+            "--color-accent",
+            "--color-warning",
+            "--color-error",
+            "--color-success"
+        ],
+        "spacing": [
+            "--space-internal-12",
+            "--space-internal-16"
+        ],
+        "radii": [
+            "--radius-md"
+        ]
+    },
+    "lightDarkVerified": true,
+    "consumers": []
 }

--- a/nextjs-app/shared/components/AnimatedGlyphBackground/AnimatedGlyphBackground.contract.json
+++ b/nextjs-app/shared/components/AnimatedGlyphBackground/AnimatedGlyphBackground.contract.json
@@ -1,46 +1,57 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "AnimatedGlyphBackground",
-  "tier": "molecule",
-  "group": "structure",
-  "status": "beta",
-  "description": "AnimatedGlyphBackground — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-animated-glyph-background",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "ariaRequirements": [],
-    "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "animate",
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "id",
-    "ref",
-    "style",
-    "tone"
-  ],
-  "consumers": []
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "AnimatedGlyphBackground",
+    "tier": "molecule",
+    "group": "structure",
+    "status": "beta",
+    "description": "AnimatedGlyphBackground — production @dt component (Storybook beta).",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-animated-glyph-background",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "tone": {
+            "values": [
+                "muted",
+                "primary",
+                "accent",
+                "contrast"
+            ],
+            "default": "muted",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "ariaRequirements": [],
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "animate",
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "id",
+        "ref",
+        "style",
+        "tone"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/components/AnimatedGlyphBackground/AnimatedGlyphBackground.stories.tsx
+++ b/nextjs-app/shared/components/AnimatedGlyphBackground/AnimatedGlyphBackground.stories.tsx
@@ -26,6 +26,7 @@ const meta: Meta<typeof AnimatedGlyphBackground> = {
       control: { type: "select" },
       options: ["muted", "primary", "accent", "contrast"],
       description: "Color tone for the animated glyph",
+      table: { defaultValue: { summary: "muted" } },
     },
 
     animate: { control: "boolean", description: "Toggle frame animation" },

--- a/nextjs-app/shared/components/Avatar/Avatar.contract.json
+++ b/nextjs-app/shared/components/Avatar/Avatar.contract.json
@@ -8,7 +8,16 @@
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=369-8",
     "radixPrimitive": null,
     "element": "button",
-    "variants": {},
+    "variants": {
+        "variant": {
+            "values": [
+                "image",
+                "initials"
+            ],
+            "default": "image",
+            "propSourced": true
+        }
+    },
     "slots": [],
     "asChild": false,
     "subParts": [],

--- a/nextjs-app/shared/components/Avatar/Avatar.stories.tsx
+++ b/nextjs-app/shared/components/Avatar/Avatar.stories.tsx
@@ -29,6 +29,7 @@ export default {
       control: { type: "inline-radio" },
       options: ["image", "initials"],
       description: "Select whether the avatar prefers an image or initials.",
+      table: { defaultValue: { summary: "image" } },
     },
 
     name: {

--- a/nextjs-app/shared/components/BusyIndicator/BusyIndicator.contract.json
+++ b/nextjs-app/shared/components/BusyIndicator/BusyIndicator.contract.json
@@ -1,48 +1,66 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "BusyIndicator",
-  "tier": "atom",
-  "group": "feedback",
-  "status": "beta",
-  "description": "BusyIndicator — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-busy-indicator",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "ariaRequirements": [],
-    "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "id",
-    "label",
-    "progress",
-    "ref",
-    "size",
-    "style",
-    "variant"
-  ],
-  "consumers": []
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "BusyIndicator",
+    "tier": "atom",
+    "group": "feedback",
+    "status": "beta",
+    "description": "BusyIndicator — production @dt component (Storybook beta).",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-busy-indicator",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "variant": {
+            "values": [
+                "inline",
+                "overlay"
+            ],
+            "default": "inline",
+            "propSourced": true
+        },
+        "size": {
+            "values": [
+                "s",
+                "m",
+                "l"
+            ],
+            "default": "s",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "ariaRequirements": [],
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "id",
+        "label",
+        "progress",
+        "ref",
+        "size",
+        "style",
+        "variant"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/components/BusyIndicator/BusyIndicator.stories.tsx
+++ b/nextjs-app/shared/components/BusyIndicator/BusyIndicator.stories.tsx
@@ -21,7 +21,20 @@ const busyIndicatorComplianceRules: ComplianceRule[] = [
 ];
 
 const meta: Meta<typeof BusyIndicator> = {
-  argTypes: {},
+  argTypes: {
+    variant: {
+      control: { type: "select" },
+      options: ["inline", "overlay"],
+      description: "Presentation context for the busy indicator",
+      table: { defaultValue: { summary: "inline" } },
+    },
+    size: {
+      control: { type: "select" },
+      options: ["s", "m", "l"],
+      description: "Spinner size",
+      table: { defaultValue: { summary: "s" } },
+    },
+  },
   title: "Atoms/BusyIndicator",
   component: BusyIndicator,
   tags: ["beta", "!autodocs"],

--- a/nextjs-app/shared/components/Button/Button.contract.json
+++ b/nextjs-app/shared/components/Button/Button.contract.json
@@ -39,7 +39,7 @@
             "propSourced": true
         },
         "size": {
-            "values": ["sm", "md", "lg", "s", "m", "l"],
+            "values": ["sm", "md", "lg", "s", "m", "l", "S", "M", "L"],
             "default": "md",
             "propSourced": true
         }

--- a/nextjs-app/shared/components/CategoryFilter/CategoryFilter.contract.json
+++ b/nextjs-app/shared/components/CategoryFilter/CategoryFilter.contract.json
@@ -1,52 +1,71 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "CategoryFilter",
-  "tier": "molecule",
-  "group": "navigation",
-  "status": "beta",
-  "description": "Filter pill row for list pages (blog archive, work index). Multiple visual treatments (pills, underline, minimal) for different surface densities.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-category-filter",
-  "radixPrimitive": null,
-  "element": "nav",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [
-      "Tab — moves between filter buttons.",
-      "Enter / Space — activates the focused filter."
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "CategoryFilter",
+    "tier": "molecule",
+    "group": "navigation",
+    "status": "beta",
+    "description": "Filter pill row for list pages (blog archive, work index). Multiple visual treatments (pills, underline, minimal) for different surface densities.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-category-filter",
+    "radixPrimitive": null,
+    "element": "nav",
+    "variants": {
+        "variant": {
+            "values": [
+                "pills",
+                "underline",
+                "minimal"
+            ],
+            "default": "pills",
+            "propSourced": true
+        },
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "default": "sm",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "ariaRequirements": [
-      "Renders a `<nav>` landmark with an accessible name describing the filter dimension ('Filter by category').",
-      "The active filter sets `aria-pressed='true'` on a toggle button (not `aria-current`) because the filter is a UI control, not a navigation target."
-    ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [
-      "--color-text",
-      "--color-accent",
-      "--color-border-default"
-    ],
-    "spacing": [
-      "--space-internal-4",
-      "--space-internal-8"
-    ],
-    "typography": [
-      "--font-size-sm",
-      "--font-size-md"
-    ]
-  },
-  "lightDarkVerified": true,
-  "consumers": []
+    "a11y": {
+        "keyboard": [
+            "Tab — moves between filter buttons.",
+            "Enter / Space — activates the focused filter."
+        ],
+        "ariaRequirements": [
+            "Renders a `<nav>` landmark with an accessible name describing the filter dimension ('Filter by category').",
+            "The active filter sets `aria-pressed='true'` on a toggle button (not `aria-current`) because the filter is a UI control, not a navigation target."
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [
+            "--color-text",
+            "--color-accent",
+            "--color-border-default"
+        ],
+        "spacing": [
+            "--space-internal-4",
+            "--space-internal-8"
+        ],
+        "typography": [
+            "--font-size-sm",
+            "--font-size-md"
+        ]
+    },
+    "lightDarkVerified": true,
+    "consumers": []
 }

--- a/nextjs-app/shared/components/CodeSnippet/CodeSnippet.contract.json
+++ b/nextjs-app/shared/components/CodeSnippet/CodeSnippet.contract.json
@@ -1,52 +1,62 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "CodeSnippet",
-  "tier": "molecule",
-  "group": "structure",
-  "status": "beta",
-  "description": "CodeSnippet — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-code-snippet",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "ariaRequirements": [],
-    "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "\"aria-label\"",
-    "allowCopy",
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "code",
-    "id",
-    "language",
-    "maxLines",
-    "onCopy",
-    "ref",
-    "showLineNumbers",
-    "style",
-    "variant"
-  ],
-  "consumers": []
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "CodeSnippet",
+    "tier": "molecule",
+    "group": "structure",
+    "status": "beta",
+    "description": "CodeSnippet — production @dt component (Storybook beta).",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-code-snippet",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "variant": {
+            "values": [
+                "inline",
+                "single",
+                "multi"
+            ],
+            "default": "inline",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "ariaRequirements": [],
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "\"aria-label\"",
+        "allowCopy",
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "code",
+        "id",
+        "language",
+        "maxLines",
+        "onCopy",
+        "ref",
+        "showLineNumbers",
+        "style",
+        "variant"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/components/CodeSnippet/CodeSnippet.stories.tsx
+++ b/nextjs-app/shared/components/CodeSnippet/CodeSnippet.stories.tsx
@@ -55,7 +55,14 @@ export function DemoComponent({ title, description }: DemoProps) { const [count,
 }`;
 
 const meta: Meta<typeof CodeSnippet> = {
-  argTypes: {},
+  argTypes: {
+    variant: {
+      control: { type: "select" },
+      options: ["inline", "single", "multi"],
+      description: "Code snippet layout variant",
+      table: { defaultValue: { summary: "inline" } },
+    },
+  },
   title: "Molecules/CodeSnippet",
   component: CodeSnippet,
   tags: ["beta", "!autodocs"],

--- a/nextjs-app/shared/components/Container/Container.contract.json
+++ b/nextjs-app/shared/components/Container/Container.contract.json
@@ -1,46 +1,58 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "Container",
-  "tier": "atom",
-  "group": "layout",
-  "status": "beta",
-  "description": "Max-width content wrapper with responsive horizontal padding.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-container",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "as",
-    "asChild",
-    "center",
-    "children",
-    "className",
-    "id",
-    "ref",
-    "size",
-    "style"
-  ],
-  "consumers": []
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Container",
+    "tier": "atom",
+    "group": "layout",
+    "status": "beta",
+    "description": "Max-width content wrapper with responsive horizontal padding.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-container",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg",
+                "xl",
+                "full"
+            ],
+            "default": "sm",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "as",
+        "asChild",
+        "center",
+        "children",
+        "className",
+        "id",
+        "ref",
+        "size",
+        "style"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/components/Divider/Divider.contract.json
+++ b/nextjs-app/shared/components/Divider/Divider.contract.json
@@ -1,41 +1,50 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "Divider",
-  "tier": "atom",
-  "group": "structure",
-  "status": "beta",
-  "description": "Visual separator between sections (horizontal or vertical).",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=368-6",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "argTypesProxyExempt": [
-    "className"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
-  },
-  "tokens": {
-    "colors": [
-      "--color-border",
-      "--color-primary"
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Divider",
+    "tier": "atom",
+    "group": "structure",
+    "status": "beta",
+    "description": "Visual separator between sections (horizontal or vertical).",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=368-6",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "orientation": {
+            "values": [
+                "horizontal",
+                "vertical"
+            ],
+            "default": "horizontal",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "consumers": []
+    "argTypesProxyExempt": [
+        "className"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+    },
+    "tokens": {
+        "colors": [
+            "--color-border",
+            "--color-primary"
+        ],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "consumers": []
 }

--- a/nextjs-app/shared/components/DonnyAvatar/DonnyAvatar.contract.json
+++ b/nextjs-app/shared/components/DonnyAvatar/DonnyAvatar.contract.json
@@ -1,60 +1,71 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "DonnyAvatar",
-  "tier": "molecule",
-  "group": "display",
-  "status": "beta",
-  "description": "DonnyAvatar — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-donny-avatar",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "ariaRequirements": [],
-    "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
-  },
-  "tokens": {
-    "colors": [
-      "--color-text"
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "DonnyAvatar",
+    "tier": "molecule",
+    "group": "display",
+    "status": "beta",
+    "description": "DonnyAvatar — production @dt component (Storybook beta).",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-donny-avatar",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg",
+                "xl"
+            ],
+            "default": "sm",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "enableIdleExpressions",
-    "enableSleepDetection",
-    "id",
-    "idleExpressionInterval",
-    "isSpeaking",
-    "onProximityChange",
-    "onTransitionEnd",
-    "proximitySelectors",
-    "proximityThreshold",
-    "ref",
-    "showLabel",
-    "size",
-    "sleepDelay",
-    "sleepyDelay",
-    "state",
-    "style",
-    "trackMouse"
-  ],
-  "consumers": []
+    "a11y": {
+        "keyboard": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "ariaRequirements": [],
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+    },
+    "tokens": {
+        "colors": [
+            "--color-text"
+        ],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "enableIdleExpressions",
+        "enableSleepDetection",
+        "id",
+        "idleExpressionInterval",
+        "isSpeaking",
+        "onProximityChange",
+        "onTransitionEnd",
+        "proximitySelectors",
+        "proximityThreshold",
+        "ref",
+        "showLabel",
+        "size",
+        "sleepDelay",
+        "sleepyDelay",
+        "state",
+        "style",
+        "trackMouse"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/components/DonnyAvatar/DonnyAvatar.stories.tsx
+++ b/nextjs-app/shared/components/DonnyAvatar/DonnyAvatar.stories.tsx
@@ -86,6 +86,7 @@ When \`enableSleepDetection\` is true, Donny will:
       description: "Size",
       control: "select",
       options: ["sm", "md", "lg", "xl"],
+      table: { defaultValue: { summary: "sm" } },
     },
     showLabel: {
       description: "Show Label",

--- a/nextjs-app/shared/components/FlexBox/FlexBox.contract.json
+++ b/nextjs-app/shared/components/FlexBox/FlexBox.contract.json
@@ -1,45 +1,57 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "FlexBox",
-  "tier": "atom",
-  "group": "layout",
-  "status": "beta",
-  "description": "Flexbox layout primitive for stacks and rows.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-flex-box",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "alignContent",
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "id",
-    "ref",
-    "style"
-  ],
-  "consumers": []
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "FlexBox",
+    "tier": "atom",
+    "group": "layout",
+    "status": "beta",
+    "description": "Flexbox layout primitive for stacks and rows.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-flex-box",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "align": {
+            "values": [
+                "center",
+                "flex-start",
+                "flex-end",
+                "stretch",
+                "baseline"
+            ],
+            "default": "center",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "alignContent",
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "id",
+        "ref",
+        "style"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/components/Grid/Grid.contract.json
+++ b/nextjs-app/shared/components/Grid/Grid.contract.json
@@ -1,45 +1,69 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "Grid",
-  "tier": "atom",
-  "group": "layout",
-  "status": "beta",
-  "description": "CSS grid layout primitive with tokenized gaps.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-grid",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "id",
-    "ref",
-    "rows",
-    "style"
-  ],
-  "consumers": []
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Grid",
+    "tier": "atom",
+    "group": "layout",
+    "status": "beta",
+    "description": "CSS grid layout primitive with tokenized gaps.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-grid",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "align": {
+            "values": [
+                "inherit",
+                "center",
+                "flex-start",
+                "flex-end",
+                "stretch",
+                "baseline",
+                "-moz-initial",
+                "initial",
+                "revert",
+                "revert-layer",
+                "unset",
+                "end",
+                "self-end",
+                "self-start",
+                "start",
+                "anchor-center",
+                "normal"
+            ],
+            "default": "inherit",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "id",
+        "ref",
+        "rows",
+        "style"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/components/Grid/Grid.stories.tsx
+++ b/nextjs-app/shared/components/Grid/Grid.stories.tsx
@@ -75,7 +75,7 @@ const meta = {
     align: {
       control: "text",
       description: "align-items",
-      table: { disable: true },
+      table: { disable: true, defaultValue: { summary: "inherit" } },
     },
     justify: {
       control: "text",

--- a/nextjs-app/shared/components/Heading/Heading.contract.json
+++ b/nextjs-app/shared/components/Heading/Heading.contract.json
@@ -1,49 +1,62 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "Heading",
-  "tier": "atom",
-  "group": "display",
-  "status": "beta",
-  "description": "Semantic heading primitive (h1–h6) with an explicit visual size axis decoupled from the HTML level so the document outline stays honest.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-heading",
-  "radixPrimitive": null,
-  "element": "h2",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [
-      "Always renders an h1–h6 element matching `level`; the visual `size` axis does not change the rendered tag.",
-      "Authors are responsible for keeping `level` aligned with the surrounding document outline — `Heading` does not introspect its DOM position."
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Heading",
+    "tier": "atom",
+    "group": "display",
+    "status": "beta",
+    "description": "Semantic heading primitive (h1–h6) with an explicit visual size axis decoupled from the HTML level so the document outline stays honest.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-heading",
+    "radixPrimitive": null,
+    "element": "h2",
+    "variants": {
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg",
+                "xl",
+                "display",
+                "xs"
+            ],
+            "default": "sm",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [
-      "--color-text"
-    ],
-    "spacing": [],
-    "typography": [
-      "--font-display",
-      "--font-size-display",
-      "--font-size-xl",
-      "--font-size-lg",
-      "--font-size-md",
-      "--font-size-sm",
-      "--line-height-tight"
-    ]
-  },
-  "lightDarkVerified": true,
-  "consumers": []
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [
+            "Always renders an h1–h6 element matching `level`; the visual `size` axis does not change the rendered tag.",
+            "Authors are responsible for keeping `level` aligned with the surrounding document outline — `Heading` does not introspect its DOM position."
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [
+            "--color-text"
+        ],
+        "spacing": [],
+        "typography": [
+            "--font-display",
+            "--font-size-display",
+            "--font-size-xl",
+            "--font-size-lg",
+            "--font-size-md",
+            "--font-size-sm",
+            "--line-height-tight"
+        ]
+    },
+    "lightDarkVerified": true,
+    "consumers": []
 }

--- a/nextjs-app/shared/components/IconButton/IconButton.contract.json
+++ b/nextjs-app/shared/components/IconButton/IconButton.contract.json
@@ -1,52 +1,71 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "IconButton",
-  "tier": "atom",
-  "group": "actions",
-  "status": "beta",
-  "description": "Icon-only action button. Wraps the underlying shadcn `Button` with a circular shape, enforced `aria-label`, and the design-system size axis.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-icon-button",
-  "radixPrimitive": null,
-  "element": "button",
-  "variants": {},
-  "slots": [
-    "icon"
-  ],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [
-      "Tab — focusable.",
-      "Enter / Space — activates."
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "IconButton",
+    "tier": "atom",
+    "group": "actions",
+    "status": "beta",
+    "description": "Icon-only action button. Wraps the underlying shadcn `Button` with a circular shape, enforced `aria-label`, and the design-system size axis.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-icon-button",
+    "radixPrimitive": null,
+    "element": "button",
+    "variants": {
+        "variant": {
+            "values": [
+                "default",
+                "ghost",
+                "outline"
+            ],
+            "default": "default",
+            "propSourced": true
+        },
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "default": "sm",
+            "propSourced": true
+        }
+    },
+    "slots": [
+        "icon"
     ],
-    "ariaRequirements": [
-      "`label` prop is required and renders as `aria-label`; the icon glyph itself is `aria-hidden`.",
-      "Disabled state forwards `aria-disabled` and removes pointer events; focus remains routable so keyboard users can discover the disabled affordance."
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [
-      "--color-text",
-      "--color-surface-elevated"
-    ],
-    "spacing": [
-      "--space-internal-8",
-      "--space-internal-12"
-    ],
-    "radii": [
-      "--radius-full"
-    ]
-  },
-  "lightDarkVerified": true,
-  "consumers": []
+    "a11y": {
+        "keyboard": [
+            "Tab — focusable.",
+            "Enter / Space — activates."
+        ],
+        "ariaRequirements": [
+            "`label` prop is required and renders as `aria-label`; the icon glyph itself is `aria-hidden`.",
+            "Disabled state forwards `aria-disabled` and removes pointer events; focus remains routable so keyboard users can discover the disabled affordance."
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [
+            "--color-text",
+            "--color-surface-elevated"
+        ],
+        "spacing": [
+            "--space-internal-8",
+            "--space-internal-12"
+        ],
+        "radii": [
+            "--radius-full"
+        ]
+    },
+    "lightDarkVerified": true,
+    "consumers": []
 }

--- a/nextjs-app/shared/components/ImagePlaceholder/ImagePlaceholder.contract.json
+++ b/nextjs-app/shared/components/ImagePlaceholder/ImagePlaceholder.contract.json
@@ -1,52 +1,63 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "ImagePlaceholder",
-  "tier": "molecule",
-  "group": "structure",
-  "status": "beta",
-  "description": "ImagePlaceholder — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-image-placeholder",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "ariaRequirements": [],
-    "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "alt",
-    "as",
-    "asChild",
-    "caption",
-    "children",
-    "className",
-    "height",
-    "id",
-    "ref",
-    "showDimensions",
-    "showIcon",
-    "style",
-    "text",
-    "variant",
-    "width"
-  ],
-  "consumers": []
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "ImagePlaceholder",
+    "tier": "molecule",
+    "group": "structure",
+    "status": "beta",
+    "description": "ImagePlaceholder — production @dt component (Storybook beta).",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-image-placeholder",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "variant": {
+            "values": [
+                "light",
+                "medium",
+                "dark",
+                "gradient"
+            ],
+            "default": "light",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "ariaRequirements": [],
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "alt",
+        "as",
+        "asChild",
+        "caption",
+        "children",
+        "className",
+        "height",
+        "id",
+        "ref",
+        "showDimensions",
+        "showIcon",
+        "style",
+        "text",
+        "variant",
+        "width"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/components/ImagePlaceholder/ImagePlaceholder.stories.tsx
+++ b/nextjs-app/shared/components/ImagePlaceholder/ImagePlaceholder.stories.tsx
@@ -64,6 +64,7 @@ const meta: Meta<typeof ImagePlaceholder> = {
       control: { type: "select" },
       options: ["light", "medium", "dark", "gradient"],
       description: "Background color variant",
+      table: { defaultValue: { summary: "light" } },
     },
 
     showDimensions: {

--- a/nextjs-app/shared/components/LinkedInQuoteCard/LinkedInQuoteCard.contract.json
+++ b/nextjs-app/shared/components/LinkedInQuoteCard/LinkedInQuoteCard.contract.json
@@ -1,53 +1,63 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "LinkedInQuoteCard",
-  "tier": "molecule",
-  "group": "structure",
-  "status": "beta",
-  "description": "LinkedInQuoteCard — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-linked-in-quote-card",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "ariaRequirements": [],
-    "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "as",
-    "asChild",
-    "avatarUrl",
-    "children",
-    "className",
-    "company",
-    "companyLogoUrl",
-    "connectionDegree",
-    "id",
-    "linkedinUrl",
-    "name",
-    "quote",
-    "ref",
-    "style",
-    "title",
-    "variant"
-  ],
-  "consumers": []
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "LinkedInQuoteCard",
+    "tier": "molecule",
+    "group": "structure",
+    "status": "beta",
+    "description": "LinkedInQuoteCard — production @dt component (Storybook beta).",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-linked-in-quote-card",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "variant": {
+            "values": [
+                "muted",
+                "light",
+                "dark"
+            ],
+            "default": "muted",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "ariaRequirements": [],
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "as",
+        "asChild",
+        "avatarUrl",
+        "children",
+        "className",
+        "company",
+        "companyLogoUrl",
+        "connectionDegree",
+        "id",
+        "linkedinUrl",
+        "name",
+        "quote",
+        "ref",
+        "style",
+        "title",
+        "variant"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/components/LinkedInQuoteCard/LinkedInQuoteCard.stories.tsx
+++ b/nextjs-app/shared/components/LinkedInQuoteCard/LinkedInQuoteCard.stories.tsx
@@ -188,7 +188,14 @@ const ScreenshotWrapper: React.FC<ScreenshotWrapperProps> = ({
 };
 
 export default {
-  argTypes: {},
+  argTypes: {
+    variant: {
+      control: { type: "select" },
+      options: ["muted", "light", "dark"],
+      description: "Surface treatment for the quote card",
+      table: { defaultValue: { summary: "muted" } },
+    },
+  },
   title: "Molecules/LinkedInQuoteCard",
   component: LinkedInQuoteCard,
   parameters: {

--- a/nextjs-app/shared/components/List/List.contract.json
+++ b/nextjs-app/shared/components/List/List.contract.json
@@ -1,46 +1,68 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "List",
-  "tier": "molecule",
-  "group": "structure",
-  "status": "beta",
-  "description": "List — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-list",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [
-    "items"
-  ],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "ariaRequirements": [],
-    "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "id",
-    "ref",
-    "style"
-  ],
-  "consumers": []
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "List",
+    "tier": "molecule",
+    "group": "structure",
+    "status": "beta",
+    "description": "List — production @dt component (Storybook beta).",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-list",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "size": {
+            "values": [
+                "S",
+                "M",
+                "L",
+                "XXS",
+                "XS",
+                "XL",
+                "XXL"
+            ],
+            "default": "S",
+            "propSourced": true
+        },
+        "terminals": {
+            "values": [
+                "serif",
+                "sans"
+            ],
+            "default": "serif",
+            "propSourced": true
+        }
+    },
+    "slots": [
+        "items"
+    ],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "ariaRequirements": [],
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "id",
+        "ref",
+        "style"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/components/List/List.stories.tsx
+++ b/nextjs-app/shared/components/List/List.stories.tsx
@@ -133,12 +133,14 @@ const meta: Meta<typeof List> = {
       control: { type: "select" },
       options: ["XXS", "XS", "S", "M", "L", "XL", "XXL"],
       description: "Text size variant",
+      table: { defaultValue: { summary: "S" } },
     },
 
     terminals: {
       control: { type: "radio" },
       options: ["sans", "serif"],
       description: "Font family",
+      table: { defaultValue: { summary: "serif" } },
     },
 
     lineHeight: {

--- a/nextjs-app/shared/components/LocationCard/LocationCard.contract.json
+++ b/nextjs-app/shared/components/LocationCard/LocationCard.contract.json
@@ -1,51 +1,61 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "LocationCard",
-  "tier": "molecule",
-  "group": "display",
-  "status": "beta",
-  "description": "Card variant for displaying a single office or service location (address, hours, map link). Visual sibling of `Card` with the location-specific slot order baked in.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-location-card",
-  "radixPrimitive": null,
-  "element": "article",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [
-      "Tab — focuses the embedded action (map link, contact CTA) in order."
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "LocationCard",
+    "tier": "molecule",
+    "group": "display",
+    "status": "beta",
+    "description": "Card variant for displaying a single office or service location (address, hours, map link). Visual sibling of `Card` with the location-specific slot order baked in.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-location-card",
+    "radixPrimitive": null,
+    "element": "article",
+    "variants": {
+        "variant": {
+            "values": [
+                "default",
+                "elevated",
+                "bordered"
+            ],
+            "default": "default",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "ariaRequirements": [
-      "Renders an `<article>` so the whole card is announced as a region.",
-      "Address content sits inside a real `<address>` element so screen readers identify it as contact information."
-    ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [
-      "--color-text",
-      "--color-text-muted",
-      "--color-surface-elevated"
-    ],
-    "spacing": [
-      "--space-internal-8",
-      "--space-internal-12",
-      "--space-internal-16"
-    ],
-    "radii": [
-      "--radius-md"
-    ]
-  },
-  "lightDarkVerified": true,
-  "consumers": []
+    "a11y": {
+        "keyboard": [
+            "Tab — focuses the embedded action (map link, contact CTA) in order."
+        ],
+        "ariaRequirements": [
+            "Renders an `<article>` so the whole card is announced as a region.",
+            "Address content sits inside a real `<address>` element so screen readers identify it as contact information."
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [
+            "--color-text",
+            "--color-text-muted",
+            "--color-surface-elevated"
+        ],
+        "spacing": [
+            "--space-internal-8",
+            "--space-internal-12",
+            "--space-internal-16"
+        ],
+        "radii": [
+            "--radius-md"
+        ]
+    },
+    "lightDarkVerified": true,
+    "consumers": []
 }

--- a/nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.contract.json
+++ b/nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.contract.json
@@ -1,48 +1,57 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "MacWindowFrame",
-  "tier": "molecule",
-  "group": "structure",
-  "status": "beta",
-  "description": "MacWindowFrame — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-mac-window-frame",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "ariaRequirements": [],
-    "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "actionLabelKey",
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "density",
-    "id",
-    "onAction",
-    "ref",
-    "style",
-    "titleKey"
-  ],
-  "consumers": []
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "MacWindowFrame",
+    "tier": "molecule",
+    "group": "structure",
+    "status": "beta",
+    "description": "MacWindowFrame — production @dt component (Storybook beta).",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-mac-window-frame",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "density": {
+            "values": [
+                "compact",
+                "comfortable"
+            ],
+            "default": "compact",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "ariaRequirements": [],
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "actionLabelKey",
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "density",
+        "id",
+        "onAction",
+        "ref",
+        "style",
+        "titleKey"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.stories.tsx
+++ b/nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.stories.tsx
@@ -3,7 +3,14 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import MacWindowFrame from "@dt/MacWindowFrame";
 
 const meta: Meta<typeof MacWindowFrame> = {
-  argTypes: {},
+  argTypes: {
+    density: {
+      control: { type: "select" },
+      options: ["compact", "comfortable"],
+      description: "Chrome density inside the window frame",
+      table: { defaultValue: { summary: "compact" } },
+    },
+  },
   title: "Molecules/MacWindowFrame",
   component: MacWindowFrame,
   parameters: {

--- a/nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.contract.json
+++ b/nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.contract.json
@@ -1,49 +1,58 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "MarkdownMessage",
-  "tier": "molecule",
-  "group": "structure",
-  "status": "beta",
-  "description": "MarkdownMessage — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-markdown-message",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "ariaRequirements": [],
-    "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "\"data-role\"",
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "content",
-    "designSystemTextSize",
-    "fallback",
-    "id",
-    "ref",
-    "renderWithDesignSystem",
-    "style"
-  ],
-  "consumers": []
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "MarkdownMessage",
+    "tier": "molecule",
+    "group": "structure",
+    "status": "beta",
+    "description": "MarkdownMessage — production @dt component (Storybook beta).",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-markdown-message",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "density": {
+            "values": [
+                "default",
+                "chat"
+            ],
+            "default": "default",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "ariaRequirements": [],
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "\"data-role\"",
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "content",
+        "designSystemTextSize",
+        "fallback",
+        "id",
+        "ref",
+        "renderWithDesignSystem",
+        "style"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/components/Modal/Modal.contract.json
+++ b/nextjs-app/shared/components/Modal/Modal.contract.json
@@ -1,68 +1,79 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "Modal",
-  "tier": "molecule",
-  "group": "overlay",
-  "status": "beta",
-  "description": "Modal dialog for confirmations, forms, and focused tasks.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=384-13",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [
-    "menu",
-    "footer",
-    "icon"
-  ],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [
-      "Escape",
-      "Tab"
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Modal",
+    "tier": "molecule",
+    "group": "overlay",
+    "status": "beta",
+    "description": "Modal dialog for confirmations, forms, and focused tasks.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=384-13",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "severity": {
+            "values": [
+                "info",
+                "success",
+                "warning",
+                "error"
+            ],
+            "default": "info",
+            "propSourced": true
+        }
+    },
+    "slots": [
+        "menu",
+        "footer",
+        "icon"
     ],
-    "ariaRequirements": [
-      "role=dialog",
-      "focus trap while open",
-      "accessible title"
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "2026-05-26 — focus trap, Escape close, aria dialog reviewed in Storybook plays.",
-    "forcedColorsVerified": true
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "closeButtonLabel",
-    "closeIconName",
-    "footer",
-    "icon",
-    "id",
-    "isLoading",
-    "isOpen",
-    "menu",
-    "onClose",
-    "ref",
-    "severity",
-    "showCloseIcon",
-    "style",
-    "title",
-    "titleSize",
-    "titleTerminals"
-  ],
-  "consumers": []
+    "a11y": {
+        "keyboard": [
+            "Escape",
+            "Tab"
+        ],
+        "ariaRequirements": [
+            "role=dialog",
+            "focus trap while open",
+            "accessible title"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-05-26 — focus trap, Escape close, aria dialog reviewed in Storybook plays.",
+        "forcedColorsVerified": true
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "closeButtonLabel",
+        "closeIconName",
+        "footer",
+        "icon",
+        "id",
+        "isLoading",
+        "isOpen",
+        "menu",
+        "onClose",
+        "ref",
+        "severity",
+        "showCloseIcon",
+        "style",
+        "title",
+        "titleSize",
+        "titleTerminals"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/components/Modal/Modal.stories.tsx
+++ b/nextjs-app/shared/components/Modal/Modal.stories.tsx
@@ -132,7 +132,11 @@ export default {
       control: { type: "select" },
       options: ["success", "error", "warning", "info"],
       description: "Semantic severity level (v1.1.0+)",
-      table: { category: "State", type: { summary: "ModalSeverity" } },
+      table: {
+        category: "State",
+        type: { summary: "ModalSeverity" },
+        defaultValue: { summary: "info" },
+      },
     },
 
     isLoading: {

--- a/nextjs-app/shared/components/Progress/Progress.contract.json
+++ b/nextjs-app/shared/components/Progress/Progress.contract.json
@@ -1,41 +1,51 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "Progress",
-  "tier": "atom",
-  "group": "feedback",
-  "status": "beta",
-  "description": "Determinate linear progress indicator.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=369-15",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "argTypesProxyExempt": [
-    "className"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
-  },
-  "tokens": {
-    "colors": [
-      "--color-border",
-      "--color-primary"
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Progress",
+    "tier": "atom",
+    "group": "feedback",
+    "status": "beta",
+    "description": "Determinate linear progress indicator.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=369-15",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "default": "sm",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "consumers": []
+    "argTypesProxyExempt": [
+        "className"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+    },
+    "tokens": {
+        "colors": [
+            "--color-border",
+            "--color-primary"
+        ],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "consumers": []
 }

--- a/nextjs-app/shared/components/Radio/Radio.contract.json
+++ b/nextjs-app/shared/components/Radio/Radio.contract.json
@@ -1,41 +1,54 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "Radio",
-  "tier": "atom",
-  "group": "form",
-  "status": "beta",
-  "description": "Single radio option; compose with RadioGroup for sets.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=372-27",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "argTypesProxyExempt": [
-    "className"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
-  },
-  "tokens": {
-    "colors": [
-      "--color-border",
-      "--color-primary"
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Radio",
+    "tier": "atom",
+    "group": "form",
+    "status": "beta",
+    "description": "Single radio option; compose with RadioGroup for sets.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=372-27",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg",
+                "S",
+                "M",
+                "L"
+            ],
+            "default": "sm",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "consumers": []
+    "argTypesProxyExempt": [
+        "className"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+    },
+    "tokens": {
+        "colors": [
+            "--color-border",
+            "--color-primary"
+        ],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "consumers": []
 }

--- a/nextjs-app/shared/components/RadioGroup/RadioGroup.contract.json
+++ b/nextjs-app/shared/components/RadioGroup/RadioGroup.contract.json
@@ -1,52 +1,64 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "RadioGroup",
-  "tier": "molecule",
-  "group": "form",
-  "status": "beta",
-  "description": "Accessible radio button group with legend and validation.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=383-36",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {
-    "orientation": {
-      "values": [
-        "vertical",
-        "horizontal"
-      ],
-      "default": "vertical",
-      "forwarded": true,
-      "forwardedTo": "fieldset layout class in RadioGroup.module.css"
-    }
-  },
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "argTypesProxyExempt": [
-    "className",
-    "options"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
-  },
-  "tokens": {
-    "colors": [
-      "--color-border",
-      "--color-primary"
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "RadioGroup",
+    "tier": "molecule",
+    "group": "form",
+    "status": "beta",
+    "description": "Accessible radio button group with legend and validation.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=383-36",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "orientation": {
+            "values": [
+                "vertical",
+                "horizontal"
+            ],
+            "default": "vertical",
+            "forwarded": true,
+            "forwardedTo": "fieldset layout class in RadioGroup.module.css"
+        },
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg",
+                "S",
+                "M",
+                "L"
+            ],
+            "default": "sm",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "consumers": []
+    "argTypesProxyExempt": [
+        "className",
+        "options"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+    },
+    "tokens": {
+        "colors": [
+            "--color-border",
+            "--color-primary"
+        ],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "consumers": []
 }

--- a/nextjs-app/shared/components/Select/Select.contract.json
+++ b/nextjs-app/shared/components/Select/Select.contract.json
@@ -13,7 +13,10 @@
       "values": [
         "sm",
         "md",
-        "lg"
+        "lg",
+        "S",
+        "M",
+        "L"
       ],
       "default": "md",
       "forwarded": true,

--- a/nextjs-app/shared/components/ServiceCard/ServiceCard.contract.json
+++ b/nextjs-app/shared/components/ServiceCard/ServiceCard.contract.json
@@ -1,52 +1,63 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "ServiceCard",
-  "tier": "molecule",
-  "group": "marketing",
-  "status": "beta",
-  "description": "Service tile with icon, title, description, and optional link.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-service-card",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "description",
-    "href",
-    "icon",
-    "iconPosition",
-    "id",
-    "ref",
-    "style",
-    "title",
-    "variant"
-  ],
-  "consumers": [],
-  "slots": [
-    "icon"
-  ]
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "ServiceCard",
+    "tier": "molecule",
+    "group": "marketing",
+    "status": "beta",
+    "description": "Service tile with icon, title, description, and optional link.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-service-card",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "variant": {
+            "values": [
+                "default",
+                "elevated",
+                "minimal",
+                "bordered"
+            ],
+            "default": "default",
+            "propSourced": true
+        }
+    },
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "description",
+        "href",
+        "icon",
+        "iconPosition",
+        "id",
+        "ref",
+        "style",
+        "title",
+        "variant"
+    ],
+    "consumers": [],
+    "slots": [
+        "icon"
+    ]
 }

--- a/nextjs-app/shared/components/Skeleton/Skeleton.contract.json
+++ b/nextjs-app/shared/components/Skeleton/Skeleton.contract.json
@@ -1,50 +1,62 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "Skeleton",
-  "tier": "atom",
-  "group": "structure",
-  "status": "beta",
-  "description": "Skeleton — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-skeleton",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "ariaRequirements": [],
-    "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "animate",
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "height",
-    "id",
-    "label",
-    "lines",
-    "ref",
-    "style",
-    "variant",
-    "width"
-  ],
-  "consumers": []
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Skeleton",
+    "tier": "atom",
+    "group": "structure",
+    "status": "beta",
+    "description": "Skeleton — production @dt component (Storybook beta).",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-skeleton",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "variant": {
+            "values": [
+                "text",
+                "circle",
+                "rect",
+                "avatar",
+                "card"
+            ],
+            "default": "text",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "ariaRequirements": [],
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "animate",
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "height",
+        "id",
+        "label",
+        "lines",
+        "ref",
+        "style",
+        "variant",
+        "width"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/components/Skeleton/Skeleton.stories.tsx
+++ b/nextjs-app/shared/components/Skeleton/Skeleton.stories.tsx
@@ -71,7 +71,14 @@ const skeletonComplianceRules: ComplianceRule[] = [
 ];
 
 const meta: Meta<typeof Skeleton> = {
-  argTypes: {},
+  argTypes: {
+    variant: {
+      control: { type: "select" },
+      options: ["text", "circle", "rect", "avatar", "card"],
+      description: "Skeleton shape preset",
+      table: { defaultValue: { summary: "text" } },
+    },
+  },
   title: "Atoms/Skeleton",
   component: Skeleton,
   tags: ["beta", "!autodocs"],

--- a/nextjs-app/shared/components/Spacer/Spacer.contract.json
+++ b/nextjs-app/shared/components/Spacer/Spacer.contract.json
@@ -1,44 +1,57 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "Spacer",
-  "tier": "atom",
-  "group": "structure",
-  "status": "beta",
-  "description": "Empty layout element that injects a fixed gap on a single axis. Used inside flex/grid containers where adding a token-sized gap as a sibling reads cleaner than the gap utility.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-spacer",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [
-      "Renders as a non-interactive `<div>`; assistive tech ignores it."
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Spacer",
+    "tier": "atom",
+    "group": "structure",
+    "status": "beta",
+    "description": "Empty layout element that injects a fixed gap on a single axis. Used inside flex/grid containers where adding a token-sized gap as a sibling reads cleaner than the gap utility.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-spacer",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg",
+                "xl",
+                "xs",
+                "2xl"
+            ],
+            "default": "sm",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": [
-      "--space-layout-4",
-      "--space-layout-8",
-      "--space-layout-12",
-      "--space-layout-16",
-      "--space-layout-24",
-      "--space-layout-32"
-    ]
-  },
-  "lightDarkVerified": true,
-  "consumers": []
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [
+            "Renders as a non-interactive `<div>`; assistive tech ignores it."
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": [
+            "--space-layout-4",
+            "--space-layout-8",
+            "--space-layout-12",
+            "--space-layout-16",
+            "--space-layout-24",
+            "--space-layout-32"
+        ]
+    },
+    "lightDarkVerified": true,
+    "consumers": []
 }

--- a/nextjs-app/shared/components/Stack/Stack.contract.json
+++ b/nextjs-app/shared/components/Stack/Stack.contract.json
@@ -1,49 +1,60 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "Stack",
-  "tier": "atom",
-  "group": "layout",
-  "status": "beta",
-  "description": "Flex stack primitive for vertical and horizontal rhythm.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-stack",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "align",
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "direction",
-    "gap",
-    "id",
-    "justify",
-    "ref",
-    "style",
-    "wrap"
-  ],
-  "consumers": []
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Stack",
+    "tier": "atom",
+    "group": "layout",
+    "status": "beta",
+    "description": "Flex stack primitive for vertical and horizontal rhythm.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-stack",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "align": {
+            "values": [
+                "center",
+                "stretch",
+                "end",
+                "start"
+            ],
+            "default": "center",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "align",
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "direction",
+        "gap",
+        "id",
+        "justify",
+        "ref",
+        "style",
+        "wrap"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/components/Stack/Stack.stories.tsx
+++ b/nextjs-app/shared/components/Stack/Stack.stories.tsx
@@ -50,6 +50,7 @@ const meta = {
       control: "select",
       options: ["start", "center", "end", "stretch"],
       description: "Cross-axis alignment",
+      table: { defaultValue: { summary: "center" } },
     },
     justify: {
       control: "select",

--- a/nextjs-app/shared/components/Tabs/Tabs.contract.json
+++ b/nextjs-app/shared/components/Tabs/Tabs.contract.json
@@ -1,63 +1,85 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "Tabs",
-  "tier": "molecule",
-  "group": "navigation",
-  "status": "beta",
-  "description": "Tablist navigation with keyboard support and variant styles.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=381-5",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [
-      "ArrowLeft",
-      "ArrowRight",
-      "Home",
-      "End"
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Tabs",
+    "tier": "molecule",
+    "group": "navigation",
+    "status": "beta",
+    "description": "Tablist navigation with keyboard support and variant styles.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=381-5",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "variant": {
+            "values": [
+                "default",
+                "pills",
+                "underline"
+            ],
+            "default": "default",
+            "propSourced": true
+        },
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg",
+                "S",
+                "M",
+                "L"
+            ],
+            "default": "sm",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "ariaRequirements": [
-      "tablist",
-      "tab",
-      "aria-selected",
-      "aria-controls"
+    "a11y": {
+        "keyboard": [
+            "ArrowLeft",
+            "ArrowRight",
+            "Home",
+            "End"
+        ],
+        "ariaRequirements": [
+            "tablist",
+            "tab",
+            "aria-selected",
+            "aria-controls"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-05-26 — arrow-key navigation and selection verified in Storybook.",
+        "forcedColorsVerified": true
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "activeKey",
+        "activeTab",
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "defaultActiveKey",
+        "defaultActiveTab",
+        "id",
+        "onChange",
+        "onTabChange",
+        "ref",
+        "size",
+        "style",
+        "tabs",
+        "variant"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "2026-05-26 — arrow-key navigation and selection verified in Storybook.",
-    "forcedColorsVerified": true
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "activeKey",
-    "activeTab",
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "defaultActiveKey",
-    "defaultActiveTab",
-    "id",
-    "onChange",
-    "onTabChange",
-    "ref",
-    "size",
-    "style",
-    "tabs",
-    "variant"
-  ],
-  "consumers": []
+    "consumers": []
 }

--- a/nextjs-app/shared/components/Tag/Tag.contract.json
+++ b/nextjs-app/shared/components/Tag/Tag.contract.json
@@ -1,53 +1,76 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "Tag",
-  "tier": "atom",
-  "group": "display",
-  "status": "beta",
-  "description": "Small static or removable label for metadata (categories, statuses, filters). Distinct from `Badge` (which is the design-system semantic chip with stable contracts) — `Tag` is the lightweight catalog primitive used by editorial surfaces.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-tag",
-  "radixPrimitive": null,
-  "element": "span",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [
-      "Backspace / Delete on a removable tag triggers the dismiss action when the close affordance is focused."
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Tag",
+    "tier": "atom",
+    "group": "display",
+    "status": "beta",
+    "description": "Small static or removable label for metadata (categories, statuses, filters). Distinct from `Badge` (which is the design-system semantic chip with stable contracts) — `Tag` is the lightweight catalog primitive used by editorial surfaces.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-tag",
+    "radixPrimitive": null,
+    "element": "span",
+    "variants": {
+        "variant": {
+            "values": [
+                "info",
+                "success",
+                "warning",
+                "error",
+                "default",
+                "secondary",
+                "outline"
+            ],
+            "default": "info",
+            "propSourced": true
+        },
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "default": "sm",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "ariaRequirements": [
-      "Static tags need no own ARIA; the visible text is the announcement.",
-      "Removable tags expose the dismiss control as a button with an accessible name like 'Remove {label}'."
-    ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [
-      "--color-text",
-      "--color-surface-elevated",
-      "--color-border-light"
-    ],
-    "spacing": [
-      "--space-internal-4",
-      "--space-internal-8"
-    ],
-    "radii": [
-      "--radius-sm"
-    ],
-    "typography": [
-      "--font-size-sm"
-    ]
-  },
-  "lightDarkVerified": true,
-  "consumers": []
+    "a11y": {
+        "keyboard": [
+            "Backspace / Delete on a removable tag triggers the dismiss action when the close affordance is focused."
+        ],
+        "ariaRequirements": [
+            "Static tags need no own ARIA; the visible text is the announcement.",
+            "Removable tags expose the dismiss control as a button with an accessible name like 'Remove {label}'."
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [
+            "--color-text",
+            "--color-surface-elevated",
+            "--color-border-light"
+        ],
+        "spacing": [
+            "--space-internal-4",
+            "--space-internal-8"
+        ],
+        "radii": [
+            "--radius-sm"
+        ],
+        "typography": [
+            "--font-size-sm"
+        ]
+    },
+    "lightDarkVerified": true,
+    "consumers": []
 }

--- a/nextjs-app/shared/components/TextArea/TextArea.contract.json
+++ b/nextjs-app/shared/components/TextArea/TextArea.contract.json
@@ -13,7 +13,10 @@
       "values": [
         "sm",
         "md",
-        "lg"
+        "lg",
+        "S",
+        "M",
+        "L"
       ],
       "default": "md",
       "forwarded": true,

--- a/nextjs-app/shared/components/TextInput/TextInput.contract.json
+++ b/nextjs-app/shared/components/TextInput/TextInput.contract.json
@@ -1,60 +1,70 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "TextInput",
-  "tier": "atom",
-  "group": "form",
-  "status": "beta",
-  "description": "Single-line text input primitive with optional start/end icon slots, an inline clear button, and an error state. Wraps a native `<input>` so HTML attributes pass through.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-text-input",
-  "radixPrimitive": null,
-  "element": "input",
-  "variants": {},
-  "slots": [
-    "startIcon",
-    "endIcon"
-  ],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [
-      "Tab — focuses the input.",
-      "Esc when `clearable` and the input has a value — clears the value (when the clear button is the active element)."
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "TextInput",
+    "tier": "atom",
+    "group": "form",
+    "status": "beta",
+    "description": "Single-line text input primitive with optional start/end icon slots, an inline clear button, and an error state. Wraps a native `<input>` so HTML attributes pass through.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-text-input",
+    "radixPrimitive": null,
+    "element": "input",
+    "variants": {
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "default": "sm",
+            "propSourced": true
+        }
+    },
+    "slots": [
+        "startIcon",
+        "endIcon"
     ],
-    "ariaRequirements": [
-      "Renders a native `<input>`; HTML autocomplete + form-association attributes pass through.",
-      "`error` is a visual state — the actual error message lives in the surrounding `FormField`'s helper text.",
-      "Clear button has `aria-label='Clear input'` and is hidden when the input is empty."
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [
-      "--color-text",
-      "--color-border-default",
-      "--color-accent"
-    ],
-    "spacing": [
-      "--space-internal-8",
-      "--space-internal-12"
-    ],
-    "radii": [
-      "--radius-md"
-    ],
-    "typography": [
-      "--font-size-sm",
-      "--font-size-md",
-      "--font-size-lg"
-    ]
-  },
-  "lightDarkVerified": true,
-  "consumers": []
+    "a11y": {
+        "keyboard": [
+            "Tab — focuses the input.",
+            "Esc when `clearable` and the input has a value — clears the value (when the clear button is the active element)."
+        ],
+        "ariaRequirements": [
+            "Renders a native `<input>`; HTML autocomplete + form-association attributes pass through.",
+            "`error` is a visual state — the actual error message lives in the surrounding `FormField`'s helper text.",
+            "Clear button has `aria-label='Clear input'` and is hidden when the input is empty."
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [
+            "--color-text",
+            "--color-border-default",
+            "--color-accent"
+        ],
+        "spacing": [
+            "--space-internal-8",
+            "--space-internal-12"
+        ],
+        "radii": [
+            "--radius-md"
+        ],
+        "typography": [
+            "--font-size-sm",
+            "--font-size-md",
+            "--font-size-lg"
+        ]
+    },
+    "lightDarkVerified": true,
+    "consumers": []
 }

--- a/nextjs-app/shared/components/TextLink/TextLink.contract.json
+++ b/nextjs-app/shared/components/TextLink/TextLink.contract.json
@@ -1,48 +1,58 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "TextLink",
-  "tier": "atom",
-  "group": "navigation",
-  "status": "beta",
-  "description": "Inline text link primitive with a stable focus ring + underline contract. Distinct from `Link` (the design-system Link wrapping `next/link`) — `TextLink` is the unwrapped underline-on-hover token used inside prose.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-text-link",
-  "radixPrimitive": null,
-  "element": "a",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [
-      "Tab — focusable in document order.",
-      "Enter — activates the link."
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "TextLink",
+    "tier": "atom",
+    "group": "navigation",
+    "status": "beta",
+    "description": "Inline text link primitive with a stable focus ring + underline contract. Distinct from `Link` (the design-system Link wrapping `next/link`) — `TextLink` is the unwrapped underline-on-hover token used inside prose.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-text-link",
+    "radixPrimitive": null,
+    "element": "a",
+    "variants": {
+        "variant": {
+            "values": [
+                "default",
+                "muted",
+                "accent"
+            ],
+            "default": "default",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "ariaRequirements": [
-      "Renders a real `<a>` element with a real `href`; never put `role='link'` on a non-anchor.",
-      "Accessible name comes from the visible link text; do not add `aria-label` unless the text is purely visual (an icon-only link)."
-    ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [
-      "--color-text",
-      "--color-link",
-      "--color-link-hover"
-    ],
-    "spacing": [],
-    "typography": [
-      "--font-size-md"
-    ]
-  },
-  "lightDarkVerified": true,
-  "consumers": []
+    "a11y": {
+        "keyboard": [
+            "Tab — focusable in document order.",
+            "Enter — activates the link."
+        ],
+        "ariaRequirements": [
+            "Renders a real `<a>` element with a real `href`; never put `role='link'` on a non-anchor.",
+            "Accessible name comes from the visible link text; do not add `aria-label` unless the text is purely visual (an icon-only link)."
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [
+            "--color-text",
+            "--color-link",
+            "--color-link-hover"
+        ],
+        "spacing": [],
+        "typography": [
+            "--font-size-md"
+        ]
+    },
+    "lightDarkVerified": true,
+    "consumers": []
 }

--- a/nextjs-app/shared/components/Toast/Toast.contract.json
+++ b/nextjs-app/shared/components/Toast/Toast.contract.json
@@ -13,7 +13,10 @@
       "values": [
         "sm",
         "md",
-        "lg"
+        "lg",
+        "S",
+        "M",
+        "L"
       ],
       "default": "md",
       "forwarded": true,

--- a/nextjs-app/shared/components/ValueCard/ValueCard.contract.json
+++ b/nextjs-app/shared/components/ValueCard/ValueCard.contract.json
@@ -1,51 +1,61 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "ValueCard",
-  "tier": "molecule",
-  "group": "display",
-  "status": "beta",
-  "description": "Card variant for values / principles grids — icon + title + short description, with the same three visual treatments as `LocationCard`.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-value-card",
-  "radixPrimitive": null,
-  "element": "article",
-  "variants": {},
-  "slots": [
-    "icon"
-  ],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [
-      "Renders an `<article>` so the whole card is announced as a region.",
-      "Decorative icons are `aria-hidden`; the title carries the announcement."
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "ValueCard",
+    "tier": "molecule",
+    "group": "display",
+    "status": "beta",
+    "description": "Card variant for values / principles grids — icon + title + short description, with the same three visual treatments as `LocationCard`.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-value-card",
+    "radixPrimitive": null,
+    "element": "article",
+    "variants": {
+        "variant": {
+            "values": [
+                "default",
+                "elevated",
+                "bordered"
+            ],
+            "default": "default",
+            "propSourced": true
+        }
+    },
+    "slots": [
+        "icon"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [
-      "--color-text",
-      "--color-text-muted",
-      "--color-surface-elevated"
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "spacing": [
-      "--space-internal-8",
-      "--space-internal-12",
-      "--space-internal-16"
-    ],
-    "radii": [
-      "--radius-md"
-    ]
-  },
-  "lightDarkVerified": true,
-  "consumers": []
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [
+            "Renders an `<article>` so the whole card is announced as a region.",
+            "Decorative icons are `aria-hidden`; the title carries the announcement."
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [
+            "--color-text",
+            "--color-text-muted",
+            "--color-surface-elevated"
+        ],
+        "spacing": [
+            "--space-internal-8",
+            "--space-internal-12",
+            "--space-internal-16"
+        ],
+        "radii": [
+            "--radius-md"
+        ]
+    },
+    "lightDarkVerified": true,
+    "consumers": []
 }

--- a/nextjs-app/shared/components/WipBadge/WipBadge.contract.json
+++ b/nextjs-app/shared/components/WipBadge/WipBadge.contract.json
@@ -1,51 +1,60 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "WipBadge",
-  "tier": "atom",
-  "group": "feedback",
-  "status": "beta",
-  "description": "Storybook-only maturity badge for non-stable components.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-wip-badge",
-  "radixPrimitive": null,
-  "element": "span",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [
-      "role=status"
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "WipBadge",
+    "tier": "atom",
+    "group": "feedback",
+    "status": "beta",
+    "description": "Storybook-only maturity badge for non-stable components.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-wip-badge",
+    "radixPrimitive": null,
+    "element": "span",
+    "variants": {
+        "variant": {
+            "values": [
+                "canvas",
+                "docs"
+            ],
+            "default": "canvas",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "2026-05-28 — Beta promotion: Storybook-only chrome (carries data-axe-ignore + axeTestExempt so it never gates host component contrast). role=status announcement is non-disruptive and stable lifecycle hides it entirely. Forced-colors + light/dark verified via dedicated stories.",
-    "forcedColorsVerified": true,
-    "axeTestExempt": "Storybook chrome only"
-  },
-  "tokens": {
-    "colors": [
-      "--color-text",
-      "--color-surface-elevated",
-      "--color-border-light"
-    ],
-    "spacing": [
-      "--space-internal-4",
-      "--space-internal-8",
-      "--space-internal-12"
-    ],
-    "radii": [
-      "--radius-sm"
-    ],
-    "typography": [
-      "--font-size-sm"
-    ]
-  },
-  "lightDarkVerified": true,
-  "consumers": []
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [
+            "role=status"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-05-28 — Beta promotion: Storybook-only chrome (carries data-axe-ignore + axeTestExempt so it never gates host component contrast). role=status announcement is non-disruptive and stable lifecycle hides it entirely. Forced-colors + light/dark verified via dedicated stories.",
+        "forcedColorsVerified": true,
+        "axeTestExempt": "Storybook chrome only"
+    },
+    "tokens": {
+        "colors": [
+            "--color-text",
+            "--color-surface-elevated",
+            "--color-border-light"
+        ],
+        "spacing": [
+            "--space-internal-4",
+            "--space-internal-8",
+            "--space-internal-12"
+        ],
+        "radii": [
+            "--radius-sm"
+        ],
+        "typography": [
+            "--font-size-sm"
+        ]
+    },
+    "lightDarkVerified": true,
+    "consumers": []
 }

--- a/nextjs-app/shared/patterns/CTASection/CTASection.contract.json
+++ b/nextjs-app/shared/patterns/CTASection/CTASection.contract.json
@@ -1,52 +1,61 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "CTASection",
-  "tier": "pattern",
-  "group": "marketing",
-  "status": "beta",
-  "description": "Call-to-action band used on marketing pages.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=502-20",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [
-      "--color-primary"
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "CTASection",
+    "tier": "pattern",
+    "group": "marketing",
+    "status": "beta",
+    "description": "Call-to-action band used on marketing pages.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=502-20",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "align": {
+            "values": [
+                "center",
+                "left"
+            ],
+            "default": "center",
+            "propSourced": true
+        }
+    },
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "align",
-    "as",
-    "asChild",
-    "background",
-    "children",
-    "className",
-    "description",
-    "id",
-    "primaryAction",
-    "ref",
-    "secondaryAction",
-    "style",
-    "title"
-  ],
-  "consumers": [],
-  "slots": []
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [
+            "--color-primary"
+        ],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "align",
+        "as",
+        "asChild",
+        "background",
+        "children",
+        "className",
+        "description",
+        "id",
+        "primaryAction",
+        "ref",
+        "secondaryAction",
+        "style",
+        "title"
+    ],
+    "consumers": [],
+    "slots": []
 }

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import { useTranslation } from "react-i18next";
 import { motion, AnimatePresence } from "framer-motion";
@@ -61,8 +61,8 @@ export function ContactPageContentEditorial({
   };
 
   const handleScrollToContactForm = useCallback(
-    (event: React.MouseEvent<HTMLAnchorElement>) => {
-      event.preventDefault();
+    (event?: React.MouseEvent<HTMLAnchorElement>) => {
+      event?.preventDefault();
       inquiryPanelRef.current?.scrollToMessageForm();
       if (typeof window !== "undefined") {
         window.history.replaceState(null, "", "#contact-form");
@@ -70,6 +70,12 @@ export function ContactPageContentEditorial({
     },
     [],
   );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (window.location.hash !== "#contact-form") return;
+    handleScrollToContactForm();
+  }, [handleScrollToContactForm]);
 
   return (
     <div className={cn(styles.page, className)}>

--- a/nextjs-app/shared/patterns/Hero/Hero.contract.json
+++ b/nextjs-app/shared/patterns/Hero/Hero.contract.json
@@ -1,59 +1,80 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "Hero",
-  "tier": "pattern",
-  "group": "marketing",
-  "status": "beta",
-  "description": "Hero — production @dt component (Storybook beta).",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-hero",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "ariaRequirements": [],
-    "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "actions",
-    "align",
-    "ariaLabel",
-    "as",
-    "asChild",
-    "background",
-    "children",
-    "className",
-    "description",
-    "id",
-    "imageAlt",
-    "imageHeight",
-    "imageSrc",
-    "imageWidth",
-    "maxWidth",
-    "ref",
-    "spacing",
-    "style",
-    "subtitle",
-    "title",
-    "titleLevel",
-    "variant"
-  ],
-  "consumers": []
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Hero",
+    "tier": "pattern",
+    "group": "marketing",
+    "status": "beta",
+    "description": "Hero — production @dt component (Storybook beta).",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-hero",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "variant": {
+            "values": [
+                "default",
+                "minimal",
+                "centered",
+                "split",
+                "stacked"
+            ],
+            "default": "default",
+            "propSourced": true
+        },
+        "align": {
+            "values": [
+                "center",
+                "left",
+                "right"
+            ],
+            "default": "center",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "ariaRequirements": [],
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "actions",
+        "align",
+        "ariaLabel",
+        "as",
+        "asChild",
+        "background",
+        "children",
+        "className",
+        "description",
+        "id",
+        "imageAlt",
+        "imageHeight",
+        "imageSrc",
+        "imageWidth",
+        "maxWidth",
+        "ref",
+        "spacing",
+        "style",
+        "subtitle",
+        "title",
+        "titleLevel",
+        "variant"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/patterns/Hero/Hero.stories.tsx
+++ b/nextjs-app/shared/patterns/Hero/Hero.stories.tsx
@@ -59,6 +59,7 @@ const meta: Meta<typeof Hero> = {
       control: { type: "select" },
       options: ["default", "centered", "split", "minimal"],
       description: "Layout variant",
+      table: { defaultValue: { summary: "default" } },
     },
 
     background: {
@@ -71,6 +72,7 @@ const meta: Meta<typeof Hero> = {
       control: { type: "select" },
       options: ["left", "center", "right"],
       description: "Content alignment",
+      table: { defaultValue: { summary: "center" } },
     },
 
     maxWidth: {

--- a/nextjs-app/shared/patterns/HeroSection/HeroSection.contract.json
+++ b/nextjs-app/shared/patterns/HeroSection/HeroSection.contract.json
@@ -1,50 +1,60 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "HeroSection",
-  "tier": "pattern",
-  "group": "marketing",
-  "status": "beta",
-  "description": "Full-bleed hero shell with min-height, alignment, and background variants.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-hero-section",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "align",
-    "ariaLabel",
-    "as",
-    "asChild",
-    "background",
-    "backgroundImage",
-    "children",
-    "className",
-    "id",
-    "justify",
-    "minHeight",
-    "ref",
-    "style"
-  ],
-  "consumers": []
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "HeroSection",
+    "tier": "pattern",
+    "group": "marketing",
+    "status": "beta",
+    "description": "Full-bleed hero shell with min-height, alignment, and background variants.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-hero-section",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "align": {
+            "values": [
+                "center",
+                "end",
+                "start"
+            ],
+            "default": "center",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "align",
+        "ariaLabel",
+        "as",
+        "asChild",
+        "background",
+        "backgroundImage",
+        "children",
+        "className",
+        "id",
+        "justify",
+        "minHeight",
+        "ref",
+        "style"
+    ],
+    "consumers": []
 }

--- a/nextjs-app/shared/patterns/HeroSection/HeroSection.stories.tsx
+++ b/nextjs-app/shared/patterns/HeroSection/HeroSection.stories.tsx
@@ -58,6 +58,7 @@ const meta = {
       control: "select",
       options: ["start", "center", "end"],
       description: "Vertical alignment of content",
+      table: { defaultValue: { summary: "center" } },
     },
     justify: {
       control: "select",

--- a/nextjs-app/shared/patterns/HighlightSection/HighlightSection.contract.json
+++ b/nextjs-app/shared/patterns/HighlightSection/HighlightSection.contract.json
@@ -1,51 +1,71 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "HighlightSection",
-  "tier": "pattern",
-  "group": "marketing",
-  "status": "beta",
-  "description": "Highlight band with variant backgrounds and CTA slots.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-highlight-section",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "ariaLabel",
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "cta",
-    "description",
-    "id",
-    "overline",
-    "ref",
-    "size",
-    "style",
-    "title",
-    "variant"
-  ],
-  "consumers": [],
-  "slots": []
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "HighlightSection",
+    "tier": "pattern",
+    "group": "marketing",
+    "status": "beta",
+    "description": "Highlight band with variant backgrounds and CTA slots.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-highlight-section",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "variant": {
+            "values": [
+                "pattern",
+                "solid",
+                "gradient",
+                "dots"
+            ],
+            "default": "pattern",
+            "propSourced": true
+        },
+        "size": {
+            "values": [
+                "compact",
+                "comfortable",
+                "spacious"
+            ],
+            "default": "compact",
+            "propSourced": true
+        }
+    },
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "ariaLabel",
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "cta",
+        "description",
+        "id",
+        "overline",
+        "ref",
+        "size",
+        "style",
+        "title",
+        "variant"
+    ],
+    "consumers": [],
+    "slots": []
 }

--- a/nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.contract.json
+++ b/nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.contract.json
@@ -1,48 +1,58 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.json",
-  "name": "WorkPreviewSection",
-  "tier": "pattern",
-  "group": "marketing",
-  "status": "beta",
-  "description": "Work index preview grid of project cards.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-work-preview-section",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "argTypesProxyExempt": [
-    "as",
-    "asChild",
-    "children",
-    "className",
-    "id",
-    "layout",
-    "projects",
-    "ref",
-    "showViewAll",
-    "style",
-    "title"
-  ],
-  "consumers": [],
-  "slots": []
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "WorkPreviewSection",
+    "tier": "pattern",
+    "group": "marketing",
+    "status": "beta",
+    "description": "Work index preview grid of project cards.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-work-preview-section",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "layout": {
+            "values": [
+                "grid",
+                "asymmetric",
+                "featured"
+            ],
+            "default": "grid",
+            "propSourced": true
+        }
+    },
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "as",
+        "asChild",
+        "children",
+        "className",
+        "id",
+        "layout",
+        "projects",
+        "ref",
+        "showViewAll",
+        "style",
+        "title"
+    ],
+    "consumers": [],
+    "slots": []
 }

--- a/scripts/design-system/cva-sync-lib.mjs
+++ b/scripts/design-system/cva-sync-lib.mjs
@@ -67,20 +67,35 @@ const PROP_SOURCED_AXES = {
  * @param {string} componentName
  * @param {object} agentBlock
  */
-export function getPropSourcedVariants(componentName, agentBlock) {
-  const allowed = PROP_SOURCED_AXES[componentName];
-  if (!allowed?.length) return {};
+function propSourcedAxis(agentBlock, axis) {
+  const def = agentBlock?.variants?.[axis];
+  const prop = agentBlock?.props?.[axis];
+  if (!def?.values?.length || !prop?.values?.length) return null;
+  const propSet = new Set(prop.values.map(normalizeVariantValue));
+  if (!def.values.every((v) => propSet.has(normalizeVariantValue(v)))) return null;
+  return {
+    values: def.values.map(normalizeVariantValue),
+    default: normalizeVariantValue(def.default ?? def.values[0]),
+    propSourced: true,
+  };
+}
 
-  const all = agentBlock?.variants ?? {};
+export function getPropSourcedVariants(componentName, agentBlock) {
   const out = {};
+  const allowed = PROP_SOURCED_AXES[componentName] ?? [];
+
   for (const axis of allowed) {
-    const def = all[axis];
-    const prop = agentBlock?.props?.[axis];
-    if (!def?.values?.length || !prop?.values?.length) continue;
-    const propSet = new Set(prop.values);
-    if (!def.values.every((v) => propSet.has(v))) continue;
-    out[axis] = { values: def.values, default: def.default, propSourced: true };
+    const entry = propSourcedAxis(agentBlock, axis);
+    if (entry) out[axis] = entry;
   }
+
+  // Auto-detect prop-driven axes present in agent blocks (no per-component allowlist required).
+  for (const axis of VARIANT_PROP_NAMES) {
+    if (out[axis]) continue;
+    const entry = propSourcedAxis(agentBlock, axis);
+    if (entry) out[axis] = entry;
+  }
+
   return out;
 }
 

--- a/scripts/design-system/dt-usage-rules.mjs
+++ b/scripts/design-system/dt-usage-rules.mjs
@@ -2,8 +2,15 @@
  * Shared @dt usage gate rules — keep in sync with eslint.config.mjs (dt/usage block).
  */
 
-/** App routes only — patterns keep their own typography/CSS; do not force @dt swaps here. */
-export const DT_USAGE_SCAN_ROOTS = ["app"];
+/**
+ * Product surfaces: app routes, layout patterns, and page modules.
+ * Still import-policy only (@/components/ui/*) — no forced raw-element swaps.
+ */
+export const DT_USAGE_SCAN_ROOTS = [
+  "app",
+  "nextjs-app/shared/patterns",
+  "nextjs-app/shared/components/pages",
+];
 
 export const DT_USAGE_SKIP_SEGMENTS = [
   "/__tests__/",

--- a/scripts/design-system/lint-dt-usage.mjs
+++ b/scripts/design-system/lint-dt-usage.mjs
@@ -76,7 +76,9 @@ for (const file of files) {
 }
 
 if (!findings.length) {
-  console.log("✓ lint:dt-usage — no violations in app/");
+  console.log(
+    `✓ lint:dt-usage — no violations in ${DT_USAGE_SCAN_ROOTS.join(", ")}`,
+  );
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary
- Expands `lint:dt-usage` to `app/`, `nextjs-app/shared/patterns`, and `nextjs-app/shared/components/pages` (still `@/components/ui/*` import policy only).
- Auto-detects `propSourced` variant axes from agent blocks; `sync:contract-api --write` filled 35+ contracts.
- Adds Storybook `argTypes` defaults for newly synced axes (17 story fixes).
- Contact page scrolls to the form when landing with `#contact-form`.
- Aligns size enums on Button/Select/TextArea/Toast with generated agent blocks (fixes strict `check:contract-drift`).

## Test plan
- [x] `npm run validate:components`
- [x] `npm run lint:dt-usage`
- [x] `npm run check:consumers`
- [x] `npm run check:contract-drift -- --strict`
- [x] `npm run typecheck` + `npm run test:ci`


Made with [Cursor](https://cursor.com)