### PR TITLE
fix(ci): stories-smoke teardown hung the farm step forever + job timeout backstop

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -8,6 +8,10 @@ jobs:
     # PR is skipped here, exactly as it never reaches the farm's secrets.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, digitaltableteur]
+    # Backstop: the farm's dashboard collector is completion-only, so a hung job is INVISIBLE
+    # on the fleet board while it zombies a runner slot (GitHub's default timeout is 6h). A
+    # clean run takes ~10 min; anything past 30 is wedged.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -41,6 +41,10 @@ jobs:
       - run: npm run lint
       - run: npm run lint:css
       - run: npm run test:stories:smoke
+      # The story matrix drives real Chromium. The farm runner container doesn't ship browsers,
+      # but it mounts a persistent volume at /home/runner/.cache — exactly Playwright's browser
+      # cache — so this download happens once per browser build, then no-ops (~2s) every run.
+      - run: npx playwright install chromium
       - run: npm run test:stories:matrix:ci
       - run: npm run test:ci
       - run: npm run build

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -41,10 +41,11 @@ jobs:
       - run: npm run lint
       - run: npm run lint:css
       - run: npm run test:stories:smoke
-      # The story matrix drives real Chromium. The farm runner container doesn't ship browsers,
-      # but it mounts a persistent volume at /home/runner/.cache — exactly Playwright's browser
-      # cache — so this download happens once per browser build, then no-ops (~2s) every run.
-      - run: npx playwright install chromium
+      # The story matrix drives real Chromium. The farm runner container doesn't ship browsers:
+      # the binary lands in the persistent /home/runner/.cache volume (downloads once per browser
+      # build, then no-ops), and --with-deps apt-installs the system libraries into the ephemeral
+      # container each run — the same proven pattern as petritapanilahdelma's ci.yml on this farm.
+      - run: npx playwright install chromium --with-deps
       - run: npm run test:stories:matrix:ci
       - run: npm run test:ci
       - run: npm run build

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--default.dark.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--default.dark.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": Select…
+- button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--default.light.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--default.light.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": Select…
+- button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--example.dark.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--example.dark.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": 1–2 months
+- button "Toggle options"
+- paragraph: When should the project start?

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--example.light.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--example.light.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": 1–2 months
+- button "Toggle options"
+- paragraph: When should the project start?

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--forced-colors.dark.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": ASAP
+- button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--forced-colors.light.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": ASAP
+- button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--keyboard-selection.dark.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--keyboard-selection.dark.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": 1–2 months
+- button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--keyboard-selection.light.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--keyboard-selection.light.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": 1–2 months
+- button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--playground.dark.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--playground.dark.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": Select…
+- button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--playground.light.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/molecules-combobox--playground.light.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": Select…
+- button "Toggle options"

--- a/nextjs-app/shared/components/Link/__a11y-snapshots__/atoms-link--playground.dark.yaml
+++ b/nextjs-app/shared/components/Link/__a11y-snapshots__/atoms-link--playground.dark.yaml
@@ -1,0 +1,4 @@
+- link "Playground Link External link":
+  - /url: https://example.com
+  - text: Playground Link
+  - img "External link"

--- a/nextjs-app/shared/components/Link/__a11y-snapshots__/atoms-link--playground.light.yaml
+++ b/nextjs-app/shared/components/Link/__a11y-snapshots__/atoms-link--playground.light.yaml
@@ -1,0 +1,4 @@
+- link "Playground Link External link":
+  - /url: https://example.com
+  - text: Playground Link
+  - img "External link"

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/atoms-logo--default.dark.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/atoms-logo--default.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Digitaltableteur"

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/atoms-logo--default.light.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/atoms-logo--default.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Digitaltableteur"

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/atoms-logo--example.dark.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/atoms-logo--example.dark.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- img "Digitaltableteur"
+- text: Digitaltableteur

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/atoms-logo--example.light.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/atoms-logo--example.light.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- img "Digitaltableteur"
+- text: Digitaltableteur

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/atoms-logo--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/atoms-logo--forced-colors.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Digitaltableteur"

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/atoms-logo--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/atoms-logo--forced-colors.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Digitaltableteur"

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/atoms-logo--playground.dark.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/atoms-logo--playground.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Digitaltableteur"

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/atoms-logo--playground.light.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/atoms-logo--playground.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Digitaltableteur"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--busy-dialog.dark.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--busy-dialog.dark.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- button "Open modal"
+- dialog "Busy":
+  - heading "Busy" [level=2]
+  - text: Loading, please wait...

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--busy-dialog.light.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--busy-dialog.light.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- button "Open modal"
+- dialog "Busy":
+  - heading "Busy" [level=2]
+  - text: Loading, please wait...

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--error-dialog.dark.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--error-dialog.dark.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (beta)
+- button "Open modal"
+- alertdialog "Error":
+  - heading "Error" [level=2]
+  - paragraph: storyModalErrorBody
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--error-dialog.light.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--error-dialog.light.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (beta)
+- button "Open modal"
+- alertdialog "Error":
+  - heading "Error" [level=2]
+  - paragraph: storyModalErrorBody
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--info-dialog.dark.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--info-dialog.dark.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (beta)
+- button "Open modal"
+- dialog "Information":
+  - heading "Information" [level=2]
+  - text: Here is some important information.
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--info-dialog.light.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--info-dialog.light.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (beta)
+- button "Open modal"
+- dialog "Information":
+  - heading "Information" [level=2]
+  - text: Here is some important information.
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--loading.dark.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--loading.dark.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- button "Open modal"
+- dialog "Loading":
+  - heading "Loading" [level=2]
+  - paragraph: storyModalPleaseWait

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--loading.light.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--loading.light.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- button "Open modal"
+- dialog "Loading":
+  - heading "Loading" [level=2]
+  - paragraph: storyModalPleaseWait

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--success-dialog.dark.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--success-dialog.dark.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (beta)
+- button "Open modal"
+- dialog "Success":
+  - heading "Success" [level=2]
+  - text: Your operation was successful!
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--success-dialog.light.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--success-dialog.light.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (beta)
+- button "Open modal"
+- dialog "Success":
+  - heading "Success" [level=2]
+  - text: Your operation was successful!
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--warning-dialog.dark.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--warning-dialog.dark.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (beta)
+- button "Open modal"
+- alertdialog "Warning":
+  - heading "Warning" [level=2]
+  - text: Please review this warning carefully.
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--warning-dialog.light.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/molecules-modal--warning-dialog.light.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (beta)
+- button "Open modal"
+- alertdialog "Warning":
+  - heading "Warning" [level=2]
+  - text: Please review this warning carefully.
+  - button "OK"

