### PR TITLE
fix(patterns): resolve undefined CSS-module class refs in block wrappers

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-06-21T14:37:30.849Z",
+  "createdAt": "2026-06-21T20:07:05.249Z",
   "directory": "nextjs-app/shared",
   "findings": [
     {
@@ -6785,8 +6785,8 @@
     {
       "column": 25,
       "file": "nextjs-app/shared/patterns/TeamBlock/TeamBlock.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/TeamBlock/TeamBlock.module.css\u001f157\u001f25\u001f-4px\u001fUnexpected raw scale value \"-4px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 157,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/TeamBlock/TeamBlock.module.css\u001f163\u001f25\u001f-4px\u001fUnexpected raw scale value \"-4px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 163,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"-4px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -6795,8 +6795,8 @@
     {
       "column": 17,
       "file": "nextjs-app/shared/patterns/TeamBlock/TeamBlock.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/TeamBlock/TeamBlock.module.css\u001f184\u001f17\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 184,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/TeamBlock/TeamBlock.module.css\u001f190\u001f17\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 190,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -6805,8 +6805,8 @@
     {
       "column": 22,
       "file": "nextjs-app/shared/patterns/TeamBlock/TeamBlock.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/TeamBlock/TeamBlock.module.css\u001f184\u001f22\u001f0.25rem\u001fUnexpected raw scale value \"0.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 184,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/TeamBlock/TeamBlock.module.css\u001f190\u001f22\u001f0.25rem\u001fUnexpected raw scale value \"0.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 190,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",

--- a/nextjs-app/shared/patterns/GridBlock/GridBlock.tsx
+++ b/nextjs-app/shared/patterns/GridBlock/GridBlock.tsx
@@ -104,7 +104,9 @@ function GridBlock({
     >
       <PageLayout maxWidth={maxWidth} spacing={spacing} as={as}>
         <div
-          className={`${gridClassName} ${gapClassName} ${responsiveGapClass} ${className}`}
+          className={[gridClassName, gapClassName, responsiveGapClass, className]
+            .filter(Boolean)
+            .join(" ")}
         >
           {cells.map((cell, index) => {
             if (cell.type === "text") {

--- a/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx
+++ b/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx
@@ -89,7 +89,7 @@ const ProcessBlock: React.FC<ProcessBlockProps> = ({
 
   return (
     <Wrapper
-      className={`${styles.processBlock} ${className}`}
+      className={[styles.processBlock, className].filter(Boolean).join(" ")}
       style={{
         backgroundColor: bgColors[backgroundColor],
         paddingBlock: "var(--space-xl, 3rem)",

--- a/nextjs-app/shared/patterns/TeamBlock/TeamBlock.module.css
+++ b/nextjs-app/shared/patterns/TeamBlock/TeamBlock.module.css
@@ -1,6 +1,12 @@
 /* TeamBlock - Reusable team member display component */
 
-/* Container styles applied via inline style (background, padding) */
+/* Container. Background + padding are prop-driven and applied inline; this
+ * base rule gives the wrapper a stable, addressable class so it never falls
+ * back to a literal "undefined" class name in the production build. */
+
+.teamBlock {
+  position: relative;
+}
 
 .sectionTitle {
   display: flex;

--- a/nextjs-app/shared/patterns/TeamBlock/TeamBlock.stories.tsx
+++ b/nextjs-app/shared/patterns/TeamBlock/TeamBlock.stories.tsx
@@ -32,12 +32,12 @@ const TeamBlockForStorybook: React.FC<TeamBlockProps> = ({
     white: "var(--color-white)",
     transparent: "transparent",
   };
-  const gridClass = `${styles.grid} ${styles[`grid${columns}Col`]}`;
-  const imageClass = roundImages ? styles.roundImage : styles.image;
+  const gridClass = styles[`grid${columns}Col`];
+  const imageClass = roundImages ? styles.roundImage : styles.teamImage;
 
   return (
     <Wrapper
-      className={`${styles.teamBlock} ${className}`}
+      className={[styles.teamBlock, className].filter(Boolean).join(" ")}
       style={{
         backgroundColor: bgColors[backgroundColor],
         paddingBlock:
@@ -47,7 +47,12 @@ const TeamBlockForStorybook: React.FC<TeamBlockProps> = ({
     >
       <PageLayout maxWidth={maxWidth} spacing={spacing} as="div">
         {sectionTitle && (
-          <Title level={2} terminals="sans" size="xl" className={styles.title}>
+          <Title
+            level={2}
+            terminals="sans"
+            size="xl"
+            className={styles.sectionTitle}
+          >
             {sectionTitle}
           </Title>
         )}

--- a/nextjs-app/shared/patterns/TeamBlock/TeamBlock.tsx
+++ b/nextjs-app/shared/patterns/TeamBlock/TeamBlock.tsx
@@ -110,7 +110,7 @@ const TeamBlock: React.FC<TeamBlockProps> = ({
 
   return (
     <Wrapper
-      className={`${styles.teamBlock} ${className}`}
+      className={[styles.teamBlock, className].filter(Boolean).join(" ")}
       style={{
         backgroundColor: bgColors[backgroundColor],
         paddingBlock: backgroundColor !== "transparent" ? "var(--space-xl, 3rem)" : "0",

--- a/nextjs-app/shared/patterns/css-module-class-references.test.ts
+++ b/nextjs-app/shared/patterns/css-module-class-references.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Static guard against the "literal undefined class" bug.
+ *
+ * The Vitest CSS Modules layer fabricates a scoped name for ANY accessed key,
+ * even one that has no matching rule (e.g. `styles.doesNotExist` resolves to a
+ * truthy `_doesNotExist_xxxx` string). The real Next.js production build does
+ * NOT: a missing key is `undefined`, so `` `${styles.missing} ${className}` ``
+ * renders the literal string "undefined" into the DOM `class` attribute.
+ *
+ * That makes the bug invisible to ordinary render tests. This check instead
+ * reads the source from disk and fails if a component references a
+ * `styles.<name>` that is never declared as a `.<name>` rule in its colocated
+ * CSS Module. Dynamic access (`styles[`grid${n}Col`]`) is intentionally not
+ * analysed here.
+ */
+const PATTERNS = ["GridBlock", "ProcessBlock", "TeamBlock"];
+
+describe("pattern CSS Module class references resolve", () => {
+  for (const name of PATTERNS) {
+    it(`${name}: every styles.x has a matching .x rule`, () => {
+      const tsx = readFileSync(join(here, name, `${name}.tsx`), "utf8");
+      const css = readFileSync(join(here, name, `${name}.module.css`), "utf8");
+
+      const referenced = new Set<string>();
+      for (const match of tsx.matchAll(/\bstyles\.([A-Za-z_$][\w$]*)/g)) {
+        referenced.add(match[1]);
+      }
+
+      const missing = [...referenced].filter(
+        // `.col` must not match `.column`; a CSS class name ends at a non
+        // word / non hyphen character.
+        (cls) => !new RegExp(`\\.${cls}(?![\\w-])`).test(css),
+      );
+
+      expect(
+        missing,
+        `${name}.tsx references CSS Module classes with no rule in ${name}.module.css`,
+      ).toEqual([]);
+    });
+  }
+});

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -3918,9 +3918,9 @@
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/patterns/TeamBlock/TeamBlock.module.css::203::33::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/patterns/TeamBlock/TeamBlock.module.css::209::33::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/patterns/TeamBlock/TeamBlock.module.css",
-      "line": 203,
+      "line": 209,
       "column": 33,
       "rule": "declaration-no-important",
       "severity": "warning",


### PR DESCRIPTION
## What

`TeamBlock` referenced `styles.teamBlock`, a class with **no rule** in its CSS Module. In the production Next.js build a missing CSS-module key is `undefined`, so the wrapper rendered a literal `class="undefined"`. Unit tests never caught it because the Vitest CSS Modules layer fabricates a scoped name for *any* key, including undefined ones (`Object.keys(styles)` is `[]` yet `styles.anything` returns a truthy `_anything_hash`).

## Changes

- **TeamBlock** (real bug): add the missing `.teamBlock` base rule (parity with `.storyBlock` / `.processBlock`) and harden the wrapper `className` to the repo's `filter(Boolean).join(" ")` idiom.
- **TeamBlock story**: the divergent `TeamBlockForStorybook` copy referenced three more non-existent classes (`grid`, `image`, `title`); repointed them at the real classes.
- **ProcessBlock / GridBlock**: audit **false positives**. Their referenced classes (`processBlock`, `responsiveGap`) *do* exist via compound/descendant selectors (`.processBlock *`, `.grid2Col.responsiveGap`), so they never rendered `undefined`. Joins hardened anyway for consistency + to drop cosmetic trailing/double spaces.
- **New static guard** `css-module-class-references.test.ts`: reads each block pattern from disk and fails if a `styles.x` reference has no matching `.x` rule, because the Vitest CSS proxy otherwise masks this entire bug class.
- Refreshed stylelint + rhythmguard baselines for pre-existing findings whose line numbers shifted (net zero; line-number shifts only).

## Verification

- `npm run typecheck` ✓
- `npm run lint` ✓
- `npm test` ✓ (1827/1827)
- `npm run build` ✓
- New guard: **RED before** the fix (reports `['teamBlock']`), **GREEN after**.

> Note: `TeamBlock` is currently imported but not rendered on any page (dead import in `HelsinkiDesignSystemPage`), so the bug was *latent*. It is a shipped DS primitive, so the fix still matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved className handling to prevent empty class contributions in GridBlock, ProcessBlock, and TeamBlock components.

* **New Features**
  * Added automated validation test to ensure CSS Module class references are properly defined.

* **Refactor**
  * Updated className construction patterns across components to use filtered array joins for cleaner code.
  * Enhanced CSS styling organization with dedicated `.teamBlock` rule and updated class assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->