### PR TITLE
feat(ds): inverse-surface pattern ranking for MCP (Phase 10)

### DIFF
--- a/nextjs-app/shared/lib/design-system-mcp/executors.test.ts
+++ b/nextjs-app/shared/lib/design-system-mcp/executors.test.ts
@@ -99,6 +99,36 @@ describe("rankPatternsForIntent", () => {
     );
     expect(ranked[0]?.name).toBe("CTASection");
   });
+
+  it("boosts inverse-aware patterns and surfaces constraints for dark CTA queries", () => {
+    const ranked = rankPatternsForIntent(
+      "inverse background CTA on dark band",
+      [
+        {
+          name: "CTASection",
+          publicImport: "@dt/CTASection",
+          useWhen: ["inverse or primary background CTA block"],
+          avoidWhen: [
+            "replacing shadcn CTA buttons with @dt/Button without variant parity review",
+          ],
+          variantNotes: {
+            inverseBackground:
+              "Production CTASection uses outline on dark bands — contrast check required.",
+          },
+          status: "beta",
+        },
+        {
+          name: "Header",
+          publicImport: "@dt/Header",
+          useWhen: ["site header navigation"],
+          status: "beta",
+        },
+      ],
+      2,
+    );
+    expect(ranked[0]?.name).toBe("CTASection");
+    expect(ranked[0]?.surfaceConstraints?.length).toBeGreaterThan(0);
+  });
 });
 
 describe("executeSuggestPatternForLayout", () => {
@@ -110,5 +140,18 @@ describe("executeSuggestPatternForLayout", () => {
       matches: Array<{ name: string }>;
     };
     expect(parsed.matches[0]?.name).toBe("HeroSection");
+  });
+
+  it("flags inverseSurface for dark-band layout queries", () => {
+    const result = executeSuggestPatternForLayout({
+      query: "inverse background CTA on dark band",
+    });
+    const parsed = JSON.parse(result.content[0].text) as {
+      inverseSurface: boolean;
+      matches: Array<{ name: string; surfaceConstraints?: string[] }>;
+    };
+    expect(parsed.inverseSurface).toBe(true);
+    expect(parsed.matches[0]?.name).toBe("CTASection");
+    expect(parsed.matches[0]?.surfaceConstraints?.length).toBeGreaterThan(0);
   });
 });

