### PR TITLE
fix(figma): 1728px Playwright captures (no Cursor browser)

### DIFF
--- a/.planning/milestones/agentic-ds-v3/ROADMAP.md
+++ b/.planning/milestones/agentic-ds-v3/ROADMAP.md
@@ -14,7 +14,7 @@
 |-------|--------|--------|
 | **13** | Green `npm test` + CI full gate | **Done** (#698) |
 | **14** | Alpha → beta promotions (patterns with stories) | **Done** (#698) |
-| **15** | Figma capture loop (9 routes, surgical binding) | **In progress** (work ✓ html-to-design `671:2`) |
+| **15** | Figma capture loop (9 routes, surgical binding) | **In progress** (1728px Playwright; `/work` needs re-capture) |
 | **16** | Production consumer auto-sync + stable fleet growth | **Started** (transitive scan + release gate) |
 | **17** | AI-Ready DS Benchmark (public doc + consulting SKU) | **Started** |
 | **18** | npm export spike (`@digitaltableteur/ds`) | Pending |

--- a/docs/FIGMA_DESIGN_SYSTEM_SYNC.md
+++ b/docs/FIGMA_DESIGN_SYSTEM_SYNC.md
@@ -65,17 +65,22 @@ Or batch via Cursor agent: apply all `nextjs-app/shared/foundations/figma/.use-f
 
 Pixel-perfect references — **no bulk DS rebuild** on capture frames.
 
+**Viewport:** captures MUST run at **1728px** width. The Cursor IDE browser (~538px) is forbidden — layouts collapse to mobile.
+
 ```bash
 npm run dev:figma-capture          # injects capture.js via FIGMA_HTML_CAPTURE=1
-npm run figma:capture-routes       # queue status + open-URL helper
+npm run figma:capture-routes       # queue status
+npm run figma:run-capture -- --route work --capture-id <uuid>   # Playwright @ 1728px
 ```
 
 Agent workflow per route:
 
 1. `generate_figma_design({ fileKey: PC2UPdYwm8qGt6ZTg0AakF })` → `captureId`
-2. `node scripts/design-system/figma-html-capture-routes.mjs --route work --capture-id <id>` → open URL
+2. `npm run figma:run-capture -- --route <key> --capture-id <id>` (Playwright Chrome, **not** Cursor browser)
 3. Poll `generate_figma_design` with `captureId` until `completed`
-4. Record new `nodeId` in `nextjs-app/shared/foundations/figma/dsb-state.json`
+4. Record `nodeId` + `captureViewportWidth: 1728` in `dsb-state.json`
+
+Override width: `FIGMA_CAPTURE_WIDTH=1728` (default). Optional height: `FIGMA_CAPTURE_HEIGHT=1080`.
 
 Optional follow-up: surgical `use_figma` for header/footer variable binding only — not `figma-rebuild-route-views.mjs`.
 

--- a/nextjs-app/shared/foundations/figma/dsb-state.json
+++ b/nextjs-app/shared/foundations/figma/dsb-state.json
@@ -16,6 +16,9 @@
       "previousNodeId": "615:33",
       "captureMethod": "html-to-design",
       "capturedAt": "2026-06-06",
+      "captureViewportWidth": 538,
+      "needsRecapture": true,
+      "recaptureReason": "Captured via Cursor browser at 538px; require 1728px via npm run figma:run-capture",
       "page": "VIews",
       "url": "https://www.digitaltableteur.com/work",
       "figmaUrl": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=671-2"
@@ -114,12 +117,17 @@
     "phase4-contract-sync"
   ],
   "htmlCaptureQueue": {
-    "completed": ["work"],
-    "remaining": ["home", "about", "pricing", "contact", "blog", "blog-article", "sitemap", "dsharp"]
+    "completed": [],
+    "needsRecapture": ["work"],
+    "remaining": ["home", "about", "pricing", "contact", "blog", "blog-article", "sitemap", "dsharp", "work"]
   },
   "captureWorkflow": {
-    "preferred": "html-to-design via FIGMA_HTML_CAPTURE=1 + generate_figma_design",
-    "avoid": "Bulk DS instance replacement on capture frames (destroys pixel-perfect reference)"
+    "preferred": "html-to-design via FIGMA_HTML_CAPTURE=1 + generate_figma_design + figma:run-capture",
+    "viewportWidthPx": 1728,
+    "forbidden": [
+      "Cursor IDE browser (~538px viewport)",
+      "Bulk DS instance replacement on capture frames (destroys pixel-perfect reference)"
+    ]
   },
   "refinementNotes": {
     "applied": [

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "build:figma-variables": "node scripts/design-system/build-figma-variables-payload.mjs && node scripts/design-system/generate-figma-phase-scripts.mjs",
     "figma:apply-variables": "node scripts/design-system/apply-figma-variables-local.mjs",
     "figma:capture-routes": "node scripts/design-system/figma-html-capture-routes.mjs",
+    "figma:run-capture": "node scripts/design-system/figma-run-capture.mjs",
     "verify:figma-in-scope": "node scripts/design-system/verify-figma-in-scope.mjs",
     "check:contrast": "node scripts/design-system/check-contrast.mjs",
     "check:token-descriptions": "tsx scripts/design-system/check-token-descriptions.ts",

--- a/scripts/design-system/figma-html-capture-lib.mjs
+++ b/scripts/design-system/figma-html-capture-lib.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * Shared constants + URL builder for html-to-design route captures.
+ */
+import { readFileSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { FIGMA_FILE_KEY, FIGMA_FILE_SLUG } from "./figma-config.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+export const STATE_PATH = join(
+  ROOT,
+  "nextjs-app/shared/foundations/figma/dsb-state.json",
+);
+
+/** Required layout width for VIews captures (desktop). */
+export const CAPTURE_VIEWPORT_WIDTH = Number(
+  process.env.FIGMA_CAPTURE_WIDTH || 1728,
+);
+
+/** Initial viewport height; html-to-design captures full document scroll height. */
+export const CAPTURE_VIEWPORT_HEIGHT = Number(
+  process.env.FIGMA_CAPTURE_HEIGHT || 1080,
+);
+
+export const CAPTURE_DELAY_MS = Number(process.env.FIGMA_CAPTURE_DELAY || 3000);
+
+export const DEV_PORT = process.env.PORT || "3001";
+export const DEV_ORIGIN = `http://localhost:${DEV_PORT}`;
+
+/** @type {Record<string, { path: string, label: string }>} */
+export const CAPTURE_ROUTES = {
+  home: { path: "/", label: "Home" },
+  work: { path: "/work", label: "Work / portfolio" },
+  about: { path: "/about", label: "About" },
+  pricing: { path: "/pricing", label: "Pricing" },
+  contact: { path: "/contact", label: "Contact" },
+  blog: { path: "/blog", label: "Blog index" },
+  "blog-article": {
+    path: "/blog/agentic-design-systems-operating-models",
+    label: "Blog article (sample)",
+  },
+  sitemap: { path: "/sitemap", label: "Sitemap" },
+  dsharp: {
+    path: "/work/dsharp-design-system",
+    label: "DSharp case study",
+  },
+};
+
+export function readDsbState() {
+  return JSON.parse(readFileSync(STATE_PATH, "utf8"));
+}
+
+export function buildCaptureUrl(localPath, captureId) {
+  const endpoint = encodeURIComponent(
+    `https://mcp.figma.com/mcp/capture/${captureId}/submit`,
+  );
+  return `${DEV_ORIGIN}${localPath}#figmacapture=${captureId}&figmaendpoint=${endpoint}&figmadelay=${CAPTURE_DELAY_MS}`;
+}
+
+export function resolveRoute(routeKey) {
+  const route = CAPTURE_ROUTES[routeKey];
+  if (!route) {
+    throw new Error(
+      `Unknown route "${routeKey}". Keys: ${Object.keys(CAPTURE_ROUTES).join(", ")}`,
+    );
+  }
+  return route;
+}
+
+export { FIGMA_FILE_KEY, FIGMA_FILE_SLUG };

--- a/scripts/design-system/figma-html-capture-routes.mjs
+++ b/scripts/design-system/figma-html-capture-routes.mjs
@@ -1,51 +1,22 @@
 #!/usr/bin/env node
 /**
  * Route manifest for html-to-design Figma captures (Phase 15).
- * Does NOT mutate Figma — use generate_figma_design MCP + dev:figma-capture.
+ * Does NOT mutate Figma — use generate_figma_design MCP + figma:run-capture.
  *
  * Usage:
  *   npm run dev:figma-capture
- *   node scripts/design-system/figma-html-capture-routes.mjs
- *   node scripts/design-system/figma-html-capture-routes.mjs --route work --capture-id <uuid>
+ *   npm run figma:capture-routes
+ *   npm run figma:run-capture -- --route work --capture-id <uuid>
  */
-import { readFileSync } from "node:fs";
-import { join, resolve, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-import { FIGMA_FILE_KEY, FIGMA_FILE_SLUG } from "./figma-config.mjs";
-
-const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
-const STATE_PATH = join(
-  ROOT,
-  "nextjs-app/shared/foundations/figma/dsb-state.json",
-);
-const DEV_PORT = process.env.PORT || "3001";
-const DEV_ORIGIN = `http://localhost:${DEV_PORT}`;
-
-/** @type {Record<string, { path: string, label: string }>} */
-export const CAPTURE_ROUTES = {
-  home: { path: "/", label: "Home" },
-  work: { path: "/work", label: "Work / portfolio" },
-  about: { path: "/about", label: "About" },
-  pricing: { path: "/pricing", label: "Pricing" },
-  contact: { path: "/contact", label: "Contact" },
-  blog: { path: "/blog", label: "Blog index" },
-  "blog-article": {
-    path: "/blog/agentic-design-systems-operating-models",
-    label: "Blog article (sample)",
-  },
-  sitemap: { path: "/sitemap", label: "Sitemap" },
-  dsharp: {
-    path: "/work/dsharp-design-system",
-    label: "DSharp case study",
-  },
-};
-
-function buildCaptureUrl(localPath, captureId) {
-  const endpoint = encodeURIComponent(
-    `https://mcp.figma.com/mcp/capture/${captureId}/submit`,
-  );
-  return `${DEV_ORIGIN}${localPath}#figmacapture=${captureId}&figmaendpoint=${endpoint}&figmadelay=3000`;
-}
+import {
+  buildCaptureUrl,
+  CAPTURE_ROUTES,
+  CAPTURE_VIEWPORT_WIDTH,
+  DEV_ORIGIN,
+  FIGMA_FILE_KEY,
+  FIGMA_FILE_SLUG,
+  readDsbState,
+} from "./figma-html-capture-lib.mjs";
 
 function main() {
   const routeArg = process.argv.indexOf("--route");
@@ -55,31 +26,39 @@ function main() {
   const captureId =
     captureArg >= 0 ? process.argv[captureArg + 1] : undefined;
 
-  const state = JSON.parse(readFileSync(STATE_PATH, "utf8"));
+  const state = readDsbState();
 
   console.log(`Figma file: ${FIGMA_FILE_KEY} (${FIGMA_FILE_SLUG})`);
-  console.log(`Dev origin: ${DEV_ORIGIN} (npm run dev:figma-capture)\n`);
+  console.log(`Dev origin: ${DEV_ORIGIN} (npm run dev:figma-capture)`);
+  console.log(`Capture viewport: ${CAPTURE_VIEWPORT_WIDTH}px wide (required)\n`);
 
   if (routeKey) {
     const route = CAPTURE_ROUTES[routeKey];
     if (!route) {
-      console.error(`Unknown route "${routeKey}". Keys: ${Object.keys(CAPTURE_ROUTES).join(", ")}`);
+      console.error(
+        `Unknown route "${routeKey}". Keys: ${Object.keys(CAPTURE_ROUTES).join(", ")}`,
+      );
       process.exit(1);
     }
     console.log(`Route: ${routeKey} — ${route.label}`);
     console.log(`Production: ${state.routeViews?.[routeKey]?.url ?? "—"}`);
     const view = state.routeViews?.[routeKey];
-    if (view?.captureMethod === "html-to-design") {
+    if (view?.captureMethod === "html-to-design" && !view?.needsRecapture) {
       console.log(`Current html-to-design node: ${view.nodeId}`);
       console.log(view.figmaUrl);
+    } else if (view?.needsRecapture) {
+      console.log(`Needs re-capture: ${view.recaptureReason ?? "viewport invalid"}`);
     } else if (view?.nodeId) {
       console.log(`Legacy VIews frame: ${view.nodeId} (replace via new capture)`);
     }
     if (captureId) {
-      console.log(`\nOpen in browser:\n${buildCaptureUrl(route.path, captureId)}`);
+      console.log(`\nCapture URL:\n${buildCaptureUrl(route.path, captureId)}`);
+      console.log(
+        `\nRun capture (Playwright @ ${CAPTURE_VIEWPORT_WIDTH}px — NOT Cursor browser):\n  npm run figma:run-capture -- --route ${routeKey} --capture-id ${captureId}`,
+      );
     } else {
       console.log(
-        "\nNext: call generate_figma_design MCP (fileKey only) → pass --capture-id to print open URL.",
+        "\nNext: generate_figma_design MCP → captureId → figma:run-capture",
       );
     }
     return;
@@ -88,12 +67,16 @@ function main() {
   console.log("Routes (html-to-design queue):\n");
   for (const [key, route] of Object.entries(CAPTURE_ROUTES)) {
     const view = state.routeViews?.[key];
-    const status =
-      view?.captureMethod === "html-to-design"
-        ? `✓ captured ${view.capturedAt ?? ""} → ${view.nodeId}`
-        : view?.nodeId
-          ? `legacy ${view.nodeId}`
-          : "pending";
+    let status;
+    if (view?.needsRecapture) {
+      status = `↻ re-capture (${view.captureViewportWidth ?? "?"}px → ${CAPTURE_VIEWPORT_WIDTH}px)`;
+    } else if (view?.captureMethod === "html-to-design") {
+      status = `✓ ${view.capturedAt ?? ""} @ ${view.captureViewportWidth ?? "?"}px → ${view.nodeId}`;
+    } else if (view?.nodeId) {
+      status = `legacy ${view.nodeId}`;
+    } else {
+      status = "pending";
+    }
     console.log(`  ${key.padEnd(14)} ${route.path.padEnd(42)} ${status}`);
   }
 
@@ -101,9 +84,10 @@ function main() {
 Workflow:
   1. npm run dev:figma-capture
   2. generate_figma_design({ fileKey: "${FIGMA_FILE_KEY}" }) → captureId
-  3. node scripts/design-system/figma-html-capture-routes.mjs --route <key> --capture-id <id>
-  4. Open printed URL; poll generate_figma_design with captureId until completed
-  5. Update dsb-state.json routeViews.<key> (nodeId, captureMethod, capturedAt)
+  3. npm run figma:run-capture -- --route <key> --capture-id <id>
+     (Playwright Chrome @ ${CAPTURE_VIEWPORT_WIDTH}px — never Cursor browser ~538px)
+  4. Poll generate_figma_design with captureId until completed
+  5. Update dsb-state.json (nodeId, captureViewportWidth: ${CAPTURE_VIEWPORT_WIDTH})
   Do NOT run figma-rebuild-route-views.mjs on capture frames.
 `);
 }

--- a/scripts/design-system/figma-run-capture.mjs
+++ b/scripts/design-system/figma-run-capture.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * Open a route capture in Playwright Chromium at 1728px viewport.
+ * Do NOT use the Cursor IDE browser (~538px) — layouts will be wrong.
+ *
+ * Prereqs: npm run dev:figma-capture (FIGMA_HTML_CAPTURE=1 on :3001)
+ *
+ * Usage:
+ *   npm run figma:run-capture -- --route work --capture-id <uuid>
+ *
+ * After the page loads, poll generate_figma_design MCP with the same captureId.
+ */
+import { chromium } from "playwright";
+import {
+  buildCaptureUrl,
+  CAPTURE_DELAY_MS,
+  CAPTURE_VIEWPORT_HEIGHT,
+  CAPTURE_VIEWPORT_WIDTH,
+  resolveRoute,
+} from "./figma-html-capture-lib.mjs";
+
+function parseArgs() {
+  const routeIdx = process.argv.indexOf("--route");
+  const captureIdx = process.argv.indexOf("--capture-id");
+  const routeKey = routeIdx >= 0 ? process.argv[routeIdx + 1] : undefined;
+  const captureId = captureIdx >= 0 ? process.argv[captureIdx + 1] : undefined;
+  if (!routeKey || !captureId) {
+    console.error(
+      "Usage: npm run figma:run-capture -- --route <key> --capture-id <uuid>",
+    );
+    process.exit(1);
+  }
+  return { routeKey, captureId };
+}
+
+async function main() {
+  const { routeKey, captureId } = parseArgs();
+  const route = resolveRoute(routeKey);
+  const url = buildCaptureUrl(route.path, captureId);
+
+  console.log(`Capture viewport: ${CAPTURE_VIEWPORT_WIDTH}×${CAPTURE_VIEWPORT_HEIGHT}px`);
+  console.log(`Route: ${routeKey} (${route.label})`);
+  console.log(`URL: ${url}\n`);
+
+  const browser = await chromium.launch({
+    headless: false,
+    channel: "chrome",
+  });
+
+  try {
+    const context = await browser.newContext({
+      viewport: {
+        width: CAPTURE_VIEWPORT_WIDTH,
+        height: CAPTURE_VIEWPORT_HEIGHT,
+      },
+    });
+    const page = await context.newPage();
+    await page.goto(url, { waitUntil: "networkidle", timeout: 120_000 });
+
+    const waitMs = CAPTURE_DELAY_MS + 2000;
+    console.log(`Waiting ${waitMs}ms for html-to-design capture…`);
+    await page.waitForTimeout(waitMs);
+
+    const innerWidth = await page.evaluate(() => window.innerWidth);
+    console.log(`Document innerWidth: ${innerWidth}px`);
+    if (innerWidth !== CAPTURE_VIEWPORT_WIDTH) {
+      console.warn(
+        `Warning: innerWidth ${innerWidth} !== target ${CAPTURE_VIEWPORT_WIDTH}. Check browser zoom and dev server.`,
+      );
+    }
+    console.log(
+      "\nCapture submitted. Poll generate_figma_design with this captureId until completed.",
+    );
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds **`npm run figma:run-capture`** — Playwright Chrome at **1728×1080px** (configurable via `FIGMA_CAPTURE_WIDTH`)
- Documents **forbidden**: Cursor IDE browser (~538px) — wrong layout for VIews
- Marks **`/work`** capture (`671:2`) as **needsRecapture** (was 538px)

## Usage

```bash
npm run dev:figma-capture
# generate_figma_design → captureId
npm run figma:run-capture -- --route work --capture-id <uuid>
# poll generate_figma_design until completed
```


Made with [Cursor](https://cursor.com)