### PR TITLE
fix(a11y,ds): clear the story-matrix debt — twMerge scale fix, WCAG inks, AT baselines

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,53 @@
 import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { extendTailwindMerge } from "tailwind-merge"
+
+/* The DT type scale ships custom font-size utilities (`text-dt-text-*`,
+ * `text-dt-title-*`, `text-dt-button-*` from the `--text-dt-*` theme tokens),
+ * and many call sites still carry legacy `text-text-*` aliases. Stock
+ * tailwind-merge classifies any unrecognised `text-*` class as a text COLOR,
+ * so e.g. cn("text-primary-foreground", "text-text-s") silently dropped the
+ * real color utility (Tag rendered #e0e0e0 on the dark-theme primary at
+ * 1.82:1). Registering both scales as font-size classes keeps color and size
+ * utilities orthogonal in every cn() merge.
+ */
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      "font-size": [
+        {
+          text: [
+            "text-xxs",
+            "text-xs",
+            "text-s",
+            "text-m",
+            "text-l",
+            "text-xl",
+            "text-xxl",
+            "dt-text",
+            "dt-text-xxs",
+            "dt-text-xs",
+            "dt-text-s",
+            "dt-text-m",
+            "dt-text-l",
+            "dt-text-xl",
+            "dt-text-xxl",
+            "dt-title",
+            "dt-title-xxs",
+            "dt-title-xs",
+            "dt-title-s",
+            "dt-title-m",
+            "dt-title-l",
+            "dt-title-xl",
+            "dt-title-xxl",
+            "dt-button-s",
+            "dt-button-m",
+            "dt-button-l",
+          ],
+        },
+      ],
+    },
+  },
+})
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))

--- a/nextjs-app/shared/components/ArticleShareSection/ArticleShareSection.tsx
+++ b/nextjs-app/shared/components/ArticleShareSection/ArticleShareSection.tsx
@@ -158,9 +158,10 @@ export function ArticleShareSection({
         </button>
       </div>
 
-      {/* Copy feedback (visual) */}
+      {/* Copy feedback (visual). green-800 ink: green-600 is only ~3:1 on
+          white, below WCAG AA for small text. */}
       {copied && (
-        <span className="text-sm font-body text-green-600 dark:text-green-400">
+        <span className="text-sm font-body text-green-800 dark:text-green-400">
           {t("articleLinkCopied", "Link copied!")}
         </span>
       )}

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/atoms-avatar--example.dark.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/atoms-avatar--example.dark.yaml
@@ -1,3 +1,4 @@
+- status: Work in progress (beta)
 - button "Open avatar menu":
   - img "Petri Lahdelma"
 - status: avatar.menuClosed

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/atoms-avatar--example.light.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/atoms-avatar--example.light.yaml
@@ -1,3 +1,4 @@
+- status: Work in progress (beta)
 - button "Open avatar menu":
   - img "Petri Lahdelma"
 - status: avatar.menuClosed

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/atoms-avatar--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/atoms-avatar--forced-colors.dark.yaml
@@ -1,0 +1,1 @@
+- status: Work in progress (beta)

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/atoms-avatar--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/atoms-avatar--forced-colors.light.yaml
@@ -1,0 +1,1 @@
+- status: Work in progress (beta)

--- a/nextjs-app/shared/components/Inputs/__a11y-snapshots__/atoms-inputs--example.dark.yaml
+++ b/nextjs-app/shared/components/Inputs/__a11y-snapshots__/atoms-inputs--example.dark.yaml
@@ -1,6 +1,6 @@
 - status: Work in progress (beta)
 - text: Input with Error (required)
-- textbox "Input with Error (required)":
+- textbox "Input with Error (required)" [invalid]:
   - /placeholder: Enter text
 - alert:
   - img

--- a/nextjs-app/shared/components/Inputs/__a11y-snapshots__/atoms-inputs--example.light.yaml
+++ b/nextjs-app/shared/components/Inputs/__a11y-snapshots__/atoms-inputs--example.light.yaml
@@ -1,6 +1,6 @@
 - status: Work in progress (beta)
 - text: Input with Error (required)
-- textbox "Input with Error (required)":
+- textbox "Input with Error (required)" [invalid]:
   - /placeholder: Enter text
 - alert:
   - img

--- a/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.stories.tsx
+++ b/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.stories.tsx
@@ -1,6 +1,6 @@
 import contract from "./LanguageSwitcher.contract.json";
 import { useState } from "react";
-import { expect, userEvent, within } from "storybook/test";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import {
@@ -94,11 +94,21 @@ export const KeyboardToggle: Story = {
       name: /show language options|english/i,
     });
     await userEvent.click(trigger);
-    expect(canvas.getByRole("button", { name: /^finnish$/i })).toBeVisible();
+    /* The option rail animates in/out (Framer Motion opacity); assert through
+       the transition, not against its first frame. */
+    await waitFor(() =>
+      expect(canvas.getByRole("button", { name: /^finnish$/i })).toBeVisible(),
+    );
     await userEvent.keyboard("{Escape}");
-    expect(
-      canvas.queryByRole("button", { name: /^finnish$/i }),
-    ).not.toBeInTheDocument();
+    /* hidden: true — the closed tray goes aria-hidden immediately, which
+       already satisfies a default role query while the exit animation still
+       renders the buttons. Track actual DOM removal so the post-play axe
+       audit runs against a settled tree. */
+    await waitFor(() =>
+      expect(
+        canvas.queryByRole("button", { name: /^finnish$/i, hidden: true }),
+      ).not.toBeInTheDocument(),
+    );
   },
 };
 

