### PR TITLE
fix(a11y): contrasting focus ring for Button onDark/onBrand surfaces

### DIFF
--- a/nextjs-app/shared/components/Button/Button.module.css
+++ b/nextjs-app/shared/components/Button/Button.module.css
@@ -52,6 +52,19 @@
   outline-color: var(--color-white);
 }
 
+/* Surface-aware focus rings. On dark/brand bands the default ring color
+   (--color-primary) can match the band itself (e.g. the navy CTA band in
+   light theme), making focus invisible. Use the surface's contrast pole. */
+
+.button.onDark:focus-visible {
+  outline-color: var(--color-white);
+}
+
+.button.onBrand:focus-visible {
+  /* Brand band is --logo-background; --logo-color is its paired contrast. */
+  outline-color: var(--logo-color);
+}
+
 /* Windows High Contrast Mode support */
 @media (forced-colors: active) {
   .button:focus-visible {


### PR DESCRIPTION
The Button focus ring defaults to `--color-primary`, which on the navy CTA band (`background="primary"`, light theme) is the band color itself, so the ring fired but was invisible (e.g. the Let's talk CTA). `onDark` surfaces now get a white ring; `onBrand` uses `--logo-color`, the paired contrast of the brand band. Mirrors the existing `.inverse` override.

Full local gate green pre-merge (typecheck, lint, test:ci, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced focus ring visibility for buttons on dark and brand surface backgrounds to ensure better contrast and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->