### PR TITLE
feat(ds): composition lint expansion + Modal AT snapshots

### DIFF
--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -6,6 +6,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { PNG } from "pngjs";
 import pixelmatch from "pixelmatch";
+import { captureStoryAccessibilityTree } from "../scripts/design-system/a11y-snapshot-capture-lib.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -205,7 +206,7 @@ const waitForStoryStability = async (
 };
 
 
-const ROOT_DIR = path.resolve(__dirname, "..");
+const ROOT_DIR = ROOT;
 const UPDATE_AT = process.env.DT_UPDATE_A11Y_SNAPSHOTS === "1";
 const BOOTSTRAP_AT = process.env.DT_BOOTSTRAP_A11Y_SNAPSHOTS === "1";
 const REQUIRE_AT = process.env.DT_REQUIRE_A11Y_SNAPSHOTS === "1";
@@ -268,8 +269,7 @@ async function captureAccessibilityTree(page: import("playwright").Page, storyId
   if (!dir) return;
   fs.mkdirSync(dir, { recursive: true });
   const file = path.join(dir, `${storyId}${snapshotVariantSuffix()}.yaml`);
-  const snapshot = await page.locator("#storybook-root").ariaSnapshot();
-  const content = typeof snapshot === "string" ? snapshot : String(snapshot);
+  const content = await captureStoryAccessibilityTree(page);
   if (!fs.existsSync(file)) {
     if (UPDATE_AT || BOOTSTRAP_AT) {
       fs.writeFileSync(file, content);

--- a/nextjs-app/shared/components/AlertBanner/AlertBanner.contract.json
+++ b/nextjs-app/shared/components/AlertBanner/AlertBanner.contract.json
@@ -103,6 +103,7 @@
         "Icon"
     ],
     "forbiddenUse": [
+        "Pair AlertBanner with blocking Modal for the same user outcome — pick one surface",
         "make errors dismissable. Letting the user hide a blocking",
         "stack more than one banner on the same page. Two competing",
         "animate the banner in on every render. AlertBanner is for"

--- a/nextjs-app/shared/components/Modal/Modal.contract.json
+++ b/nextjs-app/shared/components/Modal/Modal.contract.json
@@ -180,6 +180,7 @@
         "AdaptiveLoadingButton"
     ],
     "forbiddenUse": [
+        "Pair AlertBanner with Modal for the same status — use Modal alone for blocking alerts",
         "Nested modals — swap content in place inside one overlay",
         "Lazy-mounting Modal only when isOpen — mount always and toggle isOpen for focus restore",
         "nest a Modal inside another Modal. AT focus order becomes",

--- a/nextjs-app/shared/components/Modal/Modal.contract.json
+++ b/nextjs-app/shared/components/Modal/Modal.contract.json
@@ -113,6 +113,10 @@
                 "xxl"
             ]
         },
+        "iconSize": {
+            "optional": true,
+            "type": "IconProps[\"size\"]"
+        },
         "isOpen": {
             "optional": false,
             "type": "boolean"
@@ -180,9 +184,9 @@
         "AdaptiveLoadingButton"
     ],
     "forbiddenUse": [
-        "Pair AlertBanner with Modal for the same status — use Modal alone for blocking alerts",
         "Nested modals — swap content in place inside one overlay",
         "Lazy-mounting Modal only when isOpen — mount always and toggle isOpen for focus restore",
+        "Pair AlertBanner with Modal for the same status — use Modal alone for blocking alerts",
         "nest a Modal inside another Modal. AT focus order becomes",
         "render a Modal lazily (e.g. only mount it when `isOpen`).",
         "add `aria-live` to the dialog root. The role implies"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--error-dialog.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--error-dialog.yaml
@@ -1,2 +1,6 @@
 - status: Work in progress (beta)
 - button "Open modal"
+- alertdialog "Error":
+  - heading "Error" [level=2]
+  - paragraph: storyModalErrorBody
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--example.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--example.yaml
@@ -1,2 +1,7 @@
 - status: Work in progress (beta)
 - button "Open modal"
+- dialog "storyModalTitle":
+  - heading "storyModalTitle" [level=2]
+  - button "Close dialog"
+  - text: storyModalBody
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--forced-colors.forced-colors.yaml
@@ -1,1 +1,6 @@
 - status: Work in progress (beta)
+- button "Open modal"
+- alertdialog "Error":
+  - heading "Error" [level=2]
+  - paragraph: storyModalErrorBody
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--forced-colors.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--forced-colors.yaml
@@ -1,1 +1,6 @@
 - status: Work in progress (beta)
+- button "Open modal"
+- alertdialog "Error":
+  - heading "Error" [level=2]
+  - paragraph: storyModalErrorBody
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--info-dialog.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--info-dialog.yaml
@@ -1,2 +1,6 @@
 - status: Work in progress (beta)
 - button "Open modal"
+- dialog "Information":
+  - heading "Information" [level=2]
+  - text: Here is some important information.
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--playground.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--playground.yaml
@@ -1,1 +1,7 @@
 - status: Work in progress (beta)
+- button "Open modal"
+- dialog "storyModalTitle":
+  - heading "storyModalTitle" [level=2]
+  - button "Close dialog"
+  - text: storyModalBody
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--success-dialog.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--success-dialog.yaml
@@ -1,2 +1,6 @@
 - status: Work in progress (beta)
 - button "Open modal"
+- dialog "Success":
+  - heading "Success" [level=2]
+  - text: Your operation was successful!
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--warning-dialog.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--warning-dialog.yaml
@@ -1,2 +1,6 @@
 - status: Work in progress (beta)
 - button "Open modal"
+- alertdialog "Warning":
+  - heading "Warning" [level=2]
+  - text: Please review this warning carefully.
+  - button "OK"

--- a/scripts/design-system/a11y-snapshot-capture-lib.mjs
+++ b/scripts/design-system/a11y-snapshot-capture-lib.mjs
@@ -1,0 +1,19 @@
+/**
+ * Storybook AT snapshot capture — includes portaled overlays (Modal, etc.).
+ * @param {import('@playwright/test').Page} page
+ */
+export async function captureStoryAccessibilityTree(page) {
+  const parts = [];
+  const rootSnap = await page.locator("#storybook-root").ariaSnapshot();
+  parts.push(typeof rootSnap === "string" ? rootSnap : String(rootSnap));
+
+  const portaled = page.locator('[role="alertdialog"], [role="dialog"]');
+  const count = await portaled.count();
+  for (let i = 0; i < count; i++) {
+    const snap = await portaled.nth(i).ariaSnapshot();
+    const text = typeof snap === "string" ? snap : String(snap);
+    if (text.trim()) parts.push(text);
+  }
+
+  return parts.join("\n");
+}

--- a/scripts/design-system/agent-eval/run.mjs
+++ b/scripts/design-system/agent-eval/run.mjs
@@ -3,6 +3,7 @@
 import { readFileSync, existsSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
 import Ajv2020 from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
 
@@ -220,6 +221,18 @@ if (realFigmaStable < MIN_STABLE_FIGMA) {
   console.log(
     `✓ stable Figma deep links: ${realFigmaStable}/${stableEntries.length} (Icon uses dt-icon placeholder)`,
   );
+}
+
+const compositionTest = spawnSync(
+  process.execPath,
+  ["--test", join(ROOT, "scripts/design-system/composition-lint-lib.test.mjs")],
+  { stdio: "inherit" },
+);
+if (compositionTest.status !== 0) {
+  console.error("FAIL: composition-lint-lib unit tests");
+  failed += 1;
+} else {
+  console.log("✓ composition-lint-lib unit tests");
 }
 
 process.exit(failed ? 1 : 0);

--- a/scripts/design-system/capture-story-a11y-snapshots.mjs
+++ b/scripts/design-system/capture-story-a11y-snapshots.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Capture aria snapshots for specific Storybook story IDs.
+ * Usage: node scripts/design-system/capture-story-a11y-snapshots.mjs molecules-modal--error-dialog
+ */
+import { chromium } from "@playwright/test";
+import { captureStoryAccessibilityTree } from "./a11y-snapshot-capture-lib.mjs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const STORYBOOK_URL = process.env.STORYBOOK_URL ?? "http://127.0.0.1:6010";
+const THEME = process.env.DT_THEME ?? "";
+const FORCED_COLORS = (process.env.DT_FORCED_COLORS ?? "").toLowerCase();
+
+const storyIds = process.argv.slice(2);
+if (!storyIds.length) {
+  console.error("Usage: capture-story-a11y-snapshots.mjs <story-id> [...]");
+  process.exit(1);
+}
+
+let storyPrefixToDir = null;
+
+function loadStoryPrefixMap() {
+  if (storyPrefixToDir) return storyPrefixToDir;
+  storyPrefixToDir = new Map();
+  const roots = [
+    join(ROOT, "nextjs-app/shared/components"),
+    join(ROOT, "nextjs-app/shared/patterns"),
+  ];
+  const titleRe = /title:\s*["']([^"']+)["']/;
+
+  for (const base of roots) {
+    if (!existsSync(base)) continue;
+    for (const name of readdirSync(base)) {
+      const dir = join(base, name);
+      const contractPath = join(dir, `${name}.contract.json`);
+      const storyPath = join(dir, `${name}.stories.tsx`);
+      if (!existsSync(contractPath) || !existsSync(storyPath)) continue;
+      const text = readFileSync(storyPath, "utf8");
+      const m = text.match(titleRe);
+      if (!m) continue;
+      const prefix = m[1]
+        .split("/")
+        .map((segment) =>
+          segment
+            .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+            .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+            .toLowerCase(),
+        )
+        .join("-");
+      storyPrefixToDir.set(prefix, dir);
+    }
+  }
+  return storyPrefixToDir;
+}
+
+function snapshotVariantSuffix() {
+  const parts = [];
+  if (THEME) parts.push(THEME);
+  if (FORCED_COLORS === "active") parts.push("forced-colors");
+  return parts.length > 0 ? `.${parts.join(".")}` : "";
+}
+
+function componentSnapshotDir(storyId) {
+  const prefix = storyId.split("--")[0];
+  const componentDir = loadStoryPrefixMap().get(prefix);
+  if (!componentDir) throw new Error(`No component dir for story prefix ${prefix}`);
+  return join(componentDir, "__a11y-snapshots__");
+}
+
+const browser = await chromium.launch();
+const context = await browser.newContext();
+const page = await context.newPage();
+
+if (FORCED_COLORS === "active") {
+  await page.emulateMedia({ forcedColors: "active" });
+}
+
+if (THEME) {
+  await page.addInitScript((theme) => {
+    try {
+      window.localStorage.setItem("storybook-theme", theme);
+      window.localStorage.setItem("theme", theme);
+    } catch {
+      // ignore
+    }
+  }, THEME);
+}
+
+for (const storyId of storyIds) {
+  const url = `${STORYBOOK_URL}/iframe.html?id=${storyId}&viewMode=story`;
+  await page.goto(url, { waitUntil: "networkidle" });
+  await page.waitForTimeout(800);
+
+  const dir = componentSnapshotDir(storyId);
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, `${storyId}${snapshotVariantSuffix()}.yaml`);
+  const content = await captureStoryAccessibilityTree(page);
+  writeFileSync(file, content);
+  console.log(`wrote ${file}`);
+}
+
+await browser.close();

--- a/scripts/design-system/component-replacement-policy.mjs
+++ b/scripts/design-system/component-replacement-policy.mjs
@@ -73,6 +73,10 @@ export const FORBIDDEN_USE_CURATED = {
   Modal: [
     "Nested modals — swap content in place inside one overlay",
     "Lazy-mounting Modal only when isOpen — mount always and toggle isOpen for focus restore",
+    "Pair AlertBanner with Modal for the same status — use Modal alone for blocking alerts",
+  ],
+  AlertBanner: [
+    "Pair AlertBanner with blocking Modal for the same user outcome — pick one surface",
   ],
 };
 
@@ -94,6 +98,13 @@ export const INCOMPATIBLE_DT_IMPORT_PAIRS = [
     b: "Modal",
     message:
       "Do not pair transient Toast with blocking Modal for the same user action — use Modal alone.",
+  },
+  {
+    id: "alertbanner-modal",
+    a: "AlertBanner",
+    b: "Modal",
+    message:
+      "Do not pair inline AlertBanner with blocking Modal for the same outcome — pick one surface.",
   },
 ];
 

--- a/scripts/design-system/composition-lint-lib.test.mjs
+++ b/scripts/design-system/composition-lint-lib.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  extractDtImports,
+  findIncompatibleImportPairs,
+} from "./composition-lint-lib.mjs";
+
+describe("composition-lint-lib", () => {
+  it("flags toast, alertbanner, and modal pairings", () => {
+    const imports = extractDtImports(`
+      import Modal from "@dt/Modal";
+      import Toast from "@dt/Toast";
+      import AlertBanner from "@dt/AlertBanner";
+    `);
+    const ids = findIncompatibleImportPairs(imports).map((row) => row.id);
+    assert.ok(ids.includes("toast-modal"));
+    assert.ok(ids.includes("toast-alertbanner"));
+    assert.ok(ids.includes("alertbanner-modal"));
+  });
+
+  it("passes for compatible imports", () => {
+    const imports = extractDtImports(`
+      import Modal from "@dt/Modal";
+      import Button from "@dt/Button";
+    `);
+    assert.equal(findIncompatibleImportPairs(imports).length, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- Composition lint: new `alertbanner-modal` incompatible pair + `forbiddenUse` on Modal contract.
- AT snapshots: `captureStoryAccessibilityTree` includes portaled `dialog`/`alertdialog` nodes (fixes Modal stories that only captured the trigger button).
- Refreshed Modal severity, Example, Playground, and ForcedColors accessibility-tree snapshots.
- Added `composition-lint-lib.test.mjs` wired into `npm run agent:eval`.
- Utility: `scripts/design-system/capture-story-a11y-snapshots.mjs` for targeted snapshot refresh.

## Test plan
- [x] `npm run lint:composition`
- [x] `node --test scripts/design-system/composition-lint-lib.test.mjs`
- [x] `npm run check:contract-props`
- [x] `npm run typecheck`


Made with [Cursor](https://cursor.com)