### PR TITLE
feat(ds): v2 semantic enforcement with forbiddenUse and composition lint

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -17,6 +17,7 @@ jobs:
       - run: npm run check:generated
       - run: npm run agent:eval
       - run: npm run lint:dt-usage
+      - run: npm run lint:composition
       - run: npm run lint:dt-responsive-visibility -- --strict
       - run: npm run ds:health
       - run: npm run check:figma

--- a/nextjs-app/shared/components/Accordion/Accordion.contract.json
+++ b/nextjs-app/shared/components/Accordion/Accordion.contract.json
@@ -60,5 +60,10 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "put primary navigation inside an accordion. AT users land on",
+        "nest accordions more than one level deep. Two-level",
+        "ship long, scrollable panels. If the content scrolls inside"
+    ]
 }

--- a/nextjs-app/shared/components/AdaptiveLoadingButton/AdaptiveLoadingButton.contract.json
+++ b/nextjs-app/shared/components/AdaptiveLoadingButton/AdaptiveLoadingButton.contract.json
@@ -75,5 +75,8 @@
         "Text",
         "CheckboxGroup",
         "Toast"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/AlertBanner/AlertBanner.contract.json
+++ b/nextjs-app/shared/components/AlertBanner/AlertBanner.contract.json
@@ -101,5 +101,13 @@
     "composesWith": [
         "Button",
         "Icon"
+    ],
+    "forbiddenUse": [
+        "make errors dismissable. Letting the user hide a blocking",
+        "stack more than one banner on the same page. Two competing",
+        "animate the banner in on every render. AlertBanner is for"
+    ],
+    "prefersOver": [
+        "Toast for non-persistent status"
     ]
 }

--- a/nextjs-app/shared/components/AnimatedDialog/AnimatedDialog.contract.json
+++ b/nextjs-app/shared/components/AnimatedDialog/AnimatedDialog.contract.json
@@ -132,5 +132,9 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Animate every modal — reserve `AnimatedDialog` for moments where the animation reads as deliberate.",
+        "Stack two open dialogs — focus management collapses; close the first before opening the second."
+    ]
 }

--- a/nextjs-app/shared/components/AnimatedGlyphBackground/AnimatedGlyphBackground.contract.json
+++ b/nextjs-app/shared/components/AnimatedGlyphBackground/AnimatedGlyphBackground.contract.json
@@ -74,5 +74,8 @@
                 "contrast"
             ]
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/ArticleCard/ArticleCard.contract.json
+++ b/nextjs-app/shared/components/ArticleCard/ArticleCard.contract.json
@@ -75,5 +75,8 @@
         "CheckboxGroup",
         "FlexBox",
         "Inputs"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/AspectRatio/AspectRatio.contract.json
+++ b/nextjs-app/shared/components/AspectRatio/AspectRatio.contract.json
@@ -56,5 +56,9 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Use this as a generic flex/grid item — pick a layout primitive instead.",
+        "Add padding or margin via className — children will overlap their own padding because the wrapper is `position: relative`."
+    ]
 }

--- a/nextjs-app/shared/components/Author/Author.contract.json
+++ b/nextjs-app/shared/components/Author/Author.contract.json
@@ -59,5 +59,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/AuthorBio/AuthorBio.contract.json
+++ b/nextjs-app/shared/components/AuthorBio/AuthorBio.contract.json
@@ -61,5 +61,8 @@
     "composesWith": [
         "Title",
         "PageLayout"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/Avatar/Avatar.contract.json
+++ b/nextjs-app/shared/components/Avatar/Avatar.contract.json
@@ -143,5 +143,9 @@
         "ArticleCard",
         "Checkbox",
         "CheckboxGroup"
+    ],
+    "forbiddenUse": [
+        "render two interactive children inside Avatar (link plus menu);",
+        "nest an Avatar inside a Button. Pick one — Avatar already owns"
     ]
 }

--- a/nextjs-app/shared/components/Badge/Badge.contract.json
+++ b/nextjs-app/shared/components/Badge/Badge.contract.json
@@ -169,5 +169,9 @@
         "Title",
         "FlexBox",
         "Grid"
+    ],
+    "forbiddenUse": [
+        "rely on colour alone to convey state — pair with the icon (the",
+        "nest a Button inside a Badge. The removable affordance is"
     ]
 }

--- a/nextjs-app/shared/components/Breadcrumb/Breadcrumb.contract.json
+++ b/nextjs-app/shared/components/Breadcrumb/Breadcrumb.contract.json
@@ -60,5 +60,10 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "include the home icon as a separate item. Use `label: 'Home'`",
+        "skip levels to make the trail shorter. If the user is at",
+        "render the breadcrumb above a hero — it gets lost. Place it"
+    ]
 }

--- a/nextjs-app/shared/components/BusyIndicator/BusyIndicator.contract.json
+++ b/nextjs-app/shared/components/BusyIndicator/BusyIndicator.contract.json
@@ -100,5 +100,8 @@
         "Button",
         "Text",
         "Inputs"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/Button/Button.contract.json
+++ b/nextjs-app/shared/components/Button/Button.contract.json
@@ -337,7 +337,18 @@
         "Text",
         "Icon",
         "Inputs",
-        "CheckboxGroup",
-        "Modal"
+        "Modal",
+        "CheckboxGroup"
+    ],
+    "forbiddenUse": [
+        "tertiary on dark or inverse backgrounds without explicit contrast verification",
+        "isInverse on primary over transparent or gradient parents — use surface instead",
+        "pair an icon-only button with a tooltip as the *only* accessible",
+        "nest a Button inside another interactive control. Buttons are",
+        "use a Button for inline navigation in body copy. Use **Link**."
+    ],
+    "prefersOver": [
+        "raw button",
+        "Link for in-copy navigation"
     ]
 }

--- a/nextjs-app/shared/components/Card/Card.contract.json
+++ b/nextjs-app/shared/components/Card/Card.contract.json
@@ -350,5 +350,10 @@
         "PageLayout",
         "MarkdownMessage",
         "Icon"
+    ],
+    "forbiddenUse": [
+        "nest interactive controls inside a `link`-mode card. Use a",
+        "hide critical state in `extra`. Right-aligned slots are easy to",
+        "stretch the variant set to encode marketing themes. Compose"
     ]
 }

--- a/nextjs-app/shared/components/CategoryFilter/CategoryFilter.contract.json
+++ b/nextjs-app/shared/components/CategoryFilter/CategoryFilter.contract.json
@@ -110,5 +110,9 @@
         "Section",
         "WorkHero",
         "WorkGrid"
+    ],
+    "forbiddenUse": [
+        "Use as primary navigation — `CategoryFilter` is a UI control, not a nav surface; use `NavLink` for routes.",
+        "Stack two filter rows when one composite control would do — readability collapses."
     ]
 }

--- a/nextjs-app/shared/components/Center/Center.contract.json
+++ b/nextjs-app/shared/components/Center/Center.contract.json
@@ -228,5 +228,9 @@
                 "view"
             ]
         }
-    }
+    },
+    "forbiddenUse": [
+        "Center large layout sections — use `Section` + `Container` instead.",
+        "Rely on this to vertically center text inside a button or input — those already center via their own padding."
+    ]
 }

