### PR TITLE
fix(design-system): docs pages drop the fixed WipBadge; stale story ids re-keyed

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -267,15 +267,23 @@ const withFullscreenSafeArea: Decorator = (Story, context) => {
 
 
 const withWipBadge: Decorator = (Story, context) => {
+  // Docs pages carry status through their own affordances (DocHeader
+  // StatusPill on the frame, the sidebar lifecycle dots, the Status line on
+  // legacy MDX pages). Rendering the fixed-position badge inside docs would
+  // inject one per embedded canvas, where the Canvas block's transformed
+  // container traps `position: fixed` and clips the badge into a floating
+  // scrap over every story (seen on the LanguageSwitcher MDX page).
+  if (context.viewMode === "docs") {
+    return <Story />;
+  }
   const contractStatus =
     (context.parameters?.contractStatus as string | undefined) ??
     (context.parameters?.wip?.status as string | undefined) ??
     "alpha";
   const showBadge = contractStatus !== "stable" && context.parameters?.wip?.disabled !== true;
-  const isDocs = context.viewMode === "docs";
   return (
     <>
-      {showBadge ? <WipBadge status={contractStatus as "alpha" | "beta" | "stable" | "deprecated"} variant={isDocs ? "docs" : "canvas"} /> : null}
+      {showBadge ? <WipBadge status={contractStatus as "alpha" | "beta" | "stable" | "deprecated"} variant="canvas" /> : null}
       <Story />
     </>
   );

--- a/nextjs-app/shared/stories/MigrationDecisionBoard/MigrationBoardsHub.stories.tsx
+++ b/nextjs-app/shared/stories/MigrationDecisionBoard/MigrationBoardsHub.stories.tsx
@@ -12,13 +12,13 @@ type Story = StoryObj<typeof meta>;
 const BOARDS = [
   {
     title: "Button surfaces — CTA bands",
-    storyId: "atoms-button-surface-comparison--cta-bands",
+    storyId: "actions-button-surface-comparison--cta-bands",
     note: "Approved — surface onDark / onBrand / default on tinted bands.",
     status: "approved" as const,
   },
   {
     title: "Button surfaces — Home hero (light)",
-    storyId: "atoms-button-surface-comparison--home-hero-band",
+    storyId: "actions-button-surface-comparison--home-hero-band",
     note: "Approved — surface=default only; not onDark.",
     status: "approved" as const,
   },

--- a/scripts/migration-visual-matrix.mjs
+++ b/scripts/migration-visual-matrix.mjs
@@ -36,11 +36,11 @@ const VIEWPORTS = [
 /** Storybook story ids for migrated surfaces */
 const STORIES = [
   { id: "patterns-siteheader--example", label: "SiteHeader", region: "#storybook-root header, #storybook-root [role=banner]" },
-  { id: "atoms-iconbutton--example", label: "IconButton" },
-  { id: "molecules-formfield--example", label: "FormField" },
-  { id: "organisms-contactformeditorial--example", label: "ContactFormEditorial" },
-  { id: "atoms-button-surface-comparison--cta-bands", label: "ButtonSurfaceCtaBands" },
-  { id: "atoms-button-surface-comparison--home-hero-band", label: "ButtonSurfaceHomeHero" },
+  { id: "actions-iconbutton--example", label: "IconButton" },
+  { id: "forms-formfield--example", label: "FormField" },
+  { id: "site-contactformeditorial--example", label: "ContactFormEditorial" },
+  { id: "actions-button-surface-comparison--cta-bands", label: "ButtonSurfaceCtaBands" },
+  { id: "actions-button-surface-comparison--home-hero-band", label: "ButtonSurfaceHomeHero" },
 ];
 
 const PAGES = [


### PR DESCRIPTION
Follow-up to #806/#807 after user report: the LanguageSwitcher MDX docs page showed a clipped floating badge scrap in every canvas.

- withWipBadge now renders only in canvas mode. Docs pages carry status via the DocHeader pill, sidebar dots and the MDX status line; inside docs the Canvas block's transformed container traps position:fixed and clips the badge over each story.
- Re-keyed story ids the regroup missed: MigrationBoardsHub hub links and migration-visual-matrix.mjs targets (atoms-/molecules-/organisms- prefixes to the new taxonomy). All six hub ids verified against the live index.
- Verified live: LanguageSwitcher, AlertBanner and Select docs pages clean; canvas mode still shows the badge; docs-smoke 8/8; full local gate green (1824 tests, both builds, story smoke 200/1004).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Storybook docs pages so the work-in-progress badge no longer appears in documentation view.
* **Chores**
  * Updated several Storybook references to match the latest component library organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->