### PR TITLE
feat(design-system): controls-operability batch 1 — Actions+Content at 100% operable

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -47,6 +47,10 @@ jobs:
       # container each run — the same proven pattern as petritapanilahdelma's ci.yml on this farm.
       - run: npx playwright install chromium --with-deps
       - run: npm run test:stories:matrix:ci
+      # Controls-operability ratchet: drives the real Controls panel per component
+      # (Human-Simulated audit) against its own Storybook boot. Raise --min in
+      # audit:controls:ci as remediation batches land; end state is --min 100.
+      - run: npm run audit:controls:ci
       - run: npm run test:ci
       - run: npm run build
       - run: npm run check:drift

--- a/nextjs-app/shared/components/Avatar/Avatar.stories.tsx
+++ b/nextjs-app/shared/components/Avatar/Avatar.stories.tsx
@@ -47,7 +47,18 @@ export default {
       id: { table: { disable: true } },
       imageUrl: { control: "text", description: "Photo source; falls back to initials from name when absent.", table: { category: "Content" } },
       loading: { control: { type: "inline-radio" }, options: ["lazy", "eager"], description: "Native img loading strategy; keep lazy in lists, eager above the fold.", table: { category: "Content", defaultValue: { summary: "lazy" } } },
-      menuItems: { control: "object", description: "When provided, renders an in-place dropdown menu triggered by the avatar", table: { category: "Content" } },
+      menuItems: {
+        control: { type: "select", labels: { none: "none", profile: "profile menu (2 items)", admin: "admin menu (3 items)" } },
+        options: ["none", "profile", "admin"],
+        mapping: {
+          none: undefined,
+          profile: [{ label: "Profile" }, { label: "Sign out" }],
+          admin: [{ label: "Profile" }, { label: "Settings" }, { label: "Sign out" }],
+        },
+        description:
+          "When provided, renders an in-place dropdown menu triggered by the avatar. Pick a preset to try it; pass your own AvatarMenuItem[] in code.",
+        table: { category: "Content", type: { summary: "AvatarMenuItem[]" }, defaultValue: { summary: "undefined" } },
+      },
       menuLabel: { control: "text", description: "Accessible label announced for the avatar menu trigger", table: { category: "Accessibility" } },
       placementRefreshKey: { control: "number", description: "Optional token that forces menu placement recalculation when changed", table: { category: "Content" } },
       ref: { table: { disable: true } },
@@ -56,6 +67,16 @@ export default {
       srcSet: { control: "text", description: "Native img srcSet for responsive photo densities.", table: { category: "Content" } },
       style: { table: { disable: true } }
 },
+  // Seeded so every text/boolean/number/object control renders an operable
+  // widget; each value matches the component's no-op default.
+  args: {
+    clickable: false,
+    destinationUrl: "",
+    srcSet: "",
+    sizes: "",
+    menuLabel: "",
+    placementRefreshKey: 0,
+  },
 } as Meta<typeof Avatar>;
 
 type AvatarStoryArgs = React.ComponentProps<typeof Avatar>;
