### PR TITLE
fix(footer): round all footer focus outlines to match header controls

### DIFF
--- a/nextjs-app/shared/components/TextLink/TextLink.tsx
+++ b/nextjs-app/shared/components/TextLink/TextLink.tsx
@@ -36,7 +36,9 @@ export function TextLink({
   const isExternal = external ?? (!href.startsWith("/") && !href.startsWith("#"));
 
   const linkClasses = cn(
-    "inline-flex items-center gap-1 transition-colors font-body",
+    // rounded-sm matches header controls so the :focus-visible outline
+    // renders with consistent corner rounding site-wide.
+    "inline-flex items-center gap-1 transition-colors font-body rounded-sm",
     variantClasses[variant],
     underlineClasses[underline],
     className

--- a/nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx
+++ b/nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx
@@ -84,7 +84,10 @@ export function SiteFooter({ className }: SiteFooterProps) {
               {t("footerAddressTitle")}
             </p>
             <address className="font-body text-text-m text-muted-foreground not-italic leading-relaxed">
-              <Link href="/" className="font-medium text-foreground hover:underline">
+              <Link
+                href="/"
+                className="font-medium text-foreground hover:underline rounded-sm"
+              >
                 Digitaltableteur
               </Link>
               <br />
@@ -94,7 +97,7 @@ export function SiteFooter({ className }: SiteFooterProps) {
               <br />
               <a
                 href="mailto:mail@digitaltableteur.com"
-                className="text-foreground hover:underline"
+                className="text-foreground hover:underline rounded-sm"
               >
                 mail@digitaltableteur.com
               </a>
@@ -181,7 +184,7 @@ export function SiteFooter({ className }: SiteFooterProps) {
                 href={href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="p-2 text-muted-foreground hover:text-foreground transition-colors"
+                className="p-2 text-muted-foreground hover:text-foreground transition-colors rounded-sm"
                 aria-label={t(label)}
               >
                 <Icon className="size-5" />


### PR DESCRIPTION
rounded-sm on the footer wordmark link, mailto link, and social icon links, plus TextLink's base classes so the ten footer nav/legal links (and every other TextLink site-wide) get the same focus-ring rounding as the header controls. Outlines follow border-radius; these elements had none.

Full local gate green pre-merge (typecheck, lint, test:ci, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)