### PR TITLE
feat(design-system): Link underline modes; footer hover underlines at text width

### DIFF
--- a/nextjs-app/shared/components/Link/Link.contract.json
+++ b/nextjs-app/shared/components/Link/Link.contract.json
@@ -17,6 +17,15 @@
             ],
             "default": "md",
             "propSourced": true
+        },
+        "underline": {
+            "values": [
+                "always",
+                "hover",
+                "none"
+            ],
+            "default": "always",
+            "propSourced": true
         }
     },
     "slots": [],
@@ -131,6 +140,15 @@
                 "sm",
                 "md",
                 "lg"
+            ]
+        },
+        "underline": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "always",
+                "hover",
+                "none"
             ]
         }
     },

--- a/nextjs-app/shared/components/Link/Link.module.css
+++ b/nextjs-app/shared/components/Link/Link.module.css
@@ -38,3 +38,29 @@
     var(--focus-ring-color, var(--color-primary));
   outline-offset: 2px;
 }
+
+/* underline="hover": keep the wavy underline's reserved space (padding-bottom
+   from the global .wavyUnderline rule) so nothing shifts, but reveal the wave
+   only on hover / keyboard focus. .link.underlineHover outranks the global
+   .wavyUnderline::after regardless of stylesheet order. */
+
+.link.underlineHover::after {
+  transition: opacity var(--duration-fast) var(--ease-out-cubic);
+  opacity: 0;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .link.underlineHover:hover::after {
+    opacity: 0.9;
+  }
+}
+
+.link.underlineHover:focus-visible::after {
+  opacity: 0.9;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .link.underlineHover::after {
+    transition: none;
+  }
+}

--- a/nextjs-app/shared/components/Link/Link.stories.tsx
+++ b/nextjs-app/shared/components/Link/Link.stories.tsx
@@ -25,6 +25,13 @@ const meta: Meta<typeof Link> = {
       description: "Size.",
       table: { defaultValue: { summary: "md" } },
     },
