### PR TITLE
fix(a11y): define --color-focus-ring; restores focus outlines in 4 components

### DIFF
--- a/nextjs-app/shared/styles/variables.css
+++ b/nextjs-app/shared/styles/variables.css
@@ -96,6 +96,12 @@
   --logo-background: #dfff00;
   --logo-color: #000; /* Black logo on light themes */
 
+  /* Focus ring. Several module stylesheets and the agent docs reference
+     --color-focus-ring; it was never defined, which made those outline
+     declarations invalid (invisible focus). Tracks --color-primary so it
+     follows every theme, matching the global :focus-visible rule. */
+  --color-focus-ring: var(--color-primary);
+
   /* Greyscale palette */
   --color-black: #000;
   --color-white: #fff;


### PR DESCRIPTION
## Summary
`--color-focus-ring` was referenced by LanguageSwitcher, ContactInquiryPanel, PricingPageContent, and DonnyBookingEmbed module CSS (and documented as the convention in the agent docs) but never defined. The undefined `var()` invalidated those outline declarations, and the module rules outrank the global `:focus-visible` fallback, so those controls had no visible keyboard focus.

Defined once at `:root`, tracking `--color-primary`, so it themes exactly like the global focus rule (dark, HCB, HCW, forced-colors).

## Test plan
- Full local gate green pre-merge: typecheck, lint, test:ci, build (exit 0)
- Manual: Tab to the header language switcher in light/dark/HC themes; 2px ring now visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)