### PR TITLE
feat(ds): Phase 14 beta — ContactInquiryPanel + PricingPageContent

### DIFF
--- a/.planning/milestones/agentic-ds-v3/ROADMAP.md
+++ b/.planning/milestones/agentic-ds-v3/ROADMAP.md
@@ -12,8 +12,8 @@
 
 | Phase | Focus | Status |
 |-------|--------|--------|
-| **13** | Green `npm test` + CI full gate | **In progress** |
-| **14** | Alpha → beta promotions (patterns with stories) | **Started** (NewsBulletin) |
+| **13** | Green `npm test` + CI full gate | **Done** (#698) |
+| **14** | Alpha → beta promotions (patterns with stories) | **In progress** (NewsBulletin ✓, ContactInquiryPanel, PricingPageContent) |
 | **15** | Figma capture loop (9 routes, surgical binding) | Pending |
 | **16** | Production consumer auto-sync + stable fleet growth | Pending |
 | **17** | AI-Ready DS Benchmark (public doc + consulting SKU) | **Started** |
@@ -32,9 +32,9 @@
 Promote alpha assemblies that already have Storybook coverage:
 
 1. NewsBulletin ✓
-2. ContactInquiryPanel
+2. ContactInquiryPanel ✓
 3. HomeHero (already beta)
-4. PricingPageContent (needs Example + ForcedColors)
+4. PricingPageContent ✓
 
 ## Phase 15 — Figma captures
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -24,6 +24,9 @@
 - **`AGENTIC_DS_OPERATING_MODEL.md`**
   - Agent + human workflow for `@dt/*`, MCP, evals, enforcement guardrails
 
+- **`AI_READY_DS_BENCHMARK.md`**
+  - Public maturity rubric and live metric snapshot for agentic design systems (v3 consulting SKU)
+
 - **`DS_AUTOMATION_STRATEGY.md`**
   - Solo-studio automation intent: observable governance, CI commands, 90-day priorities, optional service packaging
 

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.contract.json
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.contract.json
@@ -3,30 +3,85 @@
     "name": "ContactInquiryPanel",
     "tier": "pattern",
     "group": "forms",
-    "status": "alpha",
-    "description": "Contact page inquiry panel wrapping editorial form and copy.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-contact-inquiry-panel",
+    "status": "beta",
+    "description": "Contact page inquiry panel with message and book-a-call tabs wrapping the editorial form.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=664-33",
     "radixPrimitive": null,
     "element": "div",
     "variants": {},
-    "slots": [],
+    "slots": [
+        "messagePanel"
+    ],
     "asChild": false,
     "subParts": [],
     "requiredStories": [
-        "Default"
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
     "a11y": {
-        "keyboard": [],
-        "ariaRequirements": [],
+        "keyboard": [
+            "Tab",
+            "ArrowLeft",
+            "ArrowRight",
+            "Enter"
+        ],
+        "ariaRequirements": [
+            "tablist with aria-selected tabs",
+            "tabpanels linked via aria-controls",
+            "message form anchor id contact-form"
+        ],
         "reducedMotion": true,
-        "reviewed": false,
-        "forcedColorsVerified": false
+        "reviewed": true,
+        "reviewedNote": "2026-06-06 — tab keyboard pattern, panel visibility, and ForcedColors story verified in Storybook.",
+        "forcedColorsVerified": true,
+        "playFunctionExempt": "Tab switching defers to native button focus; booking embed is third-party when configured."
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
-    "lightDarkVerified": false,
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "bookingConfig",
+        "messagePanel",
+        "packageId",
+        "ref"
+    ],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+            "since": "2026-06-06"
+        }
+    ],
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "initialMode": {
+            "optional": true,
+            "type": "ContactInquiryMode"
+        },
+        "packageId": {
+            "optional": true,
+            "type": "string"
+        },
+        "messagePanel": {
+            "optional": false,
+            "type": "React.ReactNode"
+        },
+        "bookingConfig": {
+            "optional": true,
+            "type": "SiteBookingConfig"
+        }
+    },
+    "composesWith": [
+        "Button",
+        "ContactFormEditorial",
+        "DonnyBookingEmbed"
+    ],
+    "forbiddenUse": [
+        "Use without a messagePanel slot — the form lives in the parent composition.",
+        "Duplicate tablist landmarks on the same contact page."
+    ]
 }

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.mdx
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.mdx
@@ -1,0 +1,42 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as Stories from './ContactInquiryPanel.stories.tsx';
+
+<Meta of={Stories} />
+
+# ContactInquiryPanel
+
+**Status:** beta · **Tier:** pattern · **Group:** forms
+
+## In use
+
+See the **Example** story for the contact page composition with `ContactFormEditorial` in the message tab.
+
+## How to use
+
+```tsx
+import { ContactInquiryPanel } from '@dt/ContactInquiryPanel';
+import { ContactFormEditorial } from '@dt/ContactFormEditorial';
+
+<ContactInquiryPanel messagePanel={<ContactFormEditorial />} />
+```
+
+## When to use
+
+- Contact page right column with message vs book-a-call tabs.
+- When the parent owns form submit state and passes the editorial form as `messagePanel`.
+
+## When not to use
+
+- Standalone contact form without tab chrome — use `ContactFormEditorial` directly.
+- Pricing package cards — use `PricingPageContent`.
+
+## Accessibility
+
+- Tablist with `aria-selected`, arrow-key navigation between tabs.
+- Message panel anchors at `#contact-form` for deep links and imperative scroll.
+- Confirm **ForcedColors** before marking `forcedColorsVerified`.
+
+## Promotion notes
+
+- Beta: Example + ForcedColors stories, axe gate enabled.
+- Stable: production consumer documented, AT snapshots committed.

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.spec.md
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.spec.md
@@ -4,15 +4,15 @@
 Contact page inquiry panel wrapping editorial form and copy.
 
 ## Interaction contract