--- a/nextjs-app/shared/components/ChatWidget/ChatWidget.contract.json
+++ b/nextjs-app/shared/components/ChatWidget/ChatWidget.contract.json
@@ -73,5 +73,10 @@
         "DonnyAvatar",
         "Header",
         "Footer"
+    ],
+    "forbiddenUse": [
+        "gate the widget behind user authentication. The widget is",
+        "store chat history in cookies. The current storage is",
+        "tamper with the email-workflow reducer state from outside."
     ]
 }

--- a/nextjs-app/shared/components/Checkbox/Checkbox.contract.json
+++ b/nextjs-app/shared/components/Checkbox/Checkbox.contract.json
@@ -120,5 +120,9 @@
         "Grid",
         "ArticleCard",
         "Avatar"
+    ],
+    "forbiddenUse": [
+        "use `checked` directly. The prefixed `isChecked` name is the",
+        "rely on the native `indeterminate` HTML attribute — there is"
     ]
 }

--- a/nextjs-app/shared/components/CheckboxField/CheckboxField.contract.json
+++ b/nextjs-app/shared/components/CheckboxField/CheckboxField.contract.json
@@ -88,5 +88,9 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Use for a checkbox group — use `CheckboxGroup`.",
+        "Use as a toggle for a setting that takes effect immediately — use `Switch`."
+    ]
 }

--- a/nextjs-app/shared/components/CheckboxGroup/CheckboxGroup.contract.json
+++ b/nextjs-app/shared/components/CheckboxGroup/CheckboxGroup.contract.json
@@ -95,5 +95,10 @@
         "Grid",
         "ArticleCard",
         "Avatar"
+    ],
+    "forbiddenUse": [
+        "render a CheckboxGroup with one option. It's an awkward",
+        "nest a CheckboxGroup inside another CheckboxGroup. AT",
+        "rely on the master label translation key without testing the"
     ]
 }

--- a/nextjs-app/shared/components/ClientLogoMarquee/ClientLogoMarquee.contract.json
+++ b/nextjs-app/shared/components/ClientLogoMarquee/ClientLogoMarquee.contract.json
@@ -47,5 +47,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.contract.json
+++ b/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.contract.json
@@ -85,5 +85,8 @@
         "Text",
         "Title",
         "Greeting"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/CodeSnippet/CodeSnippet.contract.json
+++ b/nextjs-app/shared/components/CodeSnippet/CodeSnippet.contract.json
@@ -117,5 +117,8 @@
         "Button",
         "Text",
         "Card"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/Combobox/Combobox.contract.json
+++ b/nextjs-app/shared/components/Combobox/Combobox.contract.json
@@ -96,5 +96,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "nest inside containers with `overflow: hidden` without portaling (dropdown renders on `document.body`)."
+    ]
 }

--- a/nextjs-app/shared/components/ComplianceCard/ComplianceCard.contract.json
+++ b/nextjs-app/shared/components/ComplianceCard/ComplianceCard.contract.json
@@ -78,5 +78,8 @@
         "Icon",
         "CodeSnippet",
         "Button"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/ContactForm/ContactForm.contract.json
+++ b/nextjs-app/shared/components/ContactForm/ContactForm.contract.json
@@ -56,5 +56,10 @@
         "Button",
         "Text",
         "CheckboxGroup"
+    ],
+    "forbiddenUse": [
+        "pass props. The component intentionally accepts none. If",
+        "swallow the `/api/contact` endpoint. The submit handler",
+        "remove the honeypot. It catches a meaningful share of bot"
     ]
 }

--- a/nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.contract.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.contract.json
@@ -60,5 +60,8 @@
     },
     "composesWith": [
         "ContactFormSuccessEditorial"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/Container/Container.contract.json
+++ b/nextjs-app/shared/components/Container/Container.contract.json
@@ -271,5 +271,8 @@
         "CodeBlockWindow",
         "Text",
         "Title"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/CookieConsent/CookieConsent.contract.json
+++ b/nextjs-app/shared/components/CookieConsent/CookieConsent.contract.json
@@ -51,5 +51,8 @@
     "composesWith": [
         "Button",
         "Text"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/Designerman/Designerman.contract.json
+++ b/nextjs-app/shared/components/Designerman/Designerman.contract.json
@@ -78,5 +78,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/Display/Display.contract.json
+++ b/nextjs-app/shared/components/Display/Display.contract.json
@@ -59,5 +59,9 @@
             "optional": false,
             "type": "React.ReactNode"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Use `Display` for in-page section headings — that is `Title`.",
+        "Stack two `Display` headings in the same viewport — the marketing visual collapses."
+    ]
 }

--- a/nextjs-app/shared/components/Divider/Divider.contract.json
+++ b/nextjs-app/shared/components/Divider/Divider.contract.json
@@ -69,5 +69,8 @@
     "composesWith": [
         "Layout",
         "TextLink"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/DonnyAvatar/DonnyAvatar.contract.json
+++ b/nextjs-app/shared/components/DonnyAvatar/DonnyAvatar.contract.json
@@ -167,5 +167,8 @@
             "optional": true,
             "type": "boolean"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.contract.json
+++ b/nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.contract.json
@@ -65,5 +65,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/EnhancedProjectCard/EnhancedProjectCard.contract.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/EnhancedProjectCard.contract.json
@@ -112,5 +112,8 @@
     "composesWith": [
         "Container",
         "Section"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/ExpandableSection/ExpandableSection.contract.json
+++ b/nextjs-app/shared/components/ExpandableSection/ExpandableSection.contract.json
@@ -79,5 +79,9 @@
             "optional": true,
             "type": "number"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Use a sequence of `ExpandableSection`s instead of `Accordion` — accordion owns the focus management and single-open behaviour.",
+        "Hide critical content (errors, primary CTA) behind a disclosure."
+    ]
 }

--- a/nextjs-app/shared/components/FileUpload/FileUpload.contract.json
+++ b/nextjs-app/shared/components/FileUpload/FileUpload.contract.json
@@ -130,10 +130,15 @@
     },
     "composesWith": [
         "Button",
+        "Modal",
         "PhoneInput",
         "Inputs",
         "CheckboxGroup",
-        "Modal",
         "Toast"
+    ],
+    "forbiddenUse": [
+        "render two FileUploads in the same form without unique",
+        "rely on `value` for \"the file is already on the server\".",
+        "skip the Clear button. Users who picked the wrong file have"
     ]
 }

--- a/nextjs-app/shared/components/FlexBox/FlexBox.contract.json
+++ b/nextjs-app/shared/components/FlexBox/FlexBox.contract.json
@@ -138,5 +138,8 @@
         "ArticleCard",
         "Avatar",
         "Checkbox"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/FormField/FormField.contract.json
+++ b/nextjs-app/shared/components/FormField/FormField.contract.json
@@ -87,5 +87,9 @@
         "Label",
         "Inputs",
         "HelperText"
+    ],
+    "forbiddenUse": [
+        "Render a bare `<label>` + `<input>` next to a `FormField` in the same form — the visual rhythm desyncs.",
+        "Put two controls inside one `FormField` — wrap each in its own."
     ]
 }

