### PR TITLE
feat(ds): shrink shadcn allowlist — migrate overlays and form shell

### DIFF
--- a/docs/DS_AUTOMATION_STRATEGY.md
+++ b/docs/DS_AUTOMATION_STRATEGY.md
@@ -147,7 +147,7 @@ npm run test:stories:matrix:ci
 | Area | Status |
 |------|--------|
 | `@dt/Modal` vs shadcn Dialog | **Blocked** — board must pass first |
-| Lightbox, AnimatedDialog, SkillsGrid tooltip | **Defer** |
+| Composable Radix DialogTrigger | **Defer** |
 | EnhancedContactForm full stack | **Defer** until primitives exist |
 
 ---

--- a/docs/SHADCN_TO_DT_MIGRATION.md
+++ b/docs/SHADCN_TO_DT_MIGRATION.md
@@ -20,7 +20,7 @@ Shared UI lives in `nextjs-app/shared/stories/MigrationDecisionBoard/` (`Migrati
 | Button contexts | `Migration boards/Button contexts` | `StudioMap`, `IconButton`, `ContactFormSuccess` | Migrated |
 | Contact flow | `Migration boards/Contact flow` | `ContactFormEditorial`, `ContactFormSuccessEditorial` | Migrated |
 | Form primitives | `Migration boards/Form primitives` | `FormField`, `CheckboxField` | Migrated |
-| Dialogs | `Migration boards/Dialogs` | `AnimatedDialog`, `Lightbox`; `EnhancedContactForm` error alert | **Partial** — error alert approved (`@dt/Modal` + `description`); gallery/animation/composable trigger deferred |
+| Dialogs | `Migration boards/Dialogs` | composable Radix `DialogTrigger` only | **Mostly done** — `EnhancedContactForm`, `Lightbox`, `AnimatedDialog` on `@dt/*`; composable trigger deferred |
 
 Restart Storybook after adding or renaming board files so hub `storyId` links resolve.
 
@@ -49,9 +49,6 @@ Report: `public/visual-diff/migration-matrix-report.json`
 
 ## Deferred (no @dt primitive yet)
 
-- **SkillsGrid** — shadcn Tooltip only
-- **Lightbox** — full-bleed gallery; needs spec vs `@dt/Modal`
-- **EnhancedContactForm** — migrate after primitives + dialog boards approved
 - **TailwindTest**, **`interactive/index`**, **`ui/index`** — dev/barrel only
 
 ## API decisions (locked)

--- a/nextjs-app/shared/components/AnimatedDialog/AnimatedDialog.contract.json
+++ b/nextjs-app/shared/components/AnimatedDialog/AnimatedDialog.contract.json
@@ -4,7 +4,7 @@
     "tier": "molecule",
     "group": "feedback",
     "status": "beta",
-    "description": "Dialog (modal) variant with GSAP-driven enter/exit animation. Wraps the shadcn `Dialog` primitive and adds the size axis + severity colour token + animation type axis.",
+    "description": "Dialog (modal) variant with GSAP-driven enter animation. Wraps @dt/Modal with composable header/footer slots and size + severity tokens.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-animated-dialog",
     "radixPrimitive": null,
     "element": "div",
@@ -50,7 +50,7 @@
             "Esc — closes the dialog."
         ],
         "ariaRequirements": [
-            "Renders a real `role='dialog'` with `aria-modal='true'` (via the shadcn primitive).",
+            "Renders a real `role='dialog'` with `aria-modal='true'` (via @dt/Modal portal).",
             "Focus moves to the dialog body on open and returns to the trigger on close.",
             "When `severity` is success/warning/error/info, the icon is decorative and the visible text owns the announcement; the dialog itself does not become a live region."
         ],

--- a/nextjs-app/shared/components/AnimatedDialog/AnimatedDialog.module.css
+++ b/nextjs-app/shared/components/AnimatedDialog/AnimatedDialog.module.css
@@ -1,0 +1,65 @@
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  text-align: start;
+}
+
+.footer {
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+@media (width >= 640px) {
+  .footer {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
+}
+
+.description {
+  margin: 0;
+  font-family: var(--font-text);
+  font-size: var(--font-size-text-s, 0.875rem);
+  color: var(--color-text-muted);
+}
+
+.sizeSm {
+  max-width: var(--size-width-sm, 24rem);
+}
+
+.sizeMd {
+  max-width: var(--size-width-lg, 32rem);
+}
+
+.sizeLg {
+  max-width: var(--size-width-xl, 42rem);
+}
+
+.sizeXl {
+  max-width: 56rem;
+}
+
+.sizeFull {
+  width: calc(100vw - 4rem);
+  max-width: calc(100vw - 4rem);
+  max-height: calc(100vh - 4rem);
+}
+
+.severitySuccess {
+  border-top: 4px solid var(--color-success);
+}
+
+.severityWarning {
+  border-top: 4px solid var(--color-warning);
+}
+
+.severityError {
+  border-top: 4px solid var(--color-error);
+}
+
+.severityInfo {
+  border-top: 4px solid var(--color-info);
+}

--- a/nextjs-app/shared/components/AnimatedDialog/AnimatedDialog.tsx
+++ b/nextjs-app/shared/components/AnimatedDialog/AnimatedDialog.tsx
@@ -1,21 +1,39 @@
 "use client";
 
-import { useRef, useEffect, type ReactNode } from "react";
-import { gsap } from "gsap";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
-  DialogDescription,
-  DialogTrigger,
-  DialogClose,
-} from "@/components/ui/dialog";
+  cloneElement,
+  createContext,
+  isValidElement,
+  useContext,
+  useEffect,
+  useRef,
+  type ReactNode,
+} from "react";
+import { gsap } from "gsap";
+import Modal, { type ModalProps } from "@dt/Modal";
+import Title from "@dt/Title";
+import styles from "./AnimatedDialog.module.css";
 
 type DialogSize = "sm" | "md" | "lg" | "xl" | "full";
 type DialogSeverity = "default" | "success" | "warning" | "error" | "info";
 type AnimationType = "scale" | "slide" | "fade";
+
+const sizeClassMap: Record<DialogSize, string> = {
+  sm: styles.sizeSm,
+  md: styles.sizeMd,
+  lg: styles.sizeLg,
+  xl: styles.sizeXl,
+  full: styles.sizeFull,
+};
+
+const severityClassMap: Record<Exclude<DialogSeverity, "default">, string> = {
+  success: styles.severitySuccess,
+  warning: styles.severityWarning,
+  error: styles.severityError,
+  info: styles.severityInfo,
+};
+
+const AnimatedDialogContext = createContext<(() => void) | null>(null);
 
 export interface AnimatedDialogProps {
   open?: boolean;
@@ -29,7 +47,7 @@ export interface AnimatedDialogProps {
 }
 
 export function AnimatedDialog({
-  open,
+  open = false,
   onOpenChange,
   children,
   trigger,
@@ -38,66 +56,163 @@ export function AnimatedDialog({
   animationType = "scale",
   className,
 }: AnimatedDialogProps) {
-  const contentRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const close = () => onOpenChange?.(false);
 
   useEffect(() => {
-    if (!open || !contentRef.current) return;
+    if (!open || !panelRef.current) return;
 
-    // Check for reduced motion preference
     const prefersReducedMotion = window.matchMedia(
-      "(prefers-reduced-motion: reduce)"
+      "(prefers-reduced-motion: reduce)",
     ).matches;
 
     if (prefersReducedMotion) return;
 
     const ctx = gsap.context(() => {
-      // Entry animation based on type
       if (animationType === "scale") {
-        gsap.from(contentRef.current, {
+        gsap.from(panelRef.current, {
           scale: 0.95,
           opacity: 0,
           duration: 0.2,
           ease: "power2.out",
         });
       } else if (animationType === "slide") {
-        gsap.from(contentRef.current, {
+        gsap.from(panelRef.current, {
           y: 20,
           opacity: 0,
           duration: 0.25,
           ease: "power2.out",
         });
       } else if (animationType === "fade") {
-        gsap.from(contentRef.current, {
+        gsap.from(panelRef.current, {
           opacity: 0,
           duration: 0.2,
           ease: "power2.out",
         });
       }
-    }, contentRef);
+    }, panelRef);
 
     return () => ctx.revert();
   }, [open, animationType]);
 
+  const modalSeverity: ModalProps["severity"] =
+    severity === "default" ? undefined : severity;
+
+  const panelClassName = [
+    sizeClassMap[size],
+    severity !== "default" ? severityClassMap[severity] : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
-      <DialogContent
-        ref={contentRef}
-        size={size}
-        severity={severity}
-        className={className}
+    <AnimatedDialogContext.Provider value={close}>
+      {trigger && (
+        <span
+          role="presentation"
+          onClick={() => onOpenChange?.(true)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              onOpenChange?.(true);
+            }
+          }}
+        >
+          {trigger}
+        </span>
+      )}
+      <Modal
+        isOpen={open}
+        onClose={close}
+        severity={modalSeverity}
+        showFooter={false}
+        showCloseIcon={false}
+        className={panelClassName}
+        panelRef={panelRef}
       >
         {children}
-      </DialogContent>
-    </Dialog>
+      </Modal>
+    </AnimatedDialogContext.Provider>
   );
 }
 
-// Re-export dialog parts for convenience
-export {
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
-  DialogDescription,
-  DialogClose,
-};
+export function DialogHeader({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  const merged = [styles.header, className].filter(Boolean).join(" ");
+  return <div className={merged}>{children}</div>;
+}
+
+export function DialogFooter({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  const merged = [styles.footer, className].filter(Boolean).join(" ");
+  return <div className={merged}>{children}</div>;
+}
+
+export function DialogTitle({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Title level={2} size="S" className={className}>
+      {children}
+    </Title>
+  );
+}
+
+export function DialogDescription({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  const merged = [styles.description, className].filter(Boolean).join(" ");
+  return <p className={merged}>{children}</p>;
+}
+
+export function DialogClose({
+  asChild,
+  children,
+}: {
+  asChild?: boolean;
+  children: ReactNode;
+}) {
+  const close = useContext(AnimatedDialogContext);
+
+  if (asChild && isValidElement(children)) {
+    return cloneElement(
+      children as React.ReactElement<{ onClick?: (event: React.MouseEvent) => void }>,
+      {
+        onClick: (event: React.MouseEvent) => {
+          (
+            children as React.ReactElement<{
+              onClick?: (event: React.MouseEvent) => void;
+            }>
+          ).props.onClick?.(event);
+          close?.();
+        },
+      },
+    );
+  }
+
+  return (
+    <button type="button" onClick={() => close?.()}>
+      {children}
+    </button>
+  );
+}

--- a/nextjs-app/shared/components/EnhancedContactForm/EnhancedContactForm.tsx
+++ b/nextjs-app/shared/components/EnhancedContactForm/EnhancedContactForm.tsx
@@ -4,27 +4,17 @@ import { useEffect, useReducer, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { Label } from "@/components/ui/label";
-import { Checkbox } from "@/components/ui/checkbox";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import Inputs, { TextArea } from "@dt/Inputs";
+import Select from "@dt/Select";
+import SelectOption from "@dt/Select/SelectOption";
+import Checkbox from "@dt/Checkbox";
+import Button from "@dt/Button";
 import Modal from "@dt/Modal";
-import DtButton from "@dt/Button";
 import { useToast } from "../Toaster/Toaster";
-import { FormField } from "../FormField";
 import { FormGroup } from "../FormGroup";
 import { FadeIn } from "../animations/FadeIn";
 import PhoneInput from "@dt/PhoneInput";
 import FileUpload from "@dt/FileUpload";
-import { Loader } from "lucide-react";
 import {
   CONTACT_ACCEPTED_ATTACHMENT_TYPES,
   CONTACT_ATTACHMENT_MAX_BYTES,
@@ -85,6 +75,15 @@ const INTEREST_OPTIONS = [
   { value: "digital-products", labelKey: "contactInterestDigitalProducts" },
   { value: "help-me-choose", labelKey: "contactInterestHelpMeChoose" },
 ];
+
+const HEAR_ABOUT_OPTIONS = [
+  { value: "social-media", labelKey: "contactHearSocial" },
+  { value: "search-engine", labelKey: "contactHearSearch" },
+  { value: "word-of-mouth", labelKey: "contactHearWord" },
+  { value: "event", labelKey: "contactHearEvent" },
+  { value: "existing-client", labelKey: "contactHearExisting" },
+  { value: "other", labelKey: "contactHearOther" },
+] as const;
 
 /** Maps marketing CTA `?service=` values to contact-form interest slugs. */
 const SERVICE_INTEREST_MAP: Record<string, string> = {
@@ -171,32 +170,10 @@ export function EnhancedContactForm({
       })
     : "";
 
-  // === PRESERVED HANDLERS (CRITICAL - DO NOT CHANGE LOGIC) ===
-  const handleFullNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    dispatchForm({
-      type: "UPDATE_FIELD",
-      payload: { field: "fullName", value: e.target.value },
-    });
-  };
-
-  const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    dispatchForm({
-      type: "UPDATE_FIELD",
-      payload: { field: "email", value: e.target.value },
-    });
-  };
-
   const handlePhoneChange = (value: string | undefined) => {
     dispatchForm({
       type: "UPDATE_FIELD",
       payload: { field: "phone", value: value || "" },
-    });
-  };
-
-  const handleMessageChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    dispatchForm({
-      type: "UPDATE_FIELD",
-      payload: { field: "message", value: e.target.value },
     });
   };
 
