### PR TITLE
feat(ds): agentic DS v3 kickoff — NewsBulletin beta, pattern eval, CI gate

### DIFF
--- a/.github/workflows/ds-release-gate-full.yml
+++ b/.github/workflows/ds-release-gate-full.yml
@@ -1,0 +1,19 @@
+name: DS Release Gate (full)
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  release-gate-full:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20.19.0
+      - run: npm ci
+      - run: npx playwright install chromium
+      - run: npm run release:gate -- --full

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,6 +16,7 @@ jobs:
       - run: npm run build:zod-catalog
       - run: npm run check:generated
       - run: npm run agent:eval
+      - run: npm run check:catalog-coverage
       - run: npm run lint:dt-usage
       - run: npm run lint:composition
       - run: npm run lint:dt-responsive-visibility -- --strict

--- a/.planning/milestones/agentic-ds-v3/ROADMAP.md
+++ b/.planning/milestones/agentic-ds-v3/ROADMAP.md
@@ -1,0 +1,67 @@
+# Milestone: Agentic design system v3 — proof under change
+
+**Goal:** Move from AI-ready beta to agentic-first: green full test matrix, production-proven catalog, closed Figma capture loop, commercial benchmark packaging.
+
+**Prerequisite:** v2 complete (#696 — release gate, 86% catalog, 10 stable, semver policy).
+
+**Baseline (2026-06-06):** `release:gate` fast passes; intent 20/20; patterns 9/9 → 10/10; catalog 86.3%; 10 stable.
+
+---
+
+## Phases
+
+| Phase | Focus | Status |
+|-------|--------|--------|
+| **13** | Green `npm test` + CI full gate | **In progress** |
+| **14** | Alpha → beta promotions (patterns with stories) | **Started** (NewsBulletin) |
+| **15** | Figma capture loop (9 routes, surgical binding) | Pending |
+| **16** | Production consumer auto-sync + stable fleet growth | Pending |
+| **17** | AI-Ready DS Benchmark (public doc + consulting SKU) | **Started** |
+| **18** | npm export spike (`@digitaltableteur/ds`) | Pending |
+
+---
+
+## Phase 13 — Test & CI gate
+
+- Fix Storybook browser Vitest teardown (WebSocket / HMR race)
+- Add `check:catalog-coverage` to PR validation (via `agent:eval`)
+- Optional nightly: `npm run release:gate -- --full`
+
+## Phase 14 — Pattern beta promotions
+
+Promote alpha assemblies that already have Storybook coverage:
+
+1. NewsBulletin ✓
+2. ContactInquiryPanel
+3. HomeHero (already beta)
+4. PricingPageContent (needs Example + ForcedColors)
+
+## Phase 15 — Figma captures
+
+Per `docs/FIGMA_DESIGN_SYSTEM_SYNC.md`:
+
+- html-to-design captures only (no bulk DS rebuild)
+- Remaining routes: work, about, pricing, blog, sitemap, dsharp
+- Surgical variable + text-style binding
+
+## Phase 16 — Stable fleet + consumers
+
+- `npm run audit:consumers` in stable promotion workflow
+- Container Figma node-id when mapped
+- Visual baselines on stable fleet (`test:visual`)
+
+## Phase 17 — Benchmark product
+
+- [docs/AI_READY_DS_BENCHMARK.md](../../../docs/AI_READY_DS_BENCHMARK.md)
+- Consulting deliverable aligned with `agentic-ds-audit` + `release:gate`
+
+---
+
+## Success criteria (v3 complete)
+
+1. `npm test` exits 0 locally (unit + Storybook browser).
+2. `release:gate --full` in CI (scheduled or PR label).
+3. ≥15 stable components with AT snapshots + Figma node-ids.
+4. ≥50 cataloged components with production `consumers[]` evidence.
+5. 9/9 Figma route captures with token binding (no rebuild script).
+6. Published AI-Ready DS Benchmark with live metric snapshot.

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -226,14 +226,22 @@ const config: StorybookConfig = {
       noExternal: mergedNoExternal as any,
     };
 
-    // Ensure HMR is enabled and configured properly
+    const isVitest =
+      process.env.VITEST === "true" || process.env.VITEST === "1";
+
+    // Storybook dev HMR; disable under Vitest browser tests to avoid WebSocket
+    // teardown races ("WebSocket closed without opened") on worker shutdown.
     config.server = {
       ...config.server,
-      hmr: {
-        overlay: true,
-        // Avoid clashing with other Vite instances (default 24678)
-        port: 24680,
-      },
+      ...(isVitest
+        ? { hmr: false }
+        : {
+            hmr: {
+              overlay: true,
+              // Avoid clashing with other Vite instances (default 24678)
+              port: 24680,
+            },
+          }),
       watch: {
         usePolling: false,
         interval: 100,
@@ -241,11 +249,22 @@ const config: StorybookConfig = {
       },
     };
 
-    // Add esbuild options to help with HMR
-    config.esbuild = {
-      ...config.esbuild,
-      jsxDev: true,
-    };
+    if (isVitest) {
+      config.define = {
+        ...(config.define || {}),
+        "import.meta.hot": "undefined",
+      };
+      config.esbuild = {
+        ...config.esbuild,
+        jsxDev: false,
+      };
+    } else {
+      // Add esbuild options to help with HMR
+      config.esbuild = {
+        ...config.esbuild,
+        jsxDev: true,
+      };
+    }
 
     // Set base for production builds under /storybook/
     if (process.env.NODE_ENV === "production") {

--- a/docs/AGENTIC_DS_OPERATING_MODEL.md
+++ b/docs/AGENTIC_DS_OPERATING_MODEL.md
@@ -61,7 +61,7 @@ See [PHASE-05-SUMMARY.md](../.planning/milestones/ai-native-design-system/PHASE-
 | Metric | Command / artifact |
 |--------|-------------------|
 | Intent retrieval | `npm run agent:eval` → golden-intents (20 cases, ≥85%) |
-| Pattern composition | `npm run agent:eval:patterns` — 3 layout recipes |
+| Pattern composition | `npm run agent:eval:patterns` — 10 layout recipes |
 | Local audit bundle | `npm run agentic-ds-audit` |
 | Manifest health | Schema, usage coverage, agent blocks, graph |
 | Contract drift | `npm run check:contract-drift --strict` |
@@ -76,6 +76,8 @@ node scripts/design-system/agent-eval/intent-retrieval-eval.mjs
 ---
 
 ## Roadmap
+
+Milestone v3: [`.planning/milestones/agentic-ds-v3/ROADMAP.md`](../.planning/milestones/agentic-ds-v3/ROADMAP.md) — proof under change, Figma captures, benchmark product.
 
 Milestone v2: [`.planning/milestones/agentic-ds-v2/ROADMAP.md`](../.planning/milestones/agentic-ds-v2/ROADMAP.md) — Figma loop, pattern composition MCP, portfolio proof, client audit playbook.
 

--- a/docs/AI_READY_DS_BENCHMARK.md
+++ b/docs/AI_READY_DS_BENCHMARK.md
@@ -1,0 +1,76 @@
+# AI-Ready Design System Benchmark
+
+**Version:** 1.0 (2026-06-06)  
+**Audience:** CTOs, design-system leads, and agents evaluating DS agent-readiness.
+
+Digitaltableteur publishes this benchmark as a **repeatable audit** — the same checks run locally via `npm run agentic-ds-audit` and `npm run release:gate`.
+
+---
+
+## Scoring dimensions
+
+| Dimension | Weight | Pass threshold | Command |
+|-----------|--------|----------------|---------|
+| **Manifest & schema** | 15% | Valid `agent-manifest.json`, Zod catalog | `npm run agent:eval` |
+| **Intent retrieval** | 20% | ≥90% on golden set (20 cases) | `npm run agent:eval:intents` |
+| **Pattern composition** | 15% | ≥90% on layout recipes | `npm run agent:eval:patterns` |
+| **Catalog completeness** | 10% | ≥85%, catalog-gap = 0 | `npm run check:catalog-coverage` |
+| **Contract drift** | 10% | Zero strict drift | `npm run check:contract-drift -- --strict` |
+| **Stable fleet** | 10% | ≥10 stable with Figma node-ids | manifest `summary.statusCounts.stable` |
+| **Production evidence** | 10% | ≥40 components with import evidence | `npm run audit:usage` |
+| **Release gate** | 10% | Fast gate green | `npm run release:gate` |
+
+**Overall pass:** ≥85% weighted score + no P0 failures (schema, drift, catalog-gap).
+
+---
+
+## Digitaltableteur snapshot (2026-06-06)
+
+| Metric | Value | Pass |
+|--------|-------|------|
+| Catalog completeness | 86.3% (164/190) | ✓ |
+| Catalog gap | 0 | ✓ |
+| Stable components | 10 | ✓ |
+| Intent golden set | 20/20 (100%) | ✓ |
+| Pattern golden set | 10/10 (100%) | ✓ |
+| Agent blocks | 164 | ✓ |
+| MCP tools | 6 DS + consulting | ✓ |
+| `release:gate` (fast) | Green | ✓ |
+| Full `npm test` | 1010/1010 pass; teardown noise | ⚠ |
+| Code Connect | Skipped (Figma Pro) | N/A |
+| npm export | Workspace `@dt/*` only | Pending |
+
+---
+
+## How to run (client repo or this repo)
+
+```bash
+git clone … && npm ci
+npm run build:tokens
+npm run agentic-ds-audit    # consulting + Figma + MCP checks
+npm run release:gate        # pre-release gate
+npm run release:gate -- --full   # + test:ci, visual, Playwright a11y pages
+```
+
+---
+
+## Maturity levels
+
+| Level | Name | Typical signals |
+|-------|------|-----------------|
+| 1 | Documented | Storybook + README only |
+| 2 | AI-readable | Contracts, some MDX |
+| 3 | AI-operable | Manifest, agent blocks, MCP, evals |
+| 4 | AI-ready beta | Release gate, ≥85% catalog, stable fleet |
+| 5 | Agentic-first | Green full test matrix, Figma loop closed, npm export |
+
+**Digitaltableteur (Jun 2026):** Level **4** (AI-ready beta), path to **5** via v3 milestone.
+
+---
+
+## Related
+
+- [AGENTIC_DS_OPERATING_MODEL.md](./AGENTIC_DS_OPERATING_MODEL.md)
+- [AGENTIC_DS_AUDIT_PLAYBOOK.md](./AGENTIC_DS_AUDIT_PLAYBOOK.md)
+- [PUBLIC_API.md](./PUBLIC_API.md)
+- [AGENT_READINESS.md](./AGENT_READINESS.md) — site-level agent discovery (Level 4/5)

--- a/nextjs-app/shared/foundations/figma/dsb-state.json
+++ b/nextjs-app/shared/foundations/figma/dsb-state.json
@@ -105,11 +105,14 @@
   ],
   "pendingSteps": [
     "phase4-pattern-instances",
-    "phase4-contract-sync"
+    "phase4-contract-sync",
+    "phase5-html-captures-remaining-routes"
   ],
+  "captureWorkflow": {
+    "preferred": "html-to-design via FIGMA_HTML_CAPTURE=1 + generate_figma_design",
+    "avoid": "Bulk DS instance replacement on capture frames (destroys pixel-perfect reference)"
+  },
   "refinementNotes": {
-    "tool": "plugin-figma-figma use_figma + scripts/design-system/figma-rebuild-route-views.mjs",
-    "npmScript": "npm run build:figma-rebuild-views",
     "applied": [
       "SiteHeader/SiteFooter DS instances on all 9 VIews frames",
       "NewsBulletin + CTASection pattern swaps (by frame name + CTA copy heuristics)",

--- a/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.contract.json
+++ b/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.contract.json
@@ -3,30 +3,71 @@
     "name": "NewsBulletin",
     "tier": "pattern",
     "group": "marketing",
-    "status": "alpha",
-    "description": "Homepage news bulletin strip with three topical slots.",
+    "status": "beta",
+    "description": "Homepage news bulletin strip with three topical slots above the footer.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=503-20",
     "radixPrimitive": null,
-    "element": "div",
+    "element": "section",
     "variants": {},
     "slots": [],
     "asChild": false,
     "subParts": [],
     "requiredStories": [
-        "Default"
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
     "a11y": {
-        "keyboard": [],
-        "ariaRequirements": [],
+        "keyboard": [
+            "Tab",
+            "Enter"
+        ],
+        "ariaRequirements": [
+            "region landmark",
+            "aria-label per bulletin card",
+            "external links open in new tab with rel noopener"
+        ],
         "reducedMotion": true,
-        "reviewed": false,
-        "forcedColorsVerified": false
+        "reviewed": true,
+        "reviewedNote": "2026-06-06 — card labels, link targets, and ForcedColors story verified in Storybook.",
+        "forcedColorsVerified": true,
+        "playFunctionExempt": "Marquee animation defers to CSS; keyboard order follows DOM link sequence."
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
-    "lightDarkVerified": false,
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "className",
+        "items"
+    ],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+            "since": "2026-06-06"
+        }
+    ],
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "items": {
+            "optional": true,
+            "type": "NewsBulletinItem[]"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "composesWith": [
+        "Link",
+        "Icon",
+        "Text"
+    ],
+    "forbiddenUse": [
+        "Use BlogGrid for full article listings instead of this strip.",
+        "Do not hardcode bulletin copy outside news-bulletin data module."
+    ]
 }

--- a/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.mdx
+++ b/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.mdx
@@ -1,0 +1,40 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as Stories from './NewsBulletin.stories.tsx';
+
+<Meta of={Stories} />
+
+# NewsBulletin
+
+**Status:** beta · **Tier:** pattern · **Group:** marketing
+
+## In use
+
+See the **Example** story for the canonical homepage composition (three topical slots above the footer).
+
+## How to use
+
+```tsx
+import { NewsBulletin } from '@dt/NewsBulletin';
+
+<NewsBulletin />
+```
+
+## When to use
+
+- Homepage footer-adjacent news strip with up to three topical items.
+- When items come from `NEWS_BULLETIN_ITEMS` or an equivalent typed list.
+
+## When not to use
+
+- Full blog index or article lists — use `BlogGrid` instead.
+- Alert or toast feedback — use `AlertBanner` or `Toast`.
+
+## Accessibility
+
+- Cards expose `aria-label` per item; interactive cards use native links.
+- Confirm **ForcedColors** before marking `forcedColorsVerified`.
+
+## Promotion notes
+
+- Beta: Example + ForcedColors stories, axe gate enabled.
+- Stable: production consumer documented, AT snapshots committed.

--- a/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css
+++ b/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css
@@ -207,7 +207,8 @@
   min-block-size: 1.506rem;
   justify-content: center;
   align-items: center;
-  background-color: #0085ca;
+  /* npm brand blue #0085ca is 4.03:1 on white @ ~13px — darken for WCAG AA */
+  background-color: #006da3;
   letter-spacing: -0.06em;
   color: #fff;
 }

--- a/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.spec.md
+++ b/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.spec.md
@@ -1,19 +1,19 @@
 # NewsBulletin
 
 ## Intent
-Homepage news bulletin strip with three topical slots.
+Homepage news bulletin strip with three topical slots above the footer.
 
 ## Interaction contract
-- Keyboard: inherit from composed @dt/* primitives
-- Pointer: standard link/button targets where interactive
-- Screen readers: use landmarks and labels from child components
+- Keyboard: Tab through linked cards; Enter activates internal and external links
+- Pointer: Cards with links are fully clickable targets
+- Screen readers: Each card has an aria-label combining badge context and body text
 
 ## Do / don't
-- Do: compose from cataloged @dt/* atoms and molecules for new UI in this surface
-- Do: treat this as a page assembly reference when matching production routes
-- Don't: invent parallel primitives inside this folder
-- Don't: promote to stable without production consumer evidence
+- Do: use for homepage footer-adjacent topical snippets from `NEWS_BULLETIN_ITEMS`
+- Do: keep badge + body copy synchronized with the data module for all locales
+- Don't: use for full blog indexes or article lists
+- Don't: replace with generic Card stacks without region semantics
 
 ## Design notes
-- Tokens: inherit from child components
+- Tokens: bulletin surface uses pattern CSS module tokens
 - Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=503-20

--- a/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.stories.tsx
+++ b/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.stories.tsx
@@ -1,24 +1,57 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { NewsBulletin } from "./NewsBulletin";
 import { NEWS_BULLETIN_ITEMS } from "@/nextjs-app/shared/data/news-bulletin";
+import contract from "./NewsBulletin.contract.json";
 
-const meta: Meta<typeof NewsBulletin> = {
+const meta = {
   title: "Patterns/NewsBulletin",
   component: NewsBulletin,
-  tags: ["wip"],
+  tags: ["beta", "!autodocs"],
   parameters: {
     layout: "fullscreen",
+    contractStatus: contract.status,
+    a11y: { test: "error" },
     design: {
       type: "figma",
       url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=503-20",
     },
+    docs: { description: { component: contract.description } },
   },
-};
+  argTypes: {
+    className: {
+      control: "text",
+      description: "Optional wrapper class",
+      table: { disable: true },
+    },
+    items: {
+      control: "object",
+      description: "Bulletin items (defaults to NEWS_BULLETIN_ITEMS)",
+      table: { disable: true },
+    },
+  },
+} satisfies Meta<typeof NewsBulletin>;
 
 export default meta;
-type Story = StoryObj<typeof NewsBulletin>;
+type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  tags: ["beta-matrix"],
+};
+
+export const Playground: Story = {
+  tags: ["beta-matrix"],
+};
+
+export const Example: Story = {
+  tags: ["beta-matrix"],
+  name: "Example (homepage bulletin)",
+  parameters: { controls: { disable: true }, layout: "fullscreen" },
+  render: () => <NewsBulletin />,
+};
+
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "active" },
   render: () => <NewsBulletin />,
 };
 

--- a/scripts/design-system/agent-eval/golden-patterns.json
+++ b/scripts/design-system/agent-eval/golden-patterns.json
@@ -33,6 +33,11 @@
       "expectedTop1": "SiteFooter"
     },
     {
+      "id": "news-bulletin",
+      "query": "homepage news bulletin strip footer",
+      "expectedTop1": "NewsBulletin"
+    },
+    {
       "id": "article-hero",
       "query": "blog article hero title metadata",
       "expectedTop1": "ArticleHero"

--- a/scripts/design-system/pattern-composition.recipes.json
+++ b/scripts/design-system/pattern-composition.recipes.json
@@ -126,6 +126,26 @@
       "storybookId": "patterns-sitefooter--default"
     },
     {
+      "name": "NewsBulletin",
+      "publicImport": "@dt/NewsBulletin",
+      "tier": "pattern",
+      "status": "beta",
+      "useWhen": [
+        "homepage news strip with three topical slots above footer",
+        "footer-adjacent bulletin cards with internal or external links"
+      ],
+      "avoidWhen": [
+        "full blog index or article grid",
+        "alert or toast feedback surfaces",
+        "inline card stack without region landmark"
+      ],
+      "composesWith": ["Link", "Icon", "Text"],
+      "variantNotes": {
+        "data": "Items default from NEWS_BULLETIN_ITEMS — keep copy in the data module for i18n."
+      },
+      "storybookId": "patterns-newsbulletin--example"
+    },
+    {
       "name": "ArticleHero",
       "publicImport": "@dt/ArticleHero",
       "tier": "pattern",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -136,6 +136,11 @@ export default defineConfig({
             ],
             test: {
               name: "storybook",
+              // Run storybook browser tests sequentially to avoid Vite HMR WebSocket
+              // teardown races ("WebSocket closed without opened") on worker shutdown.
+              fileParallelism: false,
+              maxWorkers: 1,
+              pool: "forks",
               browser: {
                 enabled: shouldEnableStorybookBrowserTests,
                 ...(shouldEnableStorybookBrowserTests


### PR DESCRIPTION
## Summary

- Promotes **NewsBulletin** to **beta** with Example/ForcedColors stories, contract props, MDX docs, and npm badge contrast fix (WCAG AA)
- Adds **10th golden pattern case** (NewsBulletin) and composition recipe; `agent:eval` pattern set now **10/10**
- Fixes Vitest Storybook teardown: disable HMR under `VITEST`, sequential browser workers — **1013/1013 tests pass, exit 0**
- Wires **catalog coverage** into PR validation; adds weekly **ds-release-gate-full** workflow (`release:gate --full`)
- Documents **agentic-ds-v3** roadmap and **AI-Ready DS Benchmark**; cleans `dsb-state.json` rebuild-script refs

## Test plan

- [x] `npm test` — 1013 passed
- [x] `npm run release:gate` — all steps OK
- [x] `npm run agent:eval` — intent 20/20, patterns 10/10, catalog 86.3%
- [x] `npm run validate:components` — NewsBulletin beta contract passes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NewsBulletin pattern promoted to beta status with enhanced documentation
  * Added AI-Ready Design System benchmark documentation and audit framework

* **Documentation**
  * Added comprehensive NewsBulletin usage guide with accessibility guidelines
  * Added v3 roadmap and operating model documentation

* **Bug Fixes**
  * Improved visual contrast for accessibility compliance

* **Chores**
  * Enhanced CI/release gate workflow automation
  * Updated testing infrastructure for improved performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->