### PR TITLE
fix(design-system): Badge icon spacing comes from the gap alone

### DIFF
--- a/nextjs-app/shared/components/Badge/Badge.module.css
+++ b/nextjs-app/shared/components/Badge/Badge.module.css
@@ -156,9 +156,10 @@
   }
 }
 
+/* Spacing to the label comes from the badge's gap alone — no extra margin. */
+
 .icon {
   display: inline-flex;
-  margin-inline-end: 0.4em;
   flex-shrink: 0;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## Summary
The icon slot stacked `margin-inline-end: 0.4em` on top of the badge's `0.25em` flex gap, making the icon-to-label spacing ~2.5× the intended step (13px instead of 5px on a lg badge). The margin is removed; the gap owns the spacing.

## Verification
- Storybook measured: icon margin 0, visual gap == flex gap (5px at lg, scales with font via em).
- vitest 1893/1893, typecheck, lint, build, Badge AT snapshots compare clean; stylelint baseline re-keyed (449→448).

🤖 Generated with [Claude Code](https://claude.com/claude-code)