### PR TITLE
chore(ds): regenerate contract props — unblock dependabot validate gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,25 +19,24 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
-    # Group non-security updates to reduce PR noise
+    # Group ALL minor+patch updates into two PRs; majors stay individual.
+    # Previous pattern-based groups were too narrow and produced ~15
+    # single-bump PRs per week.
     groups:
       development-dependencies:
-        patterns:
-          - "@types/*"
-          - "eslint*"
-          - "prettier"
-          - "@testing-library/*"
-          - "vitest*"
+        dependency-type: "development"
         update-types:
           - "minor"
           - "patch"
       production-dependencies:
-        patterns:
-          - "react*"
-          - "next*"
-          - "@vercel/*"
+        dependency-type: "production"
         update-types:
+          - "minor"
           - "patch"
+    ignore:
+      # Pinned at 5.5.0 — 5.6 drops Adobe SI icons used on work pages
+      # (see CLAUDE.md gotchas). Bump only with a verified icon audit.
+      - dependency-name: "react-icons"
     # Security updates always get individual PRs
     versioning-strategy: "increase"
 
@@ -94,6 +93,13 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    groups:
+      blog-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -109,3 +115,10 @@ updates:
       - "github-actions"
     commit-message:
       prefix: "chore(ci)"
+    groups:
+      ci-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/nextjs-app/shared/components/AdaptiveLoadingButton/AdaptiveLoadingButton.contract.json
+++ b/nextjs-app/shared/components/AdaptiveLoadingButton/AdaptiveLoadingButton.contract.json
@@ -68,14 +68,6 @@
             "type": "React.ReactNode"
         }
     },
-    "composesWith": [
-        "Inputs",
-        "Button",
-        "Modal",
-        "Text",
-        "CheckboxGroup",
-        "Toast"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/AlertBanner/AlertBanner.contract.json
+++ b/nextjs-app/shared/components/AlertBanner/AlertBanner.contract.json
@@ -98,10 +98,6 @@
             ]
         }
     },
-    "composesWith": [
-        "Button",
-        "Icon"
-    ],
     "forbiddenUse": [
         "Pair AlertBanner with blocking Modal for the same user outcome — pick one surface",
         "make errors dismissable. Letting the user hide a blocking",

--- a/nextjs-app/shared/components/ArticleCard/ArticleCard.contract.json
+++ b/nextjs-app/shared/components/ArticleCard/ArticleCard.contract.json
@@ -68,14 +68,6 @@
             "type": "boolean"
         }
     },
-    "composesWith": [
-        "Grid",
-        "Avatar",
-        "Checkbox",
-        "CheckboxGroup",
-        "FlexBox",
-        "Inputs"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/ArticleContent/ArticleContent.contract.json
+++ b/nextjs-app/shared/components/ArticleContent/ArticleContent.contract.json
@@ -38,5 +38,27 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "children": {
+            "optional": false,
+            "type": "ReactNode"
+        },
+        "size": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ]
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/components/ArticleShareSection/ArticleShareSection.contract.json
+++ b/nextjs-app/shared/components/ArticleShareSection/ArticleShareSection.contract.json
@@ -37,5 +37,34 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "url": {
+            "optional": false,
+            "type": "string"
+        },
+        "title": {
+            "optional": false,
+            "type": "string"
+        },
+        "layout": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "horizontal",
+                "vertical"
+            ]
+        },
+        "showTitle": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/components/AuthorBio/AuthorBio.contract.json
+++ b/nextjs-app/shared/components/AuthorBio/AuthorBio.contract.json
@@ -58,10 +58,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Title",
-        "PageLayout"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/Avatar/Avatar.contract.json
+++ b/nextjs-app/shared/components/Avatar/Avatar.contract.json
@@ -136,14 +136,6 @@
             "type": "number"
         }
     },
-    "composesWith": [
-        "Text",
-        "Title",
-        "Grid",
-        "ArticleCard",
-        "Checkbox",
-        "CheckboxGroup"
-    ],
     "forbiddenUse": [
         "render two interactive children inside Avatar (link plus menu);",
         "nest an Avatar inside a Button. Pick one — Avatar already owns"

--- a/nextjs-app/shared/components/Badge/Badge.contract.json
+++ b/nextjs-app/shared/components/Badge/Badge.contract.json
@@ -192,14 +192,6 @@
             "type": "\"status\""
         }
     },
-    "composesWith": [
-        "Link",
-        "Button",
-        "Text",
-        "Title",
-        "FlexBox",
-        "Grid"
-    ],
     "forbiddenUse": [
         "rely on colour alone to convey state — pair with the icon (the",
         "nest a Button inside a Badge. The removable affordance is"

--- a/nextjs-app/shared/components/BlogCategoryFilter/BlogCategoryFilter.contract.json
+++ b/nextjs-app/shared/components/BlogCategoryFilter/BlogCategoryFilter.contract.json
@@ -47,5 +47,52 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "tags": {
+            "optional": false,
+            "type": "string[]"
+        },
+        "selectedTag": {
+            "optional": false,
+            "type": "string | null"
+        },
+        "onTagChange": {
+            "optional": false,
+            "type": "(tag: string | null) => void"
+        },
+        "showCounts": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "tagCounts": {
+            "optional": true,
+            "type": "Record<string, number>"
+        },
+        "variant": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "pills",
+                "underline",
+                "minimal"
+            ]
+        },
+        "size": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ]
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/components/BlogGrid/BlogGrid.contract.json
+++ b/nextjs-app/shared/components/BlogGrid/BlogGrid.contract.json
@@ -38,5 +38,39 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "articles": {
+            "optional": false,
+            "type": "EnhancedArticleCardProps[]"
+        },
+        "featuredSlug": {
+            "optional": true,
+            "type": "string"
+        },
+        "layout": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "standard",
+                "featured-first",
+                "masonry"
+            ]
+        },
+        "columns": {
+            "optional": true,
+            "type": "{\n    sm?: 1 | 2;\n    md?: 1 | 2 | 3;\n    lg?: 1 | 2 | 3 | 4;\n  }"
+        },
+        "hideImages": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/components/BlogMediaImage/BlogMediaImage.contract.json
+++ b/nextjs-app/shared/components/BlogMediaImage/BlogMediaImage.contract.json
@@ -28,5 +28,62 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "src": {
+            "optional": false,
+            "type": "string"
+        },
+        "alt": {
+            "optional": false,
+            "type": "string"
+        },
+        "fill": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "width": {
+            "optional": true,
+            "type": "number"
+        },
+        "height": {
+            "optional": true,
+            "type": "number"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        },
+        "priority": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "sizes": {
+            "optional": true,
+            "type": "string"
+        },
+        "onLoad": {
+            "optional": true,
+            "type": "() => void"
+        },
+        "onError": {
+            "optional": true,
+            "type": "() => void"
+        },
+        "fit": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "cover",
+                "contain"
+            ]
+        },
+        "fluid": {
+            "optional": true,
+            "type": "boolean"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/components/BusyIndicator/BusyIndicator.contract.json
+++ b/nextjs-app/shared/components/BusyIndicator/BusyIndicator.contract.json
@@ -95,12 +95,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Modal",
-        "Button",
-        "Text",
-        "Inputs"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/Button/Button.contract.json
+++ b/nextjs-app/shared/components/Button/Button.contract.json
@@ -332,14 +332,6 @@
             "type": "boolean"
         }
     },
