### PR TITLE
fix(contact): polish contact form focus states

### DIFF
--- a/nextjs-app/shared/components/Combobox/ComboboxField.module.css
+++ b/nextjs-app/shared/components/Combobox/ComboboxField.module.css
@@ -24,19 +24,26 @@
 .control {
   display: flex;
   position: relative;
-  align-items: stretch;
   width: 100%;
   min-height: 44px;
+  align-items: stretch;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   background: transparent;
   cursor: pointer;
-  transition: border-color var(--duration-fast) var(--ease-out-cubic);
+  transition:
+    border-color var(--duration-fast) var(--ease-out-cubic),
+    outline-color var(--duration-fast) var(--ease-out-cubic);
 }
 
 .controlOpen,
 .control:focus-within {
   border-color: var(--color-primary);
+}
+
+.control:focus-within {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 
 .controlError {
@@ -45,11 +52,11 @@
 
 .trigger {
   display: flex;
-  flex: 1;
-  align-items: center;
   padding: var(--space-internal-12) var(--space-internal-16);
   padding-inline-end: calc(var(--space-internal-32) + var(--space-internal-8));
   min-width: 0;
+  flex: 1;
+  align-items: center;
   border: none;
   outline: none;
   background: transparent;
@@ -61,6 +68,10 @@
   cursor: pointer;
 }
 
+.trigger:focus-visible {
+  outline: none;
+}
+
 .triggerPlaceholder {
   /* No opacity: it would drop --color-muted below the WCAG AA 4.5:1 ratio on
      the field background. --color-muted alone is AA-compliant. */
@@ -68,38 +79,36 @@
 }
 
 .triggerLabel {
-  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  overflow: hidden;
 }
 
 .chevronButton {
   display: flex;
   position: absolute;
   inset-block: 0;
-  inset-inline-end: 0;
-  width: calc(var(--space-internal-32) + var(--space-internal-8));
-  align-items: center;
-  justify-content: flex-end;
   padding: 0;
   padding-inline-end: calc(var(--space-internal-12) + var(--space-internal-8));
+  width: calc(var(--space-internal-32) + var(--space-internal-8));
+  justify-content: flex-end;
+  align-items: center;
   border: none;
   background: transparent;
   color: var(--color-muted);
   cursor: pointer;
+  inset-inline-end: 0;
 }
 
 .chevronButton:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
-  border-radius: var(--radius-sm);
+  outline: none;
 }
 
 .chevron {
   display: block;
   flex-shrink: 0;
-  transition: transform var(--duration-normal) var(--ease-out-expo);
   pointer-events: none;
+  transition: transform var(--duration-normal) var(--ease-out-expo);
 }
 
 .chevronOpen,
@@ -122,20 +131,20 @@
   border-radius: var(--radius-lg);
   background: var(--main-body-background-color, var(--color-surface));
   box-shadow: 0 8px 24px rgb(0 0 0 / 12%);
-  overflow-y: auto;
-  overscroll-behavior: contain;
   list-style: none;
   list-style-type: " ";
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .option {
   display: flex;
+  padding: var(--space-internal-12) var(--space-internal-16);
+  width: 100%;
+  min-height: 44px;
   justify-content: space-between;
   align-items: center;
   gap: var(--space-internal-12);
-  padding: var(--space-internal-12) var(--space-internal-16);
-  min-height: 44px;
-  width: 100%;
   border: none;
   border-radius: var(--radius-md);
   background: transparent;
@@ -148,14 +157,14 @@
   transition: background-color var(--duration-fast) var(--ease-out-cubic);
 }
 
-.option:hover:not(:disabled),
-.optionHighlighted {
-  background: color-mix(in srgb, var(--color-border) 25%, transparent);
-}
-
 .option:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: -2px;
+}
+
+.option:hover:not(:disabled),
+.optionHighlighted {
+  background: color-mix(in srgb, var(--color-border) 25%, transparent);
 }
 
 .optionSelected {
@@ -181,7 +190,7 @@
 }
 
 .disabled {
-  opacity: 0.6;
   cursor: not-allowed;
   pointer-events: none;
+  opacity: 0.6;
 }