--- a/nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.contract.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.contract.json
@@ -77,5 +77,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/FormGroup/FormGroup.contract.json
+++ b/nextjs-app/shared/components/FormGroup/FormGroup.contract.json
@@ -61,5 +61,9 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Wrap a single input — use `FormField`.",
+        "Nest fieldsets more than 2 deep — screen-reader announcements collapse."
+    ]
 }

--- a/nextjs-app/shared/components/Gallery/Gallery.contract.json
+++ b/nextjs-app/shared/components/Gallery/Gallery.contract.json
@@ -71,5 +71,9 @@
         "StoryBlock",
         "ProjectDetailLayout",
         "ProjectHero"
+    ],
+    "forbiddenUse": [
+        "Use as a navigation surface — gallery items are not links.",
+        "Auto-open the lightbox on mount — confine motion to explicit user actions."
     ]
 }

--- a/nextjs-app/shared/components/Grid/Grid.contract.json
+++ b/nextjs-app/shared/components/Grid/Grid.contract.json
@@ -157,5 +157,8 @@
         "Checkbox",
         "CheckboxGroup",
         "FlexBox"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/GroupLabel/GroupLabel.contract.json
+++ b/nextjs-app/shared/components/GroupLabel/GroupLabel.contract.json
@@ -63,5 +63,9 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Use as a label for a single input — that is `Label`.",
+        "Style as a heading — screen readers will navigate to it as a heading and miss the group it labels."
+    ]
 }

--- a/nextjs-app/shared/components/Heading/Heading.contract.json
+++ b/nextjs-app/shared/components/Heading/Heading.contract.json
@@ -93,5 +93,9 @@
             "optional": false,
             "type": "React.ReactNode"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Skip levels for visual effect (h1 → h3) — screen-reader navigation breaks.",
+        "Use the same level twice for the same scope when one is a subheading of the other."
+    ]
 }

--- a/nextjs-app/shared/components/HelperText/HelperText.contract.json
+++ b/nextjs-app/shared/components/HelperText/HelperText.contract.json
@@ -74,5 +74,12 @@
         "Icon",
         "Button",
         "Inputs"
+    ],
+    "forbiddenUse": [
+        "render multiple `state=\"error\"` HelperTexts under one field —",
+        "use HelperText for page-level messages. AlertBanner and Toast"
+    ],
+    "prefersOver": [
+        "AlertBanner for field-level hints"
     ]
 }

--- a/nextjs-app/shared/components/Icon/Icon.contract.json
+++ b/nextjs-app/shared/components/Icon/Icon.contract.json
@@ -217,5 +217,9 @@
         "CodeSnippet",
         "Text",
         "HelperText"
+    ],
+    "forbiddenUse": [
+        "pass both `ariaLabel` and `decorative`. The component prefers",
+        "import a Phosphor component directly from `@phosphor-icons/react`"
     ]
 }

--- a/nextjs-app/shared/components/IconButton/IconButton.contract.json
+++ b/nextjs-app/shared/components/IconButton/IconButton.contract.json
@@ -102,5 +102,9 @@
         "NavLink",
         "Container",
         "LanguageSwitcher"
+    ],
+    "forbiddenUse": [
+        "Omit `label` — there is no fallback announcement.",
+        "Use for primary marketing CTAs — text + icon is more discoverable; use `Button` with an icon prop."
     ]
 }

--- a/nextjs-app/shared/components/ImagePlaceholder/ImagePlaceholder.contract.json
+++ b/nextjs-app/shared/components/ImagePlaceholder/ImagePlaceholder.contract.json
@@ -108,5 +108,8 @@
             "optional": true,
             "type": "React.CSSProperties"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/Inputs/Inputs.contract.json
+++ b/nextjs-app/shared/components/Inputs/Inputs.contract.json
@@ -135,5 +135,10 @@
         "Modal",
         "Label",
         "Title"
+    ],
+    "forbiddenUse": [
+        "ship a form that relies on the email validator as the only",
+        "pass a `value` plus a `defaultValue`. The component treats",
+        "use Inputs for multi-line text. Use **TextArea**, which"
     ]
 }

--- a/nextjs-app/shared/components/Label/Label.contract.json
+++ b/nextjs-app/shared/components/Label/Label.contract.json
@@ -74,5 +74,9 @@
         "Checkbox",
         "Text",
         "Title"
+    ],
+    "forbiddenUse": [
+        "place validation errors inside Label. Errors belong to the",
+        "use a Label as a section heading. Headings carry navigation"
     ]
 }

--- a/nextjs-app/shared/components/Layout/Layout.contract.json
+++ b/nextjs-app/shared/components/Layout/Layout.contract.json
@@ -47,5 +47,9 @@
     "composesWith": [
         "Divider",
         "TextLink"
+    ],
+    "forbiddenUse": [
+        "Render `Layout` inside another `Layout` — there is one global shell per page.",
+        "Use as a generic 'two-column with sidebar' wrapper — that is what a section pattern would be."
     ]
 }

--- a/nextjs-app/shared/components/Link/Link.contract.json
+++ b/nextjs-app/shared/components/Link/Link.contract.json
@@ -65,5 +65,12 @@
         "Title",
         "Grid",
         "ArticleCard"
+    ],
+    "forbiddenUse": [
+        "use Link for actions. Buttons are for actions; anchors are for",
+        "override the underline via inline styles. The token-driven"
+    ],
+    "prefersOver": [
+        "Button with href for body-copy links"
     ]
 }

--- a/nextjs-app/shared/components/LinkedInQuoteCard/LinkedInQuoteCard.contract.json
+++ b/nextjs-app/shared/components/LinkedInQuoteCard/LinkedInQuoteCard.contract.json
@@ -107,5 +107,8 @@
                 "dark"
             ]
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/List/List.contract.json
+++ b/nextjs-app/shared/components/List/List.contract.json
@@ -152,5 +152,8 @@
     "composesWith": [
         "Title",
         "Text"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/LocationCard/LocationCard.contract.json
+++ b/nextjs-app/shared/components/LocationCard/LocationCard.contract.json
@@ -89,5 +89,9 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Use as a generic 'card with an icon and label' — that is `Card`.",
+        "Stack two `LocationCard`s vertically with no spacing — they need rhythm via `Grid` or `Stack`."
+    ]
 }

--- a/nextjs-app/shared/components/MCPActionButton/MCPActionButton.contract.json
+++ b/nextjs-app/shared/components/MCPActionButton/MCPActionButton.contract.json
@@ -69,5 +69,8 @@
             "optional": true,
             "type": "React.ReactNode"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.contract.json
+++ b/nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.contract.json
@@ -84,5 +84,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.contract.json
+++ b/nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.contract.json
@@ -93,5 +93,8 @@
         "Title",
         "PageLayout",
         "OpenHours"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/Modal/Modal.contract.json
+++ b/nextjs-app/shared/components/Modal/Modal.contract.json
@@ -177,5 +177,12 @@
         "FileUpload",
         "PhoneInput",
         "AdaptiveLoadingButton"
+    ],
+    "forbiddenUse": [
+        "Nested modals — swap content in place inside one overlay",
+        "Lazy-mounting Modal only when isOpen — mount always and toggle isOpen for focus restore",
+        "nest a Modal inside another Modal. AT focus order becomes",
+        "render a Modal lazily (e.g. only mount it when `isOpen`).",
+        "add `aria-live` to the dialog root. The role implies"
     ]
 }

