### PR TITLE
chore(ci): pre-push contract gate keeps the local gate a superset of the farm validate job

### DIFF
--- a/.claude/skills/dt-design-system/SKILL.md
+++ b/.claude/skills/dt-design-system/SKILL.md
@@ -52,6 +52,14 @@ npm test -- ComponentName
 
 If validation fails, halt and fix reported contract/spec/MDX issues before proceeding.
 
+**Before pushing contract or component changes**, also run the farm-parity contract gate (the pre-push hook enforces it too):
+
+```bash
+npm run build:tokens && npm run check:contract-props && npm run check:consumers
+```
+
+`check:contract-props` compares contracts against freshly built agent blocks. Contracts with authored `usage` (doc-adopted) own their `composesWith`/`prefersOver`/`forbiddenUse`; only props are machine-checked for them. Props must be declared locally on the `<Name>Props` interface — a prop that only arrives via a native attribute extension (e.g. `disabled`) is invisible to the extractor and will be flagged stale.
+
 ### Step 4: Promote (remove WIP badge)
 
 Only when ALL pass:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,9 @@
 #!/usr/bin/env sh
-# Local pre-commit quality gate. CI is quota-dead for this repo, so the design
-# system's checks must run locally. Cheapest checks first (fail fast). The
-# heavier per-push gate in .husky/pre-push still runs validate:components etc.
+# Local pre-commit quality gate. PR Validation runs on the self-hosted farm
+# (post-#795), but the merge discipline is still local-first: cheapest checks
+# here (fail fast); the heavier per-push gate in .husky/pre-push adds the
+# contract gate (build:tokens + check:contract-props + check:consumers) and
+# validate:components for design-system paths.
 # Bypass in a genuine emergency with: git commit --no-verify
 npm run check:contrast &&
 npm run lint:css &&

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,6 +2,13 @@
 . "$(dirname "$0")/_/husky.sh"
 changed=$(git diff --name-only HEAD @{push} 2>/dev/null || git diff --name-only --cached)
 echo "$changed" | grep -qE 'nextjs-app/shared/(components|patterns|foundations)|scripts/design-system' || exit 0
+# Contract gate: keep the local gate a superset of the farm's validate job for
+# contract-touching changes (2026-07-03 incident: ten red farm runs because
+# check:contract-props only existed in CI). build:tokens regenerates the dist
+# artifacts (relationship graph + agent blocks) the two checks compare against.
+npm run build:tokens
+npm run check:contract-props
+npm run check:consumers
 npm run validate:components
 npm run typecheck
 npm run lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ npm run dev              # Next.js dev (localhost:3000)
 npm run storybook        # Components (localhost:6010)
 npm test                 # Vitest
 npm run typecheck && npm run lint && npm test && npm run build   # Pre-PR
+npm run build:tokens && npm run check:contract-props && npm run check:consumers   # Pre-PR add-on when contracts/components changed (farm CI parity; also enforced by pre-push)
 npm run validate:agent-docs   # Agent doc integrity
 npm run sanity:publish   # Publish blog → refreshes manifest
 ```

--- a/nextjs-app/shared/components/AGENTS.md
+++ b/nextjs-app/shared/components/AGENTS.md
@@ -36,6 +36,7 @@ ComponentName/
 npm run new-component ComponentName
 npm run validate:components
 npm run build:tokens          # regenerates agent-manifest.json
+npm run check:contract-props && npm run check:consumers   # farm CI parity (pre-push enforces)
 ```
 
 ---


### PR DESCRIPTION
Follow-through on today's farm CI incident: `check:contract-props` and `check:consumers` existed only in the CI workflow (since #685/#682), so ten PRs merged on green local gates while the farm went red.

- **.husky/pre-push** now runs `build:tokens && check:contract-props && check:consumers` (before the existing validate:components/typecheck/lint/lint:css) for design-system paths — the same path filter as before, so non-DS pushes stay instant.
- **CLAUDE.md**, the **dt-design-system skill** (Step 3), and **components AGENTS.md** document the same gate, including the two failure modes from today: doc-adopted contracts own their semantic fields, and props must be locally declared to be visible to the agent-blocks extractor.
- Stale "CI is quota-dead" comment in pre-commit corrected (farm CI is live since #795).

Verification: `validate:agent-docs` passes; this branch's own push exercised the new hook end to end (build:tokens + both checks + validate:components + typecheck + lint + lint:css, all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)