-    "composesWith": [
-        "Title",
-        "Text",
-        "Icon",
-        "Inputs",
-        "Modal",
-        "CheckboxGroup"
-    ],
     "forbiddenUse": [
         "tertiary on dark or inverse backgrounds without explicit contrast verification",
         "isInverse on primary over transparent or gradient parents — use surface instead",

--- a/nextjs-app/shared/components/Card/Card.contract.json
+++ b/nextjs-app/shared/components/Card/Card.contract.json
@@ -358,14 +358,6 @@
             "type": "React.ReactNode"
         }
     },
-    "composesWith": [
-        "Title",
-        "Text",
-        "Button",
-        "PageLayout",
-        "MarkdownMessage",
-        "Icon"
-    ],
     "forbiddenUse": [
         "nest interactive controls inside a `link`-mode card. Use a",
         "hide critical state in `extra`. Right-aligned slots are easy to",

--- a/nextjs-app/shared/components/CategoryFilter/CategoryFilter.contract.json
+++ b/nextjs-app/shared/components/CategoryFilter/CategoryFilter.contract.json
@@ -105,12 +105,6 @@
             ]
         }
     },
-    "composesWith": [
-        "Container",
-        "Section",
-        "WorkHero",
-        "WorkGrid"
-    ],
     "forbiddenUse": [
         "Use as primary navigation — `CategoryFilter` is a UI control, not a nav surface; use `NavLink` for routes.",
         "Stack two filter rows when one composite control would do — readability collapses."

--- a/nextjs-app/shared/components/ChatWidget/ChatWidget.contract.json
+++ b/nextjs-app/shared/components/ChatWidget/ChatWidget.contract.json
@@ -66,14 +66,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Button",
-        "Text",
-        "Inputs",
-        "DonnyAvatar",
-        "Header",
-        "Footer"
-    ],
     "forbiddenUse": [
         "gate the widget behind user authentication. The widget is",
         "store chat history in cookies. The current storage is",

--- a/nextjs-app/shared/components/Checkbox/Checkbox.contract.json
+++ b/nextjs-app/shared/components/Checkbox/Checkbox.contract.json
@@ -113,14 +113,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Inputs",
-        "Button",
-        "Label",
-        "Text",
-        "Grid",
-        "ArticleCard"
-    ],
     "forbiddenUse": [
         "use `checked` directly. The prefixed `isChecked` name is the",
         "rely on the native `indeterminate` HTML attribute — there is"

--- a/nextjs-app/shared/components/CheckboxGroup/CheckboxGroup.contract.json
+++ b/nextjs-app/shared/components/CheckboxGroup/CheckboxGroup.contract.json
@@ -88,14 +88,6 @@
             "type": "(selectedOptions: string[]) => void"
         }
     },
-    "composesWith": [
-        "Inputs",
-        "Button",
-        "Text",
-        "Grid",
-        "ArticleCard",
-        "Avatar"
-    ],
     "forbiddenUse": [
         "render a CheckboxGroup with one option. It's an awkward",
         "nest a CheckboxGroup inside another CheckboxGroup. AT",

--- a/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.contract.json
+++ b/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.contract.json
@@ -80,12 +80,6 @@
             "type": "React.ReactNode"
         }
     },
-    "composesWith": [
-        "Container",
-        "Text",
-        "Title",
-        "Greeting"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/CodeSnippet/CodeSnippet.contract.json
+++ b/nextjs-app/shared/components/CodeSnippet/CodeSnippet.contract.json
@@ -111,13 +111,6 @@
             "type": "() => void"
         }
     },
-    "composesWith": [
-        "Icon",
-        "ComplianceCard",
-        "Button",
-        "Text",
-        "Card"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/ComplianceCard/ComplianceCard.contract.json
+++ b/nextjs-app/shared/components/ComplianceCard/ComplianceCard.contract.json
@@ -74,11 +74,6 @@
             "type": "string | Date"
         }
     },
-    "composesWith": [
-        "Icon",
-        "CodeSnippet",
-        "Button"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/ContactForm/ContactForm.contract.json
+++ b/nextjs-app/shared/components/ContactForm/ContactForm.contract.json
@@ -50,13 +50,6 @@
     "consumers": [],
     "schemaVersion": 2,
     "props": {},
-    "composesWith": [
-        "FormField",
-        "Inputs",
-        "Button",
-        "Text",
-        "CheckboxGroup"
-    ],
     "forbiddenUse": [
         "pass props. The component intentionally accepts none. If",
         "swallow the `/api/contact` endpoint. The submit handler",

--- a/nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.contract.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.contract.json
@@ -58,9 +58,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "ContactFormSuccessEditorial"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/Container/Container.contract.json
+++ b/nextjs-app/shared/components/Container/Container.contract.json
@@ -265,13 +265,6 @@
             ]
         }
     },
-    "composesWith": [
-        "Section",
-        "ScrollIndicator",
-        "CodeBlockWindow",
-        "Text",
-        "Title"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/CookieConsent/CookieConsent.contract.json
+++ b/nextjs-app/shared/components/CookieConsent/CookieConsent.contract.json
@@ -48,10 +48,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Button",
-        "Text"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/Divider/Divider.contract.json
+++ b/nextjs-app/shared/components/Divider/Divider.contract.json
@@ -66,10 +66,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Layout",
-        "TextLink"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/EnhancedProjectCard/EnhancedProjectCard.contract.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/EnhancedProjectCard.contract.json
@@ -109,10 +109,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Container",
-        "Section"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/FileUpload/FileUpload.contract.json
+++ b/nextjs-app/shared/components/FileUpload/FileUpload.contract.json
@@ -128,14 +128,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Button",
-        "Inputs",
-        "Modal",
-        "Select",
-        "PhoneInput",
-        "CheckboxGroup"
-    ],
     "forbiddenUse": [
         "render two FileUploads in the same form without unique",
         "rely on `value` for \"the file is already on the server\".",

--- a/nextjs-app/shared/components/FlexBox/FlexBox.contract.json
+++ b/nextjs-app/shared/components/FlexBox/FlexBox.contract.json
@@ -131,14 +131,6 @@
             "type": "React.ReactNode"
         }
     },
