### PR TITLE
fix(storybook): stop inlining .env.local secrets into the storybook-static bundle

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -178,10 +178,36 @@ const config: StorybookConfig = {
       ]),
     );
 
-    // Define process.env for Next.js Image component
+    // SECURITY: only inline non-secret env vars that the bundled client code
+    // actually reads. Inlining the whole `process.env` (with .env.local loaded
+    // above) baked secrets — API keys, tokens, the Mongo URI, the CV password —
+    // into the deployed storybook-static bundle, because at every `process.env.X`
+    // site Vite replaced `process.env` with the full env object. Bare
+    // `process.env` now resolves to `{}`, so any unlisted var (every secret) is
+    // `undefined` in the bundle rather than exposed. Allow only what the preview
+    // and stories use: NODE_ENV, a few test/CI toggles, and the public-by-
+    // convention NEXT_PUBLIC_ / STORYBOOK_ / DT_ families.
+    const isSafeEnvKey = (key: string): boolean =>
+      key === "NODE_ENV" ||
+      key === "CI" ||
+      key === "VITEST" ||
+      key === "TARGET_URL" ||
+      key.startsWith("NEXT_PUBLIC_") ||
+      key.startsWith("STORYBOOK_") ||
+      key.startsWith("DT_");
+    const safeEnvDefines = Object.fromEntries(
+      Object.entries(process.env)
+        .filter(
+          ([key, value]) => isSafeEnvKey(key) && typeof value === "string",
+        )
+        .map(([key, value]) => [`process.env.${key}`, JSON.stringify(value)]),
+    );
     config.define = {
       ...(config.define || {}),
-      "process.env": JSON.stringify(process.env),
+      ...safeEnvDefines,
+      // Bare `process.env` reads resolve to an empty object literal (a valid
+      // esbuild define value): unlisted vars become `undefined`, no leakage.
+      "process.env": "{}",
       "process.env.NODE_ENV": JSON.stringify(
         process.env.NODE_ENV || "development",
       ),


### PR DESCRIPTION
viteFinal defined `"process.env": JSON.stringify(process.env)`, so at every
bundled `process.env.X` site Vite inlined the full env object, baking
.env.local secrets (OpenAI / Resend / Sanity / GitHub / Linear / Sentry keys,
the Mongo URI, the CV password, the Vercel OIDC token, ...) into
storybook-static, which deploys publicly under /storybook/.

Replace it with an allowlist: per-key defines for only the vars bundled client
code reads (NODE_ENV, CI / VITEST / TARGET_URL, and the public-by-convention
NEXT_PUBLIC_ / STORYBOOK_ / DT_ families). Bare `process.env` now resolves to
`{}`, so every unlisted var (every secret) is undefined in the bundle.

The "for Next.js Image component" rationale was stale: the next/image stub
reads no env. The two doc stories that mention secrets (CodeSnippet,
APIIntegration) show `process.env.X` inside template-literal code samples,
which Vite never substitutes, so they are unaffected.

Verified: `npm run storybook:build` succeeds (1671 files); grepping the built
bundle for 12 secret values finds zero, while a known marker is found (so the
grep would catch a leak). Local gate green: typecheck, lint, vitest, build.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Storybook's environment variable handling to prevent sensitive credentials from being exposed in the bundled client code. Now only whitelisted environment variables are included, protecting secrets while maintaining necessary runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->