### PR TITLE
fix(storybook): remove redundant story name annotations

### DIFF
--- a/nextjs-app/shared/components/NavMenuList/NavMenuList.stories.tsx
+++ b/nextjs-app/shared/components/NavMenuList/NavMenuList.stories.tsx
@@ -56,7 +56,6 @@ type Story = StoryObj<typeof NavMenuList>;
 
 export const Default: Story = {
   tags: ["beta-matrix"],
-  name: "Default",
   render: () => (
     <NavMenuList
       items={[
@@ -71,7 +70,6 @@ export const Default: Story = {
 };
 
 export const CustomActiveClass: Story = {
-  name: "Custom Active Class",
   render: () => (
     <NavMenuList
       items={[

--- a/nextjs-app/shared/components/Switch/Switch.stories.tsx
+++ b/nextjs-app/shared/components/Switch/Switch.stories.tsx
@@ -219,7 +219,6 @@ const ControlledTemplate = (args: SwitchProps) => {
 export const Default: Story = {
   parameters: { a11y: { disable: true } },
   tags: ["beta-matrix"],
-  name: "Default",
   render: (args) => <ControlledTemplate {...args} />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -236,7 +235,6 @@ export const Default: Story = {
 };
 
 export const Loading: Story = {
-  name: "Loading",
   args: { isLoading: true, isChecked: true },
   render: (args) => <ControlledTemplate {...args} />,
 };
@@ -264,7 +262,6 @@ export const LabelOnLeft: Story = {
 };
 
 export const WithHelperText: Story = {
-  name: "With Helper Text",
   args: {
     label: "Enable email notifications",
     helperText: "You'll receive updates about your account activity",
@@ -311,13 +308,11 @@ export const Playground: Story = {
   parameters: { a11y: { disable: true, test: "off" } },
   tags: ["beta-matrix"],
   ...Default,
-  name: "Playground",
 };
 
 export const Example: Story = {
   globals: { forcedColors: "none" },
   tags: ["beta-matrix"],
-  name: "Example",
   parameters: { a11y: { disable: true }, controls: { disable: true } },
   args: {
     label: "Enable email notifications",

--- a/nextjs-app/shared/patterns/Footer/Footer.stories.tsx
+++ b/nextjs-app/shared/patterns/Footer/Footer.stories.tsx
@@ -40,12 +40,10 @@ type Story = StoryObj<typeof Footer>;
 
 export const Default: Story = {
   tags: ["beta-matrix"],
-  name: "Default",
   render: () => <Footer />,
 };
 
 export const WithSurroundingContent: Story = {
-  name: "With Surrounding Content",
   render: () => (
     <ThemeProvider>
       <div

--- a/nextjs-app/shared/patterns/Header/Header.stories.tsx
+++ b/nextjs-app/shared/patterns/Header/Header.stories.tsx
@@ -34,7 +34,6 @@ type Story = StoryObj<typeof Header>;
 
 export const Default: Story = {
   tags: ["beta-matrix"],
-  name: "Default",
   render: () => <Header />,
 };
 


### PR DESCRIPTION
## Summary
- Removes explicit `name` fields from NavMenuList, Switch, Footer, and Header stories where Storybook already derives the same label from the export identifier
- Clears all 10 `storybook/no-redundant-story-name` ESLint warnings (lint now reports 0 warnings)

## Test plan
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run validate:components`
- [x] `npm run check:contract-props`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified internal Storybook story configurations across multiple components by removing redundant naming overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->