-    "composesWith": [
-        "Badge",
-        "Title",
-        "Grid",
-        "ArticleCard",
-        "Avatar",
-        "Checkbox"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/FormField/FormField.contract.json
+++ b/nextjs-app/shared/components/FormField/FormField.contract.json
@@ -83,11 +83,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Label",
-        "Inputs",
-        "HelperText"
-    ],
     "forbiddenUse": [
         "Render a bare `<label>` + `<input>` next to a `FormField` in the same form — the visual rhythm desyncs.",
         "Put two controls inside one `FormField` — wrap each in its own."

--- a/nextjs-app/shared/components/Gallery/Gallery.contract.json
+++ b/nextjs-app/shared/components/Gallery/Gallery.contract.json
@@ -64,14 +64,6 @@
             "type": "number"
         }
     },
-    "composesWith": [
-        "Text",
-        "Title",
-        "ProcessBlock",
-        "StoryBlock",
-        "ProjectDetailLayout",
-        "ProjectHero"
-    ],
     "forbiddenUse": [
         "Use as a navigation surface — gallery items are not links.",
         "Auto-open the lightbox on mount — confine motion to explicit user actions."

--- a/nextjs-app/shared/components/Grid/Grid.contract.json
+++ b/nextjs-app/shared/components/Grid/Grid.contract.json
@@ -150,14 +150,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Link",
-        "ArticleCard",
-        "Avatar",
-        "Checkbox",
-        "CheckboxGroup",
-        "FlexBox"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/HelperText/HelperText.contract.json
+++ b/nextjs-app/shared/components/HelperText/HelperText.contract.json
@@ -69,12 +69,6 @@
             ]
         }
     },
-    "composesWith": [
-        "Label",
-        "Icon",
-        "Button",
-        "Inputs"
-    ],
     "forbiddenUse": [
         "render multiple `state=\"error\"` HelperTexts under one field —",
         "use HelperText for page-level messages. AlertBanner and Toast"

--- a/nextjs-app/shared/components/Icon/Icon.contract.json
+++ b/nextjs-app/shared/components/Icon/Icon.contract.json
@@ -184,9 +184,9 @@
             "optional": true,
             "type": "union",
             "values": [
-                "both",
                 "horizontal",
-                "vertical"
+                "vertical",
+                "both"
             ]
         },
         "spin": {
@@ -210,14 +210,6 @@
             "type": "boolean"
         }
     },
-    "composesWith": [
-        "Button",
-        "Title",
-        "ComplianceCard",
-        "CodeSnippet",
-        "Text",
-        "HelperText"
-    ],
     "forbiddenUse": [
         "pass both `ariaLabel` and `decorative`. The component prefers",
         "import a Phosphor component directly from `@phosphor-icons/react`"

--- a/nextjs-app/shared/components/IconButton/IconButton.contract.json
+++ b/nextjs-app/shared/components/IconButton/IconButton.contract.json
@@ -97,12 +97,6 @@
             ]
         }
     },
-    "composesWith": [
-        "ThemeProvider",
-        "NavLink",
-        "Container",
-        "LanguageSwitcher"
-    ],
     "forbiddenUse": [
         "Omit `label` — there is no fallback announcement.",
         "Use for primary marketing CTAs — text + icon is more discoverable; use `Button` with an icon prop."

--- a/nextjs-app/shared/components/Inputs/Inputs.contract.json
+++ b/nextjs-app/shared/components/Inputs/Inputs.contract.json
@@ -128,14 +128,6 @@
             "type": "(value: string | number) => void"
         }
     },
-    "composesWith": [
-        "Button",
-        "Text",
-        "Modal",
-        "CheckboxGroup",
-        "Checkbox",
-        "Select"
-    ],
     "forbiddenUse": [
         "ship a form that relies on the email validator as the only",
         "pass a `value` plus a `defaultValue`. The component treats",

--- a/nextjs-app/shared/components/Label/Label.contract.json
+++ b/nextjs-app/shared/components/Label/Label.contract.json
@@ -130,14 +130,6 @@
             "type": "boolean"
         }
     },
-    "composesWith": [
-        "Inputs",
-        "HelperText",
-        "Button",
-        "Checkbox",
-        "Text",
-        "Title"
-    ],
     "forbiddenUse": [
         "place validation errors inside Label. Errors belong to the",
         "use a Label as a section heading. Headings carry navigation"

--- a/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.contract.json
+++ b/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.contract.json
@@ -83,11 +83,5 @@
             "optional": true,
             "type": "string"
         }
-    },
-    "composesWith": [
-        "ThemeProvider",
-        "NavLink",
-        "Container",
-        "IconButton"
-    ]
+    }
 }

--- a/nextjs-app/shared/components/Layout/Layout.contract.json
+++ b/nextjs-app/shared/components/Layout/Layout.contract.json
@@ -44,10 +44,6 @@
             "type": "React.ReactNode"
         }
     },
-    "composesWith": [
-        "Divider",
-        "TextLink"
-    ],
     "forbiddenUse": [
         "Render `Layout` inside another `Layout` — there is one global shell per page.",
         "Use as a generic 'two-column with sidebar' wrapper — that is what a section pattern would be."

--- a/nextjs-app/shared/components/Link/Link.contract.json
+++ b/nextjs-app/shared/components/Link/Link.contract.json
@@ -131,15 +131,8 @@
             ]
         }
     },
-    "composesWith": [
-        "Button",
-        "Text",
-        "Badge",
-        "Title",
-        "Grid",
-        "ArticleCard"
-    ],
     "forbiddenUse": [
+        "rely on the component's URL sanitisation. Don't pre-sanitise — the",
         "use Link for actions. Buttons are for actions; anchors are for",
         "override the underline via inline styles. The token-driven"
     ],

--- a/nextjs-app/shared/components/List/List.contract.json
+++ b/nextjs-app/shared/components/List/List.contract.json
@@ -149,10 +149,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Title",
-        "Text"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.contract.json
+++ b/nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.contract.json
@@ -86,14 +86,6 @@
             ]
         }
     },
