### PR TITLE
feat(about): topical Phosphor icons for What we bring values

### DIFF
--- a/nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx
+++ b/nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx
@@ -4,18 +4,20 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import {
-  Check,
   Code,
-  ChevronRight,
   Sparkles,
-  ChevronUp,
-  ChevronDown,
   UserCheck,
   Network,
   ClipboardCheck,
   RefreshCw,
   KeyRound,
 } from "lucide-react";
+import {
+  Trophy,
+  HandsClapping,
+  HeadCircuit,
+  PuzzlePiece,
+} from "@phosphor-icons/react";
 
 import { AboutHero } from "../AboutHero";
 import { ContentSection } from "../ContentSection";
@@ -44,7 +46,7 @@ export function AboutPageContent({
   const values: ValueItem[] = useMemo(
     () => [
       {
-        icon: <Check className="w-6 h-6" />,
+        icon: <Trophy className="w-6 h-6" />,
         title: t("aboutValueDesignTitle"),
         description: t("aboutValueDesignDescription"),
       },
@@ -54,17 +56,17 @@ export function AboutPageContent({
         description: t("aboutValueDevelopmentDescription"),
       },
       {
-        icon: <ChevronRight className="w-6 h-6" />,
+        icon: <HandsClapping className="w-6 h-6" />,
         title: t("aboutValueCollaborationTitle"),
         description: t("aboutValueCollaborationDescription"),
       },
       {
-        icon: <ChevronUp className="w-6 h-6" />,
+        icon: <HeadCircuit className="w-6 h-6" />,
         title: t("aboutValueAITitle"),
         description: t("aboutValueAIDescription"),
       },
       {
-        icon: <ChevronDown className="w-6 h-6" />,
+        icon: <PuzzlePiece className="w-6 h-6" />,
         title: t("aboutValueSystemsTitle"),
         description: t("aboutValueSystemsDescription"),
       },


### PR DESCRIPTION
## Summary

The "What we bring" value cards used placeholder lucide chevrons for three cards and a generic Check for Design Excellence. Swapped to the requested Phosphor marks:

| Card | Was (lucide) | Now (Phosphor) |
|---|---|---|
| Design Excellence | Check | Trophy |
| True Partnership | ChevronRight | HandsClapping |
| AI Integration | ChevronUp | HeadCircuit |
| Design Systems | ChevronDown | PuzzlePiece |

Technical Craft (Code) and Attention to Detail (Sparkles) keep their existing lucide icons. Sizing unchanged (`w-6 h-6`).

## Note: mixed icon libraries

The row now mixes Phosphor (4) and lucide (2). They read consistently at this size, but if you want a fully uniform set I'd suggest Phosphor equivalents for the remaining two (e.g. Technical Craft → `Wrench` or `Code`, Attention to Detail → `Sparkle`). Say the word and I'll fold it in.

## Verification (local — CI quota)

- `typecheck` ✓ · AboutPageContent tests 4/4 ✓
- Visually confirmed on /about: all four Phosphor marks render at 24px

🤖 Generated with [Claude Code](https://claude.com/claude-code)