### PR TITLE
fix(design-system): composesWith derivation no longer proposes deleted components

### DIFF
--- a/nextjs-app/shared/components/Button/Button.contract.json
+++ b/nextjs-app/shared/components/Button/Button.contract.json
@@ -335,11 +335,11 @@
         "Link for in-copy navigation"
     ],
     "composesWith": [
-        "Title",
         "Text",
-        "TextInput",
+        "Title",
         "Icon",
-        "Modal",
-        "CheckboxGroup"
+        "TextInput",
+        "CheckboxGroup",
+        "Modal"
     ]
 }

--- a/nextjs-app/shared/components/Checkbox/Checkbox.contract.json
+++ b/nextjs-app/shared/components/Checkbox/Checkbox.contract.json
@@ -117,9 +117,9 @@
     "composesWith": [
         "TextInput",
         "Button",
+        "Link",
         "Label",
         "Text",
-        "Grid",
-        "ArticleCard"
+        "Grid"
     ]
 }

--- a/nextjs-app/shared/components/CheckboxGroup/CheckboxGroup.contract.json
+++ b/nextjs-app/shared/components/CheckboxGroup/CheckboxGroup.contract.json
@@ -97,8 +97,8 @@
         "TextInput",
         "Button",
         "Text",
+        "TextArea",
         "Grid",
-        "ArticleCard",
-        "Avatar"
+        "ArticleCard"
     ]
 }

--- a/nextjs-app/shared/components/CodeSnippet/CodeSnippet.contract.json
+++ b/nextjs-app/shared/components/CodeSnippet/CodeSnippet.contract.json
@@ -117,7 +117,6 @@
     "composesWith": [
         "Icon",
         "ComplianceCard",
-        "Button",
         "Card"
     ]
 }

--- a/nextjs-app/shared/components/ContactForm/ContactForm.contract.json
+++ b/nextjs-app/shared/components/ContactForm/ContactForm.contract.json
@@ -60,6 +60,7 @@
         "TextInput",
         "Button",
         "Text",
+        "TextArea",
         "CheckboxGroup"
     ]
 }

--- a/nextjs-app/shared/components/Divider/Divider.contract.json
+++ b/nextjs-app/shared/components/Divider/Divider.contract.json
@@ -70,7 +70,7 @@
         "Bypass design tokens or skip forced-colors verification at beta."
     ],
     "composesWith": [
-        "Layout",
-        "Link"
+        "Link",
+        "Layout"
     ]
 }

--- a/nextjs-app/shared/components/FileUpload/FileUpload.contract.json
+++ b/nextjs-app/shared/components/FileUpload/FileUpload.contract.json
@@ -136,9 +136,9 @@
     "composesWith": [
         "Button",
         "TextInput",
+        "CheckboxGroup",
         "Modal",
-        "Select",
-        "PhoneInput",
-        "CheckboxGroup"
+        "Toast",
+        "TextArea"
     ]
 }

