### PR TITLE
feat(ds): unblock error alert migration to @dt/Modal

### DIFF
--- a/docs/SHADCN_TO_DT_MIGRATION.md
+++ b/docs/SHADCN_TO_DT_MIGRATION.md
@@ -20,7 +20,7 @@ Shared UI lives in `nextjs-app/shared/stories/MigrationDecisionBoard/` (`Migrati
 | Button contexts | `Migration boards/Button contexts` | `StudioMap`, `IconButton`, `ContactFormSuccess` | Migrated |
 | Contact flow | `Migration boards/Contact flow` | `ContactFormEditorial`, `ContactFormSuccessEditorial` | Migrated |
 | Form primitives | `Migration boards/Form primitives` | `FormField`, `CheckboxField` | Migrated |
-| Dialogs | `Migration boards/Dialogs` | `AnimatedDialog`, `Lightbox`, `EnhancedContactForm` | **Blocked** — `@dt/Modal` needs design/API work before swap |
+| Dialogs | `Migration boards/Dialogs` | `AnimatedDialog`, `Lightbox`; `EnhancedContactForm` error alert | **Partial** — error alert approved (`@dt/Modal` + `description`); gallery/animation/composable trigger deferred |
 
 Restart Storybook after adding or renaming board files so hub `storyId` links resolve.
 

--- a/nextjs-app/shared/components/EnhancedContactForm/EnhancedContactForm.tsx
+++ b/nextjs-app/shared/components/EnhancedContactForm/EnhancedContactForm.tsx
@@ -16,14 +16,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-} from "@/components/ui/dialog";
+import Modal from "@dt/Modal";
+import DtButton from "@dt/Button";
 import { useToast } from "../Toaster/Toaster";
 import { FormField } from "../FormField";
 import { FormGroup } from "../FormGroup";
@@ -560,20 +554,18 @@ export function EnhancedContactForm({
         </div>
       </form>
 
-      {/* Error Dialog */}
-      <Dialog open={isErrorOpen} onOpenChange={setIsErrorOpen}>
-        <DialogContent severity="error">
-          <DialogHeader>
-            <DialogTitle>{t("contactErrorTitle")}</DialogTitle>
-            <DialogDescription>{t("contactErrorMessage")}</DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button onClick={() => setIsErrorOpen(false)}>
-              {t("back")}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <Modal
+        isOpen={isErrorOpen}
+        severity="error"
+        title={t("contactErrorTitle")}
+        description={t("contactErrorMessage")}
+        onClose={() => setIsErrorOpen(false)}
+        footer={
+          <DtButton variant="secondary" onClick={() => setIsErrorOpen(false)}>
+            {t("back")}
+          </DtButton>
+        }
+      />
     </FadeIn>
   );
 }

--- a/nextjs-app/shared/components/Modal/Modal.a11y.test.tsx
+++ b/nextjs-app/shared/components/Modal/Modal.a11y.test.tsx
@@ -164,6 +164,23 @@ describe("Modal Accessibility", () => {
       expect(titleElement).toHaveTextContent("Modal Title");
     });
 
+    it("has aria-describedby referencing description", () => {
+      render(
+        <Modal
+          isOpen
+          title="Error"
+          severity="error"
+          description="Please try again in a moment."
+        />
+      );
+      const dialog = screen.getByRole("alertdialog");
+      expect(dialog).toHaveAttribute("aria-describedby");
+
+      const descriptionId = dialog.getAttribute("aria-describedby");
+      const descriptionElement = document.getElementById(descriptionId!);
+      expect(descriptionElement).toHaveTextContent("Please try again in a moment.");
+    });
+
     it("has aria-label when no title provided", () => {
       render(
         <Modal isOpen>

--- a/nextjs-app/shared/components/Modal/Modal.contract.json
+++ b/nextjs-app/shared/components/Modal/Modal.contract.json
@@ -120,6 +120,10 @@
             "optional": true,
             "type": "string"
         },
+        "description": {
+            "optional": true,
+            "type": "string"
+        },
         "titleTerminals": {
             "optional": true,
             "type": "union",
@@ -170,8 +174,8 @@
         "Title",
         "Text",
         "Inputs",
-        "AdaptiveLoadingButton",
-        "Toast",
-        "CheckboxGroup"
+        "FileUpload",
+        "PhoneInput",
+        "AdaptiveLoadingButton"
     ]
 }

--- a/nextjs-app/shared/components/Modal/Modal.module.css
+++ b/nextjs-app/shared/components/Modal/Modal.module.css
@@ -74,10 +74,15 @@
 .content {
   display: flex;
   padding: 0 1.5rem 0.5rem;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
   gap: 0.75rem;
   font-family: var(--font-text);
   color: var(--color-primary);
+}
+
+.description {
+  margin: 0;
 }
 
 .content :is(p, span, div) {

--- a/nextjs-app/shared/components/Modal/Modal.spec.md
+++ b/nextjs-app/shared/components/Modal/Modal.spec.md
@@ -21,6 +21,9 @@ route.
 ## Do / don't
 - Do: always pass a `title`. Title-less modals are a bad AT experience;
   the user lands on "Dialog" with no context.
+- Do: pass `description` for supporting copy (maps to `aria-describedby`,
+  shadcn `DialogDescription` parity). Prefer `description` over a lone
+  `<p>` child when the body is a single sentence.
 - Do: pick the severity that matches the message. `error` and
   `warning` flip the role to `alertdialog`, which carries an implicit
   assertive announcement.
@@ -54,3 +57,14 @@ route.
 - The default OK button is rendered only when `footer` is `undefined`
   and `isLoading` is false. Pass `footer={null}` to suppress the OK
   without supplying alternative actions.
+
+## shadcn Dialog migration
+
+| shadcn | @dt/Modal |
+|--------|-----------|
+| `open` / `onOpenChange` | `isOpen` / `onClose` — keep modal mounted; toggle `isOpen` |
+| `DialogTitle` | `title` |
+| `DialogDescription` | `description` (preferred) or `children` |
+| `DialogFooter` + actions | `footer` slot with `@dt/Button` |
+| `DialogContent severity="error"` | `severity="error"` (`alertdialog` role) |
+| `DialogTrigger asChild` | **Defer** — wrap trigger in local state until a composable API ships |

--- a/nextjs-app/shared/components/Modal/Modal.stories.tsx
+++ b/nextjs-app/shared/components/Modal/Modal.stories.tsx
@@ -96,6 +96,12 @@ export default {
       table: { category: "Content", type: { summary: "string" } },
     },
 
+    description: {
+      control: "text",
+      description: "Supporting text (aria-describedby; DialogDescription parity)",
+      table: { category: "Content", type: { summary: "string" } },
+    },
+
     children: {
       control: "text",
       description: "Modal content",
@@ -293,7 +299,7 @@ ErrorDialog.args = {
   isOpen: true,
   title: "storyModalErrorTitle",
   severity: "error",
-  children: "storyModalErrorBody",
+  description: "storyModalErrorBody",
 };
 
 export const SuccessDialog = Template.bind({});

--- a/nextjs-app/shared/components/Modal/Modal.tsx
+++ b/nextjs-app/shared/components/Modal/Modal.tsx
@@ -23,6 +23,8 @@ export interface ModalProps {
   isOpen: boolean;
   /** Title shown in header */
   title?: string;
+  /** Supporting text — wired to aria-describedby (DialogDescription parity) */
+  description?: string;
   /** Title terminals (sans or serif) */
   titleTerminals?: "sans" | "serif";
   /** Optional contextual menu or extra controls */
@@ -62,6 +64,7 @@ const Modal: React.FC<ModalProps> = ({
   titleSize = "M",
   isOpen,
   title,
+  description,
   titleTerminals = "serif",
   menu,
   children,
@@ -74,6 +77,7 @@ const Modal: React.FC<ModalProps> = ({
 }) => {
   const normalizedTitleSize = normalizeTitleSize(titleSize);
   const titleId = useId();
+  const descriptionId = useId();
   const previousActiveElement = useRef<HTMLElement | null>(null);
   const modalRef = useRef<HTMLDivElement>(null);
 
@@ -174,6 +178,7 @@ const Modal: React.FC<ModalProps> = ({
         {...(title
           ? { "aria-labelledby": titleId }
           : { "aria-label": "Dialog" })}
+        {...(description ? { "aria-describedby": descriptionId } : {})}
       >
         {title && (
           <div className={styles.header}>
@@ -206,6 +211,11 @@ const Modal: React.FC<ModalProps> = ({
         <div className={styles.content}>
           {isLoading && (
             <div className={styles.spinner} aria-hidden="true" />
+          )}
+          {description && (
+            <p id={descriptionId} className={styles.description}>
+              {description}
+            </p>
           )}
           {children}
         </div>

--- a/nextjs-app/shared/stories/MigrationDecisionBoard/DialogComparison.stories.tsx
+++ b/nextjs-app/shared/stories/MigrationDecisionBoard/DialogComparison.stories.tsx
@@ -60,15 +60,14 @@ function DtErrorModal() {
         isOpen={open}
         severity="error"
         title="Something went wrong"
+        description="Please try again in a moment."
         onClose={() => setOpen(false)}
         footer={
-          <DtButton variant="primary" onClick={() => setOpen(false)}>
+          <DtButton variant="secondary" onClick={() => setOpen(false)}>
             Back
           </DtButton>
         }
-      >
-        <p style={{ margin: 0 }}>Please try again in a moment.</p>
-      </Modal>
+      />
     </>
   );
 }
@@ -80,9 +79,11 @@ export const AlertAndDeferrals: Story = {
       title="Dialogs decision board"
       lead={
         <>
-          <strong>Blocked for production</strong> — @dt/Modal needs design/API work before
-          swapping shadcn Dialog. Board stays for comparison. Defer Lightbox, AnimatedDialog,
-          and SkillsGrid tooltips until matching @dt primitives exist.
+          <strong>Error alert approved</strong> — use @dt/Modal with{" "}
+          <code>severity=&quot;error&quot;</code>, <code>description</code>, and{" "}
+          <code>isOpen</code>/<code>onClose</code>. EnhancedContactForm error path migrated.
+          Defer Lightbox, AnimatedDialog, and composable DialogTrigger until matching
+          primitives exist.
         </>
       }
     >
@@ -126,8 +127,10 @@ export const AlertAndDeferrals: Story = {
         <MigrationDecisionBlock variant="defer" title="SkillsGrid — shadcn Tooltip">
           <span className="font-body text-sm">No @dt Tooltip; defer or use title attribute.</span>
         </MigrationDecisionBlock>
-        <MigrationDecisionBlock variant="defer" title="EnhancedContactForm — full shadcn form">
-          <span className="font-body text-sm">Migrate after primitives + Modal boards approved.</span>
+        <MigrationDecisionBlock variant="defer" title="EnhancedContactForm — shadcn form shell">
+          <span className="font-body text-sm">
+            Error alert uses @dt/Modal; inputs/selects still shadcn until form boards pass.
+          </span>
         </MigrationDecisionBlock>
       </MigrationDecisionBand>
     </MigrationDecisionPage>

--- a/nextjs-app/shared/stories/MigrationDecisionBoard/MigrationBoardsHub.stories.tsx
+++ b/nextjs-app/shared/stories/MigrationDecisionBoard/MigrationBoardsHub.stories.tsx
@@ -43,8 +43,8 @@ const BOARDS = [
   {
     title: "Dialogs & overlays",
     storyId: "design-system-migration-boards-dialogs--alert-and-deferrals",
-    note: "Blocked — @dt/Modal needs work before production swap",
-    status: "defer" as const,
+    note: "Approved — error alert via @dt/Modal + description; composable trigger deferred",
+    status: "approved" as const,
   },
 ];
 


### PR DESCRIPTION
## Summary
- Adds `description` prop to `@dt/Modal` with `aria-describedby` (shadcn `DialogDescription` parity)
- Migrates `EnhancedContactForm` submit error overlay from shadcn Dialog to `@dt/Modal`
- Approves the error-alert band on the Dialogs migration board; composable `DialogTrigger` / gallery / GSAP shells remain deferred

## Test plan
- [x] `npm run lint:dt-usage`
- [x] `npm run validate:components`
- [x] `npm run check:contract-props`
- [x] `npm run typecheck`
- [x] Modal a11y test for `aria-describedby`


Made with [Cursor](https://cursor.com)