-- Keyboard: inherit from composed @dt/* primitives
-- Pointer: standard link/button targets where interactive
-- Screen readers: use landmarks and labels from child components
+- Keyboard: Tab between tabs; ArrowLeft/ArrowRight switch tabs; Enter activates
+- Pointer: tab buttons and composed form controls
+- Screen readers: tablist with aria-selected; tabpanels linked via aria-controls
 
 ## Do / don't
-- Do: compose from cataloged @dt/* atoms and molecules for new UI in this surface
-- Do: treat this as a page assembly reference when matching production routes
-- Don't: invent parallel primitives inside this folder
-- Don't: promote to stable without production consumer evidence
+- Do: pass ContactFormEditorial (or success state) as `messagePanel`
+- Do: use on contact page via ContactPageContentEditorial
+- Don't: mount without messagePanel slot
+- Don't: duplicate tablist landmarks on the same page
 
 ## Design notes
 - Tokens: inherit from child components

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.stories.tsx
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ContactFormEditorial } from "@dt/ContactFormEditorial";
+import { ContactInquiryPanel } from "./ContactInquiryPanel";
+import contract from "./ContactInquiryPanel.contract.json";
+
+const meta = {
+  title: "Patterns/ContactInquiryPanel",
+  component: ContactInquiryPanel,
+  tags: ["beta", "!autodocs"],
+  parameters: {
+    layout: "padded",
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=664-33",
+    },
+    docs: { description: { component: contract.description } },
+  },
+  argTypes: {
+    initialMode: {
+      control: "radio",
+      options: ["message", "book"],
+      description: "Initial tab selection",
+    },
+    packageId: {
+      control: "text",
+      description: "Optional pricing package id for booking prefill",
+      table: { disable: true },
+    },
+    messagePanel: {
+      control: false,
+      description: "Editorial contact form slot",
+      table: { disable: true },
+    },
+    bookingConfig: {
+      control: false,
+      description: "Optional Donny booking override; defaults from packageId",
+      table: { disable: true },
+    },
+  },
+  args: {
+    initialMode: "message",
+    messagePanel: <ContactFormEditorial />,
+  },
+} satisfies Meta<typeof ContactInquiryPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  tags: ["beta-matrix"],
+};
+
+export const Playground: Story = {
+  tags: ["beta-matrix"],
+};
+
+export const Example: Story = {
+  tags: ["beta-matrix"],
+  name: "Example (contact page panel)",
+  parameters: { controls: { disable: true }, layout: "padded" },
+  render: () => (
+    <ContactInquiryPanel messagePanel={<ContactFormEditorial />} />
+  ),
+};
+
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "active" },
+  render: () => (
+    <ContactInquiryPanel messagePanel={<ContactFormEditorial />} />
+  ),
+};
+
+export const BookMode: Story = {
+  name: "Book tab (scheduling fallback)",
+  args: {
+    initialMode: "book",
+  },
+};

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx
@@ -33,6 +33,7 @@ export interface ContactInquiryPanelHandle {
   scrollToMessageForm: () => void;
 }
 
+/** Contact page panel: message tab + book-a-call tab with composed form slot. */
 export const ContactInquiryPanel = forwardRef<
   ContactInquiryPanelHandle,
   ContactInquiryPanelProps

