### PR TITLE
fix(alertbanner): announce error tone assertively (role=alert)

### DIFF
--- a/nextjs-app/shared/components/AlertBanner/AlertBanner.test.tsx
+++ b/nextjs-app/shared/components/AlertBanner/AlertBanner.test.tsx
@@ -75,6 +75,18 @@ describe("AlertBanner", () => {
     );
   });
 
+  it("error tone announces assertively via role=alert", () => {
+    render(<AlertBanner tone="error" title="Something failed" />);
+    const banner = screen.getByRole("alert");
+    expect(banner).toHaveAttribute("aria-live", "assertive");
+  });
+
+  it("non-error tone stays a polite status region", () => {
+    render(<AlertBanner tone="success" title="Saved" />);
+    const banner = screen.getByRole("status");
+    expect(banner).toHaveAttribute("aria-live", "polite");
+  });
+
   it("renders description as React node", () => {
     render(
       <AlertBanner

--- a/nextjs-app/shared/components/AlertBanner/AlertBanner.tsx
+++ b/nextjs-app/shared/components/AlertBanner/AlertBanner.tsx
@@ -32,13 +32,18 @@ const AlertBanner: React.FC<AlertBannerProps> = ({
   description,
   dismissible = false,
   onDismiss,
-  "aria-live": ariaLive = "polite",
+  "aria-live": ariaLive,
 }) => {
+  // Error banners must interrupt assistive tech (role=alert / assertive);
+  // other tones are polite status updates. An explicit aria-live prop wins.
+  const isError = tone === "error";
+  const role = isError ? "alert" : "status";
+  const liveRegion = ariaLive ?? (isError ? "assertive" : "polite");
   return (
     <div
       className={`${styles.banner} ${styles[tone]}`.trim()}
-      role="status"
-      aria-live={ariaLive}
+      role={role}
+      aria-live={liveRegion}
     >
       <Icon name={toneIcon[tone]} ariaLabel={tone} size="md" />
       <div className={styles.content}>


### PR DESCRIPTION
The one council-audit P0 a11y fix **not** covered by #771 (which landed the Button disabled-link, FormField aria wiring, `.themeHCB` un-nest, and react-icons pin in parallel).

AlertBanner hardcoded `role="status"` + `aria-live="polite"` for every tone, so a `tone="error"` banner was announced politely and could be missed by screen-reader users. Error now uses `role="alert"` with an assertive live region; other tones stay polite status regions; an explicit `aria-live` prop still wins. +2 tests.

Rebased onto current `main` after #771 merged; my parallel Button/FormField/token commits were dropped as redundant to avoid clobbering #771's merged work.

Verified locally (CI quota-dead): typecheck · eslint · stylelint · vitest **1824/1824** · `next build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
