### PR TITLE
fix(ds): council audit P0 stop-the-line a11y blockers + react-icons pin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ export default async function Page({ params }: Props) {
 
 **Framer Motion + Strict Mode:** wrap in `<AnimatePresence mode="wait">` with unique `key`.
 
-**react-icons:** pinned at **5.5.0** (5.6 drops Adobe SI icons on work pages).
+**react-icons:** pinned **exact** at `5.5.0` (no caret in package.json). 5.6 drops Simple Icons (`react-icons/si`) used on Work pages; do not bump without re-verifying those imports.
 
 **OG images:** use colocated `opengraph-image.tsx`; do not set `logo512.png` in page metadata.
 

--- a/nextjs-app/shared/components/Button/Button.module.css
+++ b/nextjs-app/shared/components/Button/Button.module.css
@@ -127,6 +127,13 @@
   cursor: not-allowed;
 }
 
+/* Disabled anchor: belt-and-suspenders non-interactivity. The component also
+   drops href / tabIndex / click handling, so this only hardens the mouse path. */
+
+.button[aria-disabled="true"] {
+  pointer-events: none;
+}
+
 .button.primary:disabled,
 .button.primary[aria-disabled="true"] {
   background-color: var(--color-disabled-bg);

--- a/nextjs-app/shared/components/Button/Button.test.tsx
+++ b/nextjs-app/shared/components/Button/Button.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, createEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { axe, toHaveNoViolations } from "jest-axe";
 import Button from "@dt/Button";
@@ -153,6 +153,53 @@ describe("Button", () => {
     );
     const link = screen.getByText("Disabled Link").closest("a");
     expect(link).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("makes a disabled link non-navigable (drops href, removes from tab order)", () => {
+    render(
+      <Button href="/disabled-link" disabled>
+        Disabled Link
+      </Button>,
+    );
+    const link = screen.getByText("Disabled Link").closest("a");
+    expect(link).not.toHaveAttribute("href");
+    expect(link).toHaveAttribute("tabindex", "-1");
+    expect(link).toHaveAttribute("role", "link");
+  });
+
+  it("suppresses click navigation on a disabled link and skips onClick", () => {
+    const onClick = vi.fn();
+    render(
+      <Button href="/disabled-link" disabled onClick={onClick}>
+        Disabled Link
+      </Button>,
+    );
+    const link = screen.getByText("Disabled Link").closest("a") as HTMLElement;
+    const clickEvent = createEvent.click(link);
+    fireEvent(link, clickEvent);
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("treats a loading link as non-navigable too", () => {
+    render(
+      <Button href="/loading-link" loading>
+        Loading Link
+      </Button>,
+    );
+    const link = screen.getByText("Loading Link").closest("a");
+    expect(link).not.toHaveAttribute("href");
+    expect(link).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("has no accessibility violations as a disabled link", async () => {
+    const { container } = render(
+      <Button href="/disabled-link" disabled>
+        Disabled Link
+      </Button>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 
   it("renders link with icon and maintains visual structure", () => {

--- a/nextjs-app/shared/components/Button/Button.tsx
+++ b/nextjs-app/shared/components/Button/Button.tsx
@@ -224,16 +224,34 @@ const Button = React.forwardRef<
     );
 
     if (isLink) {
-      const { href, target, rel, ...linkRest } = rest as ButtonAsLink;
+      const { href, target, rel, onClick, ...linkRest } = rest as ButtonAsLink;
+      // A disabled/loading link must not navigate: drop href (so there is no
+      // target for mouse, keyboard, or programmatic activation), remove it from
+      // the tab order, keep it announced as a disabled link, and swallow clicks.
+      const linkDisabled = disabled || loading;
       return (
         <a
           ref={ref as React.Ref<HTMLAnchorElement>}
-          href={href}
-          target={target}
-          rel={rel || (target === "_blank" ? "noopener noreferrer" : undefined)}
-          aria-disabled={disabled || loading || undefined}
           {...commonProps}
           {...linkRest}
+          href={linkDisabled ? undefined : href}
+          target={linkDisabled ? undefined : target}
+          rel={
+            linkDisabled
+              ? undefined
+              : rel || (target === "_blank" ? "noopener noreferrer" : undefined)
+          }
+          role={linkDisabled ? "link" : undefined}
+          aria-disabled={linkDisabled || undefined}
+          tabIndex={linkDisabled ? -1 : undefined}
+          onClick={
+            linkDisabled
+              ? (event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                }
+              : onClick
+          }
         >
           {content}
         </a>

--- a/nextjs-app/shared/components/FormField/FormField.test.tsx
+++ b/nextjs-app/shared/components/FormField/FormField.test.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { FormField } from "./FormField";
+
+expect.extend(toHaveNoViolations);
+
+describe("FormField", () => {
+  it("associates the label with the control via a shared id", () => {
+    render(
+      <FormField label="Email">
+        <input type="email" />
+      </FormField>,
+    );
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+  });
+
+  it("preserves a control's own id and points the label at it", () => {
+    render(
+      <FormField label="Email" id="field-wrapper">
+        <input id="custom-email" type="email" />
+      </FormField>,
+    );
+    expect(screen.getByLabelText("Email")).toHaveAttribute("id", "custom-email");
+  });
+
+  it("wires aria-describedby + aria-invalid onto the control when there is an error", () => {
+    render(
+      <FormField label="Email" error="Email is required">
+        <input type="email" />
+      </FormField>,
+    );
+    const input = screen.getByLabelText("Email");
+    const errorEl = screen.getByText("Email is required");
+    expect(errorEl).toHaveAttribute("role", "alert");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input.getAttribute("aria-describedby")?.split(" ")).toContain(
+      errorEl.id,
+    );
+  });
+
+  it("describes the control with helper text when there is no error", () => {
+    render(
+      <FormField label="Password" helperText="Use 8+ characters">
+        <input type="password" />
+      </FormField>,
+    );
+    const input = screen.getByLabelText("Password");
+    const helper = screen.getByText("Use 8+ characters");
+    expect(input).not.toHaveAttribute("aria-invalid");
+    expect(input.getAttribute("aria-describedby")?.split(" ")).toContain(
+      helper.id,
+    );
+  });
+
+  it("prefers the error over helper text for the description", () => {
+    render(
+      <FormField
+        label="Email"
+        helperText="We never share it"
+        error="Invalid email"
+      >
+        <input type="email" />
+      </FormField>,
+    );
+    expect(screen.queryByText("We never share it")).not.toBeInTheDocument();
+    const input = screen.getByLabelText("Email");
+    const errorEl = screen.getByText("Invalid email");
+    expect(input.getAttribute("aria-describedby")?.split(" ")).toContain(
+      errorEl.id,
+    );
+  });
+
+  it("merges an existing aria-describedby already on the control", () => {
+    render(
+      <FormField label="Email" error="Required">
+        <input type="email" aria-describedby="external-hint" />
+      </FormField>,
+    );
+    const tokens = screen
+      .getByLabelText("Email")
+      .getAttribute("aria-describedby")
+      ?.split(" ");
+    expect(tokens).toContain("external-hint");
+    expect(tokens?.length).toBeGreaterThan(1);
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <FormField label="Email" error="Email is required">
+        <input type="email" />
+      </FormField>,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/FormField/FormField.tsx
+++ b/nextjs-app/shared/components/FormField/FormField.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { type ReactNode, useId } from "react";
+import {
+  type ReactNode,
+  type ReactElement,
+  cloneElement,
+  isValidElement,
+  useId,
+} from "react";
 import { cn } from "@/lib/utils";
 import Label from "@dt/Label";
 
@@ -30,14 +36,37 @@ export function FormField({
   const helperId = `${id}-helper`;
   const errorId = `${id}-error`;
 
+  // Wire description + validation state onto the actual control so assistive
+  // tech announces the error/help text. The control keeps its own id when it
+  // sets one; otherwise it inherits the id the Label points at.
+  const control = isValidElement(children)
+    ? (children as ReactElement<Record<string, unknown>>)
+    : null;
+  const controlId = (control?.props.id as string | undefined) ?? id;
+  const describedBy =
+    [
+      error ? errorId : null,
+      helperText && !error ? helperId : null,
+      control?.props["aria-describedby"] as string | undefined,
+    ]
+      .filter(Boolean)
+      .join(" ") || undefined;
+
+  const field = control
+    ? cloneElement(control, {
+        id: controlId,
+        "aria-describedby": describedBy,
+        "aria-invalid": error ? true : control.props["aria-invalid"],
+      })
+    : children;
+
   return (
     <div className={cn("space-y-2", className)}>
-      <Label htmlFor={id} required={required} disabled={disabled}>
+      <Label htmlFor={controlId} required={required} disabled={disabled}>
         {label}
       </Label>
 
-      {/* Children should be Input, Textarea, or Select with id prop */}
-      {children}
+      {field}
 
       {error && (
         <p

--- a/nextjs-app/shared/styles/variables.css
+++ b/nextjs-app/shared/styles/variables.css
@@ -501,21 +501,8 @@
   --main-body-background-color: #fff;
   --color-title: #000;
 
-  /* High contrast decorative overrides */
-
-  /* High contrast decorative overrides */
-
-  /* Reduced selector specificity by removing descendant chain; rely on contextual class hooks */
-
-  .themeHCB .badge {
-    /* stylelint-disable-next-line scale-unlimited/declaration-strict-value */
-    forced-color-adjust: none;
-  }
-
-  .themeHCB .toast {
-    /* stylelint-disable-next-line scale-unlimited/declaration-strict-value */
-    forced-color-adjust: none;
-  }
+  /* HCB badge/toast forced-colors opt-out moved to top level (was mis-nested
+     here under .themeHCW, which compiled to an unreachable selector). */
 
   /* View Transition future hook (commented until adopted) */
 
@@ -581,6 +568,16 @@
   --focus-ring-color: #000;
   --focus-ring-width: 3px;
   --focus-ring-offset: 3px;
+}
+
+/* HCB badge/toast: honor the theme's own high-contrast colors instead of the
+   UA forced-colors palette. Relocated from a mis-nested rule inside .themeHCW
+   (where it compiled to the unreachable selector ".themeHCW :root .themeHCB …"). */
+
+.themeHCB .badge,
+.themeHCB .toast {
+  /* stylelint-disable-next-line scale-unlimited/declaration-strict-value */
+  forced-color-adjust: none;
 }
 
 /* Forced colors (Windows High Contrast mode)

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-i18next": "^17.0.8",
-        "react-icons": "^5.6.0",
+        "react-icons": "5.5.0",
         "react-markdown": "^10.1.0",
         "react-phone-number-input": "^3.4.17",
         "rehype-pretty-code": "^0.14.3",
@@ -39032,9 +39032,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
-      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*"

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-i18next": "^17.0.8",
-    "react-icons": "^5.6.0",
+    "react-icons": "5.5.0",
     "react-markdown": "^10.1.0",
     "react-phone-number-input": "^3.4.17",
     "rehype-pretty-code": "^0.14.3",

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -4152,9 +4152,9 @@
       "text": "Expected variable, function or keyword for \"dark\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)"
     },
     {
-      "id": "nextjs-app/shared/styles/variables.css::590::5::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"light\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)",
+      "id": "nextjs-app/shared/styles/variables.css::587::5::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"light\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)",
       "file": "nextjs-app/shared/styles/variables.css",
-      "line": 590,
+      "line": 587,
       "column": 5,
       "rule": "scale-unlimited/declaration-strict-value",
       "severity": "warning",


### PR DESCRIPTION
Council audit (2026-06-19, 8 personas) follow-up. Ships **4 of the 5 P0 "stop-the-line" items** — the pure-correctness blockers with no visual/token-value decisions. The 5th (HCW warning contrast + gate expansion) needs a design-owner call on warning-surface tokens and is intentionally deferred (see below).

## Fixes
- **P0 #2 — disabled `<Button>`-link navigated.** Kept `href` + only `aria-disabled`. Now drops `href`/`target`/`rel`, sets `tabIndex=-1` + `role="link"` + `aria-disabled`, `preventDefault`s clicks, and `pointer-events:none`. New tests incl. disabled-link axe pass.
- **P0 #4 (blocker) — `FormField` never wired aria.** Rendered `{children}` verbatim; `errorId`/`helperId` lived only on `<p>`s. Now clones the control to inject `id` (label points at the real control id), `aria-describedby` (error/helper, merged), and `aria-invalid`. Adds the missing `FormField.test.tsx` with rendered-DOM assertions.
- **P0 #5 — mis-nested HC rules.** `.themeHCB .badge`/`.toast` sat inside the `.themeHCW` block (compiled to a dead selector). Relocated to top level so the forced-colors opt-out actually applies in HCB.
- **P0 #3 — `react-icons` floating.** `^5.6.0` despite docs claiming a 5.5.0 pin; 15 Work pages import `react-icons/si`. Pinned exact `5.5.0`; corrected the CLAUDE.md gotcha.

## Deferred — P0 #1 (HCW warning contrast + gate)
The gated `warning-text-on-warning` 1.19:1 fail can't be fixed by a value tweak without a regression: `--color-warning-text` is overloaded (light text on the Toast's dark fill vs dark text on HelperText/Card's light surface), and `--color-warning` must stay dark for Progress/Modal/Dialog. Correct fix = introduce `--color-warning-bg`, repoint Toast + HelperText, fix the gate pair to mirror `error-text-on-error-bg`, then enforce the HC themes. That's a token-architecture change with value choices — flagged for design sign-off rather than done unilaterally.

## Verification (all local, CI is quota-dead)
typecheck ✓ · lint ✓ · lint:css ✓ · check:tokens ✓ · validate:components ✓ · lint:dt-usage ✓ · vitest 1822/1822 ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled links and buttons now properly prevent user interaction and navigation.
  * Form field errors and helper text are now correctly associated with form controls for assistive technologies.
  * Fixed high-contrast theme styling for badges and toasts.

* **Tests**
  * Added comprehensive tests for disabled/loading link behavior and form field accessibility.

* **Chores**
  * Pinned react-icons dependency to version 5.5.0.

* **Documentation**
  * Updated guidance on react-icons version requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->