--- a/scripts/design-system/smoke-stories.mjs
+++ b/scripts/design-system/smoke-stories.mjs
@@ -91,6 +91,11 @@ async function main() {
     {
       stdio: "pipe",
       env: { ...process.env, BROWSER: "none" },
+      // Own process group (POSIX): npm does NOT forward signals to its children, so killing
+      // only the wrapper leaves the storybook/vite tree alive holding this process's stdio
+      // pipes — on the Linux CI runners that pinned the event loop and hung the step forever
+      // AFTER the smoke had already passed (macOS happened to tear the tree down).
+      detached: process.platform !== "win32",
     },
   );
 
@@ -100,7 +105,8 @@ async function main() {
 
   const cleanup = () => {
     try {
-      storybook.kill("SIGTERM");
+      if (process.platform === "win32") storybook.kill("SIGTERM");
+      else process.kill(-storybook.pid, "SIGTERM"); // negative pid = the whole group
     } catch {
       // ignore
     }
@@ -146,9 +152,15 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  // eslint-disable-next-line no-console
-  console.error(error instanceof Error ? error.message : error);
-  process.exit(1);
-});
+main()
+  .then(() => {
+    // Explicit exit: even a stray survivor of the group kill must not keep this process
+    // (and therefore the CI step) alive via a lingering pipe. exitCode carries failures.
+    process.exit(process.exitCode ?? 0);
+  })
+  .catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
 


### PR DESCRIPTION
## Problem

PR Validation run 28615866437 (PR #798) hung `in_progress` for an hour on `npm run test:stories:smoke` and had to be cancelled from the fleet board — while silently occupying a farm runner slot (GitHub's default job timeout is 6h, and the fleet dashboard's collector is completion-only, so a hung job is invisible).

## Root cause (reproduced in the actual runner image)

The smoke itself PASSES in the farm container (Storybook ready in ~10s, 1035 stories indexed, "Storybook smoke OK") — but the step never ends. `cleanup()` SIGTERMs only the `npm` wrapper it spawned; npm does not forward signals, so the storybook/vite/esbuild tree survives, and its still-open stdio pipes pin the node event loop. The process never exits; the step hangs forever. macOS happens to tear the tree down, which is why this always passed locally.

## Fix

- `smoke-stories.mjs`: spawn storybook `detached` (own POSIX process group), kill the **group** on cleanup, and `process.exit()` explicitly after `main()` so no straggler pipe can keep the step alive. Verified inside the runner image: smoke OK, clean exit `rc=0`, no live leftovers (only a reaped zombie).
- `pr-validation.yml`: `timeout-minutes: 30` backstop on the validate job so any future wedge self-terminates instead of zombieing a slot for 6h.

## Verification

- Container (real runner image, same caps): patched smoke completes and exits cleanly.
- macOS local: smoke passes and exits.
- Full local gate: typecheck, lint, 1827/1827 tests, build — all exit 0.
- **This PR's own "PR Validation" run is the live end-to-end test** — it must complete on the farm, which no run has ever done past the smoke step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a safety timeout to PR validation so stalled jobs don’t occupy runners indefinitely.
  * Improved smoke-test cleanup so local and CI processes shut down more reliably after Storybook checks finish.
  * Made process termination more consistent across Windows and non-Windows environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->