### PR TITLE
fix(design-system): Card story badges use sm; Badge status icon follows the size step

### DIFF
--- a/nextjs-app/shared/components/Badge/Badge.tsx
+++ b/nextjs-app/shared/components/Badge/Badge.tsx
@@ -86,10 +86,13 @@ export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
     let resolvedIcon: React.ReactNode = icon;
     if (resolvedIcon == null && tone && semanticStatus) {
       // The badge already sets a contrast-correct text color per variant×tone,
-      // so the semantic icon inherits it via currentColor.
+      // so the semantic icon inherits it via currentColor. The icon follows
+      // the badge's size step so it never inflates the pill height.
+      const statusIconSize = { sm: "2xs", md: "xs", lg: "sm" } as const;
       resolvedIcon = (
         <Icon
           name={STATUS_ICON_NAMES[semanticStatus]}
+          size={statusIconSize[size]}
           color="currentColor"
           decorative
         />

--- a/nextjs-app/shared/components/Card/Card.stories.tsx
+++ b/nextjs-app/shared/components/Card/Card.stories.tsx
@@ -184,7 +184,7 @@ export const Structured: Story = {
   render: () => (
     <Card
       title="Quarterly review"
-      extra={<Badge tone="info">Draft</Badge>}
+      extra={<Badge tone="info" size="sm">Draft</Badge>}
       style={{ maxWidth: "22rem" }}
     >
       <Divider />
@@ -289,7 +289,7 @@ export const Example: Story = {
     <Card
       title="Design tokens"
       description="Layer 0 of the system: DTCG JSON, transformed per platform."
-      extra={<Badge tone="success">Stable</Badge>}
+      extra={<Badge tone="success" size="sm">Stable</Badge>}
       style={{ maxWidth: "20rem" }}
     >
       <Text size="s">


### PR DESCRIPTION
## Summary
- Card's **Structured**/**Example** stories now pass `size="sm"` to Badge, as requested.
- Root cause fixed too: **Badge's auto status icon ignored the size step** and rendered at Icon's 24px default, inflating even a `sm` badge (12px text) to 36px tall. The icon now maps sm→2xs (12px), md→xs (16px), lg→sm (20px).

## Verification
- Storybook: sm badge in the Card header measures 30px (was 36) with a 12px icon; visually proportional beside the xxs title.
- typecheck, lint, vitest 1893/1893, build, validate:components 0, contract gates ✓; Card + Badge AT snapshots compare clean (AT tree is size-agnostic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)