### PR TITLE
fix(checkbox): correct over-round radius (8px → 4px)

### DIFF
--- a/nextjs-app/shared/components/Checkbox/Checkbox.module.css
+++ b/nextjs-app/shared/components/Checkbox/Checkbox.module.css
@@ -10,7 +10,11 @@
   width: 24px;
   height: 24px;
   border: 1px solid var(--color-primary);
-  border-radius: var(--radius-lg);
+
+  /* --radius-md (4px), not --radius-lg (8px): the radius is absolute, so on
+     the 18px small box 8px read as ~89% circular. 4px holds a rounded-square
+     at every size (S/M/L = 18/24/30px). */
+  border-radius: var(--radius-md);
   cursor: pointer;
   appearance: none;
   background-color: var(--color-light-bg);


### PR DESCRIPTION
## Summary

The DS Checkbox base style used `border-radius: var(--radius-lg)` (8px). Since the radius is absolute, the small (18px) variant rendered ~89% circular — reading as a radio button. Surfaced while swapping the AskAI personalize toggle to the DS Checkbox ([#734](https://github.com/PetriLahdelma/digitaltableteur/pull/734)).

`--radius-md` (4px) holds a rounded-square at every size:

| size | box | old radius | new radius |
|---|---|---|---|
| S | 18px | 8px (0.89 of half) | 4px (0.44) |
| M | 24px | 8px (0.67) | 4px (0.33) |
| L | 30px | 8px (0.53) | 4px (0.27) |

Pre-existing (last touched #694), not related to the token sweep. Affects all checkboxes app-wide (5 consumers: contact form, cookie consent, AskAI, etc.).

## Verification (local — CI quota)

- Checkbox suite: 25/25 ✓ · `validate:components` ✓
- Visually confirmed in Storybook AllStates (unchecked/checked/indeterminate/disabled) and SizeSmall — computed radius 4px across all

🤖 Generated with [Claude Code](https://claude.com/claude-code)