-    "composesWith": [
-        "Card",
-        "Button",
-        "Text",
-        "Title",
-        "PageLayout",
-        "OpenHours"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/Modal/Modal.contract.json
+++ b/nextjs-app/shared/components/Modal/Modal.contract.json
@@ -184,15 +184,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Button",
-        "Title",
-        "Text",
-        "Inputs",
-        "Select",
-        "FileUpload",
-        "PhoneInput"
-    ],
     "forbiddenUse": [
         "Nested modals — swap content in place inside one overlay",
         "Lazy-mounting Modal only when isOpen — mount always and toggle isOpen for focus restore",

--- a/nextjs-app/shared/components/MultiCombobox/MultiCombobox.contract.json
+++ b/nextjs-app/shared/components/MultiCombobox/MultiCombobox.contract.json
@@ -98,10 +98,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Button",
-        "FileUpload"
-    ],
     "forbiddenUse": [
         "use for single-select — use `Combobox` instead."
     ]

--- a/nextjs-app/shared/components/NavLink/NavLink.contract.json
+++ b/nextjs-app/shared/components/NavLink/NavLink.contract.json
@@ -72,13 +72,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "ThemeProvider",
-        "IconButton",
-        "Container",
-        "LanguageSwitcher",
-        "SkipLink"
-    ],
     "forbiddenUse": [
         "Use inside body prose — that is `TextLink`.",
         "Use as a button — primary actions belong on `Button`."

--- a/nextjs-app/shared/components/OpenHours/OpenHours.contract.json
+++ b/nextjs-app/shared/components/OpenHours/OpenHours.contract.json
@@ -64,12 +64,6 @@
             "type": "Date"
         }
     },
-    "composesWith": [
-        "MarkdownMessage",
-        "ServicesGrid",
-        "StudioMap",
-        "DonnyBookingEmbed"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/Pagination/Pagination.contract.json
+++ b/nextjs-app/shared/components/Pagination/Pagination.contract.json
@@ -73,13 +73,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Container",
-        "Section",
-        "BlogCategoryFilter",
-        "BlogGrid",
-        "EnhancedArticleCard"
-    ],
     "forbiddenUse": [
         "Remove Previous/Next on edges — use `aria-disabled` so the visual stays stable.",
         "Render more than ~10 page numbers inline — switch to a 'Page X of Y' label with prev/next only."

--- a/nextjs-app/shared/components/PhoneInput/PhoneInput.contract.json
+++ b/nextjs-app/shared/components/PhoneInput/PhoneInput.contract.json
@@ -72,14 +72,6 @@
             "type": "(value: string | undefined) => void"
         }
     },
-    "composesWith": [
-        "Inputs",
-        "Button",
-        "Modal",
-        "Select",
-        "FileUpload",
-        "CheckboxGroup"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/ProjectCard/ProjectCard.contract.json
+++ b/nextjs-app/shared/components/ProjectCard/ProjectCard.contract.json
@@ -28,5 +28,52 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "title": {
+            "optional": false,
+            "type": "string"
+        },
+        "slug": {
+            "optional": false,
+            "type": "string"
+        },
+        "thumbnail": {
+            "optional": false,
+            "type": "string"
+        },
+        "category": {
+            "optional": true,
+            "type": "string"
+        },
+        "tags": {
+            "optional": true,
+            "type": "string[]"
+        },
+        "aspectRatio": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "video",
+                "square",
+                "portrait",
+                "landscape"
+            ]
+        },
+        "titlePosition": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "overlay",
+                "below"
+            ]
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/components/ProjectGallery/ProjectGallery.contract.json
+++ b/nextjs-app/shared/components/ProjectGallery/ProjectGallery.contract.json
@@ -28,5 +28,44 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "images": {
+            "optional": false,
+            "type": "GalleryImage[]"
+        },
+        "columns": {
+            "optional": true,
+            "type": "2 | 3 | 4"
+        },
+        "gap": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ]
+        },
+        "aspectRatio": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "mixed",
+                "video",
+                "square"
+            ]
+        },
+        "enableLightbox": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/components/ProjectNav/ProjectNav.contract.json
+++ b/nextjs-app/shared/components/ProjectNav/ProjectNav.contract.json
@@ -28,5 +28,18 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "currentSlug": {
+            "optional": false,
+            "type": "string"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/components/Section/Section.contract.json
+++ b/nextjs-app/shared/components/Section/Section.contract.json
@@ -85,13 +85,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Container",
-        "ScrollIndicator",
-        "EnhancedProjectCard",
-        "WorkHero",
-        "CategoryFilter"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.contract.json
+++ b/nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.contract.json
@@ -68,10 +68,6 @@
             "type": "boolean"
         }
     },
-    "composesWith": [
-        "Section",
-        "Container"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/Select/Select.contract.json
+++ b/nextjs-app/shared/components/Select/Select.contract.json
@@ -107,14 +107,6 @@
             "type": "(value: string) => void"
         }
     },
-    "composesWith": [
-        "Inputs",
-        "Button",
-        "Modal",
-        "FileUpload",
-        "PhoneInput",
-        "CheckboxGroup"
-    ],
     "forbiddenUse": [
         "ship a Select with `value` and `defaultValue` both set —",
         "use Select for a freeform value with suggestions. Use an",

--- a/nextjs-app/shared/components/ServiceCard/ServiceCard.contract.json
+++ b/nextjs-app/shared/components/ServiceCard/ServiceCard.contract.json
@@ -83,8 +83,8 @@
             "type": "union",
             "values": [
                 "default",
-                "elevated",
                 "minimal",
+                "elevated",
                 "bordered"
             ]
         },

--- a/nextjs-app/shared/components/ServicesGrid/ServicesGrid.contract.json
+++ b/nextjs-app/shared/components/ServicesGrid/ServicesGrid.contract.json
@@ -48,12 +48,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "MarkdownMessage",
-        "OpenHours",
-        "StudioMap",
-        "DonnyBookingEmbed"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/Skeleton/Skeleton.contract.json
+++ b/nextjs-app/shared/components/Skeleton/Skeleton.contract.json
@@ -97,9 +97,6 @@
             "type": "boolean"
         }
     },
-    "composesWith": [
-        "Text"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/SkipLink/SkipLink.contract.json
+++ b/nextjs-app/shared/components/SkipLink/SkipLink.contract.json
@@ -57,9 +57,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "NavLink"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/Tabs/Tabs.contract.json
+++ b/nextjs-app/shared/components/Tabs/Tabs.contract.json
@@ -126,13 +126,6 @@
             ]
         }
     },
-    "composesWith": [
-        "Title",
-        "Text",
-        "Link",
-        "Button",
-        "Badge"
-    ],
     "forbiddenUse": [
         "nest tablists inside another tablist. APG explicitly disallows",
         "use Tabs for non-mutually-exclusive content. Two panels open",

--- a/nextjs-app/shared/components/Text/Text.contract.json
+++ b/nextjs-app/shared/components/Text/Text.contract.json
@@ -189,14 +189,6 @@
             ]
         }
     },