--- a/nextjs-app/shared/lib/design-system-mcp/executors.ts
+++ b/nextjs-app/shared/lib/design-system-mcp/executors.ts
@@ -11,6 +11,7 @@ import type {
 import { loadPublicApiDoc, loadTokenCatalog } from "./manifest-loader";
 import {
   loadPatternRecipes,
+  queryImpliesInverseSurface,
   rankPatternsForIntent,
 } from "./pattern-composition";
 
@@ -185,11 +186,14 @@ export function executeSuggestPatternForLayout(args?: {
   const limit = Math.min(Math.max(Number(args?.limit) || 5, 1), 10);
   const ranked = rankPatternsForIntent(query, patterns, limit);
 
+  const inverseSurface = queryImpliesInverseSurface(query);
+
   return dsJsonResult({
     query,
+    inverseSurface,
     guardrails:
       "Patterns are layout shells — do not mass-replace Header/CTA chrome without design sign-off. See docs/AGENTIC_DS_OPERATING_MODEL.md",
-    matches: ranked.map(({ name, score, pattern }) => ({
+    matches: ranked.map(({ name, score, pattern, surfaceConstraints }) => ({
       name,
       score,
       publicImport: pattern.publicImport,
@@ -200,6 +204,7 @@ export function executeSuggestPatternForLayout(args?: {
       composesWith: pattern.composesWith ?? [],
       variantNotes: pattern.variantNotes ?? {},
       storybookId: pattern.storybookId,
+      ...(surfaceConstraints?.length ? { surfaceConstraints } : {}),
     })),
     resource: "digitaltableteur://design-system/pattern-recipes",
   });

--- a/nextjs-app/shared/lib/design-system-mcp/pattern-composition.ts
+++ b/nextjs-app/shared/lib/design-system-mcp/pattern-composition.ts
@@ -32,10 +32,54 @@ export function loadPatternRecipes(root = designSystemMcpRoot()): PatternRecipes
   return JSON.parse(readFileSync(path, "utf8")) as PatternRecipesFile;
 }
 
+const INVERSE_QUERY_RE =
+  /\b(inverse|dark|tinted|on[\s-]?dark|high[\s-]?contrast|gradient|colored)\b/i;
+
+const INVERSE_RECIPE_RE =
+  /\b(inverse|dark|tinted|on[\s-]?dark|primary background|contrast)\b/i;
+
+const INVERSE_CONSTRAINT_RE =
+  /\b(dark|inverse|contrast|@dt\/button|shadcn|tertiary|primary on|outline)\b/i;
+
+/** True when the layout query implies dark, inverse, or tinted surfaces. */
+export function queryImpliesInverseSurface(query: string): boolean {
+  return INVERSE_QUERY_RE.test(query);
+}
+
+function inverseSurfaceBoost(pattern: PatternRecipe): number {
+  let boost = 0;
+  const useWhen = (pattern.useWhen ?? []).join(" ").toLowerCase();
+  if (INVERSE_RECIPE_RE.test(useWhen)) boost += 8;
+
+  const notes = JSON.stringify(pattern.variantNotes ?? {}).toLowerCase();
+  if (INVERSE_RECIPE_RE.test(notes)) boost += 5;
+
+  return boost;
+}
+
+function surfaceConstraintsForPattern(
+  pattern: PatternRecipe,
+  inverseContext: boolean,
+): string[] {
+  if (!inverseContext) return [];
+
+  const constraints: string[] = [];
+  for (const note of pattern.avoidWhen ?? []) {
+    if (INVERSE_CONSTRAINT_RE.test(note)) constraints.push(note);
+  }
+  for (const [key, value] of Object.entries(pattern.variantNotes ?? {})) {
+    if (INVERSE_CONSTRAINT_RE.test(`${key} ${value}`)) {
+      constraints.push(`${key}: ${value}`);
+    }
+  }
+  return constraints;
+}
+
 export interface RankedPattern {
   name: string;
   score: number;
   pattern: PatternRecipe;
+  surfaceConstraints?: string[];
 }
 
 /** Rank pattern recipes for a layout-level intent query. */
@@ -48,6 +92,8 @@ export function rankPatternsForIntent(
     .toLowerCase()
     .split(/[^a-z0-9]+/)
     .filter((t) => t.length > 2);
+
+  const inverseContext = queryImpliesInverseSurface(query);
 
   return patterns
     .map((pattern) => {
@@ -71,7 +117,14 @@ export function rankPatternsForIntent(
       if (pattern.status === "stable") score += 2;
       else if (pattern.status === "beta") score += 1;
 
-      return { name, score, pattern };
+      if (inverseContext) score += inverseSurfaceBoost(pattern);
+
+      return {
+        name,
+        score,
+        pattern,
+        surfaceConstraints: surfaceConstraintsForPattern(pattern, inverseContext),
+      };
     })
     .filter((row) => row.score > 0)
     .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name))

--- a/scripts/design-system/agent-eval/golden-patterns.json
+++ b/scripts/design-system/agent-eval/golden-patterns.json
@@ -36,6 +36,16 @@
       "id": "article-hero",
       "query": "blog article hero title metadata",
       "expectedTop1": "ArticleHero"
+    },
+    {
+      "id": "cta-inverse",
+      "query": "inverse background CTA on dark band",
+      "expectedTop1": "CTASection"
+    },
+    {
+      "id": "home-hero",
+      "query": "homepage hero kinetic title scroll indicator",
+      "expectedTop1": "HomeHero"
     }
   ]
 }

--- a/scripts/design-system/pattern-composition-lib.mjs
+++ b/scripts/design-system/pattern-composition-lib.mjs
@@ -11,6 +11,15 @@ const RECIPES_PATH = join(
   "pattern-composition.recipes.json",
 );
 
+const INVERSE_QUERY_RE =
+  /\b(inverse|dark|tinted|on[\s-]?dark|high[\s-]?contrast|gradient|colored)\b/i;
+
+const INVERSE_RECIPE_RE =
+  /\b(inverse|dark|tinted|on[\s-]?dark|primary background|contrast)\b/i;
+
+const INVERSE_CONSTRAINT_RE =
+  /\b(dark|inverse|contrast|@dt\/button|shadcn|tertiary|primary on|outline)\b/i;
+
 /**
  * @returns {{ version: number, patterns: Array<Record<string, unknown>> }}
  */
@@ -23,6 +32,39 @@ export function loadPatternRecipes(root = ROOT) {
   return JSON.parse(readFileSync(recipesFile, "utf8"));
 }
 
+/** @param {string} query */
+export function queryImpliesInverseSurface(query) {
+  return INVERSE_QUERY_RE.test(query);
+}
+
+/** @param {Record<string, unknown>} pattern */
+function inverseSurfaceBoost(pattern) {
+  let boost = 0;
+  const useWhen = (pattern.useWhen ?? []).join(" ").toLowerCase();
+  if (INVERSE_RECIPE_RE.test(useWhen)) boost += 8;
+
+  const notes = JSON.stringify(pattern.variantNotes ?? {}).toLowerCase();
+  if (INVERSE_RECIPE_RE.test(notes)) boost += 5;
+
+  return boost;
+}
+
+/** @param {Record<string, unknown>} pattern @param {boolean} inverseContext */
+function surfaceConstraintsForPattern(pattern, inverseContext) {
+  if (!inverseContext) return [];
+
+  const constraints = [];
+  for (const note of pattern.avoidWhen ?? []) {
+    if (INVERSE_CONSTRAINT_RE.test(String(note))) constraints.push(String(note));
+  }
+  for (const [key, value] of Object.entries(pattern.variantNotes ?? {})) {
+    if (INVERSE_CONSTRAINT_RE.test(`${key} ${value}`)) {
+      constraints.push(`${key}: ${value}`);
+    }
+  }
+  return constraints;
+}
+
 /**
  * @param {string} query
  * @param {Array<Record<string, unknown>>} patterns
@@ -33,6 +75,8 @@ export function rankPatternsForIntent(query, patterns, limit = 5) {
     .toLowerCase()
     .split(/[^a-z0-9]+/)
     .filter((t) => t.length > 2);
+
+  const inverseContext = queryImpliesInverseSurface(query);
 
   return patterns
     .map((pattern) => {
@@ -56,7 +100,14 @@ export function rankPatternsForIntent(query, patterns, limit = 5) {
       if (pattern.status === "stable") score += 2;
       else if (pattern.status === "beta") score += 1;
 
-      return { name, score, pattern };
+      if (inverseContext) score += inverseSurfaceBoost(pattern);
+
+      return {
+        name,
+        score,
+        pattern,
+        surfaceConstraints: surfaceConstraintsForPattern(pattern, inverseContext),
+      };
     })
     .filter((row) => row.score > 0)
     .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name))

--- a/scripts/design-system/pattern-composition.recipes.json
+++ b/scripts/design-system/pattern-composition.recipes.json
@@ -53,13 +53,36 @@
       ],
       "avoidWhen": [
         "blog article hero — prefer ArticleHero pattern",
-        "compact inline page title without hero imagery"
+        "compact inline page title without hero imagery",
+        "production homepage with kinetic title — prefer HomeHero"
       ],
       "composesWith": ["Title", "Text", "Button", "Hero"],
       "variantNotes": {
         "background": "Supports backgroundImage and tokenized min-height; compose children rather than hardcoding layout."
       },
       "storybookId": "patterns-herosection--default"
+    },
+    {
+      "name": "HomeHero",
+      "publicImport": "@dt/HomeHero",
+      "tier": "pattern",
+      "status": "beta",
+      "useWhen": [
+        "production homepage hero with kinetic title and scroll indicator",
+        "full-bleed homepage hero on dark or gradient background bands",
+        "homepage hero with @dt/Button primary CTA on inverse surface"
+      ],
+      "avoidWhen": [
+        "generic marketing hero without homepage-specific motion",
+        "blog article hero — prefer ArticleHero",
+        "swapping outline shadcn buttons to @dt/Button tertiary on dark bands without contrast check"
+      ],
+      "composesWith": ["Button", "HeroSection", "Container", "Stack"],
+      "variantNotes": {
+        "inverseBackground": "Uses @dt/Button with surface=default on dark HeroBackground — do not use isInverse primary over gradient parents.",
+        "motion": "KineticTitle and TextReveal require reduced-motion fallbacks — do not strip animation hooks."
+      },
+      "storybookId": "patterns-homehero--default"
     },
     {
       "name": "SiteHeader",


### PR DESCRIPTION
## Summary
- Phase 10 composition intelligence: `rankPatternsForIntent` boosts inverse-aware recipes when queries mention dark/inverse/tinted surfaces.
- `suggest_pattern_for_layout` MCP tool returns `inverseSurface` flag and per-match `surfaceConstraints` from `avoidWhen` / `variantNotes`.
- Added `HomeHero` pattern recipe; golden pattern eval extended to 9/9 (100%).

## Test plan
- [x] `npm run agent:eval:patterns` — 9/9
- [x] `npx vitest run nextjs-app/shared/lib/design-system-mcp/executors.test.ts`
- [x] `npm run typecheck`


Made with [Cursor](https://cursor.com)