### PR TITLE
chore(ci): actions/upload-artifact v4 → v7

### DIFF
--- a/.github/workflows/ds-migration-visual.yml
+++ b/.github/workflows/ds-migration-visual.yml
@@ -47,7 +47,7 @@ jobs:
           fi
       - name: Upload matrix report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: migration-visual-report
           path: |


### PR DESCRIPTION
Supersedes #704. Brings ds-migration-visual.yml to v7, matching security-scanning.yml.

Usage is the stable core API (`name` + multi-line `path` + `retention-days`), unaffected by the v4→v7 majors (those were Node-runtime bumps; the immutable-artifact breaking change landed at v4, already in effect here).

CI-only change — verified by YAML validity + usage inspection (CI quota out, so it can't be exercised until quota returns anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)