--- a/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.tsx
@@ -111,6 +111,10 @@ export function LanguageSwitcher({
         className={styles.optionsTrayAnchor}
         data-open={isOpen ? "true" : "false"}
         aria-hidden={!isOpen}
+        /* aria-hidden flips at close while the exit animation still renders
+           the option buttons; inert keeps that fading window unfocusable so
+           keyboard focus can never land inside a hidden tray. */
+        inert={!isOpen}
       >
         <AnimatePresence initial={false}>
           {isOpen && (

--- a/nextjs-app/shared/components/Layout/__a11y-snapshots__/patterns-layout--default.dark.yaml
+++ b/nextjs-app/shared/components/Layout/__a11y-snapshots__/patterns-layout--default.dark.yaml
@@ -16,6 +16,9 @@
         - link "About":
           - /url: /about
       - listitem:
+        - link "Pricing":
+          - /url: /pricing
+      - listitem:
         - link "Blog":
           - /url: /blog
       - listitem:
@@ -39,7 +42,13 @@
       - /url: mailto:mail@digitaltableteur.com
       - text: mail@digitaltableteur.com
   - paragraph: Billing details
-  - paragraph: Digitaltableteur Hämeentie 8 C 00530 Helsinki VAT FI22644552
+  - paragraph:
+    - strong: E-invoice address
+    - text: "003722644552"
+    - strong: Operator
+    - text: APIX Messaging Oy
+    - strong: Operator ID
+    - text: "003723327487"
   - paragraph: Legal
   - paragraph:
     - link "Privacy Policy":
@@ -54,8 +63,6 @@
   - paragraph:
     - link "Design System Guides":
       - /url: /pseo
-    - link "Tools":
-      - /url: /tools/email-signature
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
     - img "Instagram"
@@ -81,7 +88,4 @@
     - /url: https://dribbble.com/digitaltableteur
     - img "Dribbble"
   - paragraph: © 2026 Digitaltableteur. All rights reserved.
-- button "Chat with Donny":
-  - img "Donny is waving":
-    - img
-  - text: Chat
+- button "Chat — Chat with Donny": Chat

--- a/nextjs-app/shared/components/Layout/__a11y-snapshots__/patterns-layout--default.light.yaml
+++ b/nextjs-app/shared/components/Layout/__a11y-snapshots__/patterns-layout--default.light.yaml
@@ -16,6 +16,9 @@
         - link "About":
           - /url: /about
       - listitem:
+        - link "Pricing":
+          - /url: /pricing
+      - listitem:
         - link "Blog":
           - /url: /blog
       - listitem:
@@ -39,7 +42,13 @@
       - /url: mailto:mail@digitaltableteur.com
       - text: mail@digitaltableteur.com
   - paragraph: Billing details
-  - paragraph: Digitaltableteur Hämeentie 8 C 00530 Helsinki VAT FI22644552
+  - paragraph:
+    - strong: E-invoice address
+    - text: "003722644552"
+    - strong: Operator
+    - text: APIX Messaging Oy
+    - strong: Operator ID
+    - text: "003723327487"
   - paragraph: Legal
   - paragraph:
     - link "Privacy Policy":
@@ -54,8 +63,6 @@
   - paragraph:
     - link "Design System Guides":
       - /url: /pseo
-    - link "Tools":
-      - /url: /tools/email-signature
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
     - img "Instagram"
@@ -81,7 +88,4 @@
     - /url: https://dribbble.com/digitaltableteur
     - img "Dribbble"
   - paragraph: © 2026 Digitaltableteur. All rights reserved.
-- button "Chat with Donny":
-  - img "Donny is waving":
-    - img
-  - text: Chat
+- button "Chat — Chat with Donny": Chat

--- a/nextjs-app/shared/components/Layout/__a11y-snapshots__/patterns-layout--example.dark.yaml
+++ b/nextjs-app/shared/components/Layout/__a11y-snapshots__/patterns-layout--example.dark.yaml
@@ -16,6 +16,9 @@
         - link "About":
           - /url: /about
       - listitem:
+        - link "Pricing":
+          - /url: /pricing
+      - listitem:
         - link "Blog":
           - /url: /blog
       - listitem:
@@ -39,7 +42,13 @@
       - /url: mailto:mail@digitaltableteur.com
       - text: mail@digitaltableteur.com
   - paragraph: Billing details
-  - paragraph: Digitaltableteur Hämeentie 8 C 00530 Helsinki VAT FI22644552
+  - paragraph:
+    - strong: E-invoice address
+    - text: "003722644552"
+    - strong: Operator
+    - text: APIX Messaging Oy
+    - strong: Operator ID
+    - text: "003723327487"
   - paragraph: Legal
   - paragraph:
     - link "Privacy Policy":
@@ -54,8 +63,6 @@
   - paragraph:
     - link "Design System Guides":
       - /url: /pseo
-    - link "Tools":
-      - /url: /tools/email-signature
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
     - img "Instagram"
@@ -81,7 +88,4 @@
     - /url: https://dribbble.com/digitaltableteur
     - img "Dribbble"
   - paragraph: © 2026 Digitaltableteur. All rights reserved.
-- button "Chat with Donny":
-  - img "Donny is idle":
-    - img
-  - text: Chat
+- button "Chat — Chat with Donny": Chat

--- a/nextjs-app/shared/components/Layout/__a11y-snapshots__/patterns-layout--example.light.yaml
+++ b/nextjs-app/shared/components/Layout/__a11y-snapshots__/patterns-layout--example.light.yaml
@@ -16,6 +16,9 @@
         - link "About":
           - /url: /about
       - listitem:
+        - link "Pricing":
+          - /url: /pricing
+      - listitem:
         - link "Blog":
           - /url: /blog
       - listitem:
@@ -39,7 +42,13 @@
       - /url: mailto:mail@digitaltableteur.com
       - text: mail@digitaltableteur.com
   - paragraph: Billing details
-  - paragraph: Digitaltableteur Hämeentie 8 C 00530 Helsinki VAT FI22644552
+  - paragraph:
+    - strong: E-invoice address
+    - text: "003722644552"
+    - strong: Operator
+    - text: APIX Messaging Oy
+    - strong: Operator ID
+    - text: "003723327487"
   - paragraph: Legal
   - paragraph:
     - link "Privacy Policy":
@@ -54,8 +63,6 @@
   - paragraph:
     - link "Design System Guides":
       - /url: /pseo
-    - link "Tools":
-      - /url: /tools/email-signature
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
     - img "Instagram"
@@ -81,7 +88,4 @@
     - /url: https://dribbble.com/digitaltableteur
     - img "Dribbble"
   - paragraph: © 2026 Digitaltableteur. All rights reserved.
-- button "Chat with Donny":
-  - img "Donny is idle":
-    - img
-  - text: Chat
+- button "Chat — Chat with Donny": Chat

--- a/nextjs-app/shared/components/Layout/__a11y-snapshots__/patterns-layout--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Layout/__a11y-snapshots__/patterns-layout--forced-colors.dark.yaml
@@ -16,6 +16,9 @@
         - link "About":
           - /url: /about
       - listitem:
+        - link "Pricing":
+          - /url: /pricing
+      - listitem:
         - link "Blog":
           - /url: /blog
       - listitem:
@@ -39,7 +42,13 @@
       - /url: mailto:mail@digitaltableteur.com
       - text: mail@digitaltableteur.com
   - paragraph: Billing details
-  - paragraph: Digitaltableteur Hämeentie 8 C 00530 Helsinki VAT FI22644552
+  - paragraph:
+    - strong: E-invoice address
+    - text: "003722644552"
+    - strong: Operator
+    - text: APIX Messaging Oy
+    - strong: Operator ID
+    - text: "003723327487"
   - paragraph: Legal
   - paragraph:
     - link "Privacy Policy":
@@ -54,8 +63,6 @@
   - paragraph:
     - link "Design System Guides":
       - /url: /pseo
-    - link "Tools":
-      - /url: /tools/email-signature
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
     - img "Instagram"
@@ -81,7 +88,4 @@
     - /url: https://dribbble.com/digitaltableteur
     - img "Dribbble"
   - paragraph: © 2026 Digitaltableteur. All rights reserved.
-- button "Chat with Donny":
-  - img "Donny is idle":
-    - img
-  - text: Chat
+- button "Chat — Chat with Donny": Chat

--- a/nextjs-app/shared/components/Layout/__a11y-snapshots__/patterns-layout--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Layout/__a11y-snapshots__/patterns-layout--forced-colors.light.yaml
@@ -16,6 +16,9 @@
         - link "About":
           - /url: /about
       - listitem:
+        - link "Pricing":
+          - /url: /pricing
+      - listitem:
         - link "Blog":
           - /url: /blog
       - listitem:
@@ -39,7 +42,13 @@
       - /url: mailto:mail@digitaltableteur.com
       - text: mail@digitaltableteur.com
   - paragraph: Billing details
-  - paragraph: Digitaltableteur Hämeentie 8 C 00530 Helsinki VAT FI22644552
+  - paragraph:
+    - strong: E-invoice address
+    - text: "003722644552"
+    - strong: Operator
+    - text: APIX Messaging Oy
+    - strong: Operator ID
+    - text: "003723327487"
   - paragraph: Legal
   - paragraph:
     - link "Privacy Policy":
@@ -54,8 +63,6 @@
   - paragraph:
     - link "Design System Guides":
       - /url: /pseo
-    - link "Tools":
-      - /url: /tools/email-signature
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
     - img "Instagram"
@@ -81,7 +88,4 @@
     - /url: https://dribbble.com/digitaltableteur
     - img "Dribbble"
   - paragraph: © 2026 Digitaltableteur. All rights reserved.
-- button "Chat with Donny":
-  - img "Donny is idle":
-    - img
-  - text: Chat
+- button "Chat — Chat with Donny": Chat

--- a/nextjs-app/shared/components/Layout/__a11y-snapshots__/patterns-layout--playground.dark.yaml
+++ b/nextjs-app/shared/components/Layout/__a11y-snapshots__/patterns-layout--playground.dark.yaml
@@ -16,6 +16,9 @@
         - link "About":
           - /url: /about
       - listitem:
+        - link "Pricing":
+          - /url: /pricing
+      - listitem:
         - link "Blog":
           - /url: /blog
       - listitem:
@@ -39,7 +42,13 @@
       - /url: mailto:mail@digitaltableteur.com
       - text: mail@digitaltableteur.com
   - paragraph: Billing details
-  - paragraph: Digitaltableteur Hämeentie 8 C 00530 Helsinki VAT FI22644552
+  - paragraph:
+    - strong: E-invoice address
+    - text: "003722644552"
+    - strong: Operator
+    - text: APIX Messaging Oy
+    - strong: Operator ID
+    - text: "003723327487"
   - paragraph: Legal
   - paragraph:
     - link "Privacy Policy":
@@ -54,8 +63,6 @@
   - paragraph:
     - link "Design System Guides":
       - /url: /pseo
-    - link "Tools":
-      - /url: /tools/email-signature
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
     - img "Instagram"
@@ -81,7 +88,4 @@
     - /url: https://dribbble.com/digitaltableteur
     - img "Dribbble"
   - paragraph: © 2026 Digitaltableteur. All rights reserved.
-- button "Chat with Donny":
-  - img "Donny is idle":
-    - img
-  - text: Chat
+- button "Chat — Chat with Donny": Chat

--- a/nextjs-app/shared/components/Layout/__a11y-snapshots__/patterns-layout--playground.light.yaml
+++ b/nextjs-app/shared/components/Layout/__a11y-snapshots__/patterns-layout--playground.light.yaml
@@ -16,6 +16,9 @@
         - link "About":
           - /url: /about
       - listitem:
+        - link "Pricing":
+          - /url: /pricing
+      - listitem:
         - link "Blog":
           - /url: /blog
       - listitem:
@@ -39,7 +42,13 @@
       - /url: mailto:mail@digitaltableteur.com
       - text: mail@digitaltableteur.com
   - paragraph: Billing details
-  - paragraph: Digitaltableteur Hämeentie 8 C 00530 Helsinki VAT FI22644552
+  - paragraph:
+    - strong: E-invoice address
+    - text: "003722644552"
+    - strong: Operator
+    - text: APIX Messaging Oy
+    - strong: Operator ID
+    - text: "003723327487"
   - paragraph: Legal
   - paragraph:
     - link "Privacy Policy":
@@ -54,8 +63,6 @@
   - paragraph:
     - link "Design System Guides":
       - /url: /pseo
-    - link "Tools":
-      - /url: /tools/email-signature
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
     - img "Instagram"
@@ -81,7 +88,4 @@
     - /url: https://dribbble.com/digitaltableteur
     - img "Dribbble"
   - paragraph: © 2026 Digitaltableteur. All rights reserved.
-- button "Chat with Donny":
-  - img "Donny is idle":
-    - img
-  - text: Chat
+- button "Chat — Chat with Donny": Chat

--- a/nextjs-app/shared/components/Link/__a11y-snapshots__/atoms-link--example.dark.yaml
+++ b/nextjs-app/shared/components/Link/__a11y-snapshots__/atoms-link--example.dark.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - link "Playground Link":
   - /url: https://www.digitaltableteur.com

--- a/nextjs-app/shared/components/Link/__a11y-snapshots__/atoms-link--example.light.yaml
+++ b/nextjs-app/shared/components/Link/__a11y-snapshots__/atoms-link--example.light.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - link "Playground Link":
   - /url: https://www.digitaltableteur.com

--- a/nextjs-app/shared/components/Link/__a11y-snapshots__/atoms-link--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Link/__a11y-snapshots__/atoms-link--forced-colors.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - link "Playground Link External link":
   - /url: https://example.com
   - text: Playground Link

--- a/nextjs-app/shared/components/Link/__a11y-snapshots__/atoms-link--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Link/__a11y-snapshots__/atoms-link--forced-colors.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - link "Playground Link External link":
   - /url: https://example.com
   - text: Playground Link

--- a/nextjs-app/shared/components/Tag/Tag.tsx
+++ b/nextjs-app/shared/components/Tag/Tag.tsx
@@ -15,10 +15,14 @@ const variantClasses = {
   default: "bg-primary text-primary-foreground",
   secondary: "bg-secondary text-secondary-foreground",
   outline: "border border-border bg-transparent text-foreground",
-  success: "bg-green-500/10 text-green-600 dark:text-green-400",
-  warning: "bg-yellow-500/10 text-yellow-600 dark:text-yellow-400",
-  error: "bg-red-500/10 text-red-600 dark:text-red-400",
-  info: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+  /* Semantic inks are one-two steps darker than the usual *-600: on the 10%
+     tinted backgrounds the 600 shades sit below WCAG AA (green-600 measured
+     2.95:1, yellow-600 2.75:1, red-600 4.14:1). These land at 5.5-6.6:1;
+     the dark-theme *-400 inks measure 5.6-9.2:1 on the dark tints. */
+  success: "bg-green-500/10 text-green-800 dark:text-green-400",
+  warning: "bg-yellow-500/10 text-yellow-800 dark:text-yellow-400",
+  error: "bg-red-500/10 text-red-700 dark:text-red-400",
+  info: "bg-blue-500/10 text-blue-700 dark:text-blue-400",
 } as const;
 
 const sizeClasses = {

--- a/nextjs-app/shared/foundations/token-catalog.json
+++ b/nextjs-app/shared/foundations/token-catalog.json
@@ -1,6 +1,6 @@
 {
   "source": "nextjs-app/shared/styles/variables.css",
-  "generatedAt": "2026-06-21T14:34:33.308Z",
+  "generatedAt": "2026-07-03T02:39:12.318Z",
   "tokenCount": 171,
   "usageCoverage": 139,
   "themes": [
@@ -653,7 +653,7 @@
         },
         {
           "name": "--color-muted",
-          "value": "#6c757d",
+          "value": "#626a72",
           "usage": "Color token (muted).",
           "category": "color",
           "subgroup": "Greyscale & borders"

--- a/nextjs-app/shared/foundations/tokens/production/color.json
+++ b/nextjs-app/shared/foundations/tokens/production/color.json
@@ -54,7 +54,7 @@
       }
     },
     "muted": {
-      "$value": "#6c757d",
+      "$value": "#626a72",
       "$description": "Color token (muted).",
       "$type": "color",
       "light": {

--- a/nextjs-app/shared/patterns/Footer/__a11y-snapshots__/patterns-footer--default.dark.yaml
+++ b/nextjs-app/shared/patterns/Footer/__a11y-snapshots__/patterns-footer--default.dark.yaml
@@ -10,7 +10,13 @@
       - /url: mailto:mail@digitaltableteur.com
       - text: mail@digitaltableteur.com
   - paragraph: Billing details
-  - paragraph: Digitaltableteur Hämeentie 8 C 00530 Helsinki VAT FI22644552
+  - paragraph:
+    - strong: E-invoice address
+    - text: "003722644552"
+    - strong: Operator
+    - text: APIX Messaging Oy
+    - strong: Operator ID
+    - text: "003723327487"
   - paragraph: Legal
   - paragraph:
     - link "Privacy Policy":
@@ -25,8 +31,6 @@
   - paragraph:
     - link "Design System Guides":
       - /url: /pseo
-    - link "Tools":
-      - /url: /tools/email-signature
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
     - img "Instagram"

--- a/nextjs-app/shared/patterns/Footer/__a11y-snapshots__/patterns-footer--default.light.yaml
+++ b/nextjs-app/shared/patterns/Footer/__a11y-snapshots__/patterns-footer--default.light.yaml
@@ -10,7 +10,13 @@
       - /url: mailto:mail@digitaltableteur.com
       - text: mail@digitaltableteur.com
   - paragraph: Billing details
-  - paragraph: Digitaltableteur Hämeentie 8 C 00530 Helsinki VAT FI22644552
+  - paragraph:
+    - strong: E-invoice address
+    - text: "003722644552"
+    - strong: Operator
+    - text: APIX Messaging Oy
+    - strong: Operator ID
+    - text: "003723327487"
   - paragraph: Legal
   - paragraph:
     - link "Privacy Policy":
@@ -25,8 +31,6 @@
   - paragraph:
     - link "Design System Guides":
       - /url: /pseo
-    - link "Tools":
-      - /url: /tools/email-signature
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
     - img "Instagram"

--- a/nextjs-app/shared/patterns/Footer/__a11y-snapshots__/patterns-footer--example.dark.yaml
+++ b/nextjs-app/shared/patterns/Footer/__a11y-snapshots__/patterns-footer--example.dark.yaml
@@ -10,7 +10,13 @@
       - /url: mailto:mail@digitaltableteur.com
       - text: mail@digitaltableteur.com
   - paragraph: Billing details
-  - paragraph: Digitaltableteur Hämeentie 8 C 00530 Helsinki VAT FI22644552
+  - paragraph:
+    - strong: E-invoice address
+    - text: "003722644552"
+    - strong: Operator
+    - text: APIX Messaging Oy
+    - strong: Operator ID
+    - text: "003723327487"
   - paragraph: Legal
   - paragraph:
     - link "Privacy Policy":
@@ -25,8 +31,6 @@
   - paragraph:
     - link "Design System Guides":
       - /url: /pseo
-    - link "Tools":
-      - /url: /tools/email-signature
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
     - img "Instagram"

--- a/nextjs-app/shared/patterns/Footer/__a11y-snapshots__/patterns-footer--example.light.yaml
+++ b/nextjs-app/shared/patterns/Footer/__a11y-snapshots__/patterns-footer--example.light.yaml
@@ -10,7 +10,13 @@
       - /url: mailto:mail@digitaltableteur.com
       - text: mail@digitaltableteur.com
   - paragraph: Billing details
-  - paragraph: Digitaltableteur Hämeentie 8 C 00530 Helsinki VAT FI22644552
+  - paragraph:
+    - strong: E-invoice address
+    - text: "003722644552"
+    - strong: Operator
+    - text: APIX Messaging Oy
+    - strong: Operator ID
+    - text: "003723327487"
   - paragraph: Legal
   - paragraph:
     - link "Privacy Policy":
@@ -25,8 +31,6 @@
   - paragraph:
     - link "Design System Guides":
       - /url: /pseo
-    - link "Tools":
-      - /url: /tools/email-signature
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
     - img "Instagram"

--- a/nextjs-app/shared/patterns/Footer/__a11y-snapshots__/patterns-footer--forced-colors.dark.yaml
+++ b/nextjs-app/shared/patterns/Footer/__a11y-snapshots__/patterns-footer--forced-colors.dark.yaml
@@ -10,7 +10,13 @@
       - /url: mailto:mail@digitaltableteur.com
       - text: mail@digitaltableteur.com
   - paragraph: Billing details
-  - paragraph: Digitaltableteur Hämeentie 8 C 00530 Helsinki VAT FI22644552
+  - paragraph:
+    - strong: E-invoice address
+    - text: "003722644552"
+    - strong: Operator
+    - text: APIX Messaging Oy
+    - strong: Operator ID
+    - text: "003723327487"
   - paragraph: Legal
   - paragraph:
     - link "Privacy Policy":
@@ -25,8 +31,6 @@
   - paragraph:
     - link "Design System Guides":
       - /url: /pseo
-    - link "Tools":
-      - /url: /tools/email-signature
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
     - img "Instagram"

--- a/nextjs-app/shared/patterns/Footer/__a11y-snapshots__/patterns-footer--forced-colors.light.yaml
+++ b/nextjs-app/shared/patterns/Footer/__a11y-snapshots__/patterns-footer--forced-colors.light.yaml
@@ -10,7 +10,13 @@
       - /url: mailto:mail@digitaltableteur.com
       - text: mail@digitaltableteur.com
   - paragraph: Billing details
-  - paragraph: Digitaltableteur Hämeentie 8 C 00530 Helsinki VAT FI22644552
+  - paragraph:
+    - strong: E-invoice address
+    - text: "003722644552"
+    - strong: Operator
+    - text: APIX Messaging Oy
+    - strong: Operator ID
+    - text: "003723327487"
   - paragraph: Legal
   - paragraph:
     - link "Privacy Policy":
@@ -25,8 +31,6 @@
   - paragraph:
     - link "Design System Guides":
       - /url: /pseo
-    - link "Tools":
-      - /url: /tools/email-signature
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
     - img "Instagram"

--- a/nextjs-app/shared/patterns/Header/__a11y-snapshots__/patterns-header--default.dark.yaml
+++ b/nextjs-app/shared/patterns/Header/__a11y-snapshots__/patterns-header--default.dark.yaml
@@ -15,6 +15,9 @@
         - link "About":
           - /url: /about
       - listitem:
+        - link "Pricing":
+          - /url: /pricing
+      - listitem:
         - link "Blog":
           - /url: /blog
       - listitem:

--- a/nextjs-app/shared/patterns/Header/__a11y-snapshots__/patterns-header--default.light.yaml
+++ b/nextjs-app/shared/patterns/Header/__a11y-snapshots__/patterns-header--default.light.yaml
@@ -15,6 +15,9 @@
         - link "About":
           - /url: /about
       - listitem:
+        - link "Pricing":
+          - /url: /pricing
+      - listitem:
         - link "Blog":
           - /url: /blog
       - listitem:

--- a/nextjs-app/shared/patterns/Header/__a11y-snapshots__/patterns-header--example.dark.yaml
+++ b/nextjs-app/shared/patterns/Header/__a11y-snapshots__/patterns-header--example.dark.yaml
@@ -15,6 +15,9 @@
         - link "About":
           - /url: /about
       - listitem:
+        - link "Pricing":
+          - /url: /pricing
+      - listitem:
         - link "Blog":
           - /url: /blog
       - listitem:

--- a/nextjs-app/shared/patterns/Header/__a11y-snapshots__/patterns-header--example.light.yaml
+++ b/nextjs-app/shared/patterns/Header/__a11y-snapshots__/patterns-header--example.light.yaml
@@ -15,6 +15,9 @@
         - link "About":
           - /url: /about
       - listitem:
+        - link "Pricing":
+          - /url: /pricing
+      - listitem:
         - link "Blog":
           - /url: /blog
       - listitem:

--- a/nextjs-app/shared/patterns/Header/__a11y-snapshots__/patterns-header--forced-colors.dark.yaml
+++ b/nextjs-app/shared/patterns/Header/__a11y-snapshots__/patterns-header--forced-colors.dark.yaml
@@ -15,6 +15,9 @@
         - link "About":
           - /url: /about
       - listitem:
+        - link "Pricing":
+          - /url: /pricing
+      - listitem:
         - link "Blog":
           - /url: /blog
       - listitem:

--- a/nextjs-app/shared/patterns/Header/__a11y-snapshots__/patterns-header--forced-colors.light.yaml
+++ b/nextjs-app/shared/patterns/Header/__a11y-snapshots__/patterns-header--forced-colors.light.yaml
@@ -15,6 +15,9 @@
         - link "About":
           - /url: /about
       - listitem:
+        - link "Pricing":
+          - /url: /pricing
+      - listitem:
         - link "Blog":
           - /url: /blog
       - listitem:

--- a/nextjs-app/shared/styles/variables.css
+++ b/nextjs-app/shared/styles/variables.css
@@ -121,7 +121,7 @@
   --color-dark: #222;
   --color-gray-dark: #333;
   --color-gray: #5e5e5e;
-  --color-muted: #6c757d;
+  --color-muted: #626a72; /* AA on #f5f6f6 field surfaces (5.07:1) AND their hover mix #ebeded (4.67:1), not just on white */
   --color-muted-light: #4949a7;
   --color-border: #c0c0c0;
   --color-border-light: #ccc;


### PR DESCRIPTION
## Summary
Clears the last red step on the farm's PR Validation (`test:stories:matrix:ci`, dormant until #799 revived the pipeline tail). Three real bug fixes plus vetted baseline refreshes:

- **tailwind-merge scale registration (root cause)**: stock twMerge classifies unknown `text-*` classes as text colors, so `cn("text-primary-foreground", "text-text-s")` silently dropped the color. Tag rendered #e0e0e0 on the dark-theme primary at **1.82:1**. `lib/utils.ts` now registers the DT font-size scales. (The `text-text-*` classes are themselves dead tokens — flagged as a separate follow-up task.)
- **WCAG AA inks, all measured**: `--color-muted` #6c757d→#626a72 (Combobox placeholder 4.33→5.07:1, hover 4.67:1); Tag semantic inks -600→-700/-800 (were 2.75–4.14:1 on their tints, now 5.5–6.6:1); ArticleShareSection copy feedback green-600→green-800.
- **LanguageSwitcher**: `inert` on the closed options tray (aria-hidden flipped while the exit animation still rendered focusable buttons — axe aria-hidden-focus + a real keyboard-trap window); play test asserts through the animation and tracks actual DOM removal.
- **AT baselines**: 22 stale `.light`/`.dark` snapshots refreshed (Avatar, Inputs, Layout, Link, Header, Footer). Every diff vetted against shipped changes (footer e-invoice block, Pricing link, ChatToggle rename, aria-invalid, WIP-line drops).

## Verification (local, all exit 0)
- `test:stories:matrix:ci` **GREEN both themes** (503/503 light, 503/503 dark)
- typecheck, lint, vitest 1827/1827, build
- check:contract-props, check:consumers, check:contrast, check:generated, stories smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Pricing** link to the main navigation and related page snapshots.
  * Updated footer billing details to show more structured invoice information.

* **Bug Fixes**
  * Improved keyboard/accessibility behavior for the language switcher when opening and closing.
  * Refined “copied link” and tag colors for clearer contrast.
  * Corrected error-state handling for invalid input fields.

* **Style**
  * Adjusted the app’s muted neutral color for a slightly updated visual tone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->