-    "composesWith": [
-        "Title",
-        "StoryBlock",
-        "ProjectDetailLayout",
-        "ProjectHero",
-        "RelatedProjects",
-        "Button"
-    ],
     "forbiddenUse": [
         "nest a `<Text as=\"p\">` inside another `<p>`. HTML rejects nested",
         "override font-size via inline `style`. The ladder is the contract;"

--- a/nextjs-app/shared/components/TextArea/TextArea.contract.json
+++ b/nextjs-app/shared/components/TextArea/TextArea.contract.json
@@ -105,9 +105,9 @@
             "optional": true,
             "type": "union",
             "values": [
+                "vertical",
                 "none",
-                "both",
-                "vertical"
+                "both"
             ]
         }
     },

--- a/nextjs-app/shared/components/TextLink/TextLink.contract.json
+++ b/nextjs-app/shared/components/TextLink/TextLink.contract.json
@@ -92,10 +92,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Divider",
-        "Layout"
-    ],
     "forbiddenUse": [
         "Use as a button — opening a dialog or running a side-effect is a `Button` job.",
         "Style as an icon — wrap an icon link in `IconButton` (with `aria-label`) instead."

--- a/nextjs-app/shared/components/ThemeProvider/ThemeProvider.contract.json
+++ b/nextjs-app/shared/components/ThemeProvider/ThemeProvider.contract.json
@@ -48,13 +48,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "NavLink",
-        "IconButton",
-        "Icon",
-        "Container",
-        "LanguageSwitcher"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/components/Title/Title.contract.json
+++ b/nextjs-app/shared/components/Title/Title.contract.json
@@ -192,14 +192,6 @@
             ]
         }
     },
-    "composesWith": [
-        "Text",
-        "Button",
-        "ProjectDetailLayout",
-        "StoryBlock",
-        "ProjectHero",
-        "RelatedProjects"
-    ],
     "forbiddenUse": [
         "Default Title typography on pattern headings that already define font-display or module classes — use unstyled + existing className",
         "visually size a heading by passing custom inline styles — use the",

--- a/nextjs-app/shared/components/Toast/Toast.contract.json
+++ b/nextjs-app/shared/components/Toast/Toast.contract.json
@@ -140,14 +140,6 @@
             "type": "() => void"
         }
     },
-    "composesWith": [
-        "Button",
-        "Text",
-        "Modal",
-        "Inputs",
-        "CheckboxGroup",
-        "Select"
-    ],
     "forbiddenUse": [
         "stack toasts. The provider queues them — calling `showToast`",
         "rely on Toast for compliance acknowledgements (cookie consent,",

--- a/nextjs-app/shared/components/WorkGrid/WorkGrid.contract.json
+++ b/nextjs-app/shared/components/WorkGrid/WorkGrid.contract.json
@@ -28,5 +28,40 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "projects": {
+            "optional": false,
+            "type": "Project[]"
+        },
+        "columns": {
+            "optional": true,
+            "type": "2 | 3 | 4"
+        },
+        "animateItems": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "aspectRatio": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "video",
+                "square",
+                "portrait",
+                "landscape"
+            ]
+        },
+        "showCategory": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/AboutHero/AboutHero.contract.json
+++ b/nextjs-app/shared/patterns/AboutHero/AboutHero.contract.json
@@ -28,5 +28,39 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "title": {
+            "optional": false,
+            "type": "string"
+        },
+        "subtitle": {
+            "optional": true,
+            "type": "string"
+        },
+        "background": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "image",
+                "minimal",
+                "gradient"
+            ]
+        },
+        "backgroundImage": {
+            "optional": true,
+            "type": "string"
+        },
+        "showScrollIndicator": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/ArticleHero/ArticleHero.contract.json
+++ b/nextjs-app/shared/patterns/ArticleHero/ArticleHero.contract.json
@@ -38,5 +38,47 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "title": {
+            "optional": false,
+            "type": "string"
+        },
+        "image": {
+            "optional": true,
+            "type": "{\n    src: string;\n    alt: string;\n    caption?: string;\n  }"
+        },
+        "author": {
+            "optional": true,
+            "type": "{\n    name: string;\n    slug?: string;\n    imageUrl?: string;\n  }"
+        },
+        "publishedAt": {
+            "optional": true,
+            "type": "string"
+        },
+        "readTime": {
+            "optional": true,
+            "type": "string"
+        },
+        "tags": {
+            "optional": true,
+            "type": "string[]"
+        },
+        "variant": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "minimal",
+                "full-width",
+                "contained"
+            ]
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/ArticleLayout/ArticleLayout.contract.json
+++ b/nextjs-app/shared/patterns/ArticleLayout/ArticleLayout.contract.json
@@ -28,5 +28,46 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "nav": {
+            "optional": true,
+            "type": "ReactNode"
+        },
+        "hero": {
+            "optional": false,
+            "type": "ReactNode"
+        },
+        "children": {
+            "optional": false,
+            "type": "ReactNode"
+        },
+        "sidebar": {
+            "optional": true,
+            "type": "ReactNode"
+        },
+        "relatedPosts": {
+            "optional": true,
+            "type": "ReactNode"
+        },
+        "showReadingProgress": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "contentRef": {
+            "optional": true,
+            "type": "RefObject<HTMLElement | null>"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        },
+        "lang": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.contract.json
+++ b/nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.contract.json
@@ -28,5 +28,38 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "post": {
+            "optional": false,
+            "type": "BlogPostEntry"
+        },
+        "nav": {
+            "optional": true,
+            "type": "ReactNode"
+        },
+        "shareBaseUrl": {
+            "optional": true,
+            "type": "string"
+        },
+        "showTOC": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "showRelated": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "showReadingProgress": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/BlogHero/BlogHero.contract.json
+++ b/nextjs-app/shared/patterns/BlogHero/BlogHero.contract.json
@@ -37,5 +37,42 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "title": {
+            "optional": true,
+            "type": "string"
+        },
+        "subtitle": {
+            "optional": true,
+            "type": "string"
+        },
+        "showScrollIndicator": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "scrollTargetId": {
+            "optional": true,
+            "type": "string"
+        },
+        "variant": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "full",
+                "compact"
+            ]
+        },
+        "id": {
+            "optional": true,
+            "type": "string"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.contract.json
+++ b/nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.contract.json
@@ -28,5 +28,59 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "postsPerPage": {
+            "optional": true,
+            "type": "number"
+        },
+        "showHero": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "heroVariant": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "full",
+                "compact"
+            ]
+        },
+        "showFilter": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "filterVariant": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "pills",
+                "underline",
+                "minimal"
+            ]
+        },
+        "showPagination": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "gridLayout": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "standard",
+                "featured-first"
+            ]
+        },
+        "hideImages": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/CTASection/CTASection.contract.json
+++ b/nextjs-app/shared/patterns/CTASection/CTASection.contract.json
@@ -108,14 +108,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "HomeHero",
-        "ServicesSection",
-        "WorkMagneticField",
-        "NewsBulletin",
-        "DesignSprintsSection",
-        "HighlightSection"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.contract.json
+++ b/nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.contract.json
@@ -28,5 +28,35 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "title": {
+            "optional": false,
+            "type": "string"
+        },
+        "description": {
+            "optional": false,
+            "type": "string"
+        },
+        "email": {
+            "optional": false,
+            "type": "string"
+        },
+        "background": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "primary",
+                "dark",
+                "gradient"
+            ]
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.contract.json
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.contract.json
@@ -54,7 +54,11 @@
     "props": {
         "initialMode": {
             "optional": true,
-            "type": "ContactInquiryMode"
+            "type": "union",
+            "values": [
+                "message",
+                "book"
+            ]
         },
         "packageId": {
             "optional": true,
@@ -69,13 +73,8 @@
             "type": "SiteBookingConfig"
         }
     },