--- a/nextjs-app/shared/components/FormField/FormField.contract.json
+++ b/nextjs-app/shared/components/FormField/FormField.contract.json
@@ -92,9 +92,9 @@
         }
     },
     "forbiddenUse": [
-        "Render a bare `<label>` + `<input>` next to a `FormField` in the same form — the visual rhythm desyncs.",
-        "Put two controls inside one `FormField` in single-control mode; wrap each in its own, or switch to group mode with `legend`.",
-        "Provide both `label` and `legend`; pick single-control mode (`label`) or group mode (`legend`), never both."
+        "Render a bare `<label>` + `<input>` next to a `FormField` in the same form; the visual rhythm desyncs.",
+        "Put two controls inside one `FormField` in single-control mode; wrap each in its own, or switch to group mode.",
+        "Provide both `label` and `legend`; pick one mode."
     ],
     "composesWith": [
         "Label",

--- a/nextjs-app/shared/components/FormField/FormField.spec.md
+++ b/nextjs-app/shared/components/FormField/FormField.spec.md
@@ -1,7 +1,7 @@
 # FormField
 
 ## Intent
-Eliminate the per-form boilerplate of wiring label + helper + error around an input. Owners pass children (the control), label text, and optional helper/error props. In group mode (`legend` instead of `label`), FormField renders a `<fieldset>` + `<legend>` around multiple children — the single canonical wrapper for both single-control and grouped-control forms.
+Eliminate the per-form boilerplate of wiring label + helper + error around an input. Owners pass children (the control), label text, and optional helper/error props. In group mode (`legend` instead of `label`), FormField renders a `<fieldset>` + `<legend>` around multiple children: the single canonical wrapper for both single-control and grouped-control forms.
 
 ## Interaction contract
 - Keyboard: Focus reaches the wrapped control(s). The wrapper is non-focusable.
@@ -11,15 +11,15 @@ Eliminate the per-form boilerplate of wiring label + helper + error around an in
 ## Do / don't
 - Do: Wrap every field in `FormField` so the label-control-helper triplet is consistent.
 - Do: Use `error` for submit-time validation feedback; use `helper` for hints.
-- Do: Use group mode (`legend` + `groupDescription`) for checkbox sets, radio sets, or any multi-control grouping — pass `Checkbox`/`Radio` children directly.
-- Don't: Render a bare `<label>` + `<input>` next to a `FormField` in the same form — the visual rhythm desyncs.
-- Don't: Put two controls inside one `FormField` in single-control mode — wrap each in its own, or switch to group mode.
-- Don't: Provide both `label` and `legend` — pick one mode.
+- Do: Use group mode (`legend` + `groupDescription`) for checkbox sets, radio sets, or any multi-control grouping; pass `Checkbox`/`Radio` children directly.
+- Don't: Render a bare `<label>` + `<input>` next to a `FormField` in the same form; the visual rhythm desyncs.
+- Don't: Put two controls inside one `FormField` in single-control mode; wrap each in its own, or switch to group mode.
+- Don't: Provide both `label` and `legend`; pick one mode.
 
 ## Design notes
 - Colors: --color-text, --color-text-muted
 - Spacing: --space-internal-4, --space-internal-8
 - Typography: --font-size-sm, --font-size-md
-- Figma: TODO — to be linked during the alpha → beta promotion.
+- Figma: TODO: to be linked during the alpha to beta promotion.
 - Catalog status: **alpha**, scaffolded as part of the Bucket-1
   catalog-gap migration on 2026-05-26.

--- a/nextjs-app/shared/components/HelperText/HelperText.contract.json
+++ b/nextjs-app/shared/components/HelperText/HelperText.contract.json
@@ -79,7 +79,6 @@
     "composesWith": [
         "Label",
         "Icon",
-        "Button",
-        "TextInput"
+        "Button"
     ]
 }

--- a/nextjs-app/shared/components/Label/Label.contract.json
+++ b/nextjs-app/shared/components/Label/Label.contract.json
@@ -135,10 +135,10 @@
         "use a Label as a section heading. Headings carry navigation"
     ],
     "composesWith": [
-        "TextInput",
         "HelperText",
-        "Button",
         "Checkbox",
+        "TextInput",
+        "Button",
         "Text",
         "Title"
     ]

--- a/nextjs-app/shared/components/Layout/Layout.contract.json
+++ b/nextjs-app/shared/components/Layout/Layout.contract.json
@@ -49,7 +49,9 @@
         "Use as a generic 'two-column with sidebar' wrapper — that is what a section pattern would be."
     ],
     "composesWith": [
-        "Divider",
-        "Link"
+        "Link",
+        "Checkbox",
+        "TextInput",
+        "TextArea"
     ]
 }

--- a/nextjs-app/shared/components/Link/Link.contract.json
+++ b/nextjs-app/shared/components/Link/Link.contract.json
@@ -161,10 +161,10 @@
     ],
     "composesWith": [
         "Button",
-        "Text",
         "Badge",
+        "Text",
         "Title",
-        "Grid",
-        "ArticleCard"
+        "Checkbox",
+        "TextInput"
     ]
 }

--- a/nextjs-app/shared/components/Modal/Modal.contract.json
+++ b/nextjs-app/shared/components/Modal/Modal.contract.json
@@ -207,8 +207,8 @@
         "Title",
         "Text",
         "TextInput",
-        "Select",
-        "FileUpload",
-        "PhoneInput"
+        "Toast",
+        "CheckboxGroup",
+        "TextArea"
     ]
 }

--- a/nextjs-app/shared/components/MultiCombobox/MultiCombobox.contract.json
+++ b/nextjs-app/shared/components/MultiCombobox/MultiCombobox.contract.json
@@ -103,6 +103,7 @@
     ],
     "composesWith": [
         "Button",
-        "FileUpload"
+        "FileUpload",
+        "Checkbox"
     ]
 }

