### PR TITLE
fix(a11y): OpenHours closed-cell wash + define missing --shortcut-hint-color

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-06-21T20:07:05.249Z",
+  "createdAt": "2026-07-03T03:55:39.671Z",
   "directory": "nextjs-app/shared",
   "findings": [
     {
@@ -8105,8 +8105,8 @@
     {
       "column": 19,
       "file": "nextjs-app/shared/styles/variables.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/styles/variables.css\u001f696\u001f19\u001f6px\u001fUnexpected off-scale value \"6px\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
-      "line": 696,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/styles/variables.css\u001f703\u001f19\u001f6px\u001fUnexpected off-scale value \"6px\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
+      "line": 703,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"6px\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -8115,8 +8115,8 @@
     {
       "column": 19,
       "file": "nextjs-app/shared/styles/variables.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/styles/variables.css\u001f696\u001f19\u001f6px\u001fUnexpected raw scale value \"6px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 696,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/styles/variables.css\u001f703\u001f19\u001f6px\u001fUnexpected raw scale value \"6px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 703,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"6px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",

--- a/nextjs-app/shared/components/OpenHours/OpenHours.module.css
+++ b/nextjs-app/shared/components/OpenHours/OpenHours.module.css
@@ -65,7 +65,9 @@
 }
 
 .closed {
-  opacity: 0.7;
+  /* De-emphasis via italics only. The former opacity: 0.7 composited the
+     even-row cell over the card's primary background (dark theme: #181a1b
+     over #6fa8ff -> #32455f) and washed the ink below WCAG AA. */
   font-style: italic;
 }
 

--- a/nextjs-app/shared/components/OpenHours/OpenHours.tsx
+++ b/nextjs-app/shared/components/OpenHours/OpenHours.tsx
@@ -22,7 +22,9 @@ export const OpenHours: React.FC<OpenHoursProps> = ({
   date = new Date(),
 }) => {
   const { t } = useTranslation();
-  const todayIndex = date.getDay(); // 0 sunday
+  /* WEEKLY_HOURS is Monday-first; getDay() is Sunday-based (0 = Sunday).
+     Remap so the highlighted row is actually today (was off by one). */
+  const todayIndex = (date.getDay() + 6) % 7;
   const open = isOpenAt(date);
 
   return (

--- a/nextjs-app/shared/foundations/token-catalog.json
+++ b/nextjs-app/shared/foundations/token-catalog.json
@@ -1,7 +1,7 @@
 {
   "source": "nextjs-app/shared/styles/variables.css",
-  "generatedAt": "2026-07-03T02:39:12.318Z",
-  "tokenCount": 171,
+  "generatedAt": "2026-07-03T03:43:49.197Z",
+  "tokenCount": 172,
   "usageCoverage": 139,
   "themes": [
     {
@@ -1298,6 +1298,13 @@
         {
           "name": "--inverted-text-color",
           "value": "#fff",
+          "usage": "",
+          "category": "other",
+          "subgroup": "General"
+        },
+        {
+          "name": "--shortcut-hint-color",
+          "value": "#4b5563",
           "usage": "",
           "category": "other",
           "subgroup": "General"

--- a/nextjs-app/shared/foundations/tokens/production/other.json
+++ b/nextjs-app/shared/foundations/tokens/production/other.json
@@ -60,6 +60,14 @@
       }
     }
   },
+  "shortcut": {
+    "hint": {
+      "color": {
+        "$value": "#4b5563",
+        "$description": "Production token --shortcut-hint-color"
+      }
+    }
+  },
   "wavy": {
     "underline": {
       "mask": {

--- a/nextjs-app/shared/styles/variables.css
+++ b/nextjs-app/shared/styles/variables.css
@@ -97,6 +97,10 @@
   --link-color: #041b23;
   --logo-text-color: var(--color-text); /* Logo wordmark text - theme-aware */
 
+  /* Chat composer keyboard hint. Was an undefined token whose #4b5563
+     fallback applied in every theme (2.31:1 on the dark background). */
+  --shortcut-hint-color: #4b5563;
+
   /* Accent colors */
   --accent-pink: #f205c5;
   --accent-purple: #812eff;
@@ -345,6 +349,7 @@
   --main-body-copy-color: #e0e0e0; /* Body copy, was #6fa8ff; accent blue now reserved for interactive */
   --secondary-text-color: #aaa;
   --inverted-text-color: #181a1b;
+  --shortcut-hint-color: #9ca3af; /* 6.7:1 on #181a1b */
   --link-color: #71efff;
   --color-primary: #6fa8ff;
   --color-primary-disabled: #6fa8ff50;
@@ -417,6 +422,7 @@
   --main-body-copy-color: #fff;
   --secondary-text-color: #fff;
   --inverted-text-color: #000;
+  --shortcut-hint-color: #fff;
   --link-color: #fff;
   --color-primary: #fff;
   --color-primary-disabled: color-mix(in srgb, #fff 60%, #000);
@@ -525,6 +531,7 @@
   --main-body-copy-color: #000;
   --secondary-text-color: #000;
   --inverted-text-color: #fff;
+  --shortcut-hint-color: #000;
   --link-color: #000;
   --color-primary: #000;
   --color-primary-disabled: color-mix(in srgb, #fff 60%, #000);

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -4134,27 +4134,27 @@
       "text": "Expected variable, function or keyword for \"none\" of \"forced-color-adjust\" (scale-unlimited/declaration-strict-value)"
     },
     {
-      "id": "nextjs-app/shared/styles/variables.css::337::3::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"dark\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)",
+      "id": "nextjs-app/shared/styles/variables.css::341::3::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"dark\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)",
       "file": "nextjs-app/shared/styles/variables.css",
-      "line": 337,
+      "line": 341,
       "column": 3,
       "rule": "scale-unlimited/declaration-strict-value",
       "severity": "warning",
       "text": "Expected variable, function or keyword for \"dark\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)"
     },
     {
-      "id": "nextjs-app/shared/styles/variables.css::411::3::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"dark\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)",
+      "id": "nextjs-app/shared/styles/variables.css::416::3::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"dark\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)",
       "file": "nextjs-app/shared/styles/variables.css",
-      "line": 411,
+      "line": 416,
       "column": 3,
       "rule": "scale-unlimited/declaration-strict-value",
       "severity": "warning",
       "text": "Expected variable, function or keyword for \"dark\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)"
     },
     {
-      "id": "nextjs-app/shared/styles/variables.css::603::5::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"light\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)",
+      "id": "nextjs-app/shared/styles/variables.css::610::5::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"light\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)",
       "file": "nextjs-app/shared/styles/variables.css",
-      "line": 603,
+      "line": 610,
       "column": 5,
       "rule": "scale-unlimited/declaration-strict-value",
       "severity": "warning",


### PR DESCRIPTION
## Summary
Fixes the two dark-theme axe violations the farm's matrix caught on the #800 run (both real; they passed locally because axe's background compositing differs under the Linux runner):

- **OpenHours**: `.closed` used `opacity: 0.7`, washing the even-row cell over the card's primary background (dark: composites to #32455f, 4.05:1 against pure ink and worse as rendered). De-emphasis is now italics only. Also fixed the today-highlight off-by-one (`getDay()` is Sunday-based vs Monday-first `WEEKLY_HOURS`; Fridays highlighted Saturday).
- **ChatWidget shortcut hint**: `--shortcut-hint-color` was one of the 38 missing tokens from the June audit; its #4b5563 fallback applied in every theme (2.31:1 in dark). Defined per theme: light #4b5563, dark #9ca3af (6.7:1), HCB #fff, HCW #000.
- Stylelint + rhythmguard baselines re-frozen (identical warning sets, shifted lines).

## Verification (local, all exit 0)
- `test:stories:matrix:ci` GREEN both themes (503/503 each)
- typecheck, lint, vitest 1827/1827, build, check:contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)