--- a/nextjs-app/shared/components/MultiCombobox/MultiCombobox.contract.json
+++ b/nextjs-app/shared/components/MultiCombobox/MultiCombobox.contract.json
@@ -101,5 +101,8 @@
     "composesWith": [
         "Button",
         "FileUpload"
+    ],
+    "forbiddenUse": [
+        "use for single-select — use `Combobox` instead."
     ]
 }

--- a/nextjs-app/shared/components/NavLink/NavLink.contract.json
+++ b/nextjs-app/shared/components/NavLink/NavLink.contract.json
@@ -78,5 +78,9 @@
         "Container",
         "LanguageSwitcher",
         "SkipLink"
+    ],
+    "forbiddenUse": [
+        "Use inside body prose — that is `TextLink`.",
+        "Use as a button — primary actions belong on `Button`."
     ]
 }

--- a/nextjs-app/shared/components/NavMenuList/NavMenuList.contract.json
+++ b/nextjs-app/shared/components/NavMenuList/NavMenuList.contract.json
@@ -68,5 +68,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.contract.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.contract.json
@@ -68,5 +68,10 @@
             "optional": true,
             "type": "boolean"
         }
-    }
+    },
+    "forbiddenUse": [
+        "mount more than one instance per page. The success Modal",
+        "try to control the transformation state from outside. The",
+        "bypass the validation. The regex catches obvious typos but"
+    ]
 }

--- a/nextjs-app/shared/components/NextHeader/NextHeader.contract.json
+++ b/nextjs-app/shared/components/NextHeader/NextHeader.contract.json
@@ -47,5 +47,9 @@
     "lightDarkVerified": true,
     "consumers": [],
     "schemaVersion": 2,
-    "props": {}
+    "props": {},
+    "forbiddenUse": [
+        "Render `NextHeader` outside `Layout` — it expects the global shell context (theme provider, router).",
+        "Duplicate the header in routes — `Layout` already mounts it once."
+    ]
 }

--- a/nextjs-app/shared/components/NextLayout/NextLayout.contract.json
+++ b/nextjs-app/shared/components/NextLayout/NextLayout.contract.json
@@ -47,5 +47,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/NextMobileMenu/NextMobileMenu.contract.json
+++ b/nextjs-app/shared/components/NextMobileMenu/NextMobileMenu.contract.json
@@ -73,5 +73,9 @@
             "optional": false,
             "type": "{ code: string; label: string; ariaLabel: string }[]"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Render outside `Layout` — depends on the theme provider and the header.",
+        "Mount multiple instances simultaneously — focus management collapses."
+    ]
 }

--- a/nextjs-app/shared/components/OpenHours/OpenHours.contract.json
+++ b/nextjs-app/shared/components/OpenHours/OpenHours.contract.json
@@ -69,5 +69,8 @@
         "ServicesGrid",
         "StudioMap",
         "DonnyBookingEmbed"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/Pagination/Pagination.contract.json
+++ b/nextjs-app/shared/components/Pagination/Pagination.contract.json
@@ -79,5 +79,9 @@
         "BlogCategoryFilter",
         "BlogGrid",
         "EnhancedArticleCard"
+    ],
+    "forbiddenUse": [
+        "Remove Previous/Next on edges — use `aria-disabled` so the visual stays stable.",
+        "Render more than ~10 page numbers inline — switch to a 'Page X of Y' label with prev/next only."
     ]
 }

--- a/nextjs-app/shared/components/PersonCard/PersonCard.contract.json
+++ b/nextjs-app/shared/components/PersonCard/PersonCard.contract.json
@@ -186,5 +186,8 @@
             "optional": true,
             "type": "boolean"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/PhoneInput/PhoneInput.contract.json
+++ b/nextjs-app/shared/components/PhoneInput/PhoneInput.contract.json
@@ -73,11 +73,14 @@
         }
     },
     "composesWith": [
+        "Button",
+        "Modal",
         "FileUpload",
         "Inputs",
-        "Button",
         "CheckboxGroup",
-        "Modal",
         "Toast"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/Progress/Progress.contract.json
+++ b/nextjs-app/shared/components/Progress/Progress.contract.json
@@ -86,5 +86,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/Radio/Radio.contract.json
+++ b/nextjs-app/shared/components/Radio/Radio.contract.json
@@ -97,5 +97,8 @@
             "optional": true,
             "type": "boolean"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/RadioGroup/RadioGroup.contract.json
+++ b/nextjs-app/shared/components/RadioGroup/RadioGroup.contract.json
@@ -123,5 +123,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/ReadingProgress/ReadingProgress.contract.json
+++ b/nextjs-app/shared/components/ReadingProgress/ReadingProgress.contract.json
@@ -55,5 +55,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/Section/Section.contract.json
+++ b/nextjs-app/shared/components/Section/Section.contract.json
@@ -91,5 +91,8 @@
         "EnhancedProjectCard",
         "WorkHero",
         "CategoryFilter"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.contract.json
+++ b/nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.contract.json
@@ -71,5 +71,8 @@
     "composesWith": [
         "Section",
         "Container"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/Select/Select.contract.json
+++ b/nextjs-app/shared/components/Select/Select.contract.json
@@ -114,5 +114,10 @@
         "Modal",
         "Toast",
         "FileUpload"
+    ],
+    "forbiddenUse": [
+        "ship a Select with `value` and `defaultValue` both set —",
+        "use Select for a freeform value with suggestions. Use an",
+        "wrap the native chevron with a button overlay. The native"
     ]
 }

--- a/nextjs-app/shared/components/SentrySummaryCard/SentrySummaryCard.contract.json
+++ b/nextjs-app/shared/components/SentrySummaryCard/SentrySummaryCard.contract.json
@@ -57,5 +57,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/ServiceCard/ServiceCard.contract.json
+++ b/nextjs-app/shared/components/ServiceCard/ServiceCard.contract.json
@@ -104,5 +104,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/ServicesGrid/ServicesGrid.contract.json
+++ b/nextjs-app/shared/components/ServicesGrid/ServicesGrid.contract.json
@@ -53,5 +53,8 @@
         "OpenHours",
         "StudioMap",
         "DonnyBookingEmbed"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/SiteTree/SiteTree.contract.json
+++ b/nextjs-app/shared/components/SiteTree/SiteTree.contract.json
@@ -65,5 +65,9 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Use as the primary site header navigation — use `NavMenuList` / `NextHeader` instead.",
+        "Nest more than three levels without testing keyboard focus order."
+    ]
 }

--- a/nextjs-app/shared/components/Skeleton/Skeleton.contract.json
+++ b/nextjs-app/shared/components/Skeleton/Skeleton.contract.json
@@ -99,5 +99,8 @@
     },
     "composesWith": [
         "Text"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/SkillsGrid/SkillsGrid.contract.json
+++ b/nextjs-app/shared/components/SkillsGrid/SkillsGrid.contract.json
@@ -59,5 +59,9 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Use for a small set of (≤ 4) capabilities — the grid rhythm collapses; use `Card` instead.",
+        "Mix logos and text in the same grid — pick one visual language."
+    ]
 }

