### PR TITLE
fix(storybook): static build no longer crashes with jsxDEV runtime error

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -115,7 +115,8 @@ const config: StorybookConfig = {
     ${head}
     <base href="${process.env.NODE_ENV === "production" ? "/storybook/" : "/"}">
   `,
-  viteFinal: async (config) => {
+  viteFinal: async (config, { configType }) => {
+    const isProductionBuild = configType === "PRODUCTION";
     const rootPath = fileURLToPath(new URL("..", import.meta.url));
     const componentsPath = fileURLToPath(
       new URL("../nextjs-app/shared/components", import.meta.url),
@@ -337,10 +338,13 @@ const config: StorybookConfig = {
         jsxDev: false,
       };
     } else {
-      // Add esbuild options to help with HMR
+      // jsxDev helps dev-server HMR, but it MUST stay off for `storybook
+      // build`: the transform emits jsxDEV() calls while the production
+      // react/jsx-dev-runtime stubs jsxDEV as undefined, so every page of
+      // storybook-static crashed at runtime with "e.jsxDEV is not a function".
       config.esbuild = {
         ...config.esbuild,
-        jsxDev: true,
+        jsxDev: !isProductionBuild,
       };
     }
 


### PR DESCRIPTION
One-line config fix: `.storybook/main.ts` viteFinal forced `esbuild.jsxDev = true` for every non-Vitest invocation, including `storybook build`. The production bundle emitted `jsxDEV()` calls while React's production jsx-dev-runtime stubs `jsxDEV` as undefined, so **every page of storybook-static crashed at runtime** with "TypeError: e.jsxDEV is not a function" (found while running docs-smoke against the static build during phase 3 batch 1).

Now gated on `configType === 'PRODUCTION'`: dev keeps jsxDev for HMR, builds get the prod transform.

Verified locally: `storybook:build` then `docs-smoke` 10/10 against storybook-static served under the `/storybook` base path; typecheck, lint, vitest 1835/1835, next build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Storybook build behavior so development previews keep the expected experience while production builds avoid runtime errors.
  * Fixed an issue that could cause production bundles to include development-only JSX runtime calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->