-    "composesWith": [
-        "Button",
-        "ContactFormEditorial",
-        "DonnyBookingEmbed"
-    ],
     "forbiddenUse": [
-        "Use without a messagePanel slot — the form lives in the parent composition.",
-        "Duplicate tablist landmarks on the same contact page."
+        "mount without messagePanel slot",
+        "duplicate tablist landmarks on the same page"
     ]
 }

--- a/nextjs-app/shared/patterns/ContentSection/ContentSection.contract.json
+++ b/nextjs-app/shared/patterns/ContentSection/ContentSection.contract.json
@@ -28,5 +28,57 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "subtitle": {
+            "optional": true,
+            "type": "string"
+        },
+        "title": {
+            "optional": false,
+            "type": "string"
+        },
+        "content": {
+            "optional": true,
+            "type": "ReactNode"
+        },
+        "images": {
+            "optional": true,
+            "type": "ContentImage | ContentImage[]"
+        },
+        "imageLayout": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "none",
+                "grid",
+                "single",
+                "side-by-side"
+            ]
+        },
+        "background": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "default",
+                "muted",
+                "accent"
+            ]
+        },
+        "centered": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        },
+        "donnyTarget": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.contract.json
+++ b/nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.contract.json
@@ -56,14 +56,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "HomeHero",
-        "ServicesSection",
-        "WorkMagneticField",
-        "CTASection",
-        "NewsBulletin",
-        "HighlightSection"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/patterns/Footer/Footer.contract.json
+++ b/nextjs-app/shared/patterns/Footer/Footer.contract.json
@@ -48,11 +48,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Button",
-        "ChatWidget",
-        "Header"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/patterns/GridBlock/GridBlock.contract.json
+++ b/nextjs-app/shared/patterns/GridBlock/GridBlock.contract.json
@@ -114,14 +114,6 @@
             ]
         }
     },
-    "composesWith": [
-        "Text",
-        "StoryBlock",
-        "ProjectDetailLayout",
-        "ProjectHero",
-        "RelatedProjects",
-        "ProcessBlock"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/patterns/Header/Header.contract.json
+++ b/nextjs-app/shared/patterns/Header/Header.contract.json
@@ -60,11 +60,6 @@
             "type": "(code: string) => void"
         }
     },
-    "composesWith": [
-        "Button",
-        "ChatWidget",
-        "Footer"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/patterns/HighlightSection/HighlightSection.contract.json
+++ b/nextjs-app/shared/patterns/HighlightSection/HighlightSection.contract.json
@@ -122,14 +122,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "HomeHero",
-        "ServicesSection",
-        "WorkMagneticField",
-        "CTASection",
-        "NewsBulletin",
-        "DesignSprintsSection"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/patterns/HomeHero/HomeHero.contract.json
+++ b/nextjs-app/shared/patterns/HomeHero/HomeHero.contract.json
@@ -53,14 +53,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "ServicesSection",
-        "WorkMagneticField",
-        "CTASection",
-        "NewsBulletin",
-        "DesignSprintsSection",
-        "HighlightSection"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/patterns/ManifestoSection/ManifestoSection.contract.json
+++ b/nextjs-app/shared/patterns/ManifestoSection/ManifestoSection.contract.json
@@ -28,5 +28,39 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "title": {
+            "optional": false,
+            "type": "string"
+        },
+        "tokens": {
+            "optional": false,
+            "type": "ManifestoToken[]"
+        },
+        "interval": {
+            "optional": true,
+            "type": "number"
+        },
+        "separator": {
+            "optional": true,
+            "type": "string"
+        },
+        "background": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "muted",
+                "gradient",
+                "transparent"
+            ]
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.contract.json
+++ b/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.contract.json
@@ -55,13 +55,8 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Link",
-        "Icon",
-        "Text"
-    ],
     "forbiddenUse": [
-        "Use BlogGrid for full article listings instead of this strip.",
-        "Do not hardcode bulletin copy outside news-bulletin data module."
+        "use for full blog indexes or article lists",
+        "replace with generic Card stacks without region semantics"
     ]
 }

--- a/nextjs-app/shared/patterns/PageLayout/PageLayout.contract.json
+++ b/nextjs-app/shared/patterns/PageLayout/PageLayout.contract.json
@@ -114,14 +114,6 @@
             "type": "React.CSSProperties"
         }
     },
-    "composesWith": [
-        "Title",
-        "Card",
-        "Text",
-        "Button",
-        "MarkdownMessage",
-        "AuthorBio"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.contract.json
+++ b/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.contract.json
@@ -52,14 +52,8 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Button",
-        "Icon",
-        "Text",
-        "Title"
-    ],
     "forbiddenUse": [
-        "Inline pricing card without full page context.",
-        "Hardcode package copy outside i18n keys."
+        "embed single package card without page context",
+        "promote to stable without visual baseline on stable fleet"
     ]
 }