--- a/nextjs-app/shared/components/SkipLink/SkipLink.contract.json
+++ b/nextjs-app/shared/components/SkipLink/SkipLink.contract.json
@@ -59,5 +59,8 @@
     },
     "composesWith": [
         "NavLink"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/SocialShare/SocialShare.contract.json
+++ b/nextjs-app/shared/components/SocialShare/SocialShare.contract.json
@@ -51,5 +51,8 @@
             "optional": false,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/Spacer/Spacer.contract.json
+++ b/nextjs-app/shared/components/Spacer/Spacer.contract.json
@@ -80,5 +80,9 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Stack two Spacers — collapse them into the larger size.",
+        "Use as a 'push' element to right-align content — use flex `margin-inline-start: auto` instead."
+    ]
 }

--- a/nextjs-app/shared/components/Spinner/Spinner.contract.json
+++ b/nextjs-app/shared/components/Spinner/Spinner.contract.json
@@ -70,5 +70,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/Stack/Stack.contract.json
+++ b/nextjs-app/shared/components/Stack/Stack.contract.json
@@ -296,5 +296,8 @@
                 "view"
             ]
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/Switch/Switch.contract.json
+++ b/nextjs-app/shared/components/Switch/Switch.contract.json
@@ -118,5 +118,9 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "use Switch inside a form whose values are submitted in a batch.",
+        "rely on colour alone to convey state — the position of the"
+    ]
 }

--- a/nextjs-app/shared/components/Tabs/Tabs.contract.json
+++ b/nextjs-app/shared/components/Tabs/Tabs.contract.json
@@ -132,5 +132,10 @@
         "Link",
         "Button",
         "Badge"
+    ],
+    "forbiddenUse": [
+        "nest tablists inside another tablist. APG explicitly disallows",
+        "use Tabs for non-mutually-exclusive content. Two panels open",
+        "hand-author `id=\"tab-<key>\"` / `id=\"tabpanel-<key>\"` on the"
     ]
 }

--- a/nextjs-app/shared/components/Tag/Tag.contract.json
+++ b/nextjs-app/shared/components/Tag/Tag.contract.json
@@ -109,5 +109,9 @@
             "optional": true,
             "type": "boolean"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Use as a button — `Tag` is metadata, not an action surface. Use `Button` for actions.",
+        "Stack more than ~6 tags in a row without wrapping — readability collapses; use a `Select` instead."
+    ]
 }

--- a/nextjs-app/shared/components/Testimonial/Testimonial.contract.json
+++ b/nextjs-app/shared/components/Testimonial/Testimonial.contract.json
@@ -77,5 +77,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/Text/Text.contract.json
+++ b/nextjs-app/shared/components/Text/Text.contract.json
@@ -196,5 +196,12 @@
         "ProjectHero",
         "RelatedProjects",
         "Button"
+    ],
+    "forbiddenUse": [
+        "nest a `<Text as=\"p\">` inside another `<p>`. HTML rejects nested",
+        "override font-size via inline `style`. The ladder is the contract;"
+    ],
+    "prefersOver": [
+        "raw paragraph elements"
     ]
 }

--- a/nextjs-app/shared/components/TextArea/TextArea.contract.json
+++ b/nextjs-app/shared/components/TextArea/TextArea.contract.json
@@ -110,5 +110,8 @@
                 "vertical"
             ]
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/TextInput/TextInput.contract.json
+++ b/nextjs-app/shared/components/TextInput/TextInput.contract.json
@@ -98,5 +98,9 @@
             "optional": true,
             "type": "boolean"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Use without a label — the input has no accessible name on its own.",
+        "Use for multi-line input — use `TextArea`."
+    ]
 }

--- a/nextjs-app/shared/components/TextLink/TextLink.contract.json
+++ b/nextjs-app/shared/components/TextLink/TextLink.contract.json
@@ -95,5 +95,9 @@
     "composesWith": [
         "Divider",
         "Layout"
+    ],
+    "forbiddenUse": [
+        "Use as a button — opening a dialog or running a side-effect is a `Button` job.",
+        "Style as an icon — wrap an icon link in `IconButton` (with `aria-label`) instead."
     ]
 }

--- a/nextjs-app/shared/components/ThemeProvider/ThemeProvider.contract.json
+++ b/nextjs-app/shared/components/ThemeProvider/ThemeProvider.contract.json
@@ -54,5 +54,8 @@
         "Icon",
         "Container",
         "LanguageSwitcher"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/components/Title/Title.contract.json
+++ b/nextjs-app/shared/components/Title/Title.contract.json
@@ -199,5 +199,13 @@
         "StoryBlock",
         "ProjectHero",
         "RelatedProjects"
+    ],
+    "forbiddenUse": [
+        "Default Title typography on pattern headings that already define font-display or module classes — use unstyled + existing className",
+        "visually size a heading by passing custom inline styles — use the",
+        "nest a Title inside a Button. Use the Button's text slot directly."
+    ],
+    "prefersOver": [
+        "raw heading elements"
     ]
 }

--- a/nextjs-app/shared/components/Toast/Toast.contract.json
+++ b/nextjs-app/shared/components/Toast/Toast.contract.json
@@ -147,5 +147,13 @@
         "Inputs",
         "CheckboxGroup",
         "Select"
+    ],
+    "forbiddenUse": [
+        "stack toasts. The provider queues them — calling `showToast`",
+        "rely on Toast for compliance acknowledgements (cookie consent,",
+        "use Toast for validation errors on a field. The visual is far"
+    ],
+    "prefersOver": [
+        "AlertBanner for page-level persistent status"
     ]
 }

--- a/nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.contract.json
+++ b/nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.contract.json
@@ -106,5 +106,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/ValueCard/ValueCard.contract.json
+++ b/nextjs-app/shared/components/ValueCard/ValueCard.contract.json
@@ -85,5 +85,9 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Use for content with a primary CTA — that is `ServiceCard` or `Card`.",
+        "Mix `ValueCard` with `Card` in the same grid row — the rhythm desyncs."
+    ]
 }

--- a/nextjs-app/shared/components/VisuallyHidden/VisuallyHidden.contract.json
+++ b/nextjs-app/shared/components/VisuallyHidden/VisuallyHidden.contract.json
@@ -58,5 +58,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/components/WipBadge/WipBadge.contract.json
+++ b/nextjs-app/shared/components/WipBadge/WipBadge.contract.json
@@ -77,5 +77,8 @@
                 "docs"
             ]
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.contract.json
+++ b/nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.contract.json
@@ -52,5 +52,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/patterns/CTASection/CTASection.contract.json
+++ b/nextjs-app/shared/patterns/CTASection/CTASection.contract.json
@@ -115,5 +115,8 @@
         "NewsBulletin",
         "DesignSprintsSection",
         "HighlightSection"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/patterns/ContactHero/ContactHero.contract.json
+++ b/nextjs-app/shared/patterns/ContactHero/ContactHero.contract.json
@@ -71,5 +71,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.contract.json
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.contract.json
@@ -63,5 +63,8 @@
             "optional": true,
             "type": "SiteBookingConfig"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.contract.json