--- a/nextjs-app/shared/components/ExpandableSection/ExpandableSection.module.css
+++ b/nextjs-app/shared/components/ExpandableSection/ExpandableSection.module.css
@@ -49,6 +49,12 @@
 /* Content wrapper - handles overflow during animation */
 
 .content {
+  --expandable-focus-bleed: calc(
+    var(--focus-ring-width, 2px) + var(--focus-ring-offset, 2px)
+  );
+
+  margin: calc(-1 * var(--expandable-focus-bleed));
+  padding: var(--expandable-focus-bleed);
   overflow: hidden;
 }
 

--- a/nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.module.css
+++ b/nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.module.css
@@ -31,7 +31,9 @@
   font-family: var(--font-body);
   font-size: var(--font-size-text);
   color: var(--color-text);
-  transition: border-color var(--duration-fast) var(--ease-out-cubic);
+  transition:
+    border-color var(--duration-fast) var(--ease-out-cubic),
+    outline-color var(--duration-fast) var(--ease-out-cubic);
 }
 
 .input::placeholder {
@@ -41,6 +43,8 @@
 
 .input:focus {
   border-color: var(--color-primary);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 
 .input.hasError {
@@ -60,7 +64,9 @@
   font-family: var(--font-body);
   font-size: var(--font-size-text);
   color: var(--color-text);
-  transition: border-color var(--duration-fast) var(--ease-out-cubic);
+  transition:
+    border-color var(--duration-fast) var(--ease-out-cubic),
+    outline-color var(--duration-fast) var(--ease-out-cubic);
   resize: vertical;
 }
 
@@ -71,6 +77,8 @@
 
 .textarea:focus {
   border-color: var(--color-primary);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 
 .textarea.hasError {
@@ -87,6 +95,7 @@
 
 .select {
   padding: var(--space-internal-12) var(--space-internal-16);
+  padding-inline-end: calc(var(--space-internal-32) + var(--space-internal-8));
   width: 100%;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
@@ -96,13 +105,16 @@
   font-size: var(--font-size-text);
   color: var(--color-text);
   cursor: pointer;
-  transition: border-color var(--duration-fast) var(--ease-out-cubic);
+  transition:
+    border-color var(--duration-fast) var(--ease-out-cubic),
+    outline-color var(--duration-fast) var(--ease-out-cubic);
   appearance: none;
-  padding-inline-end: calc(var(--space-internal-32) + var(--space-internal-8));
 }
 
 .select:focus {
   border-color: var(--color-primary);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 
 .select.hasError {
@@ -119,12 +131,12 @@
   display: flex;
   position: absolute;
   inset-block: 0;
-  inset-inline-end: 0;
-  width: calc(var(--space-internal-32) + var(--space-internal-8));
-  align-items: center;
-  justify-content: flex-end;
   padding-inline-end: calc(var(--space-internal-12) + var(--space-internal-8));
+  width: calc(var(--space-internal-32) + var(--space-internal-8));
+  justify-content: flex-end;
+  align-items: center;
   pointer-events: none;
+  inset-inline-end: 0;
 }
 
 .chevron {

--- a/nextjs-app/shared/components/MultiCombobox/MultiCombobox.module.css
+++ b/nextjs-app/shared/components/MultiCombobox/MultiCombobox.module.css
@@ -1,23 +1,28 @@
 .inner {
   display: flex;
+  padding: var(--space-internal-12)
+    calc(var(--space-internal-32) + var(--space-internal-8))
+    var(--space-internal-12) var(--space-internal-16);
+  padding-inline-end: 0;
+  min-width: 0;
   flex: 1;
   flex-wrap: wrap;
   align-items: center;
   gap: var(--space-internal-6);
-  padding: var(--space-internal-12)
-    calc(var(--space-internal-32) + var(--space-internal-8))
-    var(--space-internal-12) var(--space-internal-16);
-  min-width: 0;
 }
 
 .control {
+  display: grid;
+  grid-template-columns:
+    minmax(0, 1fr) calc(var(--space-internal-32) + var(--space-internal-8));
   cursor: text;
 }
 
 .input {
-  flex: 1 1 6rem;
-  min-width: 6rem;
   padding: var(--space-internal-4) 0;
+  min-width: min(6rem, 100%);
+  max-width: 100%;
+  flex: 1 1 6rem;
   border: none;
   outline: none;
   background: transparent;
@@ -27,9 +32,22 @@
   color: var(--color-text);
 }
 
+.input:focus-visible {
+  outline: none;
+}
+
 .input::placeholder {
   color: var(--color-muted);
   opacity: 0.7;
+}
+
+.control .chevronButton {
+  position: static;
+  inset: auto;
+  padding: 0;
+  padding-inline-end: calc(var(--space-internal-12) + var(--space-internal-8));
+  width: calc(var(--space-internal-32) + var(--space-internal-8));
+  justify-content: flex-end;
 }
 
 .input:disabled {
@@ -47,7 +65,7 @@
 
 .badgeLabel {
   display: block;
-  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  overflow: hidden;
 }

--- a/nextjs-app/shared/components/MultiCombobox/MultiCombobox.tsx
+++ b/nextjs-app/shared/components/MultiCombobox/MultiCombobox.tsx
@@ -361,7 +361,7 @@ export function MultiCombobox({
           <button
             type="button"
             data-chevron-toggle
-            className={fieldStyles.chevronButton}
+            className={cn(fieldStyles.chevronButton, styles.chevronButton)}
             aria-label={t("multiComboboxToggleOptions", "Toggle options")}
             aria-expanded={open}
             disabled={isDisabled}

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -1,6 +1,6 @@
 {
   "generatedBy": "npm run lint:css:update",
-  "warningCount": 496,
+  "warningCount": 475,
   "warnings": [
     {
       "id": "app/blog/NextBlogNav.module.css::7::3::order/properties-order::Expected \"margin-inline\" to come before \"max-width\" (order/properties-order)",
@@ -568,123 +568,6 @@
       "rule": "no-descending-specificity",
       "severity": "warning",
       "text": "Expected selector \".pre\" to come before selector \".single .pre\", at line 40 (no-descending-specificity)"
-    },
-    {
-      "id": "nextjs-app/shared/components/Combobox/ComboboxField.module.css::102::3::order/properties-order::Expected \"pointer-events\" to come before \"transition\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 102,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"pointer-events\" to come before \"transition\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/components/Combobox/ComboboxField.module.css::127::3::order/properties-order::Expected \"list-style\" to come before \"overscroll-behavior\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 127,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"list-style\" to come before \"overscroll-behavior\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/components/Combobox/ComboboxField.module.css::136::3::order/properties-order::Expected \"padding\" to come before \"gap\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 136,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"padding\" to come before \"gap\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/components/Combobox/ComboboxField.module.css::138::3::order/properties-order::Expected \"width\" to come before \"min-height\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 138,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"width\" to come before \"min-height\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/components/Combobox/ComboboxField.module.css::156::1::no-descending-specificity::Expected selector \".option:focus-visible\" to come before selector \".option:hover:not(:disabled)\", at line 151 (no-descending-specificity)",
-      "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 156,
-      "column": 1,
-      "rule": "no-descending-specificity",
-      "severity": "warning",
-      "text": "Expected selector \".option:focus-visible\" to come before selector \".option:hover:not(:disabled)\", at line 151 (no-descending-specificity)"
-    },
-    {
-      "id": "nextjs-app/shared/components/Combobox/ComboboxField.module.css::185::3::order/properties-order::Expected \"cursor\" to come before \"opacity\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 185,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"cursor\" to come before \"opacity\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/components/Combobox/ComboboxField.module.css::28::3::order/properties-order::Expected \"width\" to come before \"align-items\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 28,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"width\" to come before \"align-items\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/components/Combobox/ComboboxField.module.css::50::3::order/properties-order::Expected \"padding\" to come before \"align-items\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 50,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"padding\" to come before \"align-items\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/components/Combobox/ComboboxField.module.css::72::3::order/properties-order::Expected \"text-overflow\" to come before \"overflow\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 72,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"text-overflow\" to come before \"overflow\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/components/Combobox/ComboboxField.module.css::81::3::order/properties-order::Expected \"width\" to come before \"inset-inline-end\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 81,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"width\" to come before \"inset-inline-end\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/components/Combobox/ComboboxField.module.css::83::3::order/properties-order::Expected \"justify-content\" to come before \"align-items\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 83,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"justify-content\" to come before \"align-items\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/components/Combobox/ComboboxField.module.css::84::3::order/properties-order::Expected \"padding\" to come before \"justify-content\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 84,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"padding\" to come before \"justify-content\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/components/Combobox/ComboboxField.module.css::95::3::order/properties-order::Expected \"border-radius\" to come before \"outline-offset\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 95,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"border-radius\" to come before \"outline-offset\" (order/properties-order)"
     },
     {
       "id": "nextjs-app/shared/components/ComplianceCard/ComplianceCard.module.css::135::22::declaration-no-important::Disallowed !important (declaration-no-important)",
@@ -1263,42 +1146,6 @@
       "text": "Too high specificity in \".chart:hover .innerRing path:hover\", maximum \"0,4,0\" (selector-max-specificity)"
     },
     {
-      "id": "nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.module.css::101::3::order/properties-order::Expected \"padding-inline-end\" to come before \"transition\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.module.css",
-      "line": 101,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"padding-inline-end\" to come before \"transition\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.module.css::123::3::order/properties-order::Expected \"width\" to come before \"inset-inline-end\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.module.css",
-      "line": 123,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"width\" to come before \"inset-inline-end\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.module.css::125::3::order/properties-order::Expected \"justify-content\" to come before \"align-items\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.module.css",
-      "line": 125,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"justify-content\" to come before \"align-items\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.module.css::126::3::order/properties-order::Expected \"padding-inline-end\" to come before \"justify-content\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.module.css",
-      "line": 126,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"padding-inline-end\" to come before \"justify-content\" (order/properties-order)"
-    },
-    {
       "id": "nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.module.css::13::3::order/properties-order::Expected \"z-index\" to come before \"inset-inline-end\" (order/properties-order)",
       "file": "nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.module.css",
       "line": 13,
@@ -1810,42 +1657,6 @@
       "rule": "order/properties-order",
       "severity": "warning",
       "text": "Expected \"padding\" to come before \"height\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/components/MultiCombobox/MultiCombobox.module.css::19::3::order/properties-order::Expected \"min-width\" to come before \"flex\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/MultiCombobox/MultiCombobox.module.css",
-      "line": 19,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"min-width\" to come before \"flex\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/components/MultiCombobox/MultiCombobox.module.css::20::3::order/properties-order::Expected \"padding\" to come before \"min-width\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/MultiCombobox/MultiCombobox.module.css",
-      "line": 20,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"padding\" to come before \"min-width\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/components/MultiCombobox/MultiCombobox.module.css::51::3::order/properties-order::Expected \"text-overflow\" to come before \"overflow\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/MultiCombobox/MultiCombobox.module.css",
-      "line": 51,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"text-overflow\" to come before \"overflow\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/components/MultiCombobox/MultiCombobox.module.css::7::3::order/properties-order::Expected \"padding\" to come before \"gap\" (order/properties-order)",
-      "file": "nextjs-app/shared/components/MultiCombobox/MultiCombobox.module.css",
-      "line": 7,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"padding\" to come before \"gap\" (order/properties-order)"
     },
     {
       "id": "nextjs-app/shared/components/pages/Colophon/colophon.module.css::43::3::order/properties-order::Expected \"text-decoration\" to come before \"color\" (order/properties-order)",


### PR DESCRIPTION
## Summary
- move combobox focus rings to the full control surface so they are not clipped
- reserve a dedicated multiselect chevron column and match select arrow right padding
- update the stylelint baseline after clearing warnings in the touched component CSS

## Validation
- npm run lint:css
- npm run test:ci -- nextjs-app/shared/components/MultiCombobox/MultiCombobox.test.tsx
- npm run typecheck
- npm run lint
- npm run check:generated
- npm run check:bundle-budgets
- npm run validate:components
- npm run validate:translations
- npm test
- npm run build
- Browser geometry check on /contact confirmed Timeline and Project type chevrons share the same rendered inset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual focus indicators and outline styling across form inputs, comboboxes, and expandable sections for improved accessibility and user feedback.
  * Refined chevron button positioning and layout adjustments in form components.

* **Refactor**
  * Reorganized CSS structure for multi-combobox and expandable content components.

* **Chores**
  * Updated code quality baseline metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->