### PR TITLE
fix(design-system): TextArea container class resolved + static CSS-class guard

### DIFF
--- a/nextjs-app/shared/components/TextArea/TextArea.css-classes.test.ts
+++ b/nextjs-app/shared/components/TextArea/TextArea.css-classes.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Static guard against the "literal undefined class" bug (see
+ * nextjs-app/shared/patterns/css-module-class-references.test.ts and
+ * FormField/FormField.css-classes.test.ts for the full rationale). Vitest's
+ * CSS Modules proxy fabricates a truthy class for ANY accessed `styles.x` (or
+ * `styles["x"]`) key, even one with no matching rule, so a missing class is
+ * invisible to ordinary render tests. This reads TextArea's source and CSS
+ * Module from disk and fails if a referenced class has no matching rule.
+ *
+ * Covers both dot notation (`styles.foo`) and bracket notation with a
+ * literal string key (`styles["foo"]` / `styles['foo']`). Bracket access
+ * with a template-literal key has no single static class name to check and
+ * is intentionally left alone here.
+ */
+describe("TextArea CSS Module class references resolve", () => {
+  it("every styles.x / styles['x'] has a matching .x rule", () => {
+    const tsx = readFileSync(join(here, "TextArea.tsx"), "utf8");
+    const css = readFileSync(join(here, "TextArea.module.css"), "utf8");
+
+    const referenced = new Set<string>();
+    for (const match of tsx.matchAll(/\bstyles\.([A-Za-z_$][\w$]*)/g)) {
+      referenced.add(match[1]);
+    }
+    for (const match of tsx.matchAll(/\bstyles\[["']([^"'`]+)["']\]/g)) {
+      referenced.add(match[1]);
+    }
+
+    const missing = [...referenced].filter(
+      // `.col` must not match `.column`; a CSS class name ends at a non
+      // word / non hyphen character.
+      (cls) => !new RegExp(`\\.${cls}(?![\\w-])`).test(css),
+    );
+
+    expect(
+      missing,
+      "TextArea.tsx references CSS Module classes with no rule in TextArea.module.css",
+    ).toEqual([]);
+  });
+});

--- a/nextjs-app/shared/components/TextArea/TextArea.tsx
+++ b/nextjs-app/shared/components/TextArea/TextArea.tsx
@@ -100,7 +100,7 @@ const TextArea: React.FC<TextAreaProps> = ({
   const textareaClassName = `${styles.input} ${error ? styles.error : ""} ${animateResize ? styles.animatedTextarea : ""}`;
 
   return (
-    <div className={styles["input-container"]}>
+    <div className={styles.inputContainer}>
       <Label
         htmlFor={label}
         required={!!error}


### PR DESCRIPTION
Fixes the remaining half of the input-container/inputContainer CSS Modules mismatch. TextInput was fixed in #802; TextArea.tsx:103 still looked up styles["input-container"] while the CSS defines .inputContainer, so the container rendered class="undefined" and silently dropped display:flex, flex-direction:column and margin-bottom:1rem (this pre-dates the Inputs canonicalization; inherited from Inputs/TextArea.tsx).

**Visible delta after fix:** TextArea instances regain the intended 1rem bottom spacing; the flex column matches previous block stacking, so spacing is the only visual change.

Adds TextArea.css-classes.test.ts (static fs-read guard, immune to the vitest CSS-module proxy, covers dot and bracket notation) following the TextInput/FormField pattern.

Verified: 12 unit tests + 6 real-Chromium Storybook renders for TextArea pass; full local gate (typecheck, lint, npm test, build) exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the text area container to use the correct styling class, improving consistent component appearance.

* **Tests**
  * Added automated coverage to verify that text area style references match available CSS classes, helping catch broken styling links earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->