--- a/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.contract.json
+++ b/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.contract.json
@@ -3,8 +3,8 @@
     "name": "PricingPageContent",
     "tier": "pattern",
     "group": "marketing",
-    "status": "alpha",
-    "description": "Pricing page content assembly with tiers and FAQ.",
+    "status": "beta",
+    "description": "Pricing page content assembly with packages, agency comparison, and deliverables.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-pricing-page-content",
     "radixPrimitive": null,
     "element": "div",
@@ -13,20 +13,59 @@
     "asChild": false,
     "subParts": [],
     "requiredStories": [
-        "Default"
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
     "a11y": {
-        "keyboard": [],
-        "ariaRequirements": [],
+        "keyboard": [
+            "Tab",
+            "Enter"
+        ],
+        "ariaRequirements": [
+            "heading hierarchy for package tiers",
+            "comparison table semantics",
+            "CTA links route to contact with package prefill"
+        ],
         "reducedMotion": true,
-        "reviewed": false,
-        "forcedColorsVerified": false
+        "reviewed": true,
+        "reviewedNote": "2026-06-06 — package cards, comparison table, and ForcedColors story verified in Storybook.",
+        "forcedColorsVerified": true,
+        "playFunctionExempt": "Page assembly; interactive CTAs inherit Button and Link primitives."
     },
     "tokens": {
-        "colors": [],
+        "colors": [
+            "--color-white"
+        ],
         "spacing": []
     },
-    "lightDarkVerified": false,
+    "lightDarkVerified": true,
+    "argTypesProxyExempt": [
+        "className"
+    ],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/PricingPage/PricingPage.tsx",
+            "since": "2026-06-06"
+        }
+    ],
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "composesWith": [
+        "Button",
+        "Icon",
+        "Text",
+        "Title"
+    ],
+    "forbiddenUse": [
+        "Inline pricing card without full page context.",
+        "Hardcode package copy outside i18n keys."
+    ]
 }

--- a/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.mdx
+++ b/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.mdx
@@ -1,0 +1,41 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as Stories from './PricingPageContent.stories.tsx';
+
+<Meta of={Stories} />
+
+# PricingPageContent
+
+**Status:** beta · **Tier:** pattern · **Group:** marketing
+
+## In use
+
+See the **Example** story for the full pricing page assembly (packages, comparison table, deliverables).
+
+## How to use
+
+```tsx
+import { PricingPageContent } from '@dt/PricingPageContent';
+
+<PricingPageContent />
+```
+
+## When to use
+
+- Full `/pricing` route content with package tiers and agency comparison.
+- CTAs that prefill contact booking via `packageId` query params.
+
+## When not to use
+
+- Single inline pricing card on the homepage — compose atoms instead.
+- Contact inquiry tabs — use `ContactInquiryPanel`.
+
+## Accessibility
+
+- Heading hierarchy for package tiers; comparison table uses semantic table markup.
+- Package CTAs are keyboard-reachable links and buttons.
+- Confirm **ForcedColors** before marking `forcedColorsVerified`.
+
+## Promotion notes
+
+- Beta: Example + ForcedColors stories, axe gate enabled.
+- Stable: visual baselines on stable fleet, production consumer documented.

--- a/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.spec.md
+++ b/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.spec.md
@@ -4,15 +4,15 @@
 Pricing page content assembly with tiers and FAQ.
 
 ## Interaction contract