+++ b/nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.contract.json
@@ -63,5 +63,8 @@
         "CTASection",
         "NewsBulletin",
         "HighlightSection"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/patterns/Footer/Footer.contract.json
+++ b/nextjs-app/shared/patterns/Footer/Footer.contract.json
@@ -52,5 +52,8 @@
         "Button",
         "ChatWidget",
         "Header"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/patterns/GridBlock/GridBlock.contract.json
+++ b/nextjs-app/shared/patterns/GridBlock/GridBlock.contract.json
@@ -121,5 +121,8 @@
         "ProjectHero",
         "RelatedProjects",
         "ProcessBlock"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/patterns/Header/Header.contract.json
+++ b/nextjs-app/shared/patterns/Header/Header.contract.json
@@ -64,5 +64,8 @@
         "Button",
         "ChatWidget",
         "Footer"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/patterns/Hero/Hero.contract.json
+++ b/nextjs-app/shared/patterns/Hero/Hero.contract.json
@@ -175,5 +175,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/patterns/HeroSection/HeroSection.contract.json
+++ b/nextjs-app/shared/patterns/HeroSection/HeroSection.contract.json
@@ -297,5 +297,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/patterns/HighlightSection/HighlightSection.contract.json
+++ b/nextjs-app/shared/patterns/HighlightSection/HighlightSection.contract.json
@@ -129,5 +129,8 @@
         "CTASection",
         "NewsBulletin",
         "DesignSprintsSection"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/patterns/HomeHero/HomeHero.contract.json
+++ b/nextjs-app/shared/patterns/HomeHero/HomeHero.contract.json
@@ -60,5 +60,8 @@
         "NewsBulletin",
         "DesignSprintsSection",
         "HighlightSection"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/patterns/PageLayout/PageLayout.contract.json
+++ b/nextjs-app/shared/patterns/PageLayout/PageLayout.contract.json
@@ -121,5 +121,8 @@
         "Button",
         "MarkdownMessage",
         "AuthorBio"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.contract.json
+++ b/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.contract.json
@@ -127,5 +127,8 @@
         "ProjectHero",
         "RelatedProjects",
         "GridBlock"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/patterns/ProofBlock/ProofBlock.contract.json
+++ b/nextjs-app/shared/patterns/ProofBlock/ProofBlock.contract.json
@@ -82,5 +82,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.contract.json
+++ b/nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.contract.json
@@ -126,5 +126,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/nextjs-app/shared/patterns/ServicesSection/ServicesSection.contract.json
+++ b/nextjs-app/shared/patterns/ServicesSection/ServicesSection.contract.json
@@ -94,5 +94,8 @@
         "NewsBulletin",
         "DesignSprintsSection",
         "HighlightSection"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/patterns/SiteFooter/SiteFooter.contract.json
+++ b/nextjs-app/shared/patterns/SiteFooter/SiteFooter.contract.json
@@ -53,5 +53,10 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "mount more than one SiteFooter. AT users encounter two",
+        "hand-author a `<footer>` instead of using SiteFooter on a",
+        "change the Divider's margin via `className=\"my-X\"` without"
+    ]
 }

--- a/nextjs-app/shared/patterns/SiteHeader/SiteHeader.contract.json
+++ b/nextjs-app/shared/patterns/SiteHeader/SiteHeader.contract.json
@@ -64,5 +64,10 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "tamper with the IconButton variants. The header's theme",
+        "nest a `<header>` inside SiteHeader. Multiple banner",
+        "hard-code the language list. The `languages` array is the"
+    ]
 }

--- a/nextjs-app/shared/patterns/StoryBlock/StoryBlock.contract.json
+++ b/nextjs-app/shared/patterns/StoryBlock/StoryBlock.contract.json
@@ -138,5 +138,8 @@
         "RelatedProjects",
         "ProcessBlock",
         "GridBlock"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/patterns/TeamBlock/TeamBlock.contract.json
+++ b/nextjs-app/shared/patterns/TeamBlock/TeamBlock.contract.json
@@ -132,5 +132,8 @@
         "GridBlock",
         "ProjectDetailLayout",
         "ProjectHero"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.contract.json
+++ b/nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.contract.json
@@ -78,5 +78,8 @@
         "NewsBulletin",
         "DesignSprintsSection",
         "HighlightSection"
+    ],
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
     ]
 }

--- a/nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.contract.json
+++ b/nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.contract.json
@@ -86,5 +86,8 @@
             "optional": true,
             "type": "string"
         }
-    }
+    },
+    "forbiddenUse": [
+        "Bypass design tokens or skip forced-colors verification at beta."
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "sync:contract-props": "node scripts/design-system/sync-contract-props.mjs",
     "check:contract-drift": "node scripts/design-system/check-contract-drift.mjs",
     "check:contract-props": "node scripts/design-system/check-contract-props.mjs",
+    "lint:composition": "node scripts/design-system/lint-composition.mjs --strict",
     "promote:stable-atoms": "node scripts/design-system/promote-stable-atoms.mjs",
     "check:bundle-budgets": "node scripts/design-system/check-bundle-budgets.mjs"
   },

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -69,7 +69,7 @@
 
 - Run: `npm run ds:health`
 - Output: `public/ds-health/report.json`, `public/ds-health/summary.md`
-- Includes: `lint:dt-usage`, `lint:dt-responsive-visibility`, shadcn inventory, last matrix result
+- Includes: `lint:dt-usage`, `lint:composition`, `lint:dt-responsive-visibility`, shadcn inventory, last matrix result
 
 **Responsive visibility lint**
 

--- a/scripts/design-system/build-component-agent-blocks.ts
+++ b/scripts/design-system/build-component-agent-blocks.ts
@@ -11,7 +11,11 @@ import {
   extractComponentFromSourceFile,
 } from "./validate-components.ts";
 import { parseSpecAgentHints, extractSpecIntent } from "./parse-spec-agent-hints.mjs";
-import { getReplacementFor, getPrefersOver } from "./component-replacement-policy.mjs";
+import {
+  getReplacementFor,
+  getPrefersOver,
+  getForbiddenUse,
+} from "./component-replacement-policy.mjs";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const RELATIONSHIP_GRAPH = join(
@@ -254,6 +258,7 @@ function main() {
       ),
       canonicalExamples: canonicalExamplesFromStories(join(entry.dir, `${entry.name}.stories.tsx`)),
       replacementFor: getReplacementFor(entry.name),
+      forbiddenUse: getForbiddenUse(entry.name, avoidWhen),
       ...getGraphRelations(entry.name),
       declaredPropCount: extracted.declaredPropNames.length,
     };

--- a/scripts/design-system/check-contract-props.mjs
+++ b/scripts/design-system/check-contract-props.mjs
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
 /**
- * CI gate: beta/stable contracts must carry props synced from agent blocks.
+ * CI gate: beta/stable contracts must carry props + v2 semantic fields synced from agent blocks.
  *
  *   npm run check:contract-props
  */
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  diffSemanticFields,
+  expectedSemanticFields,
+} from "./contract-semantics-lib.mjs";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const AGENT_BLOCKS_PATH = join(
@@ -58,31 +62,39 @@ for (const base of roots) {
           detail: "beta/stable requires props object (may be {})",
         });
       }