--- a/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.contract.json
+++ b/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.contract.json
@@ -120,14 +120,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Text",
-        "StoryBlock",
-        "ProjectDetailLayout",
-        "ProjectHero",
-        "RelatedProjects",
-        "GridBlock"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/patterns/ProjectDetailLayout/ProjectDetailLayout.contract.json
+++ b/nextjs-app/shared/patterns/ProjectDetailLayout/ProjectDetailLayout.contract.json
@@ -28,5 +28,42 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "nav": {
+            "optional": true,
+            "type": "ReactNode"
+        },
+        "hero": {
+            "optional": false,
+            "type": "ReactNode"
+        },
+        "children": {
+            "optional": false,
+            "type": "ReactNode"
+        },
+        "cta": {
+            "optional": true,
+            "type": "ReactNode | null"
+        },
+        "relatedProjects": {
+            "optional": true,
+            "type": "ReactNode"
+        },
+        "showScrollProgress": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        },
+        "donnyTarget": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/ProjectDetailTemplate/ProjectDetailTemplate.contract.json
+++ b/nextjs-app/shared/patterns/ProjectDetailTemplate/ProjectDetailTemplate.contract.json
@@ -28,5 +28,42 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "project": {
+            "optional": false,
+            "type": "Project"
+        },
+        "hero": {
+            "optional": false,
+            "type": "{\n    image: ProjectHeroImage;\n    variant?: \"full-width\" | \"contained\" | \"split\";\n  }"
+        },
+        "meta": {
+            "optional": false,
+            "type": "{\n    services: string[];\n    duration?: string;\n    tools?: ToolItem[];\n    team?: TeamMember[];\n    client?: ClientInf"
+        },
+        "sections": {
+            "optional": false,
+            "type": "ContentSectionProps[]"
+        },
+        "gallery": {
+            "optional": true,
+            "type": "GalleryImage[]"
+        },
+        "relatedEnabled": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "nav": {
+            "optional": true,
+            "type": "ReactNode"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/ProjectHero/ProjectHero.contract.json
+++ b/nextjs-app/shared/patterns/ProjectHero/ProjectHero.contract.json
@@ -38,5 +38,59 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "title": {
+            "optional": false,
+            "type": "string"
+        },
+        "description": {
+            "optional": true,
+            "type": "string"
+        },
+        "image": {
+            "optional": true,
+            "type": "ProjectHeroImage"
+        },
+        "video": {
+            "optional": true,
+            "type": "ProjectHeroVideo"
+        },
+        "category": {
+            "optional": true,
+            "type": "string"
+        },
+        "tags": {
+            "optional": true,
+            "type": "string[]"
+        },
+        "date": {
+            "optional": true,
+            "type": "string"
+        },
+        "liveUrl": {
+            "optional": true,
+            "type": "string"
+        },
+        "variant": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "full-width",
+                "contained",
+                "split"
+            ]
+        },
+        "showScrollIndicator": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/ProjectMetaSection/ProjectMetaSection.contract.json
+++ b/nextjs-app/shared/patterns/ProjectMetaSection/ProjectMetaSection.contract.json
@@ -28,5 +28,62 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "services": {
+            "optional": false,
+            "type": "string[]"
+        },
+        "duration": {
+            "optional": true,
+            "type": "string"
+        },
+        "tools": {
+            "optional": true,
+            "type": "ToolItem[]"
+        },
+        "team": {
+            "optional": true,
+            "type": "TeamMember[]"
+        },
+        "client": {
+            "optional": true,
+            "type": "ClientInfo"
+        },
+        "overview": {
+            "optional": true,
+            "type": "ReactNode"
+        },
+        "background": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "default",
+                "muted",
+                "accent"
+            ]
+        },
+        "maxWidth": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "sm",
+                "md",
+                "lg",
+                "xl",
+                "full"
+            ]
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        },
+        "donnyTarget": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/RelatedPosts/RelatedPosts.contract.json
+++ b/nextjs-app/shared/patterns/RelatedPosts/RelatedPosts.contract.json
@@ -28,5 +28,26 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "currentSlug": {
+            "optional": false,
+            "type": "string"
+        },
+        "maxPosts": {
+            "optional": true,
+            "type": "number"
+        },
+        "title": {
+            "optional": true,
+            "type": "string"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/RelatedProjects/RelatedProjects.contract.json
+++ b/nextjs-app/shared/patterns/RelatedProjects/RelatedProjects.contract.json
@@ -28,5 +28,26 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "currentSlug": {
+            "optional": false,
+            "type": "string"
+        },
+        "maxItems": {
+            "optional": true,
+            "type": "number"
+        },
+        "title": {
+            "optional": true,
+            "type": "string"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/ServicesSection/ServicesSection.contract.json
+++ b/nextjs-app/shared/patterns/ServicesSection/ServicesSection.contract.json
@@ -69,8 +69,8 @@
             "type": "union",
             "values": [
                 "default",
-                "elevated",
                 "minimal",
+                "elevated",
                 "bordered"
             ]
         },
@@ -87,14 +87,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "HomeHero",
-        "WorkMagneticField",
-        "CTASection",
-        "NewsBulletin",
-        "DesignSprintsSection",
-        "HighlightSection"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/patterns/StatsSection/StatsSection.contract.json
+++ b/nextjs-app/shared/patterns/StatsSection/StatsSection.contract.json
@@ -28,5 +28,32 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "title": {
+            "optional": true,
+            "type": "string"
+        },
+        "stats": {
+            "optional": false,
+            "type": "StatItem[]"
+        },
+        "background": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "default",
+                "muted",
+                "primary",
+                "accent"
+            ]
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/StoryBlock/StoryBlock.contract.json
+++ b/nextjs-app/shared/patterns/StoryBlock/StoryBlock.contract.json
@@ -130,15 +130,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "Title",
-        "Text",
-        "ProjectDetailLayout",
-        "ProjectHero",
-        "RelatedProjects",
-        "ProcessBlock",
-        "GridBlock"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/patterns/TeamBlock/TeamBlock.contract.json
+++ b/nextjs-app/shared/patterns/TeamBlock/TeamBlock.contract.json
@@ -125,14 +125,6 @@
             "type": "boolean"
         }
     },
-    "composesWith": [
-        "Text",
-        "ProcessBlock",
-        "StoryBlock",
-        "GridBlock",
-        "ProjectDetailLayout",
-        "ProjectHero"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/nextjs-app/shared/patterns/ValuesSection/ValuesSection.contract.json
+++ b/nextjs-app/shared/patterns/ValuesSection/ValuesSection.contract.json
@@ -28,5 +28,44 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "title": {
+            "optional": false,
+            "type": "string"
+        },
+        "subtitle": {
+            "optional": true,
+            "type": "string"
+        },
+        "values": {
+            "optional": false,
+            "type": "ValueItem[]"
+        },
+        "cardVariant": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "default",
+                "elevated",
+                "bordered"
+            ]
+        },
+        "background": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "default",
+                "muted",
+                "accent"
+            ]
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/WorkCTA/WorkCTA.contract.json
+++ b/nextjs-app/shared/patterns/WorkCTA/WorkCTA.contract.json
@@ -28,5 +28,22 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "title": {
+            "optional": true,
+            "type": "string"
+        },
+        "description": {
+            "optional": true,
+            "type": "string"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/WorkHero/WorkHero.contract.json
+++ b/nextjs-app/shared/patterns/WorkHero/WorkHero.contract.json
@@ -28,5 +28,26 @@
     },
     "lightDarkVerified": false,
     "schemaVersion": 2,