@@ -384,37 +361,34 @@ export function EnhancedContactForm({
           />
         </div>
 
-        {/* Full Name */}
-        <FormField
+        <Inputs
+          type="text"
           label={t("contactFullName")}
+          placeholder={t("contactFullNamePlaceholder")}
+          value={formData.fullName}
           error={formErrors.fullName}
-          required
-        >
-          <Input
-            type="text"
-            placeholder={t("contactFullNamePlaceholder")}
-            value={formData.fullName}
-            onChange={handleFullNameChange}
-            className={cn(formErrors.fullName && "border-destructive")}
-          />
-        </FormField>
+          onValueChange={(value) =>
+            dispatchForm({
+              type: "UPDATE_FIELD",
+              payload: { field: "fullName", value: String(value) },
+            })
+          }
+        />
 
-        {/* Email */}
-        <FormField
+        <Inputs
+          type="email"
           label={t("contactEmail")}
+          placeholder={t("contactEmailPlaceholder")}
+          value={formData.email}
           error={formErrors.email}
-          required
-        >
-          <Input
-            type="email"
-            placeholder={t("contactEmailPlaceholder")}
-            value={formData.email}
-            onChange={handleEmailChange}
-            className={cn(formErrors.email && "border-destructive")}
-          />
-        </FormField>
+          onValueChange={(value) =>
+            dispatchForm({
+              type: "UPDATE_FIELD",
+              payload: { field: "email", value: String(value) },
+            })
+          }
+        />
 
-        {/* Phone */}
         <PhoneInput
           label={t("contactPhone")}
           placeholder={t("contactPhonePlaceholder")}
@@ -422,59 +396,44 @@ export function EnhancedContactForm({
           onChange={handlePhoneChange}
         />
 
-        {/* Interests */}
         <FormGroup legend={t("contactInterest")}>
           <div className="space-y-3">
-            {/* Select All */}
-            <div className="flex items-center gap-2">
-              <Checkbox
-                id="interest-all"
-                checked={allSelected}
-                onCheckedChange={handleSelectAllInterests}
-              />
-              <Label htmlFor="interest-all" className="text-sm font-normal cursor-pointer">
-                {t("contactAll")}
-              </Label>
-            </div>
-            {/* Individual options */}
+            <Checkbox
+              id="interest-all"
+              label={t("contactAll")}
+              isChecked={allSelected}
+              onCheckedChange={handleSelectAllInterests}
+            />
             <div className="grid grid-cols-1 tablet:grid-cols-2 gap-3 ml-6">
               {INTEREST_OPTIONS.map((option) => (
-                <div key={option.value} className="flex items-center gap-2">
-                  <Checkbox
-                    id={`interest-${option.value}`}
-                    checked={selectedInterests.includes(option.value)}
-                    onCheckedChange={(checked) =>
-                      handleInterestToggle(option.value, checked === true)
-                    }
-                  />
-                  <Label
-                    htmlFor={`interest-${option.value}`}
-                    className="text-sm font-normal cursor-pointer"
-                  >
-                    {t(option.labelKey)}
-                  </Label>
-                </div>
+                <Checkbox
+                  key={option.value}
+                  id={`interest-${option.value}`}
+                  label={t(option.labelKey)}
+                  isChecked={selectedInterests.includes(option.value)}
+                  onCheckedChange={(checked) =>
+                    handleInterestToggle(option.value, checked)
+                  }
+                />
               ))}
             </div>
           </div>
         </FormGroup>
 
-        {/* Message */}
-        <FormField
+        <TextArea
           label={t("contactMessage")}
+          placeholder={t("contactMessagePlaceholder")}
+          value={formData.message}
           error={formErrors.message}
-          required
-        >
-          <Textarea
-            placeholder={t("contactMessagePlaceholder")}
-            value={formData.message}
-            onChange={handleMessageChange}
-            rows={5}
-            className={cn(formErrors.message && "border-destructive")}
-          />
-        </FormField>
+          rows={5}
+          onChange={(value) =>
+            dispatchForm({
+              type: "UPDATE_FIELD",
+              payload: { field: "message", value },
+            })
+          }
+        />
 
-        {/* Attachment */}
         <FileUpload
           label={t("contactAttachmentLabel")}
           placeholder={t("contactAttachmentPlaceholder")}
@@ -504,24 +463,25 @@ export function EnhancedContactForm({
           </p>
         )}
 
-        {/* How did you hear about us */}
-        <FormField label={t("contactHearAbout")}>
-          <Select value={formData.hearAbout} onValueChange={handleHearAboutChange}>
-            <SelectTrigger>
-              <SelectValue placeholder={t("contactHearAboutPlaceholder")} />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="social-media">{t("contactHearSocial")}</SelectItem>
-              <SelectItem value="search-engine">{t("contactHearSearch")}</SelectItem>
-              <SelectItem value="word-of-mouth">{t("contactHearWord")}</SelectItem>
-              <SelectItem value="event">{t("contactHearEvent")}</SelectItem>
-              <SelectItem value="existing-client">{t("contactHearExisting")}</SelectItem>
-              <SelectItem value="other">{t("contactHearOther")}</SelectItem>
-            </SelectContent>
-          </Select>
-        </FormField>
+        <Select
+          label={t("contactHearAbout")}
+          value={formData.hearAbout}
+          onValueChange={handleHearAboutChange}
+        >
+          <SelectOption
+            value=""
+            label={t("contactHearAboutPlaceholder")}
+            disabled
+          />
+          {HEAR_ABOUT_OPTIONS.map((option) => (
+            <SelectOption
+              key={option.value}
+              value={option.value}
+              label={t(option.labelKey)}
+            />
+          ))}
+        </Select>
 
-        {/* Privacy Policy */}
         <p className="text-xs text-muted-foreground">
           *{t("contactPrivacyPolicy1")}{" "}
           <a
@@ -533,22 +493,22 @@ export function EnhancedContactForm({
           .
         </p>
 
-        {/* Actions */}
         <div className="flex flex-col-reverse tablet:flex-row gap-3 pt-4">
           <Button
             type="button"
-            variant="outline"
+            variant="secondary"
             onClick={resetFormState}
-            disabled={isSubmitting}
+            isDisabled={isSubmitting}
           >
             {t("contactClear")}
           </Button>
           <Button
             type="submit"
-            disabled={isSubmitting || !isFormValid}
+            variant="primary"
+            isDisabled={isSubmitting || !isFormValid}
+            isLoading={isSubmitting}
             className="flex-1"
           >
-            {isSubmitting && <Loader className="mr-2 h-4 w-4 animate-spin" />}
             {t("contactSubmit")}
           </Button>
         </div>
@@ -561,9 +521,9 @@ export function EnhancedContactForm({
         description={t("contactErrorMessage")}
         onClose={() => setIsErrorOpen(false)}
         footer={
-          <DtButton variant="secondary" onClick={() => setIsErrorOpen(false)}>
+          <Button variant="secondary" onClick={() => setIsErrorOpen(false)}>
             {t("back")}
-          </DtButton>
+          </Button>
         }
       />
     </FadeIn>

--- a/nextjs-app/shared/components/Lightbox/Lightbox.module.css
+++ b/nextjs-app/shared/components/Lightbox/Lightbox.module.css
@@ -1,0 +1,112 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 5000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgb(0 0 0 / 95%);
+}
+
+.panel {
+  position: relative;
+  display: flex;
+  width: 100%;
+  max-width: 95vw;
+  max-height: 95vh;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+}
+
+.close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 2;
+}
+
+.nav {
+  position: absolute;
+  top: 50%;
+  z-index: 2;
+  transform: translateY(-50%);
+}
+
+.navPrev {
+  left: 1rem;
+}
+
+.navNext {
+  right: 1rem;
+}
+
+.figure {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-inline: 4rem;
+}
+
+.image {
+  max-width: 100%;
+  max-height: 80vh;
+  border-radius: var(--radius-sm);
+  object-fit: contain;
+}
+
+.caption {
+  margin-top: 1rem;
+  max-width: 42rem;
+  padding-inline: 1rem;
+  font-family: var(--font-text);
+  font-size: var(--font-size-text-s, 0.875rem);
+  text-align: center;
+  color: rgb(255 255 255 / 70%);
+}
+
+.counter {
+  position: absolute;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--font-text);
+  font-size: var(--font-size-text-xs, 0.75rem);
+  color: rgb(255 255 255 / 50%);
+}
+
+.navButton {
+  padding: 0.75rem;
+  border: none;
+  border-radius: 9999px;
+  background: transparent;
+  color: rgb(255 255 255 / 70%);
+  cursor: pointer;
+  transition: color 0.15s ease, background-color 0.15s ease;
+}
+
+.navButton:hover {
+  background-color: rgb(255 255 255 / 10%);
+  color: rgb(255 255 255 / 100%);
+}
+
+.navButton:focus-visible {
+  outline: 2px solid rgb(255 255 255 / 80%);
+  outline-offset: 2px;
+}
+
+@media (forced-colors: active) {
+  .overlay {
+    background-color: Canvas;
+  }
+
+  .navButton {
+    border: 1px solid CanvasText;
+    color: CanvasText;
+  }
+
+  .caption,
+  .counter {
+    color: CanvasText;
+  }
+}

--- a/nextjs-app/shared/components/Lightbox/Lightbox.tsx
+++ b/nextjs-app/shared/components/Lightbox/Lightbox.tsx
@@ -1,12 +1,9 @@
 "use client";
 
-import { useEffect, useCallback, useState } from "react";
-import { X, CaretLeft, CaretRight } from "@phosphor-icons/react";
-import {
-  Dialog,
-  DialogContent,
-  DialogClose,
-} from "@/components/ui/dialog";
+import { useEffect, useCallback, useState, useRef } from "react";
+import { createPortal } from "react-dom";
+import Icon from "@dt/Icon";
+import styles from "./Lightbox.module.css";
 
 export interface LightboxImage {
   src: string;
@@ -24,14 +21,20 @@ export interface LightboxProps {
 export function Lightbox({
   images,
   initialIndex = 0,
-  open,
+  open = false,
   onOpenChange,
 }: LightboxProps) {
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const previousActiveElement = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     if (open) setCurrentIndex(initialIndex);
   }, [open, initialIndex]);
+
+  const close = useCallback(() => {
+    onOpenChange?.(false);
+  }, [onOpenChange]);
 
   const goNext = useCallback(() => {
     setCurrentIndex((prev) => (prev + 1) % images.length);
@@ -44,75 +47,118 @@ export function Lightbox({
   useEffect(() => {
     if (!open) return;
 
+    previousActiveElement.current = document.activeElement as HTMLElement;
+
+    const mainContent =
+      document.getElementById("main-content") ||
+      document.getElementById("__next") ||
+      document.querySelector("main") ||
+      document.body.firstElementChild;
+
+    if (mainContent && mainContent !== document.body) {
+      mainContent.setAttribute("inert", "");
+    }
+
+    const focusClose = () => {
+      panelRef.current
+        ?.querySelector<HTMLElement>("button")
+        ?.focus();
+    };
+    requestAnimationFrame(focusClose);
+
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
       if (e.key === "ArrowRight") goNext();
       if (e.key === "ArrowLeft") goPrev();
     };
 
     window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [open, goNext, goPrev]);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      if (mainContent && mainContent !== document.body) {
+        mainContent.removeAttribute("inert");
+      }
+      previousActiveElement.current?.focus();
+    };
+  }, [open, close, goNext, goPrev]);
 
   const currentImage = images[currentIndex];
 
-  if (!images.length) return null;
+  if (!images.length || !open) return null;
 
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        className="max-w-[95vw] max-h-[95vh] p-0 bg-black/95 border-none"
-        showCloseButton={false}
-        size="full"
+  const content = (
+    <div
+      className={styles.overlay}
+      role="presentation"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) close();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") close();
+      }}
+    >
+      <div
+        ref={panelRef}
+        className={styles.panel}
+        role="dialog"
+        aria-modal="true"
+        aria-label={currentImage?.alt ?? "Image gallery"}
       >
-        <div className="relative flex items-center justify-center min-h-[60vh]">
-          {/* Close button */}
-          <DialogClose className="absolute top-4 right-4 z-10 p-2 text-white/70 hover:text-white transition-colors rounded-full hover:bg-white/10">
-            <X className="size-6" />
-            <span className="sr-only">Close</span>
-          </DialogClose>
+        <button
+          type="button"
+          className={`${styles.navButton} ${styles.close}`}
+          onClick={close}
+          aria-label="Close"
+        >
+          <Icon name="x" decorative />
+        </button>
 
-          {/* Navigation */}
-          {images.length > 1 && (
-            <>
-              <button
-                onClick={goPrev}
-                className="absolute left-4 z-10 p-3 text-white/70 hover:text-white transition-colors rounded-full hover:bg-white/10"
-                aria-label="Previous image"
-              >
-                <CaretLeft className="size-8" />
-              </button>
-              <button
-                onClick={goNext}
-                className="absolute right-4 z-10 p-3 text-white/70 hover:text-white transition-colors rounded-full hover:bg-white/10"
-                aria-label="Next image"
-              >
-                <CaretRight className="size-8" />
-              </button>
-            </>
+        {images.length > 1 && (
+          <>
+            <button
+              type="button"
+              className={`${styles.navButton} ${styles.nav} ${styles.navPrev}`}
+              onClick={goPrev}
+              aria-label="Previous image"
+            >
+              <Icon name="arrow-left" size="lg" decorative />
+            </button>
+            <button
+              type="button"
+              className={`${styles.navButton} ${styles.nav} ${styles.navNext}`}
+              onClick={goNext}
+              aria-label="Next image"
+            >
+              <Icon name="arrow-right" size="lg" decorative />
+            </button>
+          </>
+        )}
+
+        <figure className={styles.figure}>
+          <img
+            src={currentImage?.src}
+            alt={currentImage?.alt ?? ""}
+            className={styles.image}
+          />
+          {currentImage?.caption && (
+            <figcaption className={styles.caption}>
+              {currentImage.caption}
+            </figcaption>
           )}
+        </figure>
 
-          {/* Image */}
-          <figure className="flex flex-col items-center px-16">
-            <img
-              src={currentImage?.src}
-              alt={currentImage?.alt ?? ""}
-              className="max-w-full max-h-[80vh] object-contain rounded"
-            />
-            {currentImage?.caption && (
-              <figcaption className="mt-4 text-white/70 font-body text-sm text-center max-w-2xl px-4">
-                {currentImage.caption}
-              </figcaption>
-            )}
-          </figure>
-
-          {/* Counter */}
-          {images.length > 1 && (
-            <div className="absolute bottom-4 left-1/2 -translate-x-1/2 text-white/50 font-body text-xs">
-              {currentIndex + 1} / {images.length}
-            </div>
-          )}
-        </div>
-      </DialogContent>
-    </Dialog>
+        {images.length > 1 && (
+          <div className={styles.counter} aria-live="polite">
+            {currentIndex + 1} / {images.length}
+          </div>
+        )}
+      </div>
+    </div>
   );
+
+  if (typeof document !== "undefined") {
+    return createPortal(content, document.body);
+  }
+
+  return content;
 }

--- a/nextjs-app/shared/components/Modal/Modal.contract.json
+++ b/nextjs-app/shared/components/Modal/Modal.contract.json
@@ -70,6 +70,8 @@
         "ref",
         "severity",
         "showCloseIcon",
+        "showFooter",
+        "panelRef",
         "style",
         "title",
         "titleSize",
@@ -164,6 +166,14 @@
         "showCloseIcon": {
             "optional": true,
             "type": "boolean"
+        },
+        "showFooter": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "panelRef": {
+            "optional": true,
+            "type": "React.Ref<HTMLDivElement>"
         },
         "closeIconName": {
             "optional": true,

--- a/nextjs-app/shared/components/Modal/Modal.tsx
+++ b/nextjs-app/shared/components/Modal/Modal.tsx
@@ -39,8 +39,12 @@ export interface ModalProps {
   onClose?: () => void;
   /** Optional icon to display in the header */
   icon?: React.ReactNode;
-  /** Optional className for additional styling */
+  /** Optional className for additional styling on the panel */
   className?: string;
+  /** When false, omit the footer region (e.g. composable dialog bodies) */
+  showFooter?: boolean;
+  /** Ref on the dialog panel for animation hooks */
+  panelRef?: React.Ref<HTMLDivElement>;
   /** Show close icon button in header */
   showCloseIcon?: boolean;
   /** Custom close icon name (defaults to "x") */
@@ -77,12 +81,24 @@ const Modal: React.FC<ModalProps> = ({
   showCloseIcon = false,
   closeIconName = "x",
   closeButtonLabel = "Close dialog",
+  className,
+  showFooter,
+  panelRef,
 }) => {
   const normalizedTitleSize = normalizeTitleSize(titleSize);
   const titleId = useId();
   const descriptionId = useId();
   const previousActiveElement = useRef<HTMLElement | null>(null);
   const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!panelRef || !modalRef.current) return;
+    if (typeof panelRef === "function") {
+      panelRef(modalRef.current);
+      return;
+    }
+    panelRef.current = modalRef.current;
+  }, [isOpen, panelRef]);
 
   // Apply inert attribute to main content when modal is open
   // This prevents focus from escaping the modal to background content
@@ -177,7 +193,9 @@ const Modal: React.FC<ModalProps> = ({
     >
       <div
         ref={modalRef}
-        className={`${styles.modal} ${styles[effectiveVariant]}`}
+        className={[styles.modal, styles[effectiveVariant], className]
+          .filter(Boolean)
+          .join(" ")}
         role={dialogRole}
         aria-modal="true"
         {...(title
@@ -225,7 +243,7 @@ const Modal: React.FC<ModalProps> = ({
           )}
           {children}
         </div>
-        {(footer !== undefined || !isLoading) && (
+        {showFooter !== false && (footer !== undefined || !isLoading) && (
           <div className={styles.footer}>{renderFooter()}</div>
         )}
       </div>

--- a/nextjs-app/shared/components/Modal/index.ts
+++ b/nextjs-app/shared/components/Modal/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Modal";
+export type { ModalProps, ModalSeverity } from "./Modal";

--- a/nextjs-app/shared/components/SkillsGrid/SkillsGrid.tsx
+++ b/nextjs-app/shared/components/SkillsGrid/SkillsGrid.tsx
@@ -7,7 +7,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@/components/ui/tooltip";
+} from "@dt/Tooltip";
 import { FadeIn } from "../animations/FadeIn";
 
 export interface Skill {
@@ -164,14 +164,9 @@ function SkillItem({ skill }: SkillItemProps) {
         <TooltipTrigger asChild>
           <div className="group">{content}</div>
         </TooltipTrigger>
-        <TooltipContent
-          className={cn(
-            "max-w-xs",
-            "font-body text-sm"
-          )}
-        >
+        <TooltipContent className="max-w-xs">
           <p className="font-semibold mb-1">{skill.name}</p>
-          <p className="text-muted-foreground">{skill.description}</p>
+          <p className="opacity-80">{skill.description}</p>
         </TooltipContent>
       </Tooltip>
     );

--- a/nextjs-app/shared/components/Tooltip/Tooltip.module.css
+++ b/nextjs-app/shared/components/Tooltip/Tooltip.module.css
@@ -1,0 +1,53 @@
+.content {
+  z-index: 6000;
+  max-width: 20rem;
+  padding: var(--space-internal-8) var(--space-internal-12);
+  border-radius: var(--radius-md);
+  background-color: var(--color-primary);
+  color: var(--main-body-background-color, var(--color-white));
+  font-family: var(--font-text);
+  font-size: var(--font-size-text-s, 0.875rem);
+  line-height: var(--line-height-normal, 1.5);
+  box-shadow: var(--shadow-md, 0 4px 12px rgb(0 0 0 / 15%));
+}
+
+.arrow {
+  fill: var(--color-primary);
+}
+
+.title {
+  margin: 0 0 0.25rem;
+  font-weight: 600;
+}
+
+.body {
+  margin: 0;
+  color: var(--color-text-muted, rgb(255 255 255 / 80%));
+}
+
+@media (forced-colors: active) {
+  .content {
+    border: 1px solid CanvasText;
+    background-color: Canvas;
+    color: CanvasText;
+    forced-color-adjust: none;
+  }
+
+  .arrow {
+    fill: Canvas;
+  }
+
+  .body {
+    color: CanvasText;
+  }
+}
+
+:global(html.sb-forced-colors-active) .content {
+  border: 1px solid CanvasText;
+  background-color: Canvas;
+  color: CanvasText;
+}
+
+:global(html.sb-forced-colors-active) .arrow {
+  fill: Canvas;
+}

--- a/nextjs-app/shared/components/Tooltip/Tooltip.tsx
+++ b/nextjs-app/shared/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import type { ReactNode } from "react";
+import styles from "./Tooltip.module.css";
+
+export function TooltipProvider({
+  delayDuration = 200,
+  children,
+}: {
+  delayDuration?: number;
+  children: ReactNode;
+}) {
+  return (
+    <TooltipPrimitive.Provider delayDuration={delayDuration}>
+      {children}
+    </TooltipPrimitive.Provider>
+  );
+}
+
+export function Tooltip({ children }: { children: ReactNode }) {
+  return <TooltipPrimitive.Root>{children}</TooltipPrimitive.Root>;
+}
+
+export function TooltipTrigger({
+  asChild,
+  children,
+}: {
+  asChild?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <TooltipPrimitive.Trigger asChild={asChild}>
+      {children}
+    </TooltipPrimitive.Trigger>
+  );
+}
+
+export function TooltipContent({
+  className,
+  sideOffset = 4,
+  children,
+}: {
+  className?: string;
+  sideOffset?: number;
+  children: ReactNode;
+}) {
+  const mergedClassName = [styles.content, className].filter(Boolean).join(" ");
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        sideOffset={sideOffset}
+        className={mergedClassName}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className={styles.arrow} width={10} height={5} />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}

--- a/nextjs-app/shared/components/Tooltip/index.ts
+++ b/nextjs-app/shared/components/Tooltip/index.ts
@@ -1,0 +1,6 @@
+export {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from "./Tooltip";

--- a/nextjs-app/shared/components/interactive/index.ts
+++ b/nextjs-app/shared/components/interactive/index.ts
@@ -31,7 +31,7 @@ export {
   TooltipTrigger,
   TooltipContent,
   TooltipProvider,
-} from "@/components/ui/tooltip";
+} from "@dt/Tooltip";
 
 export {
   DropdownMenu,

--- a/nextjs-app/shared/stories/MigrationDecisionBoard/DialogComparison.stories.tsx
+++ b/nextjs-app/shared/stories/MigrationDecisionBoard/DialogComparison.stories.tsx
@@ -81,9 +81,8 @@ export const AlertAndDeferrals: Story = {
         <>
           <strong>Error alert approved</strong> — use @dt/Modal with{" "}
           <code>severity=&quot;error&quot;</code>, <code>description</code>, and{" "}
-          <code>isOpen</code>/<code>onClose</code>. EnhancedContactForm error path migrated.
-          Defer Lightbox, AnimatedDialog, and composable DialogTrigger until matching
-          primitives exist.
+          <code>isOpen</code>/<code>onClose</code>. Production overlays migrated: EnhancedContactForm,
+          Lightbox (portal), AnimatedDialog (GSAP + @dt/Modal). Defer composable DialogTrigger only.
         </>
       }
     >
@@ -117,19 +116,11 @@ export const AlertAndDeferrals: Story = {
         </MigrationDecisionBlock>
       </MigrationDecisionBand>
 
-      <MigrationDecisionBand title="Deferred — do not migrate yet" className={board.bandMuted}>
-        <MigrationDecisionBlock variant="defer" title="AnimatedDialog — GSAP + shadcn shell">
-          <span className="font-body text-sm">Keep until Modal supports entry animation contract.</span>
-        </MigrationDecisionBlock>
-        <MigrationDecisionBlock variant="defer" title="Lightbox — ProjectGallery full-bleed">
-          <span className="font-body text-sm">Needs gallery overlay primitive or spec extension.</span>
-        </MigrationDecisionBlock>
-        <MigrationDecisionBlock variant="defer" title="SkillsGrid — shadcn Tooltip">
-          <span className="font-body text-sm">No @dt Tooltip; defer or use title attribute.</span>
-        </MigrationDecisionBlock>
-        <MigrationDecisionBlock variant="defer" title="EnhancedContactForm — shadcn form shell">
+      <MigrationDecisionBand title="Deferred — composable trigger only" className={board.bandMuted}>
+        <MigrationDecisionBlock variant="defer" title="Radix DialogTrigger + asChild">
           <span className="font-body text-sm">
-            Error alert uses @dt/Modal; inputs/selects still shadcn until form boards pass.
+            @dt/Modal stays controlled (<code>isOpen</code> / <code>onClose</code>). Wrap local state
+            or keep shadcn for trigger composition until a DT primitive ships.
           </span>
         </MigrationDecisionBlock>
       </MigrationDecisionBand>

--- a/scripts/design-system/dt-usage-rules.mjs
+++ b/scripts/design-system/dt-usage-rules.mjs
@@ -26,10 +26,6 @@ export const DT_USAGE_SHADCN_ALLOWLIST_REL = new Set([
   "nextjs-app/shared/components/ui/index.ts",
   "nextjs-app/shared/components/interactive/index.ts",
   "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx",
-  "nextjs-app/shared/components/Lightbox/Lightbox.tsx",
-  "nextjs-app/shared/components/AnimatedDialog/AnimatedDialog.tsx",
-  "nextjs-app/shared/components/SkillsGrid/SkillsGrid.tsx",
-  "nextjs-app/shared/components/EnhancedContactForm/EnhancedContactForm.tsx",
 ]);
 
 /** Root layout failure UI — no providers / theme CSS. */


### PR DESCRIPTION
## Summary

- Migrates **EnhancedContactForm** to `@dt/Inputs`, `TextArea`, `Select`, `Checkbox`, `Button`, and `Modal` (removes all `@/components/ui/*` imports).
- Adds **`@dt/Tooltip`** (Radix + CSS modules) and migrates **SkillsGrid**.
- Rewrites **Lightbox** as a portaled overlay with CSS modules (no shadcn `Dialog`).
- Rewrites **AnimatedDialog** on **`@dt/Modal`** with GSAP entry animation and local `DialogHeader`/`Footer`/`Title`/`Description`/`Close` parts.
- Extends **Modal** with `showFooter`, `panelRef`, and `className` on the panel.
- Shrinks `DT_USAGE_SHADCN_ALLOWLIST_REL` from 7 → **3** (`ui/index`, `interactive/index`, `TailwindTest` only).

## Test plan

- [x] `npm run typecheck && npm run lint && npm run lint:dt-usage -- --strict`
- [x] `npm run validate:components`
- [x] `SKIP_STORYBOOK_TESTS=1 npx vitest run nextjs-app/shared/components/Modal/` (34 pass)
- [ ] Visual check: ProjectGallery lightbox, SkillsGrid tooltips, AnimatedDialog stories
- [ ] Contact form submit + error modal on `/contact` (if EnhancedContactForm is mounted there)


Made with [Cursor](https://cursor.com)