-      continue;
+    } else {
+      const missing = expectedKeys.filter((k) => !(k in actualProps));
+      const stale = Object.keys(actualProps).filter((k) => !(k in expectedProps));
+
+      if (missing.length) {
+        failures.push({
+          name,
+          kind: "props-drift",
+          detail: `missing keys: ${missing.join(", ")} — run npm run sync:contract-props -- --write`,
+        });
+      }
+      if (stale.length) {
+        failures.push({
+          name,
+          kind: "props-stale",
+          detail: `stale keys: ${stale.join(", ")} — run npm run sync:contract-props -- --write`,
+        });
+      }
     }
 
-    const missing = expectedKeys.filter((k) => !(k in actualProps));
-    const stale = Object.keys(actualProps).filter((k) => !(k in expectedProps));
-
-    if (missing.length) {
-      failures.push({
-        name,
-        kind: "props-drift",
-        detail: `missing keys: ${missing.join(", ")} — run npm run sync:contract-props -- --write`,
-      });
-    }
-    if (stale.length) {
-      failures.push({
-        name,
-        kind: "props-stale",
-        detail: `stale keys: ${stale.join(", ")} — run npm run sync:contract-props -- --write`,
-      });
+    for (const issue of diffSemanticFields(
+      contract,
+      expectedSemanticFields(agent),
+    )) {
+      failures.push({ name, ...issue });
     }
   }
 }
 
 if (!failures.length) {
-  console.log("✓ Beta/stable contract props match agent blocks");
+  console.log(
+    "✓ Beta/stable contract props and semantic fields match agent blocks",
+  );
   process.exit(0);
 }
 

--- a/scripts/design-system/component-replacement-policy.mjs
+++ b/scripts/design-system/component-replacement-policy.mjs
@@ -61,6 +61,42 @@ export const PREFERS_OVER = {
   HelperText: ["AlertBanner for field-level hints"],
 };
 
+/** Curated anti-patterns beyond spec.md — merged with parsed Do/Don't. */
+export const FORBIDDEN_USE_CURATED = {
+  Title: [
+    "Default Title typography on pattern headings that already define font-display or module classes — use unstyled + existing className",
+  ],
+  Button: [
+    "tertiary on dark or inverse backgrounds without explicit contrast verification",
+    "isInverse on primary over transparent or gradient parents — use surface instead",
+  ],
+  Modal: [
+    "Nested modals — swap content in place inside one overlay",
+    "Lazy-mounting Modal only when isOpen — mount always and toggle isOpen for focus restore",
+  ],
+};
+
+/**
+ * When both @dt components appear in the same product file, flag a composition conflict.
+ * @type {Array<{ id: string, a: string, b: string, message: string }>}
+ */
+export const INCOMPATIBLE_DT_IMPORT_PAIRS = [
+  {
+    id: "toast-alertbanner",
+    a: "Toast",
+    b: "AlertBanner",
+    message:
+      "Toast and AlertBanner model different persistence — pick one surface per status message.",
+  },
+  {
+    id: "toast-modal",
+    a: "Toast",
+    b: "Modal",
+    message:
+      "Do not pair transient Toast with blocking Modal for the same user action — use Modal alone.",
+  },
+];
+
 /**
  * @param {string} name
  * @returns {string[]}
@@ -75,4 +111,15 @@ export function getReplacementFor(name) {
  */
 export function getPrefersOver(name) {
   return PREFERS_OVER[name] ?? [];
+}
+
+/**
+ * @param {string} name
+ * @param {string[]} [avoidWhenFromSpec]
+ * @returns {string[]}
+ */
+export function getForbiddenUse(name, avoidWhenFromSpec = []) {
+  const curated = FORBIDDEN_USE_CURATED[name] ?? [];
+  const fromSpec = avoidWhenFromSpec.filter(Boolean);
+  return [...new Set([...curated, ...fromSpec])].slice(0, 8);
 }

--- a/scripts/design-system/composition-lint-lib.mjs
+++ b/scripts/design-system/composition-lint-lib.mjs
@@ -1,0 +1,95 @@
+/**
+ * Product-surface composition lint — incompatible @dt import pairs.
+ */
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, relative, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { INCOMPATIBLE_DT_IMPORT_PAIRS } from "./component-replacement-policy.mjs";
+import {
+  DT_USAGE_EXEMPT_REL,
+  DT_USAGE_SKIP_SEGMENTS,
+} from "./dt-usage-rules.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+/** Product UI only — not internal component implementations. */
+export const COMPOSITION_SCAN_ROOTS = [
+  "app",
+  "nextjs-app/shared/patterns",
+  "nextjs-app/shared/components/pages",
+];
+
+const SKIP_SEGMENTS = DT_USAGE_SKIP_SEGMENTS;
+
+/**
+ * @param {string} source
+ * @returns {Set<string>}
+ */
+export function extractDtImports(source) {
+  const names = new Set();
+  for (const match of source.matchAll(
+    /from\s+["']@dt\/([A-Za-z][A-Za-z0-9]*)/g,
+  )) {
+    names.add(match[1]);
+  }
+  return names;
+}
+
+/**
+ * @param {Set<string>} imports
+ * @returns {Array<{ id: string, message: string, components: string[] }>}
+ */
+export function findIncompatibleImportPairs(imports) {
+  const findings = [];
+  for (const rule of INCOMPATIBLE_DT_IMPORT_PAIRS) {
+    if (imports.has(rule.a) && imports.has(rule.b)) {
+      findings.push({
+        id: rule.id,
+        message: rule.message,
+        components: [rule.a, rule.b],
+      });
+    }
+  }
+  return findings;
+}
+
+function shouldScan(filePath) {
+  const rel = relative(ROOT, filePath).replace(/\\/g, "/");
+  if (DT_USAGE_EXEMPT_REL.has(rel)) return false;
+  if (SKIP_SEGMENTS.some((seg) => rel.includes(seg))) return false;
+  return /\.(tsx|jsx)$/.test(rel);
+}
+
+function walk(dir, out) {
+  if (!existsSync(dir)) return;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === ".next") continue;
+      walk(full, out);
+      continue;
+    }
+    if (shouldScan(full)) out.push(full);
+  }
+}
+
+/**
+ * @returns {Array<{ file: string, id: string, message: string, components: string[] }>}
+ */
+export function scanCompositionViolations() {
+  const files = [];
+  for (const segment of COMPOSITION_SCAN_ROOTS) {
+    walk(join(ROOT, segment), files);
+  }
+
+  const violations = [];
+  for (const file of files) {
+    const rel = relative(ROOT, file).replace(/\\/g, "/");
+    const source = readFileSync(file, "utf8");
+    const imports = extractDtImports(source);
+    for (const finding of findIncompatibleImportPairs(imports)) {
+      violations.push({ file: rel, ...finding });
+    }
+  }
+  return violations;
+}

