### PR TITLE
ci: farm collector smoke marker

### DIFF
--- a/docs/ci/farm-smoke.md
+++ b/docs/ci/farm-smoke.md
@@ -1,0 +1,5 @@
+# CI farm smoke marker
+
+Trivial same-repo PR to exercise the self-hosted CI farm end-to-end and
+verify the run reports to the agentlab dashboard collector (which only
+receives data from same-repo PRs/pushes, not Dependabot PRs). Safe to delete.


### PR DESCRIPTION
Trivial same-repo change to exercise the self-hosted CI farm on a **non-Dependabot** PR.

Why: every farm run on this repo so far has been a Dependabot PR, which runs against Dependabot's separate secret store, so `secrets.CI_COLLECTOR_TOKEN` is empty and `report-ci.sh` fail-opens without posting. Result: the agentlab dashboard shows "no data" for digitaltableteur. A normal same-repo PR gets the real Actions secret and will POST to the collector, clearing the toast.

Note: `validate` is expected to land **red** here due to a pre-existing props-drift check (`Checkbox`/`Switch` → `npm run sync:contract-props -- --write`) — independent of the CI plumbing. The point of this PR is to prove farm → collector → dashboard, which happens via the `if: always()` report step regardless of pass/fail.

Safe to delete after the run reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a brief note describing a simple same-repository PR used to verify end-to-end CI farm reporting.
  * Clarified that the marker helps confirm runs appear in the dashboard collector and can be safely removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->