### PR TITLE
test(SecureCVDownload): fix farm-only fake-timer flake (rAF loop vs runAllTimersAsync)

### DIFF
--- a/nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.test.tsx
+++ b/nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.test.tsx
@@ -41,7 +41,11 @@ describe("SecureCVDownload", () => {
     const input = await screen.findByLabelText(/password/i);
     fireEvent.change(input, { target: { value: "secret" } });
 
-    await vi.runAllTimersAsync();
+    // Bounded advance past the 500ms validation debounce. runAllTimersAsync
+    // never drains here: the Modal keeps a rAF loop alive, and jsdom backs
+    // rAF with timers, so "run all" spins to vitest's 10k-timer abort on
+    // slow runners (farm-only flake).
+    await vi.advanceTimersByTimeAsync(600);
 
     await waitFor(() =>
       expect(screen.getByLabelText(/Valid/i)).toBeInTheDocument(),
@@ -63,7 +67,7 @@ describe("SecureCVDownload", () => {
     fireEvent.click(screen.getByRole("button", { name: /Download Resume/i }));
     const input = await screen.findByLabelText(/password/i);
     fireEvent.change(input, { target: { value: "bad" } });
-    await vi.runAllTimersAsync();
+    await vi.advanceTimersByTimeAsync(600);
 
     expect(await screen.findByText(/Incorrect password/i)).toBeInTheDocument();
   });


### PR DESCRIPTION
The #816 farm run cleared the whole validate gate except one unit test: SecureCVDownload's `vi.runAllTimersAsync()` can never drain while the Modal keeps a rAF loop alive (jsdom backs rAF with timers), so it spins to vitest's 10 000-timer abort on the slower farm runner. Local hardware happened to finish first, which is why it never failed here.

Fix: `vi.advanceTimersByTimeAsync(600)` — a bounded advance past the 500 ms validation debounce, deterministic on any hardware. Both tests pass locally; this is the last red step in the farm's validate job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for the CV download flow by using a fixed timer advance instead of draining all queued timers.
  * Kept coverage for both successful password validation and the incorrect-password error state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->