--- a/scripts/design-system/contract-semantics-lib.mjs
+++ b/scripts/design-system/contract-semantics-lib.mjs
@@ -1,0 +1,71 @@
+/**
+ * Shared helpers for v2 semantic contract fields (graph + forbiddenUse).
+ */
+
+const COMPONENT_NAME = /^[A-Z][A-Za-z0-9]*$/;
+
+/**
+ * @param {unknown} value
+ * @returns {string[]}
+ */
+export function normalizeStringList(value) {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.filter((v) => typeof v === "string" && v.trim()))];
+}
+
+/**
+ * @param {string[]} a
+ * @param {string[]} b
+ */
+export function sameStringList(a, b) {
+  return JSON.stringify(normalizeStringList(a)) === JSON.stringify(normalizeStringList(b));
+}
+
+/**
+ * @param {object | undefined} agent
+ * @returns {{ composesWith: string[], prefersOver: string[], forbiddenUse: string[] }}
+ */
+export function expectedSemanticFields(agent) {
+  return {
+    composesWith: normalizeStringList(agent?.composesWith).filter((name) =>
+      COMPONENT_NAME.test(name),
+    ),
+    prefersOver: normalizeStringList(agent?.prefersOver),
+    forbiddenUse: normalizeStringList(agent?.forbiddenUse),
+  };
+}
+
+/**
+ * @param {object} contract
+ * @param {{ composesWith: string[], prefersOver: string[], forbiddenUse: string[] }} expected
+ * @returns {Array<{ kind: string, detail: string }>}
+ */
+export function diffSemanticFields(contract, expected) {
+  const issues = [];
+  const actualComposes = normalizeStringList(contract.composesWith).filter(
+    (name) => COMPONENT_NAME.test(name),
+  );
+  const actualPrefers = normalizeStringList(contract.prefersOver);
+  const actualForbidden = normalizeStringList(contract.forbiddenUse);
+
+  if (!sameStringList(actualComposes, expected.composesWith)) {
+    issues.push({
+      kind: "composesWith-drift",
+      detail: `expected ${JSON.stringify(expected.composesWith)} — run npm run sync:contract-props -- --write`,
+    });
+  }
+  if (!sameStringList(actualPrefers, expected.prefersOver)) {
+    issues.push({
+      kind: "prefersOver-drift",
+      detail: `expected ${JSON.stringify(expected.prefersOver)} — run npm run sync:contract-props -- --write`,
+    });
+  }
+  if (!sameStringList(actualForbidden, expected.forbiddenUse)) {
+    issues.push({
+      kind: "forbiddenUse-drift",
+      detail: `expected ${JSON.stringify(expected.forbiddenUse)} — run npm run sync:contract-props -- --write`,
+    });
+  }
+
+  return issues;
+}

--- a/scripts/design-system/contract.schema.v2.json
+++ b/scripts/design-system/contract.schema.v2.json
@@ -32,7 +32,7 @@
             "enum": [
                 2
             ],
-            "description": "Contract schema version. v2 adds props, composesWith, prefersOver, and stricter beta/stable conditionals."
+            "description": "Contract schema version. v2 adds props, composesWith, prefersOver, forbiddenUse, and stricter beta/stable conditionals."
         },
         "name": {
             "type": "string",
@@ -453,6 +453,16 @@
             },
             "uniqueItems": true,
             "description": "Raw HTML or legacy patterns this component replaces (from agent graph)."
+        },
+        "forbiddenUse": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "minLength": 1
+            },
+            "uniqueItems": true,
+            "maxItems": 8,
+            "description": "Agent-facing anti-patterns from spec Do/Don't and curated policy (v2 semantic)."
         }
     },
     "allOf": [

--- a/scripts/design-system/lint-composition.mjs
+++ b/scripts/design-system/lint-composition.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Lint incompatible @dt composition pairs on product surfaces.
+ *
+ *   npm run lint:composition
+ *   npm run lint:composition -- --strict
+ */
+import { scanCompositionViolations } from "./composition-lint-lib.mjs";
+
+const strict = process.argv.includes("--strict");
+const violations = scanCompositionViolations();
+
+if (!violations.length) {
+  console.log(
+    "✓ lint:composition — no incompatible @dt import pairs in product surfaces",
+  );
+  process.exit(0);
+}
+
+const label = strict ? "error" : "warning";
+for (const v of violations) {
+  console[strict ? "error" : "warn"](
+    `${label}: ${v.file} — ${v.id} (${v.components.join(" + ")}): ${v.message}`,
+  );
+}
+
+if (strict) {
+  console.error(`\nlint:composition: ${violations.length} violation(s)`);
+  process.exit(1);
+}
+
+console.log(`\nlint:composition: ${violations.length} warning(s) (pass --strict to fail CI)`);
+process.exit(0);

--- a/scripts/design-system/sync-contract-props.mjs
+++ b/scripts/design-system/sync-contract-props.mjs
@@ -15,6 +15,14 @@ function sanitizeComponentNames(names) {
   return [...new Set((names ?? []).filter((n) => COMPONENT_NAME.test(n)))];
 }
 
+function sanitizeStringList(names) {
+  return [
+    ...new Set(
+      (names ?? []).filter((n) => typeof n === "string" && n.trim().length > 0),
+    ),
+  ].slice(0, 8);
+}
+
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const writeMode = process.argv.includes("--write");
 const AGENT_BLOCKS_PATH = join(
@@ -48,7 +56,8 @@ for (const base of roots) {
     const contract = JSON.parse(readFileSync(contractPath, "utf8"));
     const nextProps = agent.props ?? {};
     const nextComposes = sanitizeComponentNames(agent.composesWith);
-    const nextPrefers = sanitizeComponentNames(agent.prefersOver);
+    const nextPrefers = sanitizeStringList(agent.prefersOver);
+    const nextForbidden = sanitizeStringList(agent.forbiddenUse);
 
     const shouldSyncProps =
       contract.status === "beta" ||
@@ -66,8 +75,11 @@ for (const base of roots) {
       JSON.stringify(nextComposes);
     const samePrefers =
       JSON.stringify(contract.prefersOver ?? []) === JSON.stringify(nextPrefers);
+    const sameForbidden =
+      JSON.stringify(contract.forbiddenUse ?? []) ===
+      JSON.stringify(nextForbidden);
 
-    if (sameProps && sameComposes && samePrefers) continue;
+    if (sameProps && sameComposes && samePrefers && sameForbidden) continue;
 
     wouldUpdate += 1;
     if (!writeMode) {
@@ -80,6 +92,8 @@ for (const base of roots) {
     else delete contract.composesWith;
     if (nextPrefers.length) contract.prefersOver = nextPrefers;
     else delete contract.prefersOver;
+    if (nextForbidden.length) contract.forbiddenUse = nextForbidden;
+    else delete contract.forbiddenUse;
 
     writeFileSync(contractPath, `${JSON.stringify(contract, null, 4)}\n`);
     updated += 1;


### PR DESCRIPTION
## Summary
- Adds forbiddenUse to contract.schema.v2, generated from spec Do/Don't lines plus curated policy (Button, Title, Modal)
- Extends check:contract-props to validate composesWith, prefersOver, and forbiddenUse drift against agent blocks
- Adds lint:composition to flag incompatible @dt import pairs on app routes, patterns, and pages (Toast+AlertBanner, Toast+Modal)

## Test plan
- [x] npm run build:tokens && npm run sync:contract-props -- --write
- [x] npm run check:contract-props
- [x] npm run lint:composition
- [x] npm run validate:components
- [x] npm run typecheck
