### PR TITLE
ci: run PR validation on the self-hosted farm + report to dashboard

### DIFF
--- a/.github/scripts/report-ci.sh
+++ b/.github/scripts/report-ci.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Posts this gate job's result to the dashboard push-collector (POST /ci/runs). Runs as the
+# final workflow step on the self-hosted runner. It MUST NEVER fail the gate: it no-ops when
+# unconfigured and swallows all POST errors. No secrets are logged.
+set -u
+[ -n "${CI_COLLECTOR_URL:-}" ] || exit 0
+
+# conclusion = the workflow job.status, passed in as JOB_STATUS (success/failure/cancelled).
+body=$(jq -n \
+  --arg repo "${GITHUB_REPOSITORY:-}" --arg node "${CI_REPORT_NODE:-}" \
+  --arg conclusion "${JOB_STATUS:-unknown}" --arg sha "${GITHUB_SHA:-}" \
+  --arg workflow "${GITHUB_WORKFLOW:-}" --arg branch "${GITHUB_REF_NAME:-}" \
+  --arg run_id "${GITHUB_RUN_ID:-}" --arg run_attempt "${GITHUB_RUN_ATTEMPT:-}" \
+  --arg job "${GITHUB_JOB:-}" \
+  '{repo:$repo,node:$node,conclusion:$conclusion,sha:$sha,workflow:$workflow,branch:$branch,run_id:$run_id,run_attempt:$run_attempt,job:$job}')
+
+curl -fsS --max-time 5 -X POST "$CI_COLLECTOR_URL" \
+  -H "Authorization: Bearer ${CI_COLLECTOR_TOKEN:-}" \
+  -H "Content-Type: application/json" \
+  -d "$body" >/dev/null 2>&1 || true
+exit 0

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -3,7 +3,11 @@ on:
   pull_request:
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    # Self-hosted CI farm (owned hardware) instead of metered GitHub-hosted minutes. PUBLIC repo:
+    # fork PRs must NEVER run on our runners, so gate to same-repo PRs (and pushes) only — a fork
+    # PR is skipped here, exactly as it never reaches the farm's secrets.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, digitaltableteur]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -37,3 +41,11 @@ jobs:
       - run: npm run test:ci
       - run: npm run build
       - run: npm run check:drift
+      - name: Report CI result to dashboard collector
+        if: always()   # report pass AND fail; the reporting step can never fail the gate
+        env:
+          CI_COLLECTOR_URL: ${{ vars.CI_COLLECTOR_URL }}
+          CI_COLLECTOR_TOKEN: ${{ secrets.CI_COLLECTOR_TOKEN }}
+          CI_REPORT_NODE: ${{ runner.name }}
+          JOB_STATUS: ${{ job.status }}
+        run: bash .github/scripts/report-ci.sh


### PR DESCRIPTION
## What

Routes this repo's CI to the **owned-hardware self-hosted farm** instead of metered GitHub-hosted minutes, and posts each run's pass/fail to the agentlab dashboard push-collector.

- `runs-on` → `[self-hosted, <repo>]`
- final `if: always()` step runs `.github/scripts/report-ci.sh` (repo-agnostic; uses `env:` for all values; can never fail the gate — no-ops until the collector var/secret exist)

## ⚠️ Merge ordering
Depends on the agentlab side, already merged ([agentlab#82](https://github.com/PetriLahdelma/agentlab/pull/82)). Its reconciler, on the mini's ~15-min tick, **auto-installs this repo's runner and sets `CI_COLLECTOR_URL` + `CI_COLLECTOR_TOKEN`**. Before merging, confirm the runner is online:

```
gh api repos/PetriLahdelma/digitaltableteur/actions/runners --jq '.runners[]|"\(.name) \(.status)"'
```

Merging before the runner registers just queues the job (waiting for a self-hosted runner) rather than failing — it picks up once the runner is online.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Note: PUBLIC repo — gated to same-repo PRs and pushes, so fork PRs never run on our hardware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CI validation results are now reported to an external dashboard after each run.
  * Validation jobs now use a self-hosted runner pool when available.

* **Bug Fixes**
  * Forked pull requests are prevented from running on self-hosted runners.
  * Reporting is non-blocking, so dashboard updates won’t fail the workflow if the collector is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->