### PR TITLE
feat(figma): /work html-to-design capture + route queue

### DIFF
--- a/.planning/milestones/agentic-ds-v3/ROADMAP.md
+++ b/.planning/milestones/agentic-ds-v3/ROADMAP.md
@@ -14,7 +14,7 @@
 |-------|--------|--------|
 | **13** | Green `npm test` + CI full gate | **Done** (#698) |
 | **14** | Alpha → beta promotions (patterns with stories) | **Done** (#698) |
-| **15** | Figma capture loop (9 routes, surgical binding) | Pending |
+| **15** | Figma capture loop (9 routes, surgical binding) | **In progress** (work ✓ html-to-design `671:2`) |
 | **16** | Production consumer auto-sync + stable fleet growth | **Started** (transitive scan + release gate) |
 | **17** | AI-Ready DS Benchmark (public doc + consulting SKU) | **Started** |
 | **18** | npm export spike (`@digitaltableteur/ds`) | Pending |

--- a/docs/FIGMA_DESIGN_SYSTEM_SYNC.md
+++ b/docs/FIGMA_DESIGN_SYSTEM_SYNC.md
@@ -61,6 +61,24 @@ Or batch via Cursor agent: apply all `nextjs-app/shared/foundations/figma/.use-f
 - `scripts/design-system/figma-config.mjs` — file key/slug (override with `FIGMA_FILE_KEY` / `FIGMA_FILE_SLUG`).
 - Contracts still use placeholder `node-id=dt-*` until real frames exist; run `npm run sync:figma` after publishing nodes.
 
+## Html-to-design route captures (Phase 15)
+
+Pixel-perfect references — **no bulk DS rebuild** on capture frames.
+
+```bash
+npm run dev:figma-capture          # injects capture.js via FIGMA_HTML_CAPTURE=1
+npm run figma:capture-routes       # queue status + open-URL helper
+```
+
+Agent workflow per route:
+
+1. `generate_figma_design({ fileKey: PC2UPdYwm8qGt6ZTg0AakF })` → `captureId`
+2. `node scripts/design-system/figma-html-capture-routes.mjs --route work --capture-id <id>` → open URL
+3. Poll `generate_figma_design` with `captureId` until `completed`
+4. Record new `nodeId` in `nextjs-app/shared/foundations/figma/dsb-state.json`
+
+Optional follow-up: surgical `use_figma` for header/footer variable binding only — not `figma-rebuild-route-views.mjs`.
+
 ## Resume
 
 State ledger pattern: `figma-generate-library` skill — tag nodes with `setSharedPluginData('dsb', …)` and re-run discovery if a session times out.

--- a/nextjs-app/shared/foundations/figma/dsb-state.json
+++ b/nextjs-app/shared/foundations/figma/dsb-state.json
@@ -2,8 +2,8 @@
   "runId": "dt-dsb-2026-06-05",
   "fileKey": "PC2UPdYwm8qGt6ZTg0AakF",
   "fileSlug": "DT-Site-stuff",
-  "updatedAt": "2026-06-05T18:45:00.000Z",
-  "phase": "phase4-route-views-rebuilt",
+  "updatedAt": "2026-06-06T12:00:00.000Z",
+  "phase": "phase5-html-captures",
   "routeViews": {
     "home": {
       "nodeId": "606:3192",
@@ -12,10 +12,13 @@
       "figmaUrl": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=606-3192"
     },
     "work": {
-      "nodeId": "615:33",
+      "nodeId": "671:2",
+      "previousNodeId": "615:33",
+      "captureMethod": "html-to-design",
+      "capturedAt": "2026-06-06",
       "page": "VIews",
       "url": "https://www.digitaltableteur.com/work",
-      "figmaUrl": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=615-33"
+      "figmaUrl": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=671-2"
     },
     "about": {
       "nodeId": "616:2",
@@ -101,13 +104,19 @@
     "phase1-variables",
     "phase2-file-structure",
     "phase3-in-scope-components",
-    "phase4-route-views-ds-refinement"
+    "phase4-route-views-ds-refinement",
+    "phase5-html-capture-work"
   ],
   "pendingSteps": [
+    "phase5-html-captures-about-pricing-blog-sitemap-dsharp-contact-home",
+    "phase5-surgical-token-binding-on-captures",
     "phase4-pattern-instances",
-    "phase4-contract-sync",
-    "phase5-html-captures-remaining-routes"
+    "phase4-contract-sync"
   ],
+  "htmlCaptureQueue": {
+    "completed": ["work"],
+    "remaining": ["home", "about", "pricing", "contact", "blog", "blog-article", "sitemap", "dsharp"]
+  },
   "captureWorkflow": {
     "preferred": "html-to-design via FIGMA_HTML_CAPTURE=1 + generate_figma_design",
     "avoid": "Bulk DS instance replacement on capture frames (destroys pixel-perfect reference)"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "node scripts/dev-banner.mjs && next dev -p 3001",
+    "dev:figma-capture": "FIGMA_HTML_CAPTURE=1 node scripts/dev-banner.mjs && FIGMA_HTML_CAPTURE=1 next dev -p 3001",
     "dev:webpack": "node scripts/dev-banner.mjs && next dev --webpack -p 3001",
     "dev:drafts": "node scripts/dev-with-drafts.mjs",
     "dev:full": "npm run generate:blog && npm run dev",
@@ -88,6 +89,7 @@
     "build:relationship-graph": "node scripts/design-system/generate-relationship-graph.mjs",
     "build:figma-variables": "node scripts/design-system/build-figma-variables-payload.mjs && node scripts/design-system/generate-figma-phase-scripts.mjs",
     "figma:apply-variables": "node scripts/design-system/apply-figma-variables-local.mjs",
+    "figma:capture-routes": "node scripts/design-system/figma-html-capture-routes.mjs",
     "verify:figma-in-scope": "node scripts/design-system/verify-figma-in-scope.mjs",
     "check:contrast": "node scripts/design-system/check-contrast.mjs",
     "check:token-descriptions": "tsx scripts/design-system/check-token-descriptions.ts",

--- a/scripts/design-system/figma-html-capture-routes.mjs
+++ b/scripts/design-system/figma-html-capture-routes.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Route manifest for html-to-design Figma captures (Phase 15).
+ * Does NOT mutate Figma — use generate_figma_design MCP + dev:figma-capture.
+ *
+ * Usage:
+ *   npm run dev:figma-capture
+ *   node scripts/design-system/figma-html-capture-routes.mjs
+ *   node scripts/design-system/figma-html-capture-routes.mjs --route work --capture-id <uuid>
+ */
+import { readFileSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { FIGMA_FILE_KEY, FIGMA_FILE_SLUG } from "./figma-config.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const STATE_PATH = join(
+  ROOT,
+  "nextjs-app/shared/foundations/figma/dsb-state.json",
+);
+const DEV_PORT = process.env.PORT || "3001";
+const DEV_ORIGIN = `http://localhost:${DEV_PORT}`;
+
+/** @type {Record<string, { path: string, label: string }>} */
+export const CAPTURE_ROUTES = {
+  home: { path: "/", label: "Home" },
+  work: { path: "/work", label: "Work / portfolio" },
+  about: { path: "/about", label: "About" },
+  pricing: { path: "/pricing", label: "Pricing" },
+  contact: { path: "/contact", label: "Contact" },
+  blog: { path: "/blog", label: "Blog index" },
+  "blog-article": {
+    path: "/blog/agentic-design-systems-operating-models",
+    label: "Blog article (sample)",
+  },
+  sitemap: { path: "/sitemap", label: "Sitemap" },
+  dsharp: {
+    path: "/work/dsharp-design-system",
+    label: "DSharp case study",
+  },
+};
+
+function buildCaptureUrl(localPath, captureId) {
+  const endpoint = encodeURIComponent(
+    `https://mcp.figma.com/mcp/capture/${captureId}/submit`,
+  );
+  return `${DEV_ORIGIN}${localPath}#figmacapture=${captureId}&figmaendpoint=${endpoint}&figmadelay=3000`;
+}
+
+function main() {
+  const routeArg = process.argv.indexOf("--route");
+  const captureArg = process.argv.indexOf("--capture-id");
+  const routeKey =
+    routeArg >= 0 ? process.argv[routeArg + 1] : undefined;
+  const captureId =
+    captureArg >= 0 ? process.argv[captureArg + 1] : undefined;
+
+  const state = JSON.parse(readFileSync(STATE_PATH, "utf8"));
+
+  console.log(`Figma file: ${FIGMA_FILE_KEY} (${FIGMA_FILE_SLUG})`);
+  console.log(`Dev origin: ${DEV_ORIGIN} (npm run dev:figma-capture)\n`);
+
+  if (routeKey) {
+    const route = CAPTURE_ROUTES[routeKey];
+    if (!route) {
+      console.error(`Unknown route "${routeKey}". Keys: ${Object.keys(CAPTURE_ROUTES).join(", ")}`);
+      process.exit(1);
+    }
+    console.log(`Route: ${routeKey} — ${route.label}`);
+    console.log(`Production: ${state.routeViews?.[routeKey]?.url ?? "—"}`);
+    const view = state.routeViews?.[routeKey];
+    if (view?.captureMethod === "html-to-design") {
+      console.log(`Current html-to-design node: ${view.nodeId}`);
+      console.log(view.figmaUrl);
+    } else if (view?.nodeId) {
+      console.log(`Legacy VIews frame: ${view.nodeId} (replace via new capture)`);
+    }
+    if (captureId) {
+      console.log(`\nOpen in browser:\n${buildCaptureUrl(route.path, captureId)}`);
+    } else {
+      console.log(
+        "\nNext: call generate_figma_design MCP (fileKey only) → pass --capture-id to print open URL.",
+      );
+    }
+    return;
+  }
+
+  console.log("Routes (html-to-design queue):\n");
+  for (const [key, route] of Object.entries(CAPTURE_ROUTES)) {
+    const view = state.routeViews?.[key];
+    const status =
+      view?.captureMethod === "html-to-design"
+        ? `✓ captured ${view.capturedAt ?? ""} → ${view.nodeId}`
+        : view?.nodeId
+          ? `legacy ${view.nodeId}`
+          : "pending";
+    console.log(`  ${key.padEnd(14)} ${route.path.padEnd(42)} ${status}`);
+  }
+
+  console.log(`
+Workflow:
+  1. npm run dev:figma-capture
+  2. generate_figma_design({ fileKey: "${FIGMA_FILE_KEY}" }) → captureId
+  3. node scripts/design-system/figma-html-capture-routes.mjs --route <key> --capture-id <id>
+  4. Open printed URL; poll generate_figma_design with captureId until completed
+  5. Update dsb-state.json routeViews.<key> (nodeId, captureMethod, capturedAt)
+  Do NOT run figma-rebuild-route-views.mjs on capture frames.
+`);
+}
+
+main();


### PR DESCRIPTION
## Summary

- Captured **`/work`** via html-to-design → Figma node **[671:2](https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=671-2)** (replaces legacy `615:33`)
- Updated `dsb-state.json` with capture metadata and Phase 15 queue
- Added **`npm run dev:figma-capture`** and **`npm run figma:capture-routes`** helper
- Documented capture workflow in `docs/FIGMA_DESIGN_SYSTEM_SYNC.md`

No bulk DS rebuild — pixel-perfect capture reference only.

## Test plan

- [x] `generate_figma_design` poll completed for `/work`
- [x] `npm run figma:capture-routes` lists work as captured
- [ ] Remaining 8 routes captured in follow-up PRs


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI tooling and npm scripts (`dev:figma-capture`, `figma:capture-routes`) to support HTML-to-design capture workflow
  * Enabled local capture configuration with debugging support

* **Documentation**
  * Added guidance for html-to-design capture process and end-to-end agent workflow with step-by-step commands

* **Chores**
  * Updated design system build state tracking with capture metadata and phase progression
  * Updated roadmap to reflect Phase 15 ("Figma capture loop") now in progress

<!-- end of auto-generated comment: release notes by coderabbit.ai -->