### PR TITLE
feat(design-system): Astryx gap-fill, five new primitives (Kbd, StatusDot, EmptyState, ButtonGroup, AvatarGroup)

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-07-03T14:25:00.964Z",
+  "createdAt": "2026-07-03T14:57:10.919Z",
   "directory": "nextjs-app/shared",
   "findings": [
     {
@@ -193,6 +193,26 @@
       "value": "1rem"
     },
     {
+      "column": 11,
+      "file": "nextjs-app/shared/components/AvatarGroup/AvatarGroup.module.css",
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/AvatarGroup/AvatarGroup.module.css\u001f43\u001f11\u001f-1px\u001fUnexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 43,
+      "rule": "rhythmguard/use-scale",
+      "text": "Unexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "type": "off-scale",
+      "value": "-1px"
+    },
+    {
+      "column": 11,
+      "file": "nextjs-app/shared/components/AvatarGroup/AvatarGroup.module.css",
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/AvatarGroup/AvatarGroup.module.css\u001f43\u001f11\u001f-1px\u001fUnexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 43,
+      "rule": "rhythmguard/prefer-token",
+      "text": "Unexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "type": "token-opportunity",
+      "value": "-1px"
+    },
+    {
       "column": 24,
       "file": "nextjs-app/shared/components/Badge/Badge.module.css",
       "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/Badge/Badge.module.css\u001f112\u001f24\u001f0.125rem\u001fUnexpected off-scale value \"0.125rem\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
@@ -381,6 +401,26 @@
       "text": "Unexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
       "value": "0.5rem"
+    },
+    {
+      "column": 24,
+      "file": "nextjs-app/shared/components/ButtonGroup/ButtonGroup.module.css",
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/ButtonGroup/ButtonGroup.module.css\u001f14\u001f24\u001f-1px\u001fUnexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 14,
+      "rule": "rhythmguard/use-scale",
+      "text": "Unexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "type": "off-scale",
+      "value": "-1px"
+    },
+    {
+      "column": 24,
+      "file": "nextjs-app/shared/components/ButtonGroup/ButtonGroup.module.css",
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/ButtonGroup/ButtonGroup.module.css\u001f14\u001f24\u001f-1px\u001fUnexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 14,
+      "rule": "rhythmguard/prefer-token",
+      "text": "Unexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "type": "token-opportunity",
+      "value": "-1px"
     },
     {
       "column": 27,
@@ -4231,6 +4271,26 @@
       "text": "Unexpected raw scale value \"0.125rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
       "value": "0.125rem"
+    },
+    {
+      "column": 11,
+      "file": "nextjs-app/shared/components/StatusDot/StatusDot.module.css",
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/StatusDot/StatusDot.module.css\u001f73\u001f11\u001f-1px\u001fUnexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 73,
+      "rule": "rhythmguard/use-scale",
+      "text": "Unexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "type": "off-scale",
+      "value": "-1px"
+    },
+    {
+      "column": 11,
+      "file": "nextjs-app/shared/components/StatusDot/StatusDot.module.css",
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/StatusDot/StatusDot.module.css\u001f73\u001f11\u001f-1px\u001fUnexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 73,
+      "rule": "rhythmguard/prefer-token",
+      "text": "Unexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "type": "token-opportunity",
+      "value": "-1px"
     },
     {
       "column": 8,
@@ -8126,6 +8186,6 @@
   "formatVersion": 1,
   "summary": {
     "scaleCleanliness": 91,
-    "totalFindings": 812
+    "totalFindings": 818
   }
 }

--- a/docs/superpowers/specs/2026-07-03-astryx-level-design-system-roadmap.md
+++ b/docs/superpowers/specs/2026-07-03-astryx-level-design-system-roadmap.md
@@ -271,6 +271,24 @@ Batches sized to one PR each, ordered so shared conventions are settled before d
 8. Content: Avatar, List, Prose, CodeSnippet, CodeBlockWindow, Display.
 9. Tier 2 D2-lite sweep (scriptable: backfill dense lines + keywords, one PR).
 
+## 6.5 Astryx catalog gap analysis (2026-07-03, from astryx.atmeta.com/components)
+
+Full diff of the Astryx public catalog against ours. Three buckets:
+
+**Added as new DT primitives (gap-fill PR, alpha + WIP badge, full artifact set):**
+
+| Astryx | DT component | Notes |
+|---|---|---|
+| Kbd | **Kbd** | Semantic `<kbd>` keycap, sm/md/lg on the text ladder. |
+| Status Dot | **StatusDot** | tone x size + pulse; label mandatory (visible or sr-only). |
+| Empty State | **EmptyState** | Composes Title/Text/Icon; sm/md/lg; action slot. |
+| Button Group | **ButtonGroup** | role=group; attached (segmented) or spaced. Action cluster only — no selection state. |
+| Avatar Group | **AvatarGroup** | Resolves the 5.2 backlog note; overlap stack + "+N" bubble. |
+
+**Already covered (no duplicate will be documented):** Selector→Select, Typeahead→Combobox, Tokenizer/Multi Selector→MultiCombobox, File Input→FileUpload, Field→FormField, Radio List→RadioGroup, Dialog→Modal, Banner→AlertBanner, Progress Bar→Progress, Outline→TableOfContents, Top Nav→SiteHeader, Tab List→Tabs, Breadcrumbs→Breadcrumb, Code/Code Block→CodeSnippet/CodeBlockWindow, Collapsible→ExpandableSection/Accordion, Markdown→MarkdownMessage, Heading→Title, App Shell→Layout, Clickable Card→Card (clickable pattern), Chat family→ChatWidget/Donny family, VisuallyHidden→VisuallyHidden.
+
+**Declined / backlog (each is a project, not a batch item; revisit only with a concrete consumer):** Table (+ its seven hooks), Calendar / Date / DateRange / DateTime / Time inputs, Number Input, Slider, Popover / Hover Card / Overlay primitives, Command Palette, Power Search, Carousel, Segmented Control (Toggle Button / Toggle Button Group — ButtonGroup deliberately excludes selection state), Toolbar, Dropdown Menu / More Menu (SplitButton menu covers current needs), Side Nav / Top Nav Mega Menu, Resize Handle, Tree List, Blockquote / Citation / Thumbnail / Timestamp / Token, Metadata List / Overflow List.
+
 ## 7. Risks and mitigations
 
 - **Content authoring is the real cost** (300+ bestPractices entries, 200+ examples). Mitigate: author in batches with the collaborative editorial process (per feedback memory: no isolated-subagent copywriting; draft in main thread, user reviews per batch).

--- a/nextjs-app/shared/components/AvatarGroup/AvatarGroup.contract.json
+++ b/nextjs-app/shared/components/AvatarGroup/AvatarGroup.contract.json
@@ -1,0 +1,157 @@
+{
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "name": "AvatarGroup",
+    "tier": "molecule",
+    "group": "display",
+    "status": "alpha",
+    "description": "Overlapping stack of Avatars with a +N overflow bubble.",
+    "figma": null,
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "default": "md"
+        }
+    },
+    "slots": [
+        "children"
+    ],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [
+            "Tab reaches clickable Avatars only; static stacks have no stops"
+        ],
+        "ariaRequirements": [
+            "role=group with aria-label naming the cluster",
+            "overflow bubble announces 'N more' via sr-only text"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-07-03 — group semantics, overflow sr text asserted in unit tests; axe clean.",
+        "forcedColorsVerified": true
+    },
+    "tokens": {
+        "colors": [
+            "--color-surface",
+            "--color-neutral-bg",
+            "--color-neutral-text"
+        ],
+        "spacing": [
+            "--space-internal-8"
+        ],
+        "typography": [
+            "--font-body",
+            "--font-size-text-xxs"
+        ]
+    },
+    "lightDarkVerified": true,
+    "schemaVersion": 2,
+    "props": {
+        "ariaLabel": {
+            "optional": true,
+            "type": "string"
+        },
+        "max": {
+            "optional": true,
+            "type": "number"
+        },
+        "size": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ]
+        },
+        "children": {
+            "optional": false,
+            "type": "ReactNode"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "displayName": "AvatarGroup",
+    "keywords": [
+        "avatar",
+        "group",
+        "stack",
+        "team",
+        "members",
+        "overflow",
+        "faces"
+    ],
+    "dense": "role=group overlapping Avatar stack; max collapses the rest into a +N bubble with sr-only 'N more'; sm/md/lg bubble sizes",
+    "usage": {
+        "description": "AvatarGroup answers \"who is on this?\" at a glance: the first max Avatars overlap into a stack and the remainder collapses into a +N bubble that also announces itself to screen readers. Pass same-size Avatars and set the matching group size (sm=2rem, md=2.5rem, lg=3rem) so the bubble lines up.",
+        "bestPractices": [
+            {
+                "guidance": true,
+                "description": "Keep max between 3 and 5; past that the stack stops being scannable and the +N carries the message."
+            },
+            {
+                "guidance": true,
+                "description": "Match children Avatar sizes to the group size so the overflow bubble aligns with the faces."
+            },
+            {
+                "guidance": true,
+                "description": "Name the cluster with ariaLabel (\"Project members\") — the group role reads it before the names."
+            },
+            {
+                "guidance": true,
+                "description": "Order children by relevance; the first faces are the ones people see."
+            },
+            {
+                "guidance": false,
+                "description": "Do not mix Avatar sizes in one stack; the overlap rhythm breaks."
+            },
+            {
+                "guidance": false,
+                "description": "Do not use the +N bubble as a button; if the full roster matters, link to it separately."
+            }
+        ],
+        "anatomy": [
+            {
+                "name": "Group",
+                "required": true,
+                "description": "role=group wrapper with the accessible name."
+            },
+            {
+                "name": "Items",
+                "required": true,
+                "description": "Overlapping Avatars, each ringed with the surface color so edges stay legible."
+            },
+            {
+                "name": "Overflow bubble",
+                "required": false,
+                "description": "Neutral +N circle sized by the size token; sr-only text reads 'N more'."
+            }
+        ]
+    },
+    "playground": {
+        "defaults": {
+            "ariaLabel": "Project members",
+            "max": 4,
+            "size": "md"
+        }
+    },
+    "composesWith": [
+        "Avatar",
+        "PersonCard",
+        "TeamBlock"
+    ]
+}

