### PR TITLE
fix(design-system): regenerate contract props after platinum boolean rename

### DIFF
--- a/nextjs-app/shared/components/Badge/Badge.contract.json
+++ b/nextjs-app/shared/components/Badge/Badge.contract.json
@@ -128,11 +128,11 @@
             "optional": true,
             "type": "union",
             "values": [
-                "neutral",
-                "error",
-                "warning",
+                "info",
                 "success",
-                "info"
+                "warning",
+                "error",
+                "neutral"
             ]
         },
         "size": {
@@ -174,15 +174,15 @@
         }
     },
     "forbiddenUse": [
-        "rely on colour alone to convey tone — pair with the icon",
-        "nest a Button inside a Badge beyond the built-in removable affordance"
+        "rely on colour alone to convey tone — pair it with the icon or include",
+        "nest a Button inside a Badge beyond the built-in removable affordance."
     ],
     "composesWith": [
         "Title",
         "Link",
         "Button",
-        "Text",
         "FlexBox",
+        "Text",
         "Grid"
     ]
 }

--- a/nextjs-app/shared/components/Button/Button.contract.json
+++ b/nextjs-app/shared/components/Button/Button.contract.json
@@ -157,6 +157,22 @@
     ],
     "schemaVersion": 2,
     "props": {
+        "submits": {
+            "optional": true,
+            "type": "never"
+        },
+        "href": {
+            "optional": false,
+            "type": "string"
+        },
+        "target": {
+            "optional": true,
+            "type": "HTMLAttributeAnchorTarget | undefined"
+        },
+        "rel": {
+            "optional": true,
+            "type": "string | undefined"
+        },
         "variant": {
             "optional": true,
             "type": "union",
@@ -170,11 +186,11 @@
             "optional": true,
             "type": "union",
             "values": [
-                "neutral",
-                "error",
-                "warning",
+                "info",
                 "success",
-                "info"
+                "warning",
+                "error",
+                "neutral"
             ]
         },
         "size": {
@@ -234,30 +250,14 @@
         "tooltip": {
             "optional": true,
             "type": "string"
-        },
-        "submits": {
-            "optional": true,
-            "type": "boolean"
-        },
-        "href": {
-            "optional": false,
-            "type": "string"
-        },
-        "target": {
-            "optional": true,
-            "type": "HTMLAttributeAnchorTarget | undefined"
-        },
-        "rel": {
-            "optional": true,
-            "type": "string | undefined"
         }
     },
     "forbiddenUse": [
-        "tertiary on low-contrast surfaces without verifying contrast",
-        "surface onBrand without verifying brand-color contrast",
-        "an icon-only button with a tooltip as the only accessible name",
-        "nesting a Button inside another interactive control",
-        "a Button for inline navigation in body copy. Use Link instead."
+        "tertiary on dark or inverse backgrounds without explicit contrast verification",
+        "isInverse on primary over transparent or gradient parents — use surface instead",
+        "pair an icon-only button with a tooltip as the *only* accessible name",
+        "nest a Button inside another interactive control. Buttons are terminal.",
+        "use a Button for inline navigation in body copy. Use **Link**."
     ],
     "prefersOver": [
         "raw button",
@@ -266,7 +266,9 @@
     "composesWith": [
         "Title",
         "Text",
+        "Inputs",
         "Icon",
-        "Modal"
+        "Modal",
+        "CheckboxGroup"
     ]
 }

--- a/nextjs-app/shared/components/Checkbox/Checkbox.contract.json
+++ b/nextjs-app/shared/components/Checkbox/Checkbox.contract.json
@@ -76,15 +76,15 @@
             "optional": true,
             "type": "boolean"
         },
-        "isChecked": {
+        "checked": {
             "optional": true,
             "type": "boolean"
         },
-        "isIndeterminate": {
+        "indeterminate": {
             "optional": true,
             "type": "boolean"
         },
-        "isDisabled": {
+        "disabled": {
             "optional": true,
             "type": "boolean"
         },
@@ -98,10 +98,7 @@
             "values": [
                 "sm",
                 "md",
-                "lg",
-                "S",
-                "M",
-                "L"
+                "lg"
             ]
         },
         "onCheckedChange": {

--- a/nextjs-app/shared/components/CodeSnippet/CodeSnippet.contract.json
+++ b/nextjs-app/shared/components/CodeSnippet/CodeSnippet.contract.json
@@ -118,7 +118,6 @@
         "Icon",
         "ComplianceCard",
         "Button",
-        "Text",
         "Card"
     ]
 }

--- a/nextjs-app/shared/components/ComplianceCard/ComplianceCard.contract.json
+++ b/nextjs-app/shared/components/ComplianceCard/ComplianceCard.contract.json
@@ -79,7 +79,6 @@
     ],
     "composesWith": [
         "Icon",
-        "CodeSnippet",
-        "Button"
+        "CodeSnippet"
     ]
 }

