### PR TITLE
feat(ds): polish @dt/Modal severity dialogs and forced-colors story

### DIFF
--- a/nextjs-app/shared/components/Modal/Modal.contract.json
+++ b/nextjs-app/shared/components/Modal/Modal.contract.json
@@ -73,6 +73,7 @@
         "style",
         "title",
         "titleSize",
+        "iconSize",
         "titleTerminals"
     ],
     "consumers": [],

--- a/nextjs-app/shared/components/Modal/Modal.module.css
+++ b/nextjs-app/shared/components/Modal/Modal.module.css
@@ -17,9 +17,10 @@
   max-width: var(--size-width-lg);
   max-height: 90vh;
   flex-direction: column;
+  border-radius: var(--radius-lg);
   background-color: var(--main-body-background-color, var(--color-white));
   box-shadow: var(--modal-shadow, 0 4px 8px rgb(0 0 0 / 20%));
-  overflow-y: auto;
+  overflow: hidden auto;
 }
 
 .modal :is(.header, .content, .footer) {
@@ -39,19 +40,25 @@
 
 .leftHeader {
   display: flex;
+  flex: 1;
   flex-direction: row;
-  gap: 0.5rem;
-}
-
-.header svg {
-  width: 24px;
-  height: 24px;
   align-items: center;
-  vertical-align: middle;
+  gap: 0.5rem;
+  min-width: 0;
 }
 
-.title {
+.icon {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+}
+
+.leftHeader .title {
   margin: 0;
+  margin-block: 0;
+  line-height: var(--line-height-tight, 1.2);
   font-family: var(--secondary-heading-font, sans-serif);
   color: var(--color-primary);
 }
@@ -63,8 +70,15 @@
 }
 
 .closeButton {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
   padding: 0;
   border: none;
+  border-radius: var(--radius-sm);
   background: none;
   font-size: 1rem;
   color: var(--color-primary);
@@ -187,4 +201,47 @@
   .footer {
     padding: 0.75rem 1rem 1.5rem;
   }
+}
+
+/* Forced colors (Windows High Contrast) */
+@media (forced-colors: active) {
+  .overlay {
+    background-color: Canvas;
+  }
+
+  .modal {
+    border: 2px solid CanvasText;
+    box-shadow: none;
+    forced-color-adjust: none;
+  }
+
+  .error,
+  .success,
+  .warning,
+  .info {
+    border-top: 4px solid Highlight;
+  }
+
+  .closeButton:focus-visible {
+    outline: 3px solid Highlight;
+    outline-offset: 2px;
+  }
+}
+
+/* Storybook globals emulation — macOS does not trigger @media (forced-colors) */
+:global(html.sb-forced-colors-active) .overlay {
+  background-color: Canvas;
+}
+
+:global(html.sb-forced-colors-active) .modal {
+  border: 2px solid CanvasText;
+  box-shadow: none;
+  forced-color-adjust: none;
+}
+
+:global(html.sb-forced-colors-active) .error,
+:global(html.sb-forced-colors-active) .success,
+:global(html.sb-forced-colors-active) .warning,
+:global(html.sb-forced-colors-active) .info {
+  border-top: 4px solid Highlight;
 }

--- a/nextjs-app/shared/components/Modal/Modal.stories.tsx
+++ b/nextjs-app/shared/components/Modal/Modal.stories.tsx
@@ -161,7 +161,18 @@ export default {
       table: {
         category: "Appearance",
         type: { summary: "TitleSizeUnified" },
-        defaultValue: { summary: "M" },
+        defaultValue: { summary: "S" },
+      },
+    },
+
+    iconSize: {
+      control: { type: "select" },
+      options: ["2xs", "xs", "sm", "md", "lg", "xl", "2xl"],
+      description: "Header severity icon size (Icon token scale)",
+      table: {
+        category: "Appearance",
+        type: { summary: "IconProps[\"size\"]" },
+        defaultValue: { summary: "lg" },
       },
     },
 
@@ -182,7 +193,7 @@ export default {
       table: {
         category: "Appearance",
         type: { summary: "boolean" },
-        defaultValue: { summary: "true" },
+        defaultValue: { summary: "false" },
       },
     },
 
@@ -256,7 +267,11 @@ const Template: StoryFn<ModalProps> = (args: ModalProps) => {
 };
 
 export const Default = Template.bind({});
-Default.args = { title: "storyModalTitle", children: "storyModalBody" };
+Default.args = {
+  title: "storyModalTitle",
+  children: "storyModalBody",
+  showCloseIcon: true,
+};
 Default.parameters = {};
 Default.play = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
   const canvas = within(canvasElement);
@@ -448,6 +463,8 @@ export const LoadingState: StoryFn = () => {
 export const Playground: Story = {
   parameters: { a11y: { disable: true, test: "off" } },
   tags: ["beta-matrix"],
+  render: Template,
+  args: Default.args,
 };
 
 export const Example = {
@@ -461,4 +478,10 @@ export const ForcedColors: Story = {
   parameters: { a11y: { disable: true, test: "off" } },
   tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
+  render: Template,
+  args: {
+    title: "storyModalErrorTitle",
+    severity: "error",
+    description: "storyModalErrorBody",
+  },
 };

--- a/nextjs-app/shared/components/Modal/Modal.test.tsx
+++ b/nextjs-app/shared/components/Modal/Modal.test.tsx
@@ -44,4 +44,28 @@ describe("Modal", () => {
     const dialog = within(document.body).getByRole("alertdialog");
     expect(dialog).not.toHaveAttribute("aria-live");
   });
+
+  it("uses iconSize for semantic severity icons (default lg)", () => {
+    render(
+      <Modal isOpen title="Error" severity="error">
+        <p>Content</p>
+      </Modal>,
+    );
+    const iconRoot = document.body.querySelector('[data-semantic-icon="error"]');
+    const svg = iconRoot?.querySelector("svg");
+    expect(svg).toHaveAttribute("width", "32");
+    expect(svg).toHaveAttribute("height", "32");
+  });
+
+  it("accepts iconSize override for semantic severity icons", () => {
+    render(
+      <Modal isOpen title="Error" severity="error" iconSize="xl">
+        <p>Content</p>
+      </Modal>,
+    );
+    const iconRoot = document.body.querySelector('[data-semantic-icon="error"]');
+    const svg = iconRoot?.querySelector("svg");
+    expect(svg).toHaveAttribute("width", "48");
+    expect(svg).toHaveAttribute("height", "48");
+  });
 });

--- a/nextjs-app/shared/components/Modal/Modal.tsx
+++ b/nextjs-app/shared/components/Modal/Modal.tsx
@@ -4,7 +4,7 @@ import styles from "./Modal.module.css";
 import Button from "@dt/Button";
 import Title from "@dt/Title";
 import { getSemanticIcon } from "../../utils/semanticIcons";
-import Icon from "@dt/Icon";
+import Icon, { type IconProps } from "@dt/Icon";
 import { normalizeTitleSize, type TitleSizeUnified } from "../../utils/sizeNormalization";
 
 export type ModalSeverity = "success" | "error" | "warning" | "info";
@@ -17,6 +17,8 @@ export interface ModalProps {
   isLoading?: boolean;
   /** Title size - supports both modern (sm/md/lg) and legacy (S/M/L) formats */
   titleSize?: TitleSizeUnified;
+  /** Header icon size — Icon token scale (default lg for severity dialogs) */
+  iconSize?: IconProps["size"];
 
   // EXISTING PROPS
   /** Controls visibility */
@@ -61,7 +63,8 @@ const SEVERITY_STATUS_MAP: Record<
 const Modal: React.FC<ModalProps> = ({
   severity,
   isLoading = false,
-  titleSize = "M",
+  titleSize = "S",
+  iconSize = "lg",
   isOpen,
   title,
   description,
@@ -71,7 +74,7 @@ const Modal: React.FC<ModalProps> = ({
   footer,
   onClose,
   icon,
-  showCloseIcon = true,
+  showCloseIcon = false,
   closeIconName = "x",
   closeButtonLabel = "Close dialog",
 }) => {
@@ -128,7 +131,9 @@ const Modal: React.FC<ModalProps> = ({
 
   const resolvedHeaderIcon =
     icon ??
-    (severity ? getSemanticIcon(SEVERITY_STATUS_MAP[severity]) : null);
+    (severity
+      ? getSemanticIcon(SEVERITY_STATUS_MAP[severity], { size: iconSize })
+      : null);
 
   const renderFooter = () => {
     if (footer !== undefined) {
@@ -189,6 +194,7 @@ const Modal: React.FC<ModalProps> = ({
               <Title
                 level={2}
                 size={normalizedTitleSize}
+                lineHeight="tight"
                 id={titleId}
                 className={styles.title}
                 terminals={titleTerminals}

--- a/nextjs-app/shared/styles/variables.css
+++ b/nextjs-app/shared/styles/variables.css
@@ -600,6 +600,13 @@
     --logo-color: Canvas;
     --logo-text-color: CanvasText;
     --focus-ring-color: Highlight;
+    --modal-overlay-bg: Canvas;
+    --modal-shadow: none;
+    --color-success: CanvasText;
+    --color-error: CanvasText;
+    --color-warning: CanvasText;
+    --color-warning-contrast: CanvasText;
+    --color-info: CanvasText;
   }
 }
 

--- a/nextjs-app/shared/utils/semanticIcons.test.tsx
+++ b/nextjs-app/shared/utils/semanticIcons.test.tsx
@@ -31,6 +31,13 @@ describe("semanticIcons", () => {
     ).toBeInTheDocument();
   });
 
+  it("forwards size option to Icon", () => {
+    const { container } = render(getSemanticIcon("error", { size: "xl" }));
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveAttribute("width", "48");
+    expect(svg).toHaveAttribute("height", "48");
+  });
+
   it("has correct icon names in STATUS_ICON_NAMES", () => {
     expect(STATUS_ICON_NAMES.success).toBe("check-circle");
     expect(STATUS_ICON_NAMES.error).toBe("x-circle");

--- a/nextjs-app/shared/utils/semanticIcons.tsx
+++ b/nextjs-app/shared/utils/semanticIcons.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Icon from "@dt/Icon";
+import Icon, { type IconProps } from "@dt/Icon";
 
 export type SemanticStatus = "success" | "info" | "warning" | "error";
 
@@ -17,10 +17,18 @@ const STATUS_COLORS: Record<SemanticStatus, string> = {
   info: "var(--color-info)",
 };
 
-export const getSemanticIcon = (status: SemanticStatus) => {
+export type SemanticIconOptions = {
+  size?: IconProps["size"];
+};
+
+export const getSemanticIcon = (
+  status: SemanticStatus,
+  options?: SemanticIconOptions,
+) => {
   return (
     <Icon
       name={STATUS_ICON_NAMES[status]}
+      size={options?.size}
       color={STATUS_COLORS[status]}
       ariaLabel={status}
       aria-hidden="true"


### PR DESCRIPTION
## Summary
- Rounded modal corners, vertically centered severity icon + title, smaller default heading (`titleSize` S), and `showCloseIcon` defaulting off for alert-style dialogs.
- New `iconSize` prop (default `lg`) wired through `getSemanticIcon`; removed CSS cap that forced 24px icons.
- Fixed blank ForcedColors story (`render` + args) and added forced-colors CSS/token overrides for overlay, border, and severity stripe.

## Test plan
- [x] `SKIP_STORYBOOK_TESTS=1 npx vitest run nextjs-app/shared/components/Modal/`
- [x] `npm run typecheck && npm run lint`
- [x] `npm run check:contract-props`
- [ ] Storybook: Molecules/Modal → ErrorDialog + ForcedColors visual check


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Modal component now supports customizable header icon sizing
- Enhanced accessibility with Windows High Contrast mode support, including updated color tokens and visible focus indicators

## Style
- Refined modal layout and spacing with improved header alignment
- Extended close button styling with improved focus visibility and border treatment

## Tests
- Added tests for header icon sizing functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->