-    "composesWith": []
+    "props": {
+        "title": {
+            "optional": true,
+            "type": "string"
+        },
+        "description": {
+            "optional": true,
+            "type": "string"
+        },
+        "id": {
+            "optional": true,
+            "type": "string"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "invent parallel primitives inside this folder",
+        "promote to stable without production consumer evidence"
+    ]
 }

--- a/nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.contract.json
+++ b/nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.contract.json
@@ -71,14 +71,6 @@
             "type": "string"
         }
     },
-    "composesWith": [
-        "HomeHero",
-        "ServicesSection",
-        "CTASection",
-        "NewsBulletin",
-        "DesignSprintsSection",
-        "HighlightSection"
-    ],
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
     ]

--- a/public/ds-health/report.json
+++ b/public/ds-health/report.json
@@ -1,11 +1,11 @@
 {
-  "generatedAt": "2026-06-04T14:07:07.365Z",
+  "generatedAt": "2026-06-11T11:38:56.769Z",
   "checks": [
     {
       "name": "lint:dt-usage",
       "ok": true,
       "status": 0,
-      "stdout": "> nextjs-app@2.0.0 lint:dt-usage\n> node scripts/design-system/lint-dt-usage.mjs --strict --strict\n\n✓ lint:dt-usage — no violations in app/",
+      "stdout": "> nextjs-app@2.0.0 lint:dt-usage\n> node scripts/design-system/lint-dt-usage.mjs --strict --strict\n\n✓ lint:dt-usage — no violations in app, nextjs-app/shared/patterns, nextjs-app/shared/components/pages, nextjs-app/shared/components",
       "stderr": ""
     },
     {
@@ -19,46 +19,6 @@
   "shadcnByArea": {
     "app": [],
     "nextjs-app/shared/components": [
-      {
-        "file": "nextjs-app/shared/components/AnimatedDialog/AnimatedDialog.tsx",
-        "line": 14
-      },
-      {
-        "file": "nextjs-app/shared/components/EnhancedContactForm/EnhancedContactForm.tsx",
-        "line": 7
-      },
-      {
-        "file": "nextjs-app/shared/components/EnhancedContactForm/EnhancedContactForm.tsx",
-        "line": 8
-      },
-      {
-        "file": "nextjs-app/shared/components/EnhancedContactForm/EnhancedContactForm.tsx",
-        "line": 9
-      },
-      {
-        "file": "nextjs-app/shared/components/EnhancedContactForm/EnhancedContactForm.tsx",
-        "line": 10
-      },
-      {
-        "file": "nextjs-app/shared/components/EnhancedContactForm/EnhancedContactForm.tsx",
-        "line": 11
-      },
-      {
-        "file": "nextjs-app/shared/components/EnhancedContactForm/EnhancedContactForm.tsx",
-        "line": 18
-      },
-      {
-        "file": "nextjs-app/shared/components/EnhancedContactForm/EnhancedContactForm.tsx",
-        "line": 26
-      },
-      {
-        "file": "nextjs-app/shared/components/Lightbox/Lightbox.tsx",
-        "line": 9
-      },
-      {
-        "file": "nextjs-app/shared/components/SkillsGrid/SkillsGrid.tsx",
-        "line": 10
-      },
       {
         "file": "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx",
         "line": 4
@@ -90,7 +50,7 @@
     ],
     "nextjs-app/shared/patterns": []
   },
-  "shadcnTotal": 17,
+  "shadcnTotal": 7,
   "migrationBoards": {
     "buttonSurfaces": "approved",
     "buttonContexts": "migrated",
@@ -100,7 +60,7 @@
   },
   "migrationMatrix": {
     "present": true,
-    "generatedAt": "2026-06-04T12:56:27.686Z",
+    "generatedAt": "2026-06-05T13:10:40.288Z",
     "passed": 96,
     "total": 96,
     "failed": 0,

--- a/public/ds-health/summary.md
+++ b/public/ds-health/summary.md
@@ -1,6 +1,6 @@
 # Design system health
 
-Generated: 2026-06-04T14:07:07.365Z
+Generated: 2026-06-11T11:38:56.769Z
 
 ## Governance checks
 
@@ -10,9 +10,9 @@ Generated: 2026-06-04T14:07:07.365Z
 ## shadcn import inventory (informational)
 
 - `app`: 0 import line(s)
-- `nextjs-app/shared/components`: 17 import line(s)
+- `nextjs-app/shared/components`: 7 import line(s)
 - `nextjs-app/shared/patterns`: 0 import line(s)
-- **Total:** 17 (see report.json for paths)
+- **Total:** 7 (see report.json for paths)
 
 ## Migration boards
 
@@ -25,7 +25,7 @@ Generated: 2026-06-04T14:07:07.365Z
 ## Last visual matrix
 
 - 96/96 passed
-- Report time: 2026-06-04T12:56:27.686Z
+- Report time: 2026-06-05T13:10:40.288Z
 
 ## Before merging DS changes
 


### PR DESCRIPTION
## Summary

The `validate` job in pr-validation has been failing on **main-inherited contract drift** (`composesWith-drift` / `forbiddenUse-drift` on ContactInquiryPanel, NewsBulletin, PricingPageContent, StoryBlock and others). Every branch forked from main inherits the failure — which is why **all 16 open Dependabot PRs show the same single red check**. None of them are actually broken by their version bumps (two have additional real failures, handled separately).

## Change

Metadata only — no component code:
- `npm run build:agent-blocks && npm run sync:contract-props -- --write` → 101 regenerated `.contract.json` files
- Updated tracked `public/ds-health` report artifacts

## Verification

- `sync:contract-props` dry-run now reports **0 contracts would update**
- `validate:components`, `ds:health`, `check:consumers` all pass locally

## Follow-up

Once merged, the open Dependabot PRs get `@dependabot rebase` and most go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated design system component contracts to include explicit property definitions and usage guidelines across components and patterns.
  * Refined dependency management strategy for npm and GitHub Actions to consolidate minor and patch updates into fewer pull requests while maintaining individual security updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->