@@ -297,7 +318,9 @@ export const Playground = DefaultVariant;
 export const Example = {
   tags: ["beta-matrix"],
   parameters: { controls: { disable: true } },
-  render: (args: AvatarStoryArgs) => <Avatar {...WithMenu.args} {...args} />,
+  // WithMenu.args last: controls are disabled here, and the meta-level seeded
+  // args (menuLabel: "" etc.) must not override the curated example props.
+  render: (args: AvatarStoryArgs) => <Avatar {...args} {...WithMenu.args} />,
 };
 
 export const ForcedColors = {

--- a/nextjs-app/shared/components/Avatar/Avatar.tsx
+++ b/nextjs-app/shared/components/Avatar/Avatar.tsx
@@ -347,9 +347,9 @@ const Avatar = React.forwardRef<HTMLButtonElement, AvatarProps>(
 
     const resolvedImageUrl = resolveImageUrl(imageUrl);
     const resolvedSrcSet =
-      srcSet ?? (resolvedImageUrl ? `${resolvedImageUrl} 1x` : undefined);
+      srcSet || (resolvedImageUrl ? `${resolvedImageUrl} 1x` : undefined);
     const defaultSizes = "(max-width: 600px) 56px, 40px";
-    const resolvedSizes = sizes ?? (size ? `${size}` : defaultSizes);
+    const resolvedSizes = sizes || (size ? `${size}` : defaultSizes);
 
     const handleClick = () => {
       if (clickable && destinationUrl) {
@@ -362,7 +362,7 @@ const Avatar = React.forwardRef<HTMLButtonElement, AvatarProps>(
       "--avatar-size": resolvedSize,
     } as React.CSSProperties;
     const avatarMenuLabel =
-      menuLabel ??
+      menuLabel ||
       (name ? t("avatar.menuLabel", { name }) : t("avatar.menuLabelGeneric"));
 
     const renderMenuItems = () => {

--- a/nextjs-app/shared/components/AvatarGroup/AvatarGroup.stories.tsx
+++ b/nextjs-app/shared/components/AvatarGroup/AvatarGroup.stories.tsx
@@ -6,6 +6,11 @@ import contract from "./AvatarGroup.contract.json";
 
 const PEOPLE = ["Aino Virtanen", "Bo Lindqvist", "Carla Mendes", "Deniz Aydın", "Eero Salmi", "Freja Holm"];
 
+const avatars = (count: number, size: "2rem" | "2.5rem" | "3rem" = "2.5rem") =>
+  PEOPLE.slice(0, count).map((name) => (
+    <Avatar key={name} name={name} variant="initials" size={size} />
+  ));
+
 const meta = {
   title: "Content/AvatarGroup",
   component: AvatarGroup,
@@ -28,18 +33,22 @@ const meta = {
       description: "Overflow bubble size; children Avatars should match",
       table: { defaultValue: { summary: "md" } },
     },
-    children: { control: false, description: "@dt/Avatar elements" },
+    children: {
+      control: {
+        type: "select",
+        labels: { three: "3 members", six: "6 members (overflows at max 4)" },
+      },
+      options: ["three", "six"],
+      mapping: { three: avatars(3), six: avatars(6) },
+      description: "@dt/Avatar elements (member presets here; pass Avatars in code)",
+      table: { type: { summary: "ReactNode" } },
+    },
   },
-  args: { ariaLabel: "Project members", max: 4, size: "md" },
+  args: { ariaLabel: "Project members", max: 4, size: "md", children: "six" },
 } satisfies Meta<typeof AvatarGroup>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
-
-const avatars = (count: number, size: "2rem" | "2.5rem" | "3rem" = "2.5rem") =>
-  PEOPLE.slice(0, count).map((name) => (
-    <Avatar key={name} name={name} variant="initials" size={size} />
-  ));
 
 export const Default: Story = {
   tags: ["example"],
@@ -48,12 +57,9 @@ export const Default: Story = {
       description: { story: "Six members, max 4: the stack shows four and collapses the rest into +2." },
     },
   },
-  render: (args) => <AvatarGroup {...args}>{avatars(6)}</AvatarGroup>,
 };
 
-export const Playground: Story = {
-  render: (args) => <AvatarGroup {...args}>{avatars(6)}</AvatarGroup>,
-};
+export const Playground: Story = {};
 
 export const NoOverflow: Story = {
   tags: ["example"],

--- a/nextjs-app/shared/components/Badge/Badge.stories.tsx
+++ b/nextjs-app/shared/components/Badge/Badge.stories.tsx
@@ -42,8 +42,23 @@ const meta: Meta<typeof Badge> = {
       table: { category: "Content" },
     },
     icon: {
-      // ReactNode — nothing useful to control; documented in the contract.
-      table: { disable: true },
+      control: {
+        type: "select",
+        labels: { none: "none", check: "check icon", sparkle: "sparkle icon" },
+      },
+      options: ["none", "check", "sparkle"],
+      mapping: {
+        none: undefined,
+        check: <Icon name="check" ariaLabel="check" />,
+        sparkle: <Icon name="sparkle" ariaLabel="sparkle" />,
+      },
+      description:
+        "Custom leading icon node (presets here; pass any ReactNode in code). The iconName knob and semantic tone icons take precedence when set.",
+      table: {
+        category: "Content",
+        type: { summary: "ReactNode" },
+        defaultValue: { summary: "undefined" },
+      },
     },
 
     // Appearance
@@ -122,7 +137,7 @@ type BadgeProps = React.ComponentProps<typeof Badge>;
 
 const BadgeStoryTemplate: React.FC<BadgeProps & { iconName?: string }> = (args) => {
   const { t } = useTranslation();
-  const { iconName, children, tone, ...rest } = args;
+  const { iconName, children, tone, icon, ...rest } = args;
   let content = children;
   if (typeof children === "string" && children.startsWith("badge")) {
     content = t(children);
@@ -131,7 +146,9 @@ const BadgeStoryTemplate: React.FC<BadgeProps & { iconName?: string }> = (args) 
     iconName && iconName.trim() ? iconName.trim() : tone && TONE_ICON_MAP[tone];
   const resolvedIcon = resolvedName ? (
     <Icon name={resolvedName} ariaLabel={resolvedName} />
-  ) : undefined;
+  ) : (
+    icon
+  );
   return (
     <Badge {...rest} tone={tone} icon={resolvedIcon}>
       {content}

--- a/nextjs-app/shared/components/Button/Button.stories.tsx
+++ b/nextjs-app/shared/components/Button/Button.stories.tsx
@@ -1,10 +1,33 @@
 import contract from "./Button.contract.json";
+import { action } from "storybook/actions";
 import { userEvent, within, expect } from "storybook/test";
 import React from "react";
 import { Meta, StoryFn, type StoryObj } from "@storybook/react-vite";
 import Button from "@dt/Button";
 import { useTranslation } from "react-i18next";
 import schema from "./schema.json";
+
+// Selectable async behaviors for the clickAction control: picking one and
+// clicking the button demonstrates the pending/dedupe handling live.
+const clickActionPresets: Record<
+  string,
+  ((e: React.MouseEvent<HTMLButtonElement>) => Promise<void>) | undefined
+> = {
+  none: undefined,
+  resolve: (e) => {
+    action("clickAction (resolves in 1.2s)")(e);
+    return new Promise((resolve) => setTimeout(resolve, 1200));
+  },
+  reject: (e) => {
+    action("clickAction (rejects in 1.2s)")(e);
+    return new Promise((_, reject) => setTimeout(reject, 1200));
+  },
+};
+const clickActionLabels = {
+  none: "none",
+  resolve: "async success (1.2s)",
+  reject: "async failure (1.2s)",
+};
 
 export default {
   title: "Actions/Button",
@@ -98,12 +121,15 @@ export default {
       table: { category: "Behavior", type: { summary: "(e: MouseEvent) => void" } },
     },
     clickAction: {
-      action: "clickAction",
+      control: { type: "select", labels: clickActionLabels },
+      options: Object.keys(clickActionPresets),
+      mapping: clickActionPresets,
       description:
-        "Async click handler (button form only). While the returned promise is pending, the button shows its loading state, sets aria-busy, and disables itself to dedupe repeat clicks. onClick still fires first if both are provided. Rejections are swallowed after clearing the pending state — callers own error UX.",
+        "Async click handler (button form only). While the returned promise is pending, the button shows its loading state, sets aria-busy, and disables itself to dedupe repeat clicks. onClick still fires first if both are provided. Rejections are swallowed after clearing the pending state — callers own error UX. The presets here let you click and watch the pending state live.",
       table: {
         category: "Behavior",
         type: { summary: "(e: MouseEvent<HTMLButtonElement>) => void | Promise<void>" },
+        defaultValue: { summary: "undefined" },
       },
     },
     href: {
@@ -146,14 +172,37 @@ export default {
       description: "Additional CSS classes merged onto the rendered element.",
       table: { category: "Advanced", type: { summary: "string" } },
     },
+    rel: {
+      control: "text",
+      description:
+        "Anchor rel (link buttons only). Left empty, _blank targets auto-add 'noopener noreferrer'.",
+      table: { category: "Behavior", type: { summary: "string" } },
+    },
       form: { table: { disable: true } },
       id: { table: { disable: true } },
       name: { table: { disable: true } },
       ref: { table: { disable: true } },
-      rel: { table: { disable: true } },
       type: { table: { disable: true } },
       value: { table: { disable: true } }
 },
+  // Seeded so every text/boolean control renders an operable widget instead of
+  // a "Set string" button; each value matches the component's no-op default.
+  args: {
+    icon: "",
+    endIcon: "",
+    href: "",
+    target: "",
+    rel: "",
+    submits: false,
+    disabled: false,
+    loading: false,
+    rounded: false,
+    accessibleName: "",
+    accessibleNameRef: "",
+    accessibleDescription: "",
+    tooltip: "",
+    className: "",
+  },
 } as Meta;
 
 type Story = StoryObj<typeof Button>;

--- a/nextjs-app/shared/components/Button/Button.tsx
+++ b/nextjs-app/shared/components/Button/Button.tsx
@@ -153,7 +153,7 @@ const Button = React.forwardRef<
       }
     }
 
-    const isLink = "href" in rest && rest.href !== undefined;
+    const isLink = "href" in rest && rest.href !== undefined && rest.href !== "";
 
     // Icons are decorative (the button supplies the accessible name) and inherit
     // the button's resolved text color via currentColor. The icon's rendered
@@ -212,10 +212,10 @@ const Button = React.forwardRef<
         .filter(Boolean)
         .join(" "),
       "aria-label": effectiveAriaLabel,
-      "aria-labelledby": accessibleNameRef,
-      "aria-describedby": accessibleDescription,
+      "aria-labelledby": accessibleNameRef || undefined,
+      "aria-describedby": accessibleDescription || undefined,
       "aria-busy": isLoading || undefined,
-      title: tooltip,
+      title: tooltip || undefined,
     };
 
     const content = (

--- a/nextjs-app/shared/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/nextjs-app/shared/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -21,9 +21,29 @@ const meta = {
       description: "Fuse children into one segmented surface",
       table: { defaultValue: { summary: "true" } },
     },
-    children: { control: false, description: "Buttons / IconButtons (same variant + size)" },
+    children: {
+      control: {
+        type: "select",
+        labels: { two: "2 segments", three: "3 segments" },
+      },
+      options: ["two", "three"],
+      mapping: {
+        two: [
+          <Button key="one" variant="secondary" size="md">One</Button>,
+          <Button key="two" variant="secondary" size="md">Two</Button>,
+        ],
+        three: [
+          <Button key="one" variant="secondary" size="md">One</Button>,
+          <Button key="two" variant="secondary" size="md">Two</Button>,
+          <Button key="three" variant="secondary" size="md">Three</Button>,
+        ],
+      },
+      description:
+        "Buttons / IconButtons (same variant + size). Segment presets here; compose your own in code.",
+      table: { type: { summary: "ReactNode" } },
+    },
   },
-  args: { ariaLabel: "Text alignment" },
+  args: { ariaLabel: "Text alignment", attached: true, children: "three" },
 } satisfies Meta<typeof ButtonGroup>;
 
 export default meta;
@@ -45,15 +65,7 @@ export const Default: Story = {
   ),
 };
 
-export const Playground: Story = {
-  render: (args) => (
-    <ButtonGroup {...args}>
-      <Button variant="secondary" size="md">One</Button>
-      <Button variant="secondary" size="md">Two</Button>
-      <Button variant="secondary" size="md">Three</Button>
-    </ButtonGroup>
-  ),
-};
+export const Playground: Story = {};
 
 export const Spaced: Story = {
   tags: ["example"],

--- a/nextjs-app/shared/components/CodeSnippet/CodeSnippet.stories.tsx
+++ b/nextjs-app/shared/components/CodeSnippet/CodeSnippet.stories.tsx
@@ -71,7 +71,7 @@ const meta: Meta<typeof CodeSnippet> = {
       code: { control: "text", description: "The code string to highlight.", table: { category: "Content" } },
       id: { table: { disable: true } },
       language: { control: "text", description: "Highlighting grammar (typescript, bash, python, ...).", table: { category: "Content" } },
-      maxLines: { control: "number", description: "Clamp height to this many lines; longer code scrolls.", table: { category: "Content" } },
+      maxLines: { control: { type: "number", min: 0 }, description: "Clamp height to this many lines; longer code scrolls. 0 disables the clamp.", table: { category: "Content", defaultValue: { summary: "0" } } },
       onCopy: { action: "onCopy", table: { disable: true } },
       ref: { table: { disable: true } },
       showLineNumbers: { control: "boolean", description: "Render a line-number gutter.", table: { category: "Content" } },
@@ -116,6 +116,7 @@ const meta: Meta<typeof CodeSnippet> = {
     showLineNumbers: true,
     allowCopy: true,
     variant: "multi",
+    maxLines: 0,
   },
 };
 

--- a/nextjs-app/shared/components/EmptyState/EmptyState.stories.tsx
+++ b/nextjs-app/shared/components/EmptyState/EmptyState.stories.tsx
@@ -32,13 +32,36 @@ const meta = {
       description: "Size token",
       table: { defaultValue: { summary: "md" } },
     },
-    children: { control: false, description: "Action slot (Buttons)" },
+    children: {
+      control: {
+        type: "select",
+        labels: {
+          none: "none",
+          primary: "primary action",
+          pair: "primary + tertiary actions",
+        },
+      },
+      options: ["none", "primary", "pair"],
+      mapping: {
+        none: undefined,
+        primary: [
+          <Button key="new" variant="primary" size="md">New project</Button>,
+        ],
+        pair: [
+          <Button key="new" variant="primary" size="md">New project</Button>,
+          <Button key="import" variant="tertiary" size="md">Import</Button>,
+        ],
+      },
+      description: "Action slot (Buttons). Presets here; compose your own in code.",
+      table: { type: { summary: "ReactNode" } },
+    },
   },
   args: {
     icon: "magnifying-glass",
     title: "No results found",
     description: "Try a different search term, or clear the filters to see everything.",
     size: "md",
+    children: "none",
   },
 } satisfies Meta<typeof EmptyState>;
 

