### PR TITLE
fix(header): round logo and nav link focus outlines to match language switcher

### DIFF
--- a/nextjs-app/shared/components/NavLink/NavLink.tsx
+++ b/nextjs-app/shared/components/NavLink/NavLink.tsx
@@ -36,7 +36,9 @@ export function NavLink({
     <Link
       href={href}
       className={cn(
-        "font-body text-text-m transition-colors",
+        // rounded-sm matches the LanguageSwitcher buttons so the global
+        // :focus-visible outline renders with the same corner rounding.
+        "font-body text-text-m transition-colors rounded-sm",
         className,
         isActive ? activeClassName : inactiveClassName
       )}

--- a/nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx
+++ b/nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx
@@ -154,7 +154,9 @@ export function SiteHeader({
         {/* Logo */}
         <Link
           href="/"
-          className="flex items-center gap-3 group"
+          // rounded-sm matches the LanguageSwitcher so the focus outline
+          // renders with the same corner rounding as the other header controls.
+          className="flex items-center gap-3 group rounded-sm"
           onMouseEnter={() => setIsLogoHovered(true)}
           onMouseLeave={() => setIsLogoHovered(false)}
         >


### PR DESCRIPTION
Focus outlines follow border-radius; the logo link and NavLink had none, so the global :focus-visible ring rendered square next to the rounded LanguageSwitcher ring. Both now use the same rounded-sm as the switcher buttons, applied in NavLink's base classes so the mobile drawer and all consumers match.

Full local gate green pre-merge (typecheck, lint, test:ci, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)