--- a/nextjs-app/shared/components/PhoneInput/PhoneInput.contract.json
+++ b/nextjs-app/shared/components/PhoneInput/PhoneInput.contract.json
@@ -78,9 +78,9 @@
     "composesWith": [
         "TextInput",
         "Button",
+        "CheckboxGroup",
         "Modal",
-        "Select",
-        "FileUpload",
-        "CheckboxGroup"
+        "Toast",
+        "TextArea"
     ]
 }

--- a/nextjs-app/shared/components/Select/Select.contract.json
+++ b/nextjs-app/shared/components/Select/Select.contract.json
@@ -115,9 +115,9 @@
     "composesWith": [
         "TextInput",
         "Button",
+        "CheckboxGroup",
         "Modal",
-        "FileUpload",
-        "PhoneInput",
-        "CheckboxGroup"
+        "Toast",
+        "TextArea"
     ]
 }

--- a/nextjs-app/shared/components/TextInput/TextInput.contract.json
+++ b/nextjs-app/shared/components/TextInput/TextInput.contract.json
@@ -136,9 +136,8 @@
     "composesWith": [
         "Button",
         "Text",
-        "Modal",
+        "TextArea",
         "CheckboxGroup",
-        "Checkbox",
-        "Select"
+        "Checkbox"
     ]
 }

--- a/nextjs-app/shared/components/Toast/Toast.contract.json
+++ b/nextjs-app/shared/components/Toast/Toast.contract.json
@@ -148,6 +148,6 @@
         "Modal",
         "TextInput",
         "CheckboxGroup",
-        "Select"
+        "TextArea"
     ]
 }

--- a/scripts/design-system/component-replacement-policy.mjs
+++ b/scripts/design-system/component-replacement-policy.mjs
@@ -35,15 +35,17 @@ export const REPLACEMENT_FOR = {
   Grid: ["manual CSS grid with arbitrary gap literals"],
   Container: ["max-width div without tokens"],
   FormField: ["label + input wired manually"],
-  Inputs: ["raw <input> without design-system field shell"],
+  TextInput: ["raw <input> without design-system field shell"],
 };
 
 /** @type {Record<string, string[]>} */
 export const COMPOSES_WITH = {
   AlertBanner: ["Button", "Icon"],
-  ContactForm: ["FormField", "Inputs", "Button", "Text"],
-  ChatWidget: ["Button", "Text", "Inputs", "DonnyAvatar"],
-  FormField: ["Label", "Inputs", "HelperText"],
+  ContactForm: ["FormField", "TextInput", "Button", "Text"],
+  ChatWidget: ["Button", "Text", "TextInput", "DonnyAvatar"],
+  // Canonical TextInput self-labels and must not sit inside FormField;
+  // Checkbox is the sanctioned wrapped control (see FormField contract).
+  FormField: ["Label", "Checkbox", "HelperText"],
   Card: ["Title", "Text", "Button"],
   Modal: ["Button", "Title", "Text"],
   CookieConsent: ["Button", "Text"],


### PR DESCRIPTION
npm run check:contract-props flagged composesWith-drift on 18 contracts after the #802 consolidations. Root cause: the hand-curated COMPOSES_WITH/REPLACEMENT_FOR policy in scripts/design-system/component-replacement-policy.mjs still named Inputs (renamed to TextInput) and pointed FormField at a control that cannot sit inside it (canonical TextInput self-labels).

- Fixed the policy source; FormField now composes Checkbox, matching its contract.
- Regenerated relationship-graph + agent blocks; verified programmatically that zero graph edges and zero contract composesWith entries reference a nonexistent component directory.
- Reconciled all 18 flagged contracts against the fresh derivation (hand-applied, not sync --write, to keep the diff reviewable).
- Removed em dashes from FormField.spec.md Do/Don'ts so the spec-derived forbiddenUse matches the contract without reintroducing them.

check:contract-props now exits 0. Local gate: typecheck, lint, full tests, build all exit 0; validate:components exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated component compatibility guidance across the design system so related controls and layouts are paired more accurately.
  * Refined form-related guidance to better match valid usage patterns and reduce conflicting combinations.
  * Adjusted several component relationship lists to reflect current supported pairings.

* **Documentation**
  * Clarified form-field usage notes and improved wording in component guidance docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->