### PR TITLE
fix(design-system): ProcessBlock phase titles to xxs + flush em-dash list alignment

### DIFF
--- a/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.module.css
+++ b/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.module.css
@@ -116,14 +116,17 @@
 
 .activityList :global(li) {
   /* List defaults to 20ch; process activities need full column width when stacked */
-  max-inline-size: 100%;
+  position: relative;
   padding-inline-start: 1.5em;
-  text-indent: -1.5em;
+  max-inline-size: 100%;
 }
 
+/* Marker lives in the padding so wrapped lines stay flush with first-line text */
+
 .activityList :global(li)::before {
-  margin-inline-end: 0.5rem;
-  content: "— ";
+  position: absolute;
+  content: "—";
+  inset-inline-start: 0;
 }
 
 /* Accessibility */

--- a/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx
+++ b/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx
@@ -123,7 +123,7 @@ const ProcessBlock: React.FC<ProcessBlockProps> = ({
           {phases.map((phase, index) => (
             <div key={phase.title || index} className={styles.col}>
               <Title
-                size="xs"
+                size="xxs"
                 terminals="sans"
                 level={3}
                 className={styles.phaseTitle}

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -1,6 +1,6 @@
 {
   "generatedBy": "npm run lint:css:update",
-  "warningCount": 450,
+  "warningCount": 448,
   "warnings": [
     {
       "id": "app/blog/NextBlogNav.module.css::7::3::order/properties-order::Expected \"margin-inline\" to come before \"max-width\" (order/properties-order)",
@@ -3684,36 +3684,27 @@
       "text": "Expected \"color\" to come before \"text-wrap\" (order/properties-order)"
     },
     {
-      "id": "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.module.css::120::3::order/properties-order::Expected \"padding-inline-start\" to come before \"max-inline-size\" (order/properties-order)",
+      "id": "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.module.css::135::33::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.module.css",
-      "line": 120,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"padding-inline-start\" to come before \"max-inline-size\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.module.css::132::33::declaration-no-important::Disallowed !important (declaration-no-important)",
-      "file": "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.module.css",
-      "line": 132,
+      "line": 135,
       "column": 33,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.module.css::133::32::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.module.css::136::32::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.module.css",
-      "line": 133,
+      "line": 136,
       "column": 32,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.module.css::134::34::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.module.css::137::34::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.module.css",
-      "line": 134,
+      "line": 137,
       "column": 34,
       "rule": "declaration-no-important",
       "severity": "warning",


### PR DESCRIPTION
## Summary
- Phase titles in `ProcessBlock` keep their `h3` semantics but drop from `size="xs"` (clamps up to 28px) to `size="xxs"`, so they read as column labels instead of oversized section headings on the 4-up Approach grids.
- The em-dash list marker moves from a hanging-indent hack (`padding-inline-start: 1.5em; text-indent: -1.5em` with a `0.5rem` margin on the `::before`, which was wider than the indent) to an absolutely positioned `::before` inside the padding. Wrapped activity lines now sit exactly flush with first-line text (verified both line boxes start at the same x).
- Stylelint baseline re-keyed for shifted lines; one genuine property-order warning fixed (449 -> 448).

## Verification
- Local gate: typecheck, lint, vitest 1837/1837, build all pass; `build:tokens` + `check:contract-props` + `check:consumers` pass.
- Verified in-browser on `/work/dsharp-design-system`: h3 renders 22px, wrapped lines measure flush (x = 353.2 for both line boxes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alignment of custom list markers in process/activity lists for cleaner, more consistent rendering.
  * Made phase titles in the process block display smaller for better visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->