--- a/nextjs-app/shared/components/Icon/Icon.stories.tsx
+++ b/nextjs-app/shared/components/Icon/Icon.stories.tsx
@@ -15,11 +15,17 @@ const meta: Meta<typeof Icon> = {
   title: "Content/Icon",
   component: Icon,
   tags: ["stable", "autodocs"],
+  // spin/pulse/mirrored/decorative seeded false (their effective defaults with
+  // an ariaLabel set) so the boolean controls render toggles, not Set-buttons.
   args: {
     name: "circle-info",
     weight: "regular",
     size: "lg",
     ariaLabel: "Information",
+    spin: false,
+    pulse: false,
+    mirrored: false,
+    decorative: false,
   },
   argTypes: {
     name: {
@@ -29,19 +35,15 @@ const meta: Meta<typeof Icon> = {
     },
 
     weight: {
-      control: {
-        type: "select",
-        options: ["thin", "light", "regular", "bold", "fill", "duotone"],
-      },
+      control: { type: "select" },
+      options: ["thin", "light", "regular", "bold", "fill", "duotone"],
       description: "Phosphor stroke/fill weight",
       table: { defaultValue: { summary: "regular" } },
     },
 
     size: {
-      control: {
-        type: "select",
-        options: ["2xs", "xs", "sm", "md", "lg", "xl", "2xl"],
-      },
+      control: { type: "select" },
+      options: ["2xs", "xs", "sm", "md", "lg", "xl", "2xl"],
       description: "Tokenized icon size",
       table: { defaultValue: { summary: "lg" } },
     },
@@ -52,14 +54,17 @@ const meta: Meta<typeof Icon> = {
     },
 
     rotate: {
-      control: { type: "select", options: [0, 90, 180, 270] },
+      control: { type: "select" },
+      options: [0, 90, 180, 270],
       description: "Rotation in degrees",
       table: { defaultValue: { summary: "0" } },
     },
 
     flip: {
-      control: { type: "select", options: ["horizontal", "vertical", "both"] },
+      control: { type: "select", labels: { undefined: "none" } },
+      options: [undefined, "horizontal", "vertical", "both"],
       description: "Mirror the icon along an axis",
+      table: { defaultValue: { summary: "undefined" } },
     },
 
     spin: {
@@ -90,7 +95,12 @@ const meta: Meta<typeof Icon> = {
       children: { table: { disable: true } },
       className: { table: { disable: true } },
       id: { table: { disable: true } },
-      legacyStyle: { control: false, description: "Legacy FontAwesome-style weight string kept for backward compatibility.", table: { category: "Content" } },
+      legacyStyle: {
+        control: { type: "select", labels: { undefined: "none" } },
+        options: [undefined, "solid", "regular", "light", "thin", "duotone", "brands"],
+        description: "Legacy FontAwesome-style weight string kept for backward compatibility; weight wins when both are set.",
+        table: { category: "Content", defaultValue: { summary: "undefined" } },
+      },
       mirrored: { control: "boolean", description: "Flip the glyph horizontally (RTL-aware icons).", table: { category: "Content" } },
       ref: { table: { disable: true } },
       style: { table: { disable: true } }

--- a/nextjs-app/shared/components/IconButton/IconButton.stories.tsx
+++ b/nextjs-app/shared/components/IconButton/IconButton.stories.tsx
@@ -10,6 +10,7 @@ const defaultArgs = {
   variant: "tertiary" as const,
   size: "md" as const,
   disabled: false,
+  tooltip: "",
   onClick: fn(),
 };
 

--- a/nextjs-app/shared/components/List/List.stories.tsx
+++ b/nextjs-app/shared/components/List/List.stories.tsx
@@ -55,8 +55,18 @@ const meta: Meta<typeof List> = {
   },
   argTypes: {
     items: {
-      control: "object",
-      description: "Array of list items (strings or React nodes)",
+      control: {
+        type: "select",
+        labels: { three: "3 items", four: "4 items" },
+      },
+      options: ["three", "four"],
+      mapping: {
+        three: ["storyListItem1", "storyListItem2", "storyListItem3"],
+        four: ["storyListItem1", "storyListItem2", "storyListItem3", "storyListItem4"],
+      },
+      description:
+        "Array of list items (strings or React nodes). Presets here; pass your own array in code.",
+      table: { type: { summary: "ReactNode[]" } },
     },
 
     as: {
@@ -110,7 +120,12 @@ const meta: Meta<typeof List> = {
 
     className: { control: "text", description: "Custom class name" },
 
-    role: { control: "text", description: "ARIA role override" },
+    role: {
+      control: { type: "inline-radio", labels: { undefined: "none" } },
+      options: [undefined, "list", "menu", "listbox", "presentation"],
+      description: "ARIA role override",
+      table: { type: { summary: "string" }, defaultValue: { summary: "undefined" } },
+    },
       asChild: { table: { disable: true } },
       children: { table: { disable: true } },
       id: { table: { disable: true } },
@@ -358,7 +373,9 @@ export const WithLineHeights: StoryFn = () => {
 
 const defaultListArgs = {
   as: "ul" as const,
-  items: ["storyListItem1", "storyListItem2", "storyListItem3"],
+  // "three" resolves through the items control mapping to three list items.
+  items: "three" as unknown as React.ReactNode[],
+  className: "",
 };
 
 export const Default = {

--- a/nextjs-app/shared/components/SplitButton/SplitButton.stories.tsx
+++ b/nextjs-app/shared/components/SplitButton/SplitButton.stories.tsx
@@ -5,6 +5,32 @@ import SplitButton from "@dt/SplitButton";
 import contract from "./SplitButton.contract.json";
 import schema from "./schema.json";
 
+const saveOptions = [
+  {
+    id: "save-as",
+    label: "Save as",
+    title: "Choose a new name for this draft",
+    icon: "pencil",
+  },
+  {
+    id: "save-cloud",
+    label: "Save to cloud",
+    title: "Sync to shared workspace",
+    icon: "cloud-arrow-up",
+  },
+  {
+    id: "save-copy",
+    label: "Save a copy",
+    title: "Duplicate and keep editing",
+    icon: "copy",
+  },
+];
+
+const basicOptions = [
+  { id: "duplicate", label: "Duplicate" },
+  { id: "archive", label: "Archive" },
+];
+
 const meta: Meta<typeof SplitButton> = {
   title: "Actions/SplitButton",
   component: SplitButton,
@@ -26,9 +52,14 @@ const meta: Meta<typeof SplitButton> = {
       table: { category: "Content", type: { summary: "ReactNode" } },
     },
     options: {
-      control: "object",
+      control: {
+        type: "select",
+        labels: { save: "save menu (3 items, icons)", basic: "two plain actions" },
+      },
+      options: ["save", "basic"],
+      mapping: { save: saveOptions, basic: basicOptions },
       description:
-        "Menu entries; leaf options carry onSelect, parent options carry children (one nested level).",
+        "Menu entries; leaf options carry onSelect, parent options carry children (one nested level). Presets here; pass SplitButtonOption[] in code.",
       table: { category: "Content", type: { summary: "SplitButtonOption[]" } },
     },
     variant: {
@@ -115,38 +146,28 @@ const meta: Meta<typeof SplitButton> = {
       table: { category: "Advanced", type: { summary: "string" } },
     },
   },
+  // Seeded so every text/boolean control renders an operable widget; each
+  // value matches the component's no-op default.
+  args: {
+    disabled: false,
+    usePortal: false,
+    toggleLabel: "",
+    accessibleName: "",
+    tooltip: "",
+    className: "",
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof SplitButton>;
-
-const saveOptions = [
-  {
-    id: "save-as",
-    label: "Save as",
-    title: "Choose a new name for this draft",
-    icon: "pencil",
-  },
-  {
-    id: "save-cloud",
-    label: "Save to cloud",
-    title: "Sync to shared workspace",
-    icon: "cloud-arrow-up",
-  },
-  {
-    id: "save-copy",
-    label: "Save a copy",
-    title: "Duplicate and keep editing",
-    icon: "copy",
-  },
-];
 
 export const Default: Story = {
   tags: ["beta-matrix"],
   args: {
     label: "Save",
     variant: "primary",
-    options: saveOptions,
+    // "save" resolves through the options control mapping to saveOptions.
+    options: "save" as unknown as typeof saveOptions,
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -300,7 +321,8 @@ export const Playground: Story = {
     label: "Save",
     variant: "primary",
     size: "md",
-    options: saveOptions,
+    // "save" resolves through the options control mapping to saveOptions.
+    options: "save" as unknown as typeof saveOptions,
   },
 };
 

--- a/nextjs-app/shared/components/SplitButton/SplitButton.tsx
+++ b/nextjs-app/shared/components/SplitButton/SplitButton.tsx
@@ -84,7 +84,7 @@ const SplitButton = React.forwardRef<HTMLDivElement, SplitButtonProps>(
     ref,
   ) => {
     const { t } = useTranslation();
-    const defaultToggleLabel = toggleLabel ?? t("splitButton.moreOptions");
+    const defaultToggleLabel = toggleLabel || t("splitButton.moreOptions");
     const isSecondary = variant === "secondary";
     const hasOptions = Array.isArray(options) && options.length > 0;
     const [open, setOpen] = React.useState(false);

--- a/nextjs-app/shared/components/Title/Title.stories.tsx
+++ b/nextjs-app/shared/components/Title/Title.stories.tsx
@@ -124,7 +124,7 @@ export default {
     className: {
       control: "text",
       description: "Additional CSS class names",
-      table: { disable: true },
+      table: { category: "Advanced" },
     },
 
     terminals: {
@@ -158,6 +158,12 @@ export default {
       ref: { table: { disable: true } },
       style: { table: { disable: true } }
 },
+  // Seeded to the component defaults so the text/boolean controls render
+  // operable widgets instead of Set-buttons.
+  args: {
+    className: "",
+    unstyled: false,
+  },
 } as Meta<typeof Title>;
 
 export const AllSizes = () => {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "report:doc-coverage": "node scripts/design-system/report-doc-coverage.mjs",
     "audit:catalog": "node scripts/design-system/audit-catalog-coverage.mjs",
     "audit:controls": "node scripts/design-system/audit-controls.mjs",
+    "audit:controls:ci": "concurrently -k -s first -n SB,AUDIT \"npm run storybook -- --ci --no-open --quiet\" \"npm run storybook:wait && node scripts/design-system/audit-controls.mjs --min 50\"",
     "new-component": "node scripts/design-system/scaffold-component.mjs",
     "bootstrap:contracts": "node scripts/design-system/bootstrap-contracts.mjs",
     "elevate:storybook": "python3 scripts/design-system/elevate_storybook_beta.py",


### PR DESCRIPTION
## Summary

First batch of the controls-operability remediation sweep (roadmap section 7.5). All 15 Actions+Content components now score **100%** on the Human-Simulated Controls audit; global operability ratchets **44% → 50%** (fully operable components **5 → 17/125**).

## Per-component treatments

- **Seeded no-op default args** so text/number/boolean controls render real inputs/toggles instead of dead "Set X" buttons (Button, Avatar, Icon, IconButton, Title, CodeSnippet, List, SplitButton).
- **Mapped select presets** for array/ReactNode props a JSON editor cannot serve: `Avatar.menuItems`, `AvatarGroup`/`ButtonGroup`/`EmptyState` `children`, `Badge.icon`, `List.items`, `SplitButton.options`.
- **Button.clickAction**: selectable async presets (resolve/reject in 1.2s) — the pending/dedupe behavior is now observable from the Controls panel.
- **Syntax/conflict fixes**: Storybook 8+ top-level `options` on Icon (`weight`, `size`, `rotate`, `flip`); constrained enum controls for `Icon.legacyStyle` and `List.role`; `Title.className` and `Button.rel` freed from control-vs-disable conflicts.
- **Component-side empty-string normalization** so seeded `""` args are true no-ops: Button `title`/`aria-labelledby`/`aria-describedby` and `href=""` link branch; Avatar `srcSet`/`sizes`/`menuLabel`; SplitButton `toggleLabel`.

## Verification

- `audit:controls --only <Name>` = 100% for all 15 batch components; full audit `CONTROLS_OPERABLE_PCT=50`.
- AT snapshots: compare mode passes in normal AND forced-colors modes for all touched components with **unchanged** committed baselines — zero rendered-output drift from seeding. (Avatar `Example` spread order fixed so meta seeds cannot override curated props.) Pre-existing stale Link/Footer baselines are out of scope (follow-up task spawned).
- Local gate: typecheck, lint, lint:css, vitest 1893/1893, build — all exit 0. Farm parity: build:tokens, check:contract-props, check:consumers, validate:components, test:stories:smoke — all green.

## CI ratchet

`audit:controls:ci` (own Storybook boot, `--min 50`) added to farm PR Validation after the story matrix. Raise `--min` per remediation batch; end state `--min 100`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Storybook demos across several UI components with clearer preset controls and more consistent default examples.
  * Added more interactive options for buttons, badges, lists, avatars, icons, and empty states, making previews easier to explore.

* **Bug Fixes**
  * Fixed cases where empty values could hide default button, avatar, and split-button labels.
  * Improved button rendering so an empty link value now behaves like a normal button.
  * Default story settings now better match each component’s expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->