+    underline: {
+      control: { type: "inline-radio" },
+      options: ["always", "hover", "none"],
+      description:
+        "Wavy underline mode: permanent, revealed on hover/focus (nav lists), or omitted.",
+      table: { defaultValue: { summary: "always" } },
+    },
     href: {
       control: "text",
       description: "Destination URL; sanitised, and external links get rel=noopener noreferrer.",
@@ -68,6 +75,22 @@ const SizesContent: React.FC = () => {
 };
 
 export const Sizes: Story = { render: () => <SizesContent /> };
+
+const UnderlineModesContent: React.FC = () => (
+  <div style={{ display: "flex", gap: "1.5rem", alignItems: "baseline" }}>
+    <Link href="/about" underline="always">
+      Always underlined
+    </Link>
+    <Link href="/about" underline="hover">
+      Underline on hover
+    </Link>
+    <Link href="/about" underline="none">
+      No underline
+    </Link>
+  </div>
+);
+
+export const UnderlineModes: Story = { render: () => <UnderlineModesContent /> };
 
 export const External: Story = {
   render: () => (

--- a/nextjs-app/shared/components/Link/Link.test.tsx
+++ b/nextjs-app/shared/components/Link/Link.test.tsx
@@ -11,6 +11,35 @@ describe("Link", () => {
     expect(linkElement).toHaveAttribute("href", "#");
   });
 
+  it("shows the wavy underline by default", () => {
+    render(<Link href="/test">Test Link</Link>);
+    const linkElement = screen.getByRole("link");
+    expect(linkElement.className).toContain("wavyUnderline");
+    expect(linkElement.className).not.toContain("underlineHover");
+  });
+
+  it("adds the hover modifier for underline=\"hover\"", () => {
+    render(
+      <Link href="/test" underline="hover">
+        Test Link
+      </Link>,
+    );
+    const linkElement = screen.getByRole("link");
+    expect(linkElement.className).toContain("wavyUnderline");
+    expect(linkElement.className).toContain("underlineHover");
+  });
+
+  it("omits the underline classes for underline=\"none\"", () => {
+    render(
+      <Link href="/test" underline="none">
+        Test Link
+      </Link>,
+    );
+    const linkElement = screen.getByRole("link");
+    expect(linkElement.className).not.toContain("wavyUnderline");
+    expect(linkElement.className).not.toContain("underlineHover");
+  });
+
   it("renders with custom href", () => {
     render(<Link href="/test">Test Link</Link>);
     const linkElement = screen.getByRole("link");

--- a/nextjs-app/shared/components/Link/Link.tsx
+++ b/nextjs-app/shared/components/Link/Link.tsx
@@ -7,6 +7,12 @@ export interface LinkProps
   extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   /** Size. @default "md" */
   size?: "sm" | "md" | "lg";
+  /**
+   * Wavy underline mode. "always" shows it permanently, "hover" reveals it
+   * on hover and keyboard focus (nav lists like the site footer), "none"
+   * omits it entirely. @default "always"
+   */
+  underline?: "always" | "hover" | "none";
 }
 
 const INTERNAL_HOST = "digitaltableteur.com";
@@ -104,9 +110,25 @@ const SIZE_CLASS = {
 
 const ICON_SIZE = { sm: 20, md: 24, lg: 32 } as const;
 
-/** Accessible inline link with size tokens, a focus ring, and an optional external-link icon. */
+const UNDERLINE_CLASS = {
+  always: "wavyUnderline",
+  hover: `wavyUnderline ${styles.underlineHover}`,
+  none: "",
+} as const;
+
+/** Accessible inline link with size tokens, a focus ring, an optional external-link icon, and always/hover/none wavy underline modes. */
 const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
-  ({ href = "#", size = "md", children, className = "", ...rest }, ref) => {
+  (
+    {
+      href = "#",
+      size = "md",
+      underline = "always",
+      children,
+      className = "",
+      ...rest
+    },
+    ref,
+  ) => {
     const normalizedHref = React.useMemo(() => normalizeHref(href), [href]);
     const isExternal = React.useMemo(
       () => isExternalHref(normalizedHref),
@@ -127,7 +149,9 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
             ? [rest.rel, "noopener", "noreferrer"].filter(Boolean).join(" ")
             : rest.rel
         }
-        className={`${styles.link} ${SIZE_CLASS[size]} wavyUnderline ${className}`.trim()}
+        className={`${styles.link} ${SIZE_CLASS[size]} ${UNDERLINE_CLASS[underline]} ${className}`
+          .replace(/\s+/g, " ")
+          .trim()}
       >
         {children}
         {isExternal && hasTextContent && (

--- a/nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx
+++ b/nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx
@@ -129,20 +129,20 @@ export function SiteFooter({ className }: SiteFooterProps) {
             <p className="font-heading text-text-m font-semibold mb-3">
               {t("footerExploreTitle")}
             </p>
-            <Stack gap="xs">
-              <DtLink href="/work" size="sm">
+            <Stack gap="xs" align="start">
+              <DtLink underline="hover" href="/work" size="sm">
                 {t("navWork")}
               </DtLink>
-              <DtLink href="/about" size="sm">
+              <DtLink underline="hover" href="/about" size="sm">
                 {t("navAbout")}
               </DtLink>
-              <DtLink href="/blog" size="sm">
+              <DtLink underline="hover" href="/blog" size="sm">
                 {t("navBlog")}
               </DtLink>
-              <DtLink href="/pricing" size="sm">
+              <DtLink underline="hover" href="/pricing" size="sm">
                 {t("navPricing")}
               </DtLink>
-              <DtLink href="/contact" size="sm">
+              <DtLink underline="hover" href="/contact" size="sm">
                 {t("navContact")}
               </DtLink>
             </Stack>
@@ -153,20 +153,20 @@ export function SiteFooter({ className }: SiteFooterProps) {
             <p className="font-heading text-text-m font-semibold mb-3">
               {t("footerLegalTitle")}
             </p>
-            <Stack gap="xs">
-              <DtLink href="/privacy-policy" size="sm">
+            <Stack gap="xs" align="start">
+              <DtLink underline="hover" href="/privacy-policy" size="sm">
                 {t("footerPrivacyPolicy")}
               </DtLink>
-              <DtLink href="/imprint" size="sm">
+              <DtLink underline="hover" href="/imprint" size="sm">
                 {t("footerImprint")}
               </DtLink>
-              <DtLink href="/ai-use" size="sm">
+              <DtLink underline="hover" href="/ai-use" size="sm">
                 {t("footerAiUse")}
               </DtLink>
-              <DtLink href="/accessibility" size="sm">
+              <DtLink underline="hover" href="/accessibility" size="sm">
                 {t("footerAccessibility")}
               </DtLink>
-              <DtLink href="/sitemap" size="sm">
+              <DtLink underline="hover" href="/sitemap" size="sm">
                 {t("footerSiteMap")}
               </DtLink>
             </Stack>


### PR DESCRIPTION
Fixes the always-on wavy underline the footer inherited when TextLink was absorbed into Link (#802).

- Link gains `underline?: "always" | "hover" | "none"` (default "always", zero change for existing consumers). Hover mode keeps the underline's reserved space (no layout shift), reveals the wave on hover (hover-capable pointers) and keyboard focus-visible, and drops the fade under reduced motion.
- SiteFooter link lists use `underline="hover"` plus `Stack align="start"`, so anchors shrink to text width and the wave spans only the label, not the column.
- Contract (props + variants axis), story control + UnderlineModes example, and three unit tests added.

Verified live in the dev preview: wave hidden at rest on all 10 footer links, content-width boxes (e.g. Work 42px in a 244px column), reveal wired to the same :focus-visible selector as the existing focus ring.

Local gate: typecheck, lint, full tests, build all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)