### PR TITLE
docs(work): tighten DSharp Approach phase titles

### DIFF
--- a/nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx
@@ -1857,7 +1857,7 @@ export function DSharpDesignSystemPage({ nav }: { nav?: React.ReactNode }) {
       <ProcessBlock
         phases={[
           {
-            title: "1. Contracts & guardrails",
+            title: "Contracts",
             activities: [
               "Four files per component",
               "Scaffolder, never hand-written",
@@ -1866,7 +1866,7 @@ export function DSharpDesignSystemPage({ nav }: { nav?: React.ReactNode }) {
             ],
           },
           {
-            title: "2. Tokens",
+            title: "Tokens",
             activities: [
               "DTCG JSON as Layer 0",
               "Style Dictionary transforms",
@@ -1875,7 +1875,7 @@ export function DSharpDesignSystemPage({ nav }: { nav?: React.ReactNode }) {
             ],
           },
           {
-            title: "3. Atoms, molecules, organisms",
+            title: "Atomic structure",
             activities: [
               "Domain semantics as atoms",
               "Molecules combine atoms",
@@ -1884,7 +1884,7 @@ export function DSharpDesignSystemPage({ nav }: { nav?: React.ReactNode }) {
             ],
           },
           {
-            title: "4. Patterns & templates",
+            title: "Patterns & templates",
             activities: [
               "Layout primitives",
               "Product workflow templates",


### PR DESCRIPTION
## Summary
Retitles the four Approach columns on the DSharp case study:
- "1. Contracts & guardrails" -> "Contracts"
- "2. Tokens" -> "Tokens"
- "3. Atoms, molecules, organisms" -> "Atomic structure"
- "4. Patterns & templates" -> "Patterns & templates"

Numbering prefixes dropped; content-only change in `DSharpDesignSystemPage.tsx`.

## Verification
- Local gate: typecheck, lint, vitest 1837/1837, build all pass.
- Rendered titles verified on the running dev server at `/work/dsharp-design-system`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)