--- a/nextjs-app/shared/components/Link/Link.contract.json
+++ b/nextjs-app/shared/components/Link/Link.contract.json
@@ -95,9 +95,8 @@
         }
     },
     "forbiddenUse": [
-        "pre-sanitise the href — the component sanitises and rejects unsafe protocols",
-        "use Link for actions. Buttons are for actions; anchors are for navigation",
-        "override the underline via inline styles. The token-driven treatment owns it"
+        "use Link for actions. Buttons are for actions; anchors are for",
+        "override the underline via inline styles; the token-driven treatment"
     ],
     "prefersOver": [
         "Button with href for body-copy links"

--- a/nextjs-app/shared/components/List/List.contract.json
+++ b/nextjs-app/shared/components/List/List.contract.json
@@ -95,12 +95,12 @@
             "optional": true,
             "type": "union",
             "values": [
+                "xl",
                 "s",
                 "m",
                 "l",
-                "xxs",
                 "xs",
-                "xl",
+                "xxs",
                 "xxl"
             ]
         },

--- a/nextjs-app/shared/components/Modal/Modal.contract.json
+++ b/nextjs-app/shared/components/Modal/Modal.contract.json
@@ -103,16 +103,16 @@
                 "md",
                 "lg",
                 "xl",
+                "xs",
                 "S",
                 "M",
                 "L",
-                "xs",
+                "xxs",
+                "xxl",
                 "XXS",
                 "XS",
                 "XL",
-                "XXL",
-                "xxs",
-                "xxl"
+                "XXL"
             ]
         },
         "iconSize": {

--- a/nextjs-app/shared/components/Switch/Switch.contract.json
+++ b/nextjs-app/shared/components/Switch/Switch.contract.json
@@ -69,19 +69,19 @@
     "consumers": [],
     "schemaVersion": 2,
     "props": {
-        "isChecked": {
-            "optional": true,
-            "type": "boolean"
-        },
-        "isDisabled": {
-            "optional": true,
-            "type": "boolean"
-        },
-        "isLoading": {
+        "checked": {
             "optional": true,
             "type": "boolean"
         },
         "defaultChecked": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "disabled": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "loading": {
             "optional": true,
             "type": "boolean"
         },
@@ -91,10 +91,7 @@
             "values": [
                 "sm",
                 "md",
-                "lg",
-                "S",
-                "M",
-                "L"
+                "lg"
             ]
         },
         "onCheckedChange": {

--- a/nextjs-app/shared/components/Text/Text.contract.json
+++ b/nextjs-app/shared/components/Text/Text.contract.json
@@ -168,12 +168,12 @@
             "optional": true,
             "type": "union",
             "values": [
+                "xl",
                 "s",
                 "m",
                 "l",
-                "xxs",
                 "xs",
-                "xl",
+                "xxs",
                 "xxl"
             ]
         },

--- a/nextjs-app/shared/components/Title/Title.contract.json
+++ b/nextjs-app/shared/components/Title/Title.contract.json
@@ -159,12 +159,12 @@
             "optional": true,
             "type": "union",
             "values": [
+                "xl",
                 "s",
                 "m",
                 "l",
-                "xxs",
                 "xs",
-                "xl",
+                "xxs",
                 "xxl"
             ]
         },

--- a/nextjs-app/shared/components/Toast/Toast.contract.json
+++ b/nextjs-app/shared/components/Toast/Toast.contract.json
@@ -94,10 +94,10 @@
             "optional": true,
             "type": "union",
             "values": [
+                "info",
                 "success",
-                "error",
                 "warning",
-                "info"
+                "error"
             ]
         },
         "position": {


### PR DESCRIPTION
## Summary
- `npm run check:contract-props` was red with 11 issues: Checkbox/Switch contracts still documented pre-platinum prefixed booleans (`isChecked`/`isDisabled`/`isIndeterminate`/`isLoading`) plus legacy `S/M/L` size unions, and Badge/Button/CodeSnippet/ComplianceCard/Link carried stale `composesWith`/`forbiddenUse` blocks.
- Drift shipped with #769 (platinum uplift, 2026-06-19): the check only lives in `pr-validation.yml`, which never runs (CI quota-dead), and it was not part of the local pre-merge gate.
- Regenerated all 12 drifted contracts from agent blocks via `npm run sync:contract-props -- --write`. No hand-edited `variants` touched.

## Verification (local, all exit 0)
- `check:contract-props`, `check:generated`, `validate:components`
- `typecheck`, `lint`, `npm test` (1827/1827), `build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated several component contracts to use clearer, more consistent prop names and size/tone options.
  * Refined component composition and usage guidance for buttons, links, badges, and related UI elements.
  * Adjusted some allowed variant orderings and removed a few outdated size aliases.

* **Documentation**
  * Improved guidance text for safe and accessible component usage across badges, buttons, and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->