### PR TITLE
fix(design-system): Badge icons scale with the size step (sm 16, md 24, lg 32)

### DIFF
--- a/nextjs-app/shared/components/Badge/Badge.tsx
+++ b/nextjs-app/shared/components/Badge/Badge.tsx
@@ -83,16 +83,17 @@ export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
     const semanticStatus =
       tone && tone !== "neutral" ? TONE_TO_STATUS[tone] : undefined;
 
+    // Icons track the badge's size step: sm 16px, md 24px, lg 32px.
+    const badgeIconSize = { sm: "xs", md: "md", lg: "lg" } as const;
+
     let resolvedIcon: React.ReactNode = icon;
     if (resolvedIcon == null && tone && semanticStatus) {
       // The badge already sets a contrast-correct text color per variant×tone,
-      // so the semantic icon inherits it via currentColor. The icon follows
-      // the badge's size step so it never inflates the pill height.
-      const statusIconSize = { sm: "2xs", md: "xs", lg: "sm" } as const;
+      // so the semantic icon inherits it via currentColor.
       resolvedIcon = (
         <Icon
           name={STATUS_ICON_NAMES[semanticStatus]}
-          size={statusIconSize[size]}
+          size={badgeIconSize[size]}
           color="currentColor"
           decorative
         />
@@ -119,6 +120,19 @@ export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
         );
       }
       resolvedIcon = null;
+    }
+    // Custom DT Icons without an explicit size follow the size step too, so
+    // sm/md/lg badges scale their icons instead of all rendering Icon's 24px
+    // default. An explicit consumer size always wins.
+    if (
+      isValidElement(resolvedIcon) &&
+      resolvedIcon.type === Icon &&
+      (resolvedIcon.props as { size?: string }).size == null
+    ) {
+      resolvedIcon = React.cloneElement(
+        resolvedIcon as React.ReactElement<{ size?: string }>,
+        { size: badgeIconSize[size] },
+      );
     }
 
     if (!visible) return null;


### PR DESCRIPTION
## Summary
Fixes the reported regression: sm/md/lg badge icons rendered at one size while the font scaled 12/16/20.

- **Custom icons (`icon` prop) never scaled** — every DT Icon without an explicit size rendered at Icon's 24px default. Badge now clones un-sized DT Icon elements with the step size; an explicit consumer size still wins.
- **Auto status icon scale corrected** to spec: sm → 16px, md → 24px, lg → 32px (the #832 map was 12/16/20).

## Verification
- Storybook Playground measured at all three sizes: fonts 12/16/20px, icons 16/24/32px, both icon paths.
- typecheck, lint, vitest 1893/1893, build, validate:components 0, contract gates, Badge AT snapshots compare clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)