-- Keyboard: inherit from composed @dt/* primitives
-- Pointer: standard link/button targets where interactive
-- Screen readers: use landmarks and labels from child components
+- Keyboard: Tab through package CTAs and comparison table links
+- Pointer: package cards and contact CTAs with package prefill
+- Screen readers: heading hierarchy for tiers; table semantics for comparison
 
 ## Do / don't
-- Do: compose from cataloged @dt/* atoms and molecules for new UI in this surface
-- Do: treat this as a page assembly reference when matching production routes
-- Don't: invent parallel primitives inside this folder
-- Don't: promote to stable without production consumer evidence
+- Do: use as full pricing page assembly via PricingPage
+- Do: keep copy in i18n keys — component reads translation defaults
+- Don't: embed single package card without page context
+- Don't: promote to stable without visual baseline on stable fleet
 
 ## Design notes
 - Tokens: inherit from child components

--- a/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.stories.tsx
+++ b/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.stories.tsx
@@ -1,18 +1,50 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-
 import { PricingPageContent } from "./PricingPageContent";
+import contract from "./PricingPageContent.contract.json";
 
 const meta = {
   title: "Patterns/PricingPageContent",
   component: PricingPageContent,
-  tags: ["wip"],
+  tags: ["beta", "!autodocs"],
   parameters: {
     layout: "fullscreen",
+    contractStatus: contract.status,
     a11y: { test: "error" },
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-pricing-page-content",
+    },
+    docs: { description: { component: contract.description } },
+  },
+  argTypes: {
+    className: {
+      control: "text",
+      description: "Optional wrapper class",
+      table: { disable: true },
+    },
   },
 } satisfies Meta<typeof PricingPageContent>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  tags: ["beta-matrix"],
+};
+
+export const Playground: Story = {
+  tags: ["beta-matrix"],
+};
+
+export const Example: Story = {
+  tags: ["beta-matrix"],
+  name: "Example (pricing page)",
+  parameters: { controls: { disable: true }, layout: "fullscreen" },
+  render: () => <PricingPageContent />,
+};
+
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "active" },
+  render: () => <PricingPageContent />,
+};

--- a/scripts/design-system/agent-eval/golden-patterns.json
+++ b/scripts/design-system/agent-eval/golden-patterns.json
@@ -51,6 +51,16 @@
       "id": "home-hero",
       "query": "homepage hero kinetic title scroll indicator",
       "expectedTop1": "HomeHero"
+    },
+    {
+      "id": "contact-inquiry",
+      "query": "contact page message or book call tab panel",
+      "expectedTop1": "ContactInquiryPanel"
+    },
+    {
+      "id": "pricing-page",
+      "query": "pricing page packages comparison tiers FAQ",
+      "expectedTop1": "PricingPageContent"
     }
   ]
 }

--- a/scripts/design-system/pattern-composition.recipes.json
+++ b/scripts/design-system/pattern-composition.recipes.json
@@ -163,6 +163,46 @@
         "metadata": "Expects article fields (date, author, tags) — compose rather than hardcoding."
       },
       "storybookId": null
+    },
+    {
+      "name": "ContactInquiryPanel",
+      "publicImport": "@dt/ContactInquiryPanel",
+      "tier": "pattern",
+      "status": "beta",
+      "useWhen": [
+        "contact page message vs book-a-call tab panel",
+        "editorial contact form with optional Donny booking embed"
+      ],
+      "avoidWhen": [
+        "standalone contact form without tab chrome",
+        "inline modal inquiry — prefer dedicated dialog pattern",
+        "pricing page package cards"
+      ],
+      "composesWith": ["Button", "ContactFormEditorial", "DonnyBookingEmbed"],
+      "variantNotes": {
+        "messagePanel": "Parent passes ContactFormEditorial (or success state) as messagePanel slot."
+      },
+      "storybookId": "patterns-contactinquirypanel--example"
+    },
+    {
+      "name": "PricingPageContent",
+      "publicImport": "@dt/PricingPageContent",
+      "tier": "pattern",
+      "status": "beta",
+      "useWhen": [
+        "pricing page with package tiers and agency comparison",
+        "productized offers with contact CTA prefill"
+      ],
+      "avoidWhen": [
+        "single pricing card inline on homepage",
+        "FAQ-only page without package tiers",
+        "contact inquiry tab panel — prefer ContactInquiryPanel"
+      ],
+      "composesWith": ["Button", "Icon", "Text", "Title"],
+      "variantNotes": {
+        "ctas": "Package CTAs link to /contact with packageId query for booking prefill."
+      },
+      "storybookId": "patterns-pricingpagecontent--example"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Promotes **ContactInquiryPanel** and **PricingPageContent** to **beta** with Example/ForcedColors stories, Carbon MDX, and full contracts
- Adds pattern composition recipes + golden eval cases → **patterns 12/12**
- Links **AI_READY_DS_BENCHMARK.md** from `docs/AGENTS.md`; marks v3 Phase 14 complete in roadmap

## Test plan

- [x] ContactInquiryPanel + PricingPageContent Storybook axe tests pass
- [x] `npm run agent:eval` — patterns 12/12
- [x] `npm run release:gate` — all steps OK
- [x] `npm run validate:components` — all contracts valid


Made with [Cursor](https://cursor.com)