### PR TITLE
fix(design-system): Badge Controls polish — hide inert rows, live text inputs

### DIFF
--- a/nextjs-app/shared/components/Badge/Badge.stories.tsx
+++ b/nextjs-app/shared/components/Badge/Badge.stories.tsx
@@ -42,10 +42,8 @@ const meta: Meta<typeof Badge> = {
       table: { category: "Content" },
     },
     icon: {
-      control: false,
-      description:
-        "Custom icon element; un-sized DT Icons follow the badge's size step (16/24/32px). Prefer the iconName knob here in Storybook.",
-      table: { category: "Content", type: { summary: "React.ReactNode" } },
+      // ReactNode — nothing useful to control; documented in the contract.
+      table: { disable: true },
     },
 
     // Appearance
@@ -82,8 +80,7 @@ const meta: Meta<typeof Badge> = {
     },
     onRemove: {
       action: "removed",
-      description: "Called after the badge is dismissed.",
-      table: { category: "Behavior", type: { summary: "() => void" } },
+      table: { disable: true },
     },
 
     // Accessibility
@@ -102,7 +99,7 @@ const meta: Meta<typeof Badge> = {
 
     // Advanced
     className: {
-      control: false,
+      control: "text",
       description: "Additional CSS classes on the badge.",
       table: { category: "Advanced" },
     },
@@ -111,6 +108,8 @@ const meta: Meta<typeof Badge> = {
     variant: "primary",
     children: "Badge",
     iconName: "",
+    title: "",
+    className: "",
     removable: false,
     square: false,
     size: "md",


### PR DESCRIPTION
## Summary
Follow-up to #836 per review:
- `icon` and `onRemove` rows hidden from Controls/props table (ReactNode control does nothing; the action pane covers onRemove). Both remain documented in the contract.
- `className` and `title` are live text inputs (empty-string default args) instead of Set-string buttons.

## Verification
- Storybook docs table checked: icon/onRemove rows gone, className/title render text inputs.
- vitest 1893/1893, typecheck, lint, build, validate:components 0, Badge AT snapshots compare clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Badge component’s Storybook controls and prop display.
  * Simplified the visible props table by hiding some internal details and clarifying that one prop is documented separately.
  * Added a text control for the class name field and set cleaner default values for the example state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->