--- a/nextjs-app/shared/components/AvatarGroup/AvatarGroup.module.css
+++ b/nextjs-app/shared/components/AvatarGroup/AvatarGroup.module.css
@@ -1,0 +1,61 @@
+.group {
+  display: inline-flex;
+  align-items: center;
+}
+
+.item {
+  display: inline-flex;
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px var(--color-surface);
+}
+
+.item:not(:first-child) {
+  margin-inline-start: calc(-1 * var(--space-internal-8));
+}
+
+.overflow {
+  justify-content: center;
+  align-items: center;
+  background-color: var(--color-neutral-bg);
+  font-family: var(--font-body);
+  font-size: var(--font-size-text-xxs);
+  line-height: 1;
+  color: var(--color-neutral-text);
+}
+
+.sm .overflow {
+  block-size: 2rem;
+  inline-size: 2rem;
+}
+
+.md .overflow {
+  block-size: 2.5rem;
+  inline-size: 2.5rem;
+}
+
+.lg .overflow {
+  block-size: 3rem;
+  inline-size: 3rem;
+}
+
+.srOnly {
+  position: absolute;
+  margin: -1px;
+  padding: 0;
+  block-size: 1px;
+  inline-size: 1px;
+  border: 0;
+  white-space: nowrap;
+  clip-path: inset(50%);
+  overflow: hidden;
+}
+
+@media (forced-colors: active) {
+  .item {
+    box-shadow: 0 0 0 2px Canvas;
+  }
+
+  .overflow {
+    border: 1px solid CanvasText;
+  }
+}

--- a/nextjs-app/shared/components/AvatarGroup/AvatarGroup.spec.md
+++ b/nextjs-app/shared/components/AvatarGroup/AvatarGroup.spec.md
@@ -1,0 +1,27 @@
+# AvatarGroup
+
+## Intent
+Compact "who is involved" cluster: overlapping Avatars with a `+N`
+overflow bubble. The Astryx-parity companion to Avatar noted as backlog
+in the roadmap (5.2).
+
+## Interaction contract
+- Static by default; individual Avatars keep their own behavior
+  (clickable, menu) if configured.
+- Screen readers: `role="group"` + `ariaLabel` names the cluster; each
+  Avatar announces its own name; the bubble announces "N more".
+
+## Do / don't
+- Do: pass Avatars of one size and match the group `size` (sm=2rem,
+  md=2.5rem, lg=3rem) so the bubble aligns.
+- Do: keep `max` low (3-5); the stack is a summary, not a roster.
+- Don't: mix clickable and static Avatars in one stack.
+- Don't: use it as navigation to profiles when the count matters more
+  than the identities — use a list instead.
+
+## Design notes
+- Overlap is a fixed token step (`--space-internal-8`) which reads right
+  for the three supported sizes.
+- Each item carries a 2px `--color-surface` ring (Canvas in forced
+  colors) so overlapping edges stay legible on any background.
+- Overflow bubble uses the neutral Badge palette tokens.

--- a/nextjs-app/shared/components/AvatarGroup/AvatarGroup.stories.tsx
+++ b/nextjs-app/shared/components/AvatarGroup/AvatarGroup.stories.tsx
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import React from "react";
+import AvatarGroup from "./AvatarGroup";
+import Avatar from "@dt/Avatar";
+import contract from "./AvatarGroup.contract.json";
+
+const PEOPLE = ["Aino Virtanen", "Bo Lindqvist", "Carla Mendes", "Deniz Aydın", "Eero Salmi", "Freja Holm"];
+
+const meta = {
+  title: "Content/AvatarGroup",
+  component: AvatarGroup,
+  tags: ["alpha", "autodocs"],
+  parameters: {
+    layout: "centered",
+    a11y: { test: "error" },
+    contractStatus: contract.status,
+  },
+  argTypes: {
+    ariaLabel: { control: "text", description: "Accessible name for the cluster" },
+    max: {
+      control: { type: "number", min: 1, max: 8 },
+      description: "Avatars shown before collapsing into +N",
+      table: { defaultValue: { summary: "4" } },
+    },
+    size: {
+      control: "radio",
+      options: ["sm", "md", "lg"],
+      description: "Overflow bubble size; children Avatars should match",
+      table: { defaultValue: { summary: "md" } },
+    },
+    children: { control: false, description: "@dt/Avatar elements" },
+  },
+  args: { ariaLabel: "Project members", max: 4, size: "md" },
+} satisfies Meta<typeof AvatarGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const avatars = (count: number, size: "2rem" | "2.5rem" | "3rem" = "2.5rem") =>
+  PEOPLE.slice(0, count).map((name) => (
+    <Avatar key={name} name={name} variant="initials" size={size} />
+  ));
+
+export const Default: Story = {
+  tags: ["example"],
+  parameters: {
+    docs: {
+      description: { story: "Six members, max 4: the stack shows four and collapses the rest into +2." },
+    },
+  },
+  render: (args) => <AvatarGroup {...args}>{avatars(6)}</AvatarGroup>,
+};
+
+export const Playground: Story = {
+  render: (args) => <AvatarGroup {...args}>{avatars(6)}</AvatarGroup>,
+};
+
+export const NoOverflow: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: { story: "At or under max, every Avatar renders and no bubble appears." },
+    },
+  },
+  render: () => <AvatarGroup ariaLabel="Reviewers">{avatars(3)}</AvatarGroup>,
+};
+
+export const Sizes: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: { story: "size sizes the +N bubble; pass matching Avatar sizes (sm=2rem, md=2.5rem, lg=3rem)." },
+    },
+  },
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem", alignItems: "flex-start" }}>
+      <AvatarGroup ariaLabel="Team" size="sm" max={3}>
+        {avatars(5, "2rem")}
+      </AvatarGroup>
+      <AvatarGroup ariaLabel="Team" size="md" max={3}>
+        {avatars(5, "2.5rem")}
+      </AvatarGroup>
+      <AvatarGroup ariaLabel="Team" size="lg" max={3}>
+        {avatars(5, "3rem")}
+      </AvatarGroup>
+    </div>
+  ),
+};
+
+export const WithLabel: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: { story: "Pair the stack with a text label when the count matters as much as the faces." },
+    },
+  },
+  render: () => (
+    <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+      <AvatarGroup ariaLabel="Contributors" max={3}>
+        {avatars(6)}
+      </AvatarGroup>
+      <span>6 contributors</span>
+    </div>
+  ),
+};
+
+export const Example: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <AvatarGroup ariaLabel="Project members" max={4}>
+      {avatars(6)}
+    </AvatarGroup>
+  ),
+};
+
+export const ForcedColors: Story = {
+  globals: { forcedColors: "active" },
+  parameters: { a11y: { disable: true, test: "off" } },
+  render: () => <AvatarGroup ariaLabel="Project members">{avatars(5)}</AvatarGroup>,
+};

--- a/nextjs-app/shared/components/AvatarGroup/AvatarGroup.test.tsx
+++ b/nextjs-app/shared/components/AvatarGroup/AvatarGroup.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import AvatarGroup from "./AvatarGroup";
+import Avatar from "@dt/Avatar";
+
+expect.extend(toHaveNoViolations);
+
+const avatars = (count: number) =>
+  ["Aino V", "Bo L", "Carla M", "Deniz A", "Eero S", "Freja H"]
+    .slice(0, count)
+    .map((name) => <Avatar key={name} name={name} variant="initials" size="2.5rem" />);
+
+describe("AvatarGroup", () => {
+  it("renders a labelled group", () => {
+    render(<AvatarGroup ariaLabel="Members">{avatars(3)}</AvatarGroup>);
+    expect(screen.getByRole("group", { name: "Members" })).toBeInTheDocument();
+  });
+
+  it("collapses avatars beyond max into a +N bubble with sr text", () => {
+    render(
+      <AvatarGroup ariaLabel="Members" max={4}>
+        {avatars(6)}
+      </AvatarGroup>,
+    );
+    expect(screen.getByText("+2")).toBeInTheDocument();
+    expect(screen.getByText("2 more")).toBeInTheDocument();
+  });
+
+  it("shows no bubble when children fit within max", () => {
+    render(
+      <AvatarGroup ariaLabel="Members" max={4}>
+        {avatars(3)}
+      </AvatarGroup>,
+    );
+    expect(screen.queryByText(/^\+\d/)).not.toBeInTheDocument();
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(
+      <AvatarGroup ariaLabel="Project members" max={4}>
+        {avatars(6)}
+      </AvatarGroup>,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/AvatarGroup/AvatarGroup.tsx
+++ b/nextjs-app/shared/components/AvatarGroup/AvatarGroup.tsx
@@ -1,0 +1,54 @@
+import React, { Children } from "react";
+import { cn } from "@/lib/utils";
+import styles from "./AvatarGroup.module.css";
+
+export type AvatarGroupSize = "sm" | "md" | "lg";
+
+export interface AvatarGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Accessible name for the cluster (e.g. "Project members"). */
+  ariaLabel?: string;
+  /** Avatars beyond this count collapse into a "+N" bubble. @default 4 */
+  max?: number;
+  /**
+   * Size of the overflow bubble; children Avatars should match
+   * (sm=2rem, md=2.5rem, lg=3rem). @default "md"
+   */
+  size?: AvatarGroupSize;
+  /** @dt/Avatar elements (all the same size). */
+  children: React.ReactNode;
+}
+
+/** Overlapping stack of Avatars with a +N overflow bubble. */
+export const AvatarGroup = React.forwardRef<HTMLDivElement, AvatarGroupProps>(
+  ({ ariaLabel, max = 4, size = "md", children, className, ...rest }, ref) => {
+    const items = Children.toArray(children);
+    const visible = items.slice(0, Math.max(0, max));
+    const overflow = items.length - visible.length;
+
+    return (
+      <div
+        ref={ref}
+        role="group"
+        aria-label={ariaLabel}
+        className={cn(styles.group, styles[size], className)}
+        {...rest}
+      >
+        {visible.map((child, index) => (
+          <span key={index} className={styles.item}>
+            {child}
+          </span>
+        ))}
+        {overflow > 0 ? (
+          <span className={cn(styles.item, styles.overflow)}>
+            <span aria-hidden="true">+{overflow}</span>
+            <span className={styles.srOnly}>{`${overflow} more`}</span>
+          </span>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+AvatarGroup.displayName = "AvatarGroup";
+
+export default AvatarGroup;

--- a/nextjs-app/shared/components/AvatarGroup/index.ts
+++ b/nextjs-app/shared/components/AvatarGroup/index.ts
@@ -1,0 +1,2 @@
+export { default, AvatarGroup } from "./AvatarGroup";
+export type { AvatarGroupProps, AvatarGroupSize } from "./AvatarGroup";

--- a/nextjs-app/shared/components/ButtonGroup/ButtonGroup.contract.json
+++ b/nextjs-app/shared/components/ButtonGroup/ButtonGroup.contract.json
@@ -1,0 +1,124 @@
+{
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "name": "ButtonGroup",
+    "tier": "molecule",
+    "group": "actions",
+    "status": "alpha",
+    "description": "Groups related Buttons into one attached (segmented) or spaced row.",
+    "figma": null,
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {},
+    "slots": [
+        "children"
+    ],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [
+            "Tab moves through each child button (no roving tabindex)"
+        ],
+        "ariaRequirements": [
+            "role=group with aria-label naming the cluster"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-07-03 — group semantics + labelled-group asserted in unit tests; axe clean; focus ring lift verified in Storybook.",
+        "forcedColorsVerified": true
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": [
+            "--space-internal-8"
+        ],
+        "typography": []
+    },
+    "lightDarkVerified": true,
+    "schemaVersion": 2,
+    "props": {
+        "ariaLabel": {
+            "optional": true,
+            "type": "string"
+        },
+        "attached": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "children": {
+            "optional": false,
+            "type": "ReactNode"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "displayName": "ButtonGroup",
+    "keywords": [
+        "button group",
+        "segmented",
+        "toolbar",
+        "actions",
+        "cluster",
+        "attached"
+    ],
+    "dense": "role=group row of Buttons/IconButtons; attached mode fuses seams (segmented look), attached=false spaces on the token gap",
+    "usage": {
+        "description": "ButtonGroup presents sibling actions as one surface. Attached (default) collapses inner radii and shares 1px seams for view switchers and compact toolbars; attached=false keeps the group semantics but spaces the buttons for form action rows. Children should share variant and size. It groups independent actions; it does not manage selection state.",
+        "bestPractices": [
+            {
+                "guidance": true,
+                "description": "Use one variant and one size for every segment; mixed weights read as unrelated buttons touching."
+            },
+            {
+                "guidance": true,
+                "description": "Name the group with ariaLabel (\"Text alignment\", \"View\") so AT users get the context first."
+            },
+            {
+                "guidance": true,
+                "description": "Prefer secondary variant for attached segments; the outline makes the shared seams legible."
+            },
+            {
+                "guidance": true,
+                "description": "Use IconButtons for compact toolbar clusters; each still needs its own label."
+            },
+            {
+                "guidance": false,
+                "description": "Do not use it for exclusive selection (active segment state); that is a toggle-group pattern this component deliberately does not implement."
+            },
+            {
+                "guidance": false,
+                "description": "Do not put a menu trigger inside; SplitButton owns primary-action + menu."
+            }
+        ],
+        "anatomy": [
+            {
+                "name": "Group",
+                "required": true,
+                "description": "role=group wrapper carrying the accessible name and the seam styles."
+            },
+            {
+                "name": "Segments",
+                "required": true,
+                "description": "Two or more @dt Button / IconButton children; inner radii collapse in attached mode."
+            }
+        ]
+    },
+    "playground": {
+        "defaults": {
+            "ariaLabel": "View",
+            "attached": true
+        }
+    },
+    "composesWith": [
+        "Button",
+        "IconButton",
+        "SplitButton"
+    ]
+}

--- a/nextjs-app/shared/components/ButtonGroup/ButtonGroup.module.css
+++ b/nextjs-app/shared/components/ButtonGroup/ButtonGroup.module.css
@@ -1,0 +1,29 @@
+.group {
+  display: inline-flex;
+  align-items: stretch;
+}
+
+.spaced {
+  gap: var(--space-internal-8);
+}
+
+/* Doubled class beats the child button's single-class radius/border rules
+   without !important. */
+
+.attached.attached > :not(:first-child) {
+  margin-inline-start: -1px;
+  border-end-start-radius: 0;
+  border-start-start-radius: 0;
+}
+
+.attached.attached > :not(:last-child) {
+  border-end-end-radius: 0;
+  border-start-end-radius: 0;
+}
+
+/* Keep the focused segment's ring on top of its neighbors. */
+
+.attached.attached > :focus-visible {
+  position: relative;
+  z-index: 1;
+}

--- a/nextjs-app/shared/components/ButtonGroup/ButtonGroup.spec.md
+++ b/nextjs-app/shared/components/ButtonGroup/ButtonGroup.spec.md
@@ -1,0 +1,27 @@
+# ButtonGroup
+
+## Intent
+Row of related actions presented as one control surface. Attached mode
+fuses Buttons/IconButtons into segments (view switchers, toolbars);
+spaced mode keeps group semantics with the token gap (form action rows).
+
+## Interaction contract
+- Keyboard: each child button keeps its own Tab stop (no roving tabindex;
+  the group is not a radio-style segmented control).
+- Screen readers: `role="group"` with `ariaLabel` names the cluster before
+  the individual buttons are announced.
+
+## Do / don't
+- Do: use one variant and one size across the group.
+- Do: pass `ariaLabel` whenever the buttons' purpose isn't obvious alone.
+- Don't: mix primary and secondary segments in attached mode.
+- Don't: use ButtonGroup for exclusive selection state — that is a future
+  ToggleButtonGroup; this is an action cluster.
+
+## Design notes
+- Attached seams: inner radii collapse and borders overlap by 1px; the
+  doubled-class selector outranks the child button's radius rules without
+  `!important`.
+- Focus ring of the focused segment lifts above neighbors via z-index.
+- SplitButton remains the primary-action + menu pattern; ButtonGroup is
+  for peer actions.

--- a/nextjs-app/shared/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/nextjs-app/shared/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import React from "react";
+import ButtonGroup from "./ButtonGroup";
+import Button from "@dt/Button";
+import { IconButton } from "@dt/IconButton";
+import contract from "./ButtonGroup.contract.json";
+
+const meta = {
+  title: "Actions/ButtonGroup",
+  component: ButtonGroup,
+  tags: ["alpha", "autodocs"],
+  parameters: {
+    layout: "centered",
+    a11y: { test: "error" },
+    contractStatus: contract.status,
+  },
+  argTypes: {
+    ariaLabel: { control: "text", description: "Accessible group name" },
+    attached: {
+      control: "boolean",
+      description: "Fuse children into one segmented surface",
+      table: { defaultValue: { summary: "true" } },
+    },
+    children: { control: false, description: "Buttons / IconButtons (same variant + size)" },
+  },
+  args: { ariaLabel: "Text alignment" },
+} satisfies Meta<typeof ButtonGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  tags: ["example"],
+  parameters: {
+    docs: {
+      description: { story: "Attached segments share seams; use one variant and size across the group." },
+    },
+  },
+  render: (args) => (
+    <ButtonGroup {...args}>
+      <Button variant="secondary" size="md">Day</Button>
+      <Button variant="secondary" size="md">Week</Button>
+      <Button variant="secondary" size="md">Month</Button>
+    </ButtonGroup>
+  ),
+};
+
+export const Playground: Story = {
+  render: (args) => (
+    <ButtonGroup {...args}>
+      <Button variant="secondary" size="md">One</Button>
+      <Button variant="secondary" size="md">Two</Button>
+      <Button variant="secondary" size="md">Three</Button>
+    </ButtonGroup>
+  ),
+};
+
+export const Spaced: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: { story: "attached=false keeps the group semantics but spaces the buttons on the token gap." },
+    },
+  },
+  render: () => (
+    <ButtonGroup ariaLabel="Form actions" attached={false}>
+      <Button variant="primary" size="md">Save</Button>
+      <Button variant="tertiary" size="md">Cancel</Button>
+    </ButtonGroup>
+  ),
+};
+
+export const WithIconButtons: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: { story: "IconButtons make a compact toolbar cluster; every segment still carries its own label." },
+    },
+  },
+  render: () => (
+    <ButtonGroup ariaLabel="Text formatting">
+      <IconButton variant="secondary" size="md" icon="text-b" label="Bold" />
+      <IconButton variant="secondary" size="md" icon="text-italic" label="Italic" />
+      <IconButton variant="secondary" size="md" icon="text-underline" label="Underline" />
+    </ButtonGroup>
+  ),
+};
+
+export const Pager: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: { story: "Prev/next pager: two attached secondary segments with icon labels." },
+    },
+  },
+  render: () => (
+    <ButtonGroup ariaLabel="Pagination">
+      <IconButton variant="secondary" size="md" icon="caret-left" label="Previous page" />
+      <IconButton variant="secondary" size="md" icon="caret-right" label="Next page" />
+    </ButtonGroup>
+  ),
+};
+
+export const Example: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <ButtonGroup ariaLabel="View">
+      <Button variant="secondary" size="md">List</Button>
+      <Button variant="secondary" size="md">Grid</Button>
+    </ButtonGroup>
+  ),
+};
+
+export const ForcedColors: Story = {
+  globals: { forcedColors: "active" },
+  parameters: { a11y: { disable: true, test: "off" } },
+  render: () => (
+    <ButtonGroup ariaLabel="View">
+      <Button variant="secondary" size="md">List</Button>
+      <Button variant="secondary" size="md">Grid</Button>
+    </ButtonGroup>
+  ),
+};

--- a/nextjs-app/shared/components/ButtonGroup/ButtonGroup.test.tsx
+++ b/nextjs-app/shared/components/ButtonGroup/ButtonGroup.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import ButtonGroup from "./ButtonGroup";
+import styles from "./ButtonGroup.module.css";
+
+expect.extend(toHaveNoViolations);
+
+describe("ButtonGroup", () => {
+  it("renders a labelled group with its children", () => {
+    render(
+      <ButtonGroup ariaLabel="View">
+        <button type="button">List</button>
+        <button type="button">Grid</button>
+      </ButtonGroup>,
+    );
+    const group = screen.getByRole("group", { name: "View" });
+    expect(group).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "List" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Grid" })).toBeInTheDocument();
+  });
+
+  it("is attached by default and spaced when attached=false", () => {
+    const { rerender } = render(
+      <ButtonGroup ariaLabel="View">
+        <button type="button">A</button>
+      </ButtonGroup>,
+    );
+    expect(screen.getByRole("group")).toHaveClass(styles.attached);
+
+    rerender(
+      <ButtonGroup ariaLabel="View" attached={false}>
+        <button type="button">A</button>
+      </ButtonGroup>,
+    );
+    expect(screen.getByRole("group")).toHaveClass(styles.spaced);
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(
+      <ButtonGroup ariaLabel="Text alignment">
+        <button type="button">Left</button>
+        <button type="button">Center</button>
+        <button type="button">Right</button>
+      </ButtonGroup>,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/ButtonGroup/ButtonGroup.tsx
+++ b/nextjs-app/shared/components/ButtonGroup/ButtonGroup.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+import styles from "./ButtonGroup.module.css";
+
+export interface ButtonGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Accessible name for the group (announced by screen readers). */
+  ariaLabel?: string;
+  /** Fuse the children into one segmented control surface. @default true */
+  attached?: boolean;
+  /** Buttons / IconButtons of the same variant and size. */
+  children: React.ReactNode;
+}
+
+/** Groups related Buttons into one row — attached (segmented) or evenly spaced. */
+export const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
+  ({ ariaLabel, attached = true, children, className, ...rest }, ref) => (
+    <div
+      ref={ref}
+      role="group"
+      aria-label={ariaLabel}
+      className={cn(styles.group, attached ? styles.attached : styles.spaced, className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  ),
+);
+
+ButtonGroup.displayName = "ButtonGroup";
+
+export default ButtonGroup;

--- a/nextjs-app/shared/components/ButtonGroup/index.ts
+++ b/nextjs-app/shared/components/ButtonGroup/index.ts
@@ -1,0 +1,2 @@
+export { default, ButtonGroup } from "./ButtonGroup";
+export type { ButtonGroupProps } from "./ButtonGroup";

--- a/nextjs-app/shared/components/EmptyState/EmptyState.contract.json
+++ b/nextjs-app/shared/components/EmptyState/EmptyState.contract.json
@@ -1,0 +1,177 @@
+{
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "name": "EmptyState",
+    "tier": "molecule",
+    "group": "display",
+    "status": "alpha",
+    "description": "Placeholder block for empty lists, zero search results, and first-run screens.",
+    "figma": null,
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "default": "md"
+        }
+    },
+    "slots": [
+        "children"
+    ],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [
+            "Tab reaches actions in the slot"
+        ],
+        "ariaRequirements": [
+            "title is a real heading; headingLevel must fit the page outline",
+            "icon is decorative (aria-hidden)"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-07-03 — static block; heading semantics + decorative icon asserted in unit tests; axe clean.",
+        "forcedColorsVerified": true
+    },
+    "tokens": {
+        "colors": [
+            "--color-muted",
+            "--color-text"
+        ],
+        "spacing": [
+            "--space-internal-4",
+            "--space-internal-8",
+            "--space-internal-12",
+            "--space-internal-16",
+            "--space-internal-32",
+            "--space-layout-48"
+        ],
+        "typography": []
+    },
+    "lightDarkVerified": true,
+    "schemaVersion": 2,
+    "props": {
+        "icon": {
+            "optional": true,
+            "type": "string"
+        },
+        "title": {
+            "optional": false,
+            "type": "string"
+        },
+        "description": {
+            "optional": true,
+            "type": "string"
+        },
+        "headingLevel": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "h2",
+                "h3",
+                "h4"
+            ]
+        },
+        "size": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ]
+        },
+        "children": {
+            "optional": true,
+            "type": "ReactNode"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "displayName": "EmptyState",
+    "keywords": [
+        "empty",
+        "no results",
+        "placeholder",
+        "zero state",
+        "first run",
+        "blank"
+    ],
+    "dense": "centered icon + heading + description + action slot for empty lists/search/first-run; sm/md/lg step padding and type together",
+    "usage": {
+        "description": "EmptyState fills the space where content should be with an explanation and a way forward: a decorative icon, a real heading, up to two sentences of description, and an action slot for Buttons. Use sm inside panels and cards, md in content areas, lg on full pages. For failures use AlertBanner; EmptyState is for legitimate absence.",
+        "bestPractices": [
+            {
+                "guidance": true,
+                "description": "Name what is empty in the title (\"No projects yet\"), not a generic \"Nothing here\"."
+            },
+            {
+                "guidance": true,
+                "description": "Give a way forward: an action button, or a description telling the user what will populate this space."
+            },
+            {
+                "guidance": true,
+                "description": "Set headingLevel so the title fits the page outline (h3 inside a card that sits under an h2)."
+            },
+            {
+                "guidance": true,
+                "description": "Keep zero-search-results copy actionable: suggest clearing filters or broadening the term."
+            },
+            {
+                "guidance": false,
+                "description": "Do not use EmptyState for errors or loading; AlertBanner owns failures and Skeleton owns loading."
+            },
+            {
+                "guidance": false,
+                "description": "Do not stack more than two actions; one primary path plus one escape hatch."
+            }
+        ],
+        "anatomy": [
+            {
+                "name": "Icon",
+                "required": false,
+                "description": "Decorative Phosphor icon in --color-muted, sized with the block."
+            },
+            {
+                "name": "Title",
+                "required": true,
+                "description": "@dt/Title heading (h2-h4) naming what is empty."
+            },
+            {
+                "name": "Description",
+                "required": false,
+                "description": "@dt/Text capped at 40ch explaining why or what to do."
+            },
+            {
+                "name": "Actions",
+                "required": false,
+                "description": "children slot; typically one primary Button and an optional tertiary."
+            }
+        ]
+    },
+    "playground": {
+        "defaults": {
+            "icon": "magnifying-glass",
+            "title": "No results found",
+            "description": "Try a different search term."
+        }
+    },
+    "composesWith": [
+        "Title",
+        "Text",
+        "Icon",
+        "Button",
+        "Card"
+    ]
+}

--- a/nextjs-app/shared/components/EmptyState/EmptyState.module.css
+++ b/nextjs-app/shared/components/EmptyState/EmptyState.module.css
@@ -1,0 +1,51 @@
+.root {
+  display: flex;
+  inline-size: 100%;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+.sm {
+  padding-block: var(--space-internal-16);
+  padding-inline: var(--space-internal-16);
+  gap: var(--space-internal-4);
+}
+
+.md {
+  padding-block: var(--space-internal-32);
+  padding-inline: var(--space-internal-16);
+  gap: var(--space-internal-8);
+}
+
+.lg {
+  padding-block: var(--space-layout-48);
+  padding-inline: var(--space-internal-16);
+  gap: var(--space-internal-12);
+}
+
+.icon {
+  display: inline-flex;
+  color: var(--color-muted);
+}
+
+.title {
+  margin: 0;
+  color: var(--color-text);
+}
+
+.description {
+  margin: 0;
+  max-inline-size: 40ch;
+  color: var(--color-muted);
+}
+
+.actions {
+  display: flex;
+  margin-block-start: var(--space-internal-8);
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: var(--space-internal-8);
+}

--- a/nextjs-app/shared/components/EmptyState/EmptyState.spec.md
+++ b/nextjs-app/shared/components/EmptyState/EmptyState.spec.md
@@ -1,0 +1,24 @@
+# EmptyState
+
+## Intent
+The standard placeholder for "there is nothing here yet / nothing matched":
+empty lists, zero search results, first-run screens, and cleared filters.
+Composes @dt Title, Text, and Icon so the typography stays on the ladder.
+
+## Interaction contract
+- The block itself is static; interactivity lives in the action slot
+  (children), which should hold @dt Buttons.
+- Screen readers: the title is a real heading (h2 default; set
+  `headingLevel` to fit the page outline). The icon is decorative.
+
+## Do / don't
+- Do: say what is empty and give a way forward (description or action).
+- Do: fit `headingLevel` into the surrounding document outline.
+- Don't: stack more than two actions; one primary path, one escape hatch.
+- Don't: use it for error states — AlertBanner owns failures.
+
+## Design notes
+- Sizes: sm (panels/cards), md (content areas), lg (full pages); vertical
+  padding and type scale step together.
+- Description is capped at 40ch for readable centered lines.
+- Icon renders in `--color-muted` to stay behind the headline.

--- a/nextjs-app/shared/components/EmptyState/EmptyState.stories.tsx
+++ b/nextjs-app/shared/components/EmptyState/EmptyState.stories.tsx
@@ -1,0 +1,142 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import React from "react";
+import EmptyState from "./EmptyState";
+import Button from "@dt/Button";
+import contract from "./EmptyState.contract.json";
+
+const meta = {
+  title: "Content/EmptyState",
+  component: EmptyState,
+  tags: ["alpha", "autodocs"],
+  parameters: {
+    layout: "padded",
+    a11y: { test: "error" },
+    contractStatus: contract.status,
+  },
+  argTypes: {
+    icon: { control: "text", description: "Phosphor icon name (decorative)" },
+    title: { control: "text", description: "Short headline stating what is empty" },
+    description: {
+      control: "text",
+      description: "Why it is empty, or what to do next",
+    },
+    headingLevel: {
+      control: "radio",
+      options: ["h2", "h3", "h4"],
+      description: "Heading tag for the title",
+      table: { defaultValue: { summary: "h2" } },
+    },
+    size: {
+      control: "radio",
+      options: ["sm", "md", "lg"],
+      description: "Size token",
+      table: { defaultValue: { summary: "md" } },
+    },
+    children: { control: false, description: "Action slot (Buttons)" },
+  },
+  args: {
+    icon: "magnifying-glass",
+    title: "No results found",
+    description: "Try a different search term, or clear the filters to see everything.",
+    size: "md",
+  },
+} satisfies Meta<typeof EmptyState>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  tags: ["example"],
+  parameters: {
+    docs: {
+      description: { story: "Search empty state: icon, headline, and a way forward in the description." },
+    },
+  },
+};
+
+export const Playground: Story = {};
+
+export const WithAction: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: { story: "First-run empty state: the action slot carries the primary next step." },
+    },
+  },
+  render: () => (
+    <EmptyState
+      icon="folder-open"
+      title="No projects yet"
+      description="Projects you create will show up here."
+    >
+      <Button variant="primary" size="md">
+        New project
+      </Button>
+      <Button variant="tertiary" size="md">
+        Import
+      </Button>
+    </EmptyState>
+  ),
+};
+
+export const Sizes: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: { story: "sm for panels and cards, md for content areas, lg for full pages." },
+    },
+  },
+  render: () => (
+    <div>
+      <EmptyState size="sm" icon="tray" title="Nothing here" headingLevel="h3" />
+      <EmptyState
+        size="md"
+        icon="tray"
+        title="Nothing here"
+        headingLevel="h3"
+        description="Items you add will appear in this list."
+      />
+    </div>
+  ),
+};
+
+export const ClearedFilters: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: { story: "Zero-results state with an escape hatch action that undoes the filters." },
+    },
+  },
+  render: () => (
+    <EmptyState
+      size="sm"
+      icon="funnel"
+      title="No matches"
+      headingLevel="h3"
+      description="Nothing matches the current filters."
+    >
+      <Button variant="secondary" size="sm">
+        Clear filters
+      </Button>
+    </EmptyState>
+  ),
+};
+
+export const Example: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <EmptyState
+      icon="magnifying-glass"
+      title="No results found"
+      description="Try a different search term."
+    />
+  ),
+};
+
+export const ForcedColors: Story = {
+  globals: { forcedColors: "active" },
+  parameters: { a11y: { disable: true, test: "off" } },
+};

--- a/nextjs-app/shared/components/EmptyState/EmptyState.test.tsx
+++ b/nextjs-app/shared/components/EmptyState/EmptyState.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import EmptyState from "./EmptyState";
+
+expect.extend(toHaveNoViolations);
+
+describe("EmptyState", () => {
+  it("renders title as a heading and optional description", () => {
+    render(
+      <EmptyState title="No results" description="Try another term." />,
+    );
+    expect(
+      screen.getByRole("heading", { level: 2, name: "No results" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Try another term.")).toBeInTheDocument();
+  });
+
+  it("respects headingLevel", () => {
+    render(<EmptyState title="Empty" headingLevel="h3" />);
+    expect(
+      screen.getByRole("heading", { level: 3, name: "Empty" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the action slot", () => {
+    render(
+      <EmptyState title="No projects">
+        <button type="button">New project</button>
+      </EmptyState>,
+    );
+    expect(
+      screen.getByRole("button", { name: "New project" }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the icon decorative", () => {
+    const { container } = render(<EmptyState title="Empty" icon="tray" />);
+    const iconWrap = container.querySelector("[aria-hidden='true']");
+    expect(iconWrap).not.toBeNull();
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(
+      <EmptyState
+        icon="magnifying-glass"
+        title="No results found"
+        description="Try a different search term."
+      >
+        <button type="button">Clear filters</button>
+      </EmptyState>,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/EmptyState/EmptyState.tsx
+++ b/nextjs-app/shared/components/EmptyState/EmptyState.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+import Icon from "@dt/Icon";
+import Text from "@dt/Text";
+import Title from "@dt/Title";
+import styles from "./EmptyState.module.css";
+
+export type EmptyStateSize = "sm" | "md" | "lg";
+
+export interface EmptyStateProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Phosphor icon name rendered decoratively above the title. */
+  icon?: string;
+  /** Short headline stating what is empty. */
+  title: string;
+  /** One or two sentences explaining why, or what to do next. */
+  description?: string;
+  /** Heading tag for the title. @default "h2" */
+  headingLevel?: "h2" | "h3" | "h4";
+  /** Size token. @default "md" */
+  size?: EmptyStateSize;
+  /** Action slot — typically one primary Button, optionally a secondary. */
+  children?: React.ReactNode;
+}
+
+const titleSizeMap = { sm: "xxs", md: "xs", lg: "s" } as const;
+const textSizeMap = { sm: "xs", md: "s", lg: "m" } as const;
+const iconSizeMap = { sm: "lg", md: "xl", lg: "2xl" } as const;
+
+/** Placeholder block for empty lists, searches, and first-run screens. */
+export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
+  (
+    { icon, title, description, headingLevel = "h2", size = "md", children, className, ...rest },
+    ref,
+  ) => (
+    <div ref={ref} className={cn(styles.root, styles[size], className)} {...rest}>
+      {icon ? (
+        <span className={styles.icon} aria-hidden="true">
+          <Icon name={icon} size={iconSizeMap[size]} decorative />
+        </span>
+      ) : null}
+      <Title as={headingLevel} size={titleSizeMap[size]} className={styles.title}>
+        {title}
+      </Title>
+      {description ? (
+        <Text as="p" size={textSizeMap[size]} className={styles.description}>
+          {description}
+        </Text>
+      ) : null}
+      {children ? <div className={styles.actions}>{children}</div> : null}
+    </div>
+  ),
+);
+
+EmptyState.displayName = "EmptyState";
+
+export default EmptyState;

--- a/nextjs-app/shared/components/EmptyState/index.ts
+++ b/nextjs-app/shared/components/EmptyState/index.ts
@@ -1,0 +1,2 @@
+export { default, EmptyState } from "./EmptyState";
+export type { EmptyStateProps, EmptyStateSize } from "./EmptyState";

--- a/nextjs-app/shared/components/Kbd/Kbd.contract.json
+++ b/nextjs-app/shared/components/Kbd/Kbd.contract.json
@@ -1,0 +1,125 @@
+{
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "name": "Kbd",
+    "tier": "atom",
+    "group": "display",
+    "status": "alpha",
+    "description": "Inline keyboard-key indicator rendered as a semantic kbd keycap.",
+    "figma": null,
+    "radixPrimitive": null,
+    "element": "kbd",
+    "variants": {
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "default": "md"
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [
+            "none — static text semantics via the kbd element"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-07-03 — static inline element; axe asserted in unit test and story gate.",
+        "forcedColorsVerified": true
+    },
+    "tokens": {
+        "colors": [
+            "--color-border",
+            "--color-surface",
+            "--color-text"
+        ],
+        "spacing": [
+            "--space-internal-2",
+            "--space-internal-6"
+        ],
+        "typography": [
+            "--font-mono"
+        ]
+    },
+    "lightDarkVerified": true,
+    "schemaVersion": 2,
+    "props": {
+        "size": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ]
+        },
+        "children": {
+            "optional": true,
+            "type": "ReactNode"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "displayName": "Kbd",
+    "keywords": [
+        "keyboard",
+        "shortcut",
+        "keycap",
+        "hotkey",
+        "command",
+        "key"
+    ],
+    "dense": "semantic <kbd> keycap; sm/md/lg mono sizes; compose combos as sibling Kbds with literal separators",
+    "usage": {
+        "description": "Kbd marks keyboard input inline: a single keycap per component, composed into chords with literal separators between siblings. It is purely presentational text with correct kbd semantics, sized to sit inside prose, tooltips, and menu hints.",
+        "bestPractices": [
+            {
+                "guidance": true,
+                "description": "One key per Kbd; write chords as <Kbd>⌘</Kbd> + <Kbd>K</Kbd> so screen readers hear the separator."
+            },
+            {
+                "guidance": true,
+                "description": "Match size to the surrounding text scale; sm inside Tooltip and menu hints, md in prose."
+            },
+            {
+                "guidance": true,
+                "description": "Use platform-correct symbols (⌘/Ctrl) from your own platform detection; Kbd renders what you pass."
+            },
+            {
+                "guidance": true,
+                "description": "Pair every shortcut hint with a clickable way to do the same action; the hint is an accelerator, not the affordance."
+            },
+            {
+                "guidance": false,
+                "description": "Do not make Kbd interactive; it is not a button and never receives focus."
+            },
+            {
+                "guidance": false,
+                "description": "Do not put full words or phrases in one keycap except actual key names (Esc, Enter, Space)."
+            }
+        ]
+    },
+    "playground": {
+        "defaults": {
+            "children": "⌘",
+            "size": "md"
+        }
+    },
+    "composesWith": [
+        "Text",
+        "Tooltip",
+        "CodeSnippet"
+    ]
+}

--- a/nextjs-app/shared/components/Kbd/Kbd.module.css
+++ b/nextjs-app/shared/components/Kbd/Kbd.module.css
@@ -1,0 +1,34 @@
+.kbd {
+  display: inline-flex;
+  padding-block: var(--space-internal-2);
+  padding-inline: var(--space-internal-6);
+  min-inline-size: 1.5em;
+  justify-content: center;
+  align-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background-color: var(--color-surface);
+  font-family: var(--font-mono);
+  line-height: 1.2;
+  white-space: nowrap;
+  color: var(--color-text);
+  border-block-end-width: 2px;
+}
+
+.sm {
+  font-size: calc(var(--font-size-text-xxs) * 0.85);
+}
+
+.md {
+  font-size: calc(var(--font-size-text-xxs) * 0.95);
+}
+
+.lg {
+  font-size: var(--font-size-text-s);
+}
+
+@media (forced-colors: active) {
+  .kbd {
+    border-color: ButtonText;
+  }
+}

--- a/nextjs-app/shared/components/Kbd/Kbd.spec.md
+++ b/nextjs-app/shared/components/Kbd/Kbd.spec.md
@@ -1,0 +1,21 @@
+# Kbd
+
+## Intent
+Inline keyboard-key indicator for docs, tooltips, and command hints. Renders
+a semantic `<kbd>` styled as a keycap with the mono font token.
+
+## Interaction contract
+- Static, non-interactive; no keyboard or pointer behavior of its own.
+- Screen readers: announced as regular text; `<kbd>` conveys the semantic.
+
+## Do / don't
+- Do: compose combos as sibling Kbds with a literal separator (`⌘ + K`).
+- Do: match `size` to the surrounding text scale.
+- Don't: use Kbd as a button; it never receives focus or handles clicks.
+- Don't: put whole phrases inside one Kbd; one key (or chord symbol) per cap.
+
+## Design notes
+- Tokens: `--font-mono`, `--color-border`, `--color-surface`, `--color-text`,
+  `--radius-sm`, `--space-internal-2/6`.
+- The thicker bottom border gives the keycap depth without shadows.
+- Forced colors: border maps to `ButtonText`.

--- a/nextjs-app/shared/components/Kbd/Kbd.stories.tsx
+++ b/nextjs-app/shared/components/Kbd/Kbd.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import React from "react";
+import Kbd from "./Kbd";
+import contract from "./Kbd.contract.json";
+
+const meta = {
+  title: "Content/Kbd",
+  component: Kbd,
+  tags: ["alpha", "autodocs"],
+  parameters: {
+    layout: "centered",
+    a11y: { test: "error" },
+    contractStatus: contract.status,
+  },
+  argTypes: {
+    size: {
+      control: "radio",
+      options: ["sm", "md", "lg"],
+      description: "Size token",
+      table: { defaultValue: { summary: "md" } },
+    },
+    children: {
+      control: "text",
+      description: "Key label (text or symbols)",
+    },
+  },
+  args: { size: "md", children: "⌘" },
+} satisfies Meta<typeof Kbd>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  tags: ["example"],
+  parameters: {
+    docs: {
+      description: { story: "A single keycap; the element is a semantic <kbd>." },
+    },
+  },
+  args: { children: "Esc" },
+};
+
+export const Playground: Story = {};
+
+export const Example: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story: "Shortcut combinations read naturally inline: compose several Kbds with + between them.",
+      },
+    },
+  },
+  render: () => (
+    <span>
+      <Kbd>⌘</Kbd> + <Kbd>K</Kbd>
+    </span>
+  ),
+};
+
+export const Sizes: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: { story: "sm/md/lg track the text ladder so keycaps sit well in prose of any size." },
+    },
+  },
+  render: () => (
+    <span>
+      <Kbd size="sm">Shift</Kbd> <Kbd size="md">Shift</Kbd> <Kbd size="lg">Shift</Kbd>
+    </span>
+  ),
+};
+
+export const KeyNames: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: { story: "Named keys keep their full word; symbols stay symbols." },
+    },
+  },
+  render: () => (
+    <span>
+      <Kbd>Esc</Kbd> <Kbd>Enter</Kbd> <Kbd>Space</Kbd> <Kbd>Tab</Kbd>
+    </span>
+  ),
+};
+
+export const ForcedColors: Story = {
+  globals: { forcedColors: "active" },
+  parameters: { a11y: { disable: true, test: "off" } },
+  args: { children: "Enter" },
+};

--- a/nextjs-app/shared/components/Kbd/Kbd.test.tsx
+++ b/nextjs-app/shared/components/Kbd/Kbd.test.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import Kbd from "./Kbd";
+import styles from "./Kbd.module.css";
+
+expect.extend(toHaveNoViolations);
+
+describe("Kbd", () => {
+  it("renders a semantic kbd element with its label", () => {
+    render(<Kbd>Esc</Kbd>);
+    const el = screen.getByText("Esc");
+    expect(el.tagName).toBe("KBD");
+  });
+
+  it("applies the size class", () => {
+    render(<Kbd size="lg">K</Kbd>);
+    expect(screen.getByText("K")).toHaveClass(styles.lg);
+  });
+
+  it("defaults to md and merges custom className", () => {
+    render(<Kbd className="extra">A</Kbd>);
+    const el = screen.getByText("A");
+    expect(el).toHaveClass(styles.md);
+    expect(el).toHaveClass("extra");
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(
+      <p>
+        Press <Kbd>⌘</Kbd> + <Kbd>K</Kbd> to open search.
+      </p>,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/Kbd/Kbd.tsx
+++ b/nextjs-app/shared/components/Kbd/Kbd.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+import styles from "./Kbd.module.css";
+
+export type KbdSize = "sm" | "md" | "lg";
+
+export interface KbdProps extends React.HTMLAttributes<HTMLElement> {
+  /** Size token. @default "md" */
+  size?: KbdSize;
+}
+
+/** Keyboard key indicator: renders a semantic <kbd> styled as a keycap. */
+export const Kbd = React.forwardRef<HTMLElement, KbdProps>(
+  ({ size = "md", className, children, ...rest }, ref) => (
+    <kbd
+      ref={ref}
+      className={cn(styles.kbd, styles[size], className)}
+      {...rest}
+    >
+      {children}
+    </kbd>
+  ),
+);
+
+Kbd.displayName = "Kbd";
+
+export default Kbd;

--- a/nextjs-app/shared/components/Kbd/index.ts
+++ b/nextjs-app/shared/components/Kbd/index.ts
@@ -1,0 +1,2 @@
+export { default, Kbd } from "./Kbd";
+export type { KbdProps, KbdSize } from "./Kbd";

--- a/nextjs-app/shared/components/StatusDot/StatusDot.contract.json
+++ b/nextjs-app/shared/components/StatusDot/StatusDot.contract.json
@@ -1,0 +1,174 @@
+{
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "name": "StatusDot",
+    "tier": "atom",
+    "group": "feedback",
+    "status": "alpha",
+    "description": "Tiny semantic status indicator: colored dot with visible or sr-only label.",
+    "figma": null,
+    "radixPrimitive": null,
+    "element": "span",
+    "variants": {
+        "tone": {
+            "values": [
+                "neutral",
+                "success",
+                "warning",
+                "error",
+                "info"
+            ],
+            "default": "neutral"
+        },
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "default": "md"
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [
+            "dot is aria-hidden; meaning carried by visible children or sr-only label",
+            "color never the sole carrier of state"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-07-03 — pulse animation disabled under prefers-reduced-motion; axe asserted in unit test.",
+        "forcedColorsVerified": true
+    },
+    "tokens": {
+        "colors": [
+            "--color-muted",
+            "--color-success",
+            "--color-warning",
+            "--color-error",
+            "--color-info",
+            "--color-text"
+        ],
+        "spacing": [
+            "--space-internal-6"
+        ],
+        "typography": [
+            "--font-body",
+            "--font-size-text-xxs",
+            "--font-size-text-s",
+            "--font-size-text-m"
+        ]
+    },
+    "lightDarkVerified": true,
+    "schemaVersion": 2,
+    "props": {
+        "tone": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "neutral",
+                "success",
+                "warning",
+                "error",
+                "info"
+            ]
+        },
+        "size": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ]
+        },
+        "pulse": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "label": {
+            "optional": true,
+            "type": "string"
+        },
+        "children": {
+            "optional": true,
+            "type": "ReactNode"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "displayName": "StatusDot",
+    "keywords": [
+        "status",
+        "dot",
+        "indicator",
+        "online",
+        "live",
+        "health",
+        "presence"
+    ],
+    "dense": "colored semantic dot + label (visible children or sr-only label); tone x sm/md/lg, optional pulse for live states",
+    "usage": {
+        "description": "StatusDot is the lightest way to show state: a tone-colored dot with a label, sized to sit inline in list rows, nav items, and dashboard lines. The dot is decorative; the label (visible children, or sr-only via label) carries the meaning. Use Badge instead when the status needs a chip surface, a count, or removability.",
+        "bestPractices": [
+            {
+                "guidance": true,
+                "description": "Always pass children or label; a bare dot is invisible to assistive tech and ambiguous to everyone."
+            },
+            {
+                "guidance": true,
+                "description": "Reserve pulse for genuinely live states (recording, deploy in progress); a static dot reads calmer for steady states."
+            },
+            {
+                "guidance": true,
+                "description": "Use tone semantically: success=healthy, warning=degraded, error=down, info=transitional, neutral=idle/unknown."
+            },
+            {
+                "guidance": true,
+                "description": "Keep labels to one or two words; StatusDot is a glance signal, not a sentence."
+            },
+            {
+                "guidance": false,
+                "description": "Do not use StatusDot for counts, filters, or removable chips; Badge owns those surfaces."
+            },
+            {
+                "guidance": false,
+                "description": "Do not encode more states than the five tones; if you need custom colors, the state model is too wide for a dot."
+            }
+        ],
+        "anatomy": [
+            {
+                "name": "Dot",
+                "required": true,
+                "description": "0.5em tone-colored circle, aria-hidden; optional pulse ring for live states."
+            },
+            {
+                "name": "Label",
+                "required": false,
+                "description": "Visible text next to the dot (children), or sr-only text via the label prop."
+            }
+        ]
+    },
+    "playground": {
+        "defaults": {
+            "tone": "success",
+            "children": "Operational"
+        }
+    },
+    "composesWith": [
+        "Badge",
+        "Text",
+        "List",
+        "Avatar"
+    ]
+}

--- a/nextjs-app/shared/components/StatusDot/StatusDot.module.css
+++ b/nextjs-app/shared/components/StatusDot/StatusDot.module.css
@@ -1,0 +1,94 @@
+.root {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-internal-6);
+  font-family: var(--font-body);
+  color: var(--color-text);
+}
+
+.dot {
+  block-size: 0.5em;
+  inline-size: 0.5em;
+  flex: none;
+  border-radius: 50%;
+  background-color: currentcolor;
+}
+
+.sm {
+  font-size: var(--font-size-text-xxs);
+}
+
+.md {
+  font-size: var(--font-size-text-s);
+}
+
+.lg {
+  font-size: var(--font-size-text-m);
+}
+
+.dot.neutral {
+  background-color: var(--color-muted);
+}
+
+.dot.success {
+  background-color: var(--color-success);
+}
+
+.dot.warning {
+  background-color: var(--color-warning);
+}
+
+.dot.error {
+  background-color: var(--color-error);
+}
+
+.dot.info {
+  background-color: var(--color-info);
+}
+
+.pulse {
+  animation: statusdot-pulse 2s var(--ease-out-cubic) infinite;
+}
+
+@keyframes statusdot-pulse {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, currentcolor 45%, transparent);
+  }
+
+  70% {
+    box-shadow: 0 0 0 0.4em transparent;
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+
+.label {
+  line-height: 1.3;
+}
+
+.srOnly {
+  position: absolute;
+  margin: -1px;
+  padding: 0;
+  block-size: 1px;
+  inline-size: 1px;
+  border: 0;
+  white-space: nowrap;
+  clip-path: inset(50%);
+  overflow: hidden;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pulse {
+    animation: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .dot {
+    border: 1px solid CanvasText;
+    background-color: CanvasText;
+  }
+}

--- a/nextjs-app/shared/components/StatusDot/StatusDot.spec.md
+++ b/nextjs-app/shared/components/StatusDot/StatusDot.spec.md
@@ -1,0 +1,25 @@
+# StatusDot
+
+## Intent
+The smallest status signal: a semantic colored dot paired with a label.
+Complements Badge (which carries a filled chip surface) for dense lines,
+list rows, nav items, and dashboards where a chip is too heavy.
+
+## Interaction contract
+- Static, non-interactive.
+- Screen readers: the dot is `aria-hidden`; meaning always comes from the
+  visible children or the sr-only `label`. Color is never the only carrier.
+
+## Do / don't
+- Do: always provide `children` (visible) or `label` (sr-only).
+- Do: use `pulse` only for genuinely live/ongoing states.
+- Don't: use StatusDot for counts or removable chips — Badge owns those.
+- Don't: rely on the color alone to convey state.
+
+## Design notes
+- Tone colors come straight from the semantic tokens (`--color-success`,
+  `--color-warning`, `--color-error`, `--color-info`, `--color-muted`),
+  which already remap under dark/HCB/HCW themes and forced colors.
+- The dot is sized in `em` (0.5em) so it tracks the size token's font-size.
+- Pulse ring uses `color-mix` on `currentcolor`; disabled under
+  `prefers-reduced-motion`.

--- a/nextjs-app/shared/components/StatusDot/StatusDot.stories.tsx
+++ b/nextjs-app/shared/components/StatusDot/StatusDot.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import React from "react";
+import StatusDot from "./StatusDot";
+import contract from "./StatusDot.contract.json";
+
+const meta = {
+  title: "Feedback/StatusDot",
+  component: StatusDot,
+  tags: ["alpha", "autodocs"],
+  parameters: {
+    layout: "centered",
+    a11y: { test: "error" },
+    contractStatus: contract.status,
+  },
+  argTypes: {
+    tone: {
+      control: "select",
+      options: ["neutral", "success", "warning", "error", "info"],
+      description: "Semantic tone of the status",
+      table: { defaultValue: { summary: "neutral" } },
+    },
+    size: {
+      control: "radio",
+      options: ["sm", "md", "lg"],
+      description: "Size token",
+      table: { defaultValue: { summary: "md" } },
+    },
+    pulse: {
+      control: "boolean",
+      description: "Soft pulse for live states (off under reduced motion)",
+      table: { defaultValue: { summary: "false" } },
+    },
+    label: {
+      control: "text",
+      description: "Screen-reader label when no visible children",
+    },
+    children: { control: "text", description: "Visible label text" },
+  },
+  args: { tone: "success", size: "md", children: "Operational" },
+} satisfies Meta<typeof StatusDot>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  tags: ["example"],
+  parameters: {
+    docs: {
+      description: { story: "Dot + visible label; the dot itself is decorative (aria-hidden)." },
+    },
+  },
+};
+
+export const Playground: Story = {};
+
+export const Tones: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: { story: "The five semantic tones; color always pairs with a text label, never alone." },
+    },
+  },
+  render: () => (
+    <div style={{ display: "flex", gap: "1.5rem", flexWrap: "wrap" }}>
+      <StatusDot tone="neutral">Idle</StatusDot>
+      <StatusDot tone="success">Operational</StatusDot>
+      <StatusDot tone="warning">Degraded</StatusDot>
+      <StatusDot tone="error">Down</StatusDot>
+      <StatusDot tone="info">Maintenance</StatusDot>
+    </div>
+  ),
+};
+
+export const Live: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: { story: "pulse marks an ongoing/live state; the animation is disabled under prefers-reduced-motion." },
+    },
+  },
+  render: () => (
+    <StatusDot tone="success" pulse>
+      Live
+    </StatusDot>
+  ),
+};
+
+export const SrOnlyLabel: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story: "Dot-only visuals still announce their meaning: label renders as screen-reader-only text.",
+      },
+    },
+  },
+  render: () => <StatusDot tone="error" label="Connection lost" />,
+};
+
+export const Example: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => <StatusDot tone="success">Operational</StatusDot>,
+};
+
+export const ForcedColors: Story = {
+  globals: { forcedColors: "active" },
+  parameters: { a11y: { disable: true, test: "off" } },
+};

--- a/nextjs-app/shared/components/StatusDot/StatusDot.test.tsx
+++ b/nextjs-app/shared/components/StatusDot/StatusDot.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import StatusDot from "./StatusDot";
+import styles from "./StatusDot.module.css";
+
+expect.extend(toHaveNoViolations);
+
+describe("StatusDot", () => {
+  it("renders a visible label with a decorative dot", () => {
+    const { container } = render(<StatusDot tone="success">Operational</StatusDot>);
+    expect(screen.getByText("Operational")).toBeInTheDocument();
+    const dot = container.querySelector(`.${styles.dot}`);
+    expect(dot).toHaveAttribute("aria-hidden", "true");
+    expect(dot).toHaveClass(styles.success);
+  });
+
+  it("renders an sr-only label when only label is given", () => {
+    render(<StatusDot tone="error" label="Connection lost" />);
+    const sr = screen.getByText("Connection lost");
+    expect(sr).toHaveClass(styles.srOnly);
+  });
+
+  it("defaults to neutral tone and md size", () => {
+    const { container } = render(<StatusDot>Idle</StatusDot>);
+    expect(container.querySelector(`.${styles.dot}`)).toHaveClass(styles.neutral);
+    expect(container.querySelector(`.${styles.root}`)).toHaveClass(styles.md);
+  });
+
+  it("applies the pulse class only when pulse is set", () => {
+    const { container, rerender } = render(<StatusDot>Idle</StatusDot>);
+    expect(container.querySelector(`.${styles.pulse}`)).toBeNull();
+    rerender(<StatusDot pulse>Idle</StatusDot>);
+    expect(container.querySelector(`.${styles.pulse}`)).not.toBeNull();
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(
+      <div>
+        <StatusDot tone="success">Operational</StatusDot>
+        <StatusDot tone="error" label="Down" />
+      </div>,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/StatusDot/StatusDot.tsx
+++ b/nextjs-app/shared/components/StatusDot/StatusDot.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+import styles from "./StatusDot.module.css";
+
+export type StatusDotTone = "neutral" | "success" | "warning" | "error" | "info";
+export type StatusDotSize = "sm" | "md" | "lg";
+
+export interface StatusDotProps extends React.HTMLAttributes<HTMLSpanElement> {
+  /** Semantic tone of the status. @default "neutral" */
+  tone?: StatusDotTone;
+  /** Size token. @default "md" */
+  size?: StatusDotSize;
+  /** Animates a soft pulse for live/ongoing states (respects reduced motion). @default false */
+  pulse?: boolean;
+  /** Accessible label when no visible children are given (e.g. "Online"). */
+  label?: string;
+  /** Visible label text rendered next to the dot. */
+  children?: React.ReactNode;
+}
+
+/** Tiny semantic status indicator: a colored dot with a visible or sr-only label. */
+export const StatusDot = React.forwardRef<HTMLSpanElement, StatusDotProps>(
+  (
+    { tone = "neutral", size = "md", pulse = false, label, children, className, ...rest },
+    ref,
+  ) => (
+    <span ref={ref} className={cn(styles.root, styles[size], className)} {...rest}>
+      <span
+        aria-hidden="true"
+        className={cn(styles.dot, styles[tone], pulse && styles.pulse)}
+      />
+      {children ? (
+        <span className={styles.label}>{children}</span>
+      ) : label ? (
+        <span className={styles.srOnly}>{label}</span>
+      ) : null}
+    </span>
+  ),
+);
+
+StatusDot.displayName = "StatusDot";
+
+export default StatusDot;

--- a/nextjs-app/shared/components/StatusDot/index.ts
+++ b/nextjs-app/shared/components/StatusDot/index.ts
@@ -1,0 +1,2 @@
+export { default, StatusDot } from "./StatusDot";
+export type { StatusDotProps, StatusDotTone, StatusDotSize } from "./StatusDot";

--- a/nextjs-app/shared/components/index.ts
+++ b/nextjs-app/shared/components/index.ts
@@ -3,9 +3,11 @@ export { default as ArticleCard } from "./ArticleCard/ArticleCard";
 export { default as Author } from "./Author/Author";
 export { default as AuthorBio } from "./AuthorBio/AuthorBio";
 export { default as Avatar } from "./Avatar/Avatar";
+export { default as AvatarGroup } from "./AvatarGroup/AvatarGroup";
 export { default as Badge } from "./Badge/Badge";
 export { default as BusyIndicator } from "./BusyIndicator/BusyIndicator";
 export { default as Button } from "./Button/Button";
+export { default as ButtonGroup } from "./ButtonGroup/ButtonGroup";
 export { default as Card } from "./Card/Card";
 export { default as Checkbox } from "./Checkbox/Checkbox";
 export { default as CheckboxGroup } from "./CheckboxGroup/CheckboxGroup";
@@ -24,6 +26,7 @@ export {
   type DonnyState,
   type DonnyAvatarProps,
 } from "./DonnyAvatar";
+export { default as EmptyState } from "./EmptyState/EmptyState";
 export { default as FlexBox } from "./FlexBox/FlexBox";
 export { default as FileUpload } from "./FileUpload/FileUpload";
 export { default as Gallery } from "./Gallery/Gallery";
@@ -31,6 +34,8 @@ export { default as Grid } from "./Grid/Grid";
 export { default as GroupLabel } from "./GroupLabel/GroupLabel";
 export { default as Icon } from "./Icon/Icon";
 export { default as HelsinkiClock } from "./HelsinkiClock/HelsinkiClock";
+export { default as Kbd } from "./Kbd/Kbd";
+export { default as StatusDot } from "./StatusDot/StatusDot";
 export { default as TextInput } from "./TextInput/TextInput";
 export { default as Label } from "./Label/Label";
 export { default as Layout } from "./Layout/Layout";

--- a/scripts/design-system/docs-smoke.mjs
+++ b/scripts/design-system/docs-smoke.mjs
@@ -46,6 +46,11 @@ const PROVEN = [
   { name: "PhoneInput", docsId: "forms-phoneinput--docs" },
   { name: "FileUpload", docsId: "forms-fileupload--docs" },
   { name: "Card", docsId: "layout-card--docs" },
+  { name: "Kbd", docsId: "content-kbd--docs" },
+  { name: "StatusDot", docsId: "feedback-statusdot--docs" },
+  { name: "EmptyState", docsId: "content-emptystate--docs" },
+  { name: "ButtonGroup", docsId: "actions-buttongroup--docs" },
+  { name: "AvatarGroup", docsId: "content-avatargroup--docs" },
 ];
 
 function contractFor(name) {


### PR DESCRIPTION
Astryx catalog gap-fill: full diff of https://astryx.atmeta.com/components/ against the DT catalog, documented in the roadmap spec (new section 6.5), plus five new primitives closing the small, clearly-missing gaps.

## Gap analysis (roadmap section 6.5)
- **Added (this PR):** Kbd, StatusDot, EmptyState, ButtonGroup, AvatarGroup.
- **Already covered (mapped, will not be duplicated):** ~20 entries, e.g. Selector→Select, Typeahead→Combobox, Tokenizer→MultiCombobox, File Input→FileUpload, Dialog→Modal, Banner→AlertBanner, Heading→Title, Outline→TableOfContents.
- **Declined / backlog (projects, not batch items):** Table + hooks, Calendar/Date/Time inputs, Slider, Number Input, Popover/Hover Card/Overlay, Command Palette, Carousel, Segmented Control (toggle groups), Side Nav, Resize Handle, Tree List, and the small content atoms (Blockquote, Citation, Timestamp, Kbd-adjacent Token).

## The five new components
All alpha with the WIP badge, full artifact set (tsx + module.css + contract v2.1 doc data + example stories on the DT autodocs frame + unit tests with axe + spec.md + barrel export), platinum API conventions:

- **Kbd** — semantic `<kbd>` keycap; sm/md/lg on the text ladder; `--font-mono`.
- **StatusDot** — tone (neutral/success/warning/error/info) x size dot with optional reduced-motion-aware pulse; a label is mandatory (visible children or sr-only `label`).
- **EmptyState** — composes Title/Text/Icon; `headingLevel` to fit the page outline; action slot; sm/md/lg step padding and type together.
- **ButtonGroup** — `role=group` action cluster; attached segmented seams (doubled-class specificity, no `!important`) or token-gap spacing; deliberately NOT a selection/toggle group.
- **AvatarGroup** — overlapping Avatar stack with an accessible "+N" overflow bubble; resolves the roadmap 5.2 backlog note.

docs-smoke PROVEN extended 25 → 30 pages, verified against the static build. rhythmguard baseline refreshed for the sr-only/seam `-1px` hairlines and new-file entries.

## Gate (local, all green)
typecheck, lint (incl. stylelint baseline), vitest 1854/1854, next build, validate:components, storybook:build + docs-smoke 30/30 static, test-storybook 34/34 on the new stories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
