### PR TITLE
fix(design-system): ButtonGroup children control actually drives the story

### DIFF
--- a/nextjs-app/shared/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/nextjs-app/shared/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -5,6 +5,17 @@ import Button from "@dt/Button";
 import { IconButton } from "@dt/IconButton";
 import contract from "./ButtonGroup.contract.json";
 
+// Children presets are generated, not hand-written: the select maps a segment
+// count to that many secondary Buttons so the control drives the real prop.
+const SEGMENT_LABELS = ["Day", "Week", "Month", "Quarter", "Year"];
+const SEGMENT_COUNTS = [2, 3, 4, 5];
+const segments = (count: number) =>
+  SEGMENT_LABELS.slice(0, count).map((label) => (
+    <Button key={label} variant="secondary" size="md">
+      {label}
+    </Button>
+  ));
+
 const meta = {
   title: "Actions/ButtonGroup",
   component: ButtonGroup,
@@ -24,26 +35,16 @@ const meta = {
     children: {
       control: {
         type: "select",
-        labels: { two: "2 segments", three: "3 segments" },
+        labels: Object.fromEntries(SEGMENT_COUNTS.map((n) => [n, `${n} segments`])),
       },
-      options: ["two", "three"],
-      mapping: {
-        two: [
-          <Button key="one" variant="secondary" size="md">One</Button>,
-          <Button key="two" variant="secondary" size="md">Two</Button>,
-        ],
-        three: [
-          <Button key="one" variant="secondary" size="md">One</Button>,
-          <Button key="two" variant="secondary" size="md">Two</Button>,
-          <Button key="three" variant="secondary" size="md">Three</Button>,
-        ],
-      },
+      options: SEGMENT_COUNTS,
+      mapping: Object.fromEntries(SEGMENT_COUNTS.map((n) => [n, segments(n)])),
       description:
-        "Buttons / IconButtons (same variant + size). Segment presets here; compose your own in code.",
+        "Buttons / IconButtons (same variant + size). Pick a segment count here; compose your own in code.",
       table: { type: { summary: "ReactNode" } },
     },
   },
-  args: { ariaLabel: "Text alignment", attached: true, children: "three" },
+  args: { ariaLabel: "Text alignment", attached: true, children: 3 },
 } satisfies Meta<typeof ButtonGroup>;
 
 export default meta;
@@ -56,13 +57,6 @@ export const Default: Story = {
       description: { story: "Attached segments share seams; use one variant and size across the group." },
     },
   },
-  render: (args) => (
-    <ButtonGroup {...args}>
-      <Button variant="secondary" size="md">Day</Button>
-      <Button variant="secondary" size="md">Week</Button>
-      <Button variant="secondary" size="md">Month</Button>
-    </ButtonGroup>
-  ),
 };
 
 export const Playground: Story = {};


### PR DESCRIPTION
## Summary

User-reported: on `actions-buttongroup--default`, the `children` select was inert. Three segments rendered regardless of the arg, because the Default story's custom `render` hardcoded three `<Button>` children (JSX children override the spread arg).

## Fix

- Default drops its custom render and renders from args, same as Playground.
- Presets are generated from a segment-count list (2 to 5) via a `segments(n)` helper: no hand-written JSX arrays, and the preset set is no longer hardcoded to two entries.
- Options are numeric, so URLs read `args=children:2` through `children:5`.
- Default keeps its previous Day/Week/Month appearance (count 3 seeds the same labels), so the docs prose still matches.

## Verification

Driven against the running Storybook via iframe URLs:
- no args: 3 segments (Day/Week/Month, unchanged)
- `children:2` gives 2, `children:5` gives 5, Playground `children:4` gives 4

`audit:controls --only ButtonGroup` = 100%. Local gate: typecheck, lint, vitest 1893/1893, build, all exit 0. ButtonGroup is alpha (no AT baselines affected). The other batch-1 mapped-prop stories were swept for the same args-ignoring-render trap; ButtonGroup was the only one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
