### PR TITLE
fix(a11y): resolve HCW warning contrast — final council P0 item

### DIFF
--- a/nextjs-app/shared/components/Card/Card.module.css
+++ b/nextjs-app/shared/components/Card/Card.module.css
@@ -429,7 +429,7 @@
 .statusWarning {
   border-color: var(--color-warning-border, rgb(245 158 11 / 20%));
   background-color: var(--color-warning-bg, rgb(245 158 11 / 10%));
-  color: var(--color-warning-text);
+  color: var(--color-warning-contrast);
 }
 
 /* Border Variants */

--- a/nextjs-app/shared/components/HelperText/HelperText.module.css
+++ b/nextjs-app/shared/components/HelperText/HelperText.module.css
@@ -20,7 +20,9 @@
 }
 
 .warning {
-  color: var(--color-warning-text);
+  /* On-canvas warning text: use the accessible warning foreground, not
+     --color-warning-text (which is the text color *on* a warning fill). */
+  color: var(--color-warning-contrast);
 }
 
 .success {

--- a/nextjs-app/shared/foundations/token-catalog.json
+++ b/nextjs-app/shared/foundations/token-catalog.json
@@ -1,6 +1,6 @@
 {
   "source": "nextjs-app/shared/styles/variables.css",
-  "generatedAt": "2026-06-13T09:53:27.042Z",
+  "generatedAt": "2026-06-20T09:49:47.707Z",
   "tokenCount": 164,
   "usageCoverage": 132,
   "themes": [
@@ -442,11 +442,11 @@
         "label": "Warning text on warning",
         "largeText": false,
         "themeId": "hcw",
-        "fgRaw": "#041b23",
+        "fgRaw": "#fff",
         "bgRaw": "#000",
-        "ratio": 1.19,
-        "level": "Fail",
-        "pass": false
+        "ratio": 21,
+        "level": "AAA",
+        "pass": true
       }
     ]
   },

--- a/nextjs-app/shared/styles/variables.css
+++ b/nextjs-app/shared/styles/variables.css
@@ -520,7 +520,10 @@
   --color-error: #000;
   --color-warning: #000;
   --color-warning-contrast: #000;
-  --color-warning-text: #041b23;
+
+  /* White text for the dark (#000) warning surface (e.g. Toast .toast--warning).
+     On-canvas warning text uses --color-warning-contrast (HelperText, Card). */
+  --color-warning-text: #fff;
   --color-neutral-bg: #fff;
   --color-neutral-text: #000;
   --color-error-bg: #fff;

--- a/scripts/design-system/check-contrast.mjs
+++ b/scripts/design-system/check-contrast.mjs
@@ -11,7 +11,9 @@ const catalog = JSON.parse(
 );
 
 let failed = 0;
-const ENFORCED_THEMES = new Set(["light", "dark"]);
+// All four shipped themes are gated, including the two high-contrast themes —
+// the audit shipped an HCW warning-on-warning 1.19:1 fail because they weren't.
+const ENFORCED_THEMES = new Set(["light", "dark", "hcb", "hcw"]);
 for (const [themeId, rows] of Object.entries(catalog.contrastByTheme ?? {})) {
   if (!ENFORCED_THEMES.has(themeId)) continue;
   for (const row of rows) {

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -4152,9 +4152,9 @@
       "text": "Expected variable, function or keyword for \"dark\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)"
     },
     {
-      "id": "nextjs-app/shared/styles/variables.css::587::5::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"light\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)",
+      "id": "nextjs-app/shared/styles/variables.css::590::5::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"light\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)",
       "file": "nextjs-app/shared/styles/variables.css",
-      "line": 587,
+      "line": 590,
       "column": 5,
       "rule": "scale-unlimited/declaration-strict-value",
       "severity": "warning",


### PR DESCRIPTION
Completes the council-audit **P0 stop-the-line** set: this is item #1 (the shipped WCAG fail), the last of the five. The other four landed in #771.

## The problem
The HC-White theme's `warning-text-on-warning` pair shipped at **1.19:1** (near-black `#041b23` on black `#000`) — flagged red by the studio's own Contrast story but never gated, because `check-contrast.mjs` only enforced `light`+`dark`.

It isn't a one-value tweak: `--color-warning-text` is **overloaded** — light-on-dark for the Toast's `--color-warning` fill, but dark-on-light for HelperText/Card on the canvas — so no single value satisfies both.

## The fix
- HCW `--color-warning-text` `#041b23 → #fff` — white text on the `#000` warning surface (Toast) → **21:1**.
- Repoint **HelperText** `.warning` and **Card** `.statusWarning` text to `--color-warning-contrast`, the token *designed* for accessible on-canvas warning text. This also fixes their **previously-broken dark + HCB** warning text (dark-on-dark today, ungated).
- **Gate hardening:** `ENFORCED_THEMES` now includes `hcb`+`hcw` (hcb already passed all 7 pairs), so a high-contrast contrast fail can never ship again.

No new tokens, no Toast/Progress/Modal changes. Regenerated `token-catalog.json`.

## Visible change (default themes)
HelperText/Card **warning text** in light mode shifts from brand ink `#041b23` to amber `#8d5a00` (the existing `--color-warning-contrast`, already used by Badge). This is intentional — warning text now *reads* as a warning and is consistent across all four themes — but it's the one user-facing color change here. Easy to revert that single token reference if you'd rather keep brand ink (at the cost of re-breaking dark/HCB).

## Verification (all local, CI quota-dead)
check:contrast (all 4 themes) ✓ · typecheck ✓ · lint ✓ · lint:css ✓ · check:tokens ✓ · validate:components ✓ · vitest 1824/1824 ✓ · build ✓ · pre-commit hook ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved contrast for warning status indicators across components to meet AAA accessibility standards in high-contrast themes.
  * Updated warning text colors to enhance readability and accessibility compliance.

* **Chores**
  * Extended contrast validation to cover all shipped themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->