### PR TITLE
feat(design-system): controls effect pass — presence is not effect

### DIFF
--- a/nextjs-app/shared/components/Button/Button.tsx
+++ b/nextjs-app/shared/components/Button/Button.tsx
@@ -273,8 +273,19 @@ const Button = React.forwardRef<
       );
     }
 
-    const { submits = false, type, clickAction, onClick, ...buttonRest } =
-      rest as ButtonAsButton;
+    // href/target/rel belong to the link form only; when the link branch was
+    // not taken (e.g. href="") they must not leak onto the <button> as raw
+    // DOM attributes.
+    const {
+      submits = false,
+      type,
+      clickAction,
+      onClick,
+      href: _href,
+      target: _target,
+      rel: _rel,
+      ...buttonRest
+    } = rest as ButtonAsButton & Partial<Pick<ButtonAsLink, "href" | "target" | "rel">>;
 
     const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
       onClick?.(event);

--- a/nextjs-app/shared/components/Icon/Icon.stories.tsx
+++ b/nextjs-app/shared/components/Icon/Icon.stories.tsx
@@ -17,9 +17,10 @@ const meta: Meta<typeof Icon> = {
   tags: ["stable", "autodocs"],
   // spin/pulse/mirrored/decorative seeded false (their effective defaults with
   // an ariaLabel set) so the boolean controls render toggles, not Set-buttons.
+  // weight is deliberately NOT seeded: a defined weight arg would permanently
+  // mask legacyStyle (weight ?? legacyStyle) and the select offers "default".
   args: {
     name: "circle-info",
-    weight: "regular",
     size: "lg",
     ariaLabel: "Information",
     spin: false,
@@ -35,9 +36,10 @@ const meta: Meta<typeof Icon> = {
     },
 
     weight: {
-      control: { type: "select" },
-      options: ["thin", "light", "regular", "bold", "fill", "duotone"],
-      description: "Phosphor stroke/fill weight",
+      control: { type: "select", labels: { undefined: "default (regular)" } },
+      options: [undefined, "thin", "light", "regular", "bold", "fill", "duotone"],
+      description:
+        "Phosphor stroke/fill weight. Leave on default to let legacyStyle apply; an explicit weight always wins.",
       table: { defaultValue: { summary: "regular" } },
     },
 

--- a/scripts/design-system/audit-controls.mjs
+++ b/scripts/design-system/audit-controls.mjs
@@ -23,6 +23,38 @@ const arg = (f, d) => { const i = process.argv.indexOf(f); return i >= 0 ? proce
 const URL = arg('--url', 'http://127.0.0.1:6010')
 const JSON_OUT = process.argv.includes('--json')
 const ONLY = arg('--only', null)
+const EFFECTS = process.argv.includes('--effects')
+
+// --effects: presence is not effect. A widget can render, be operable, and
+// still drive nothing (a custom render that hardcodes the prop, a masked
+// fallback chain, a mapping nobody consumes). This pass perturbs each operable
+// widget IN THE REAL PANEL and diffs the canvas DOM; identical DOM => INERT.
+// Exemptions are for props whose effect is real but not canvas-visible at the
+// story's default state — every entry carries its justification and how the
+// effect was verified instead.
+const EFFECT_EXEMPT = {
+    Avatar: {
+        clickable: 'behavior-only: wires onClick navigation, no DOM signature; verified by click->URL navigation probe',
+        destinationUrl: 'behavior-only: consumed by the clickable click handler; verified by click->URL navigation probe',
+        menuLabel: 'labels the menu trigger, which only exists when menuItems is set; verified with menuItems preset + aria-label probe',
+        placementRefreshKey: 'recalc token: recomputes placement only while a menu is open',
+    },
+    Button: {
+        clickAction: 'function preset: effect appears after click (pending state); verified via click -> aria-busy probe',
+        target: 'anchor-only attribute, inert on the button form by design; verified on the link form',
+        rel: 'anchor-only attribute, inert on the button form by design; verified on the link form (rel:noopener reaches the anchor)',
+    },
+    SplitButton: {
+        usePortal: 'relocates the open menu to document.body; canvas DOM unchanged while the menu is closed',
+        options: 'menu content: visible only while open; verified by open-menu interaction (basic preset -> 2 menuitems)',
+        menuAlign: 'collision-aware placement (resolvedAlign) auto-flips near viewport edges; Playground pins the trigger at the left edge so start/end resolve identically there',
+    },
+}
+
+// Icon-name text knobs: appending characters makes an UNKNOWN icon (renders
+// nothing = false inert). Perturb them to a known registry icon instead.
+const ICON_NAME_PROP = /icon|^name$/i
+const TEXT_PROBE_ICON = 'check'
 
 const ROOTS = [
     resolve(__dirname, '../../nextjs-app/shared/components'),
@@ -66,6 +98,92 @@ const browser = await chromium.launch()
 const page = await browser.newPage()
 const results = []
 
+const canvasHtml = async () => {
+    const frame = page.frames().find((f) => f.url().includes('iframe.html'))
+    if (!frame) return null
+    try { return await frame.$eval('#storybook-root', (el) => el.innerHTML) } catch { return null }
+}
+
+const rowFor = async (prop) => {
+    const rows = page.locator('tr', { has: page.locator('td') })
+    const count = await rows.count()
+    for (let i = 0; i < count; i++) {
+        const nm = ((await rows.nth(i).locator('td,th').first().textContent()) || '').trim().replace(/\*$/, '').trim()
+        if (nm === prop) return rows.nth(i)
+    }
+    return null
+}
+
+// Perturb one operable widget and report whether the canvas DOM changed.
+// Returns 'effect' | 'inert' | 'skipped' | 'unstable'.
+async function testEffect(storyUrl, prop, kind) {
+    await page.goto(storyUrl, { waitUntil: 'domcontentloaded' })
+    await page.waitForSelector('tr td', { timeout: 9000 }).catch(() => {})
+    await page.waitForTimeout(800)
+    const before1 = await canvasHtml()
+    await page.waitForTimeout(300)
+    const before = await canvasHtml()
+    if (before == null) return 'skipped'
+    if (before1 !== before) return 'unstable' // canvas animates at rest; a diff proves nothing
+    const row = await rowFor(prop)
+    if (!row) return 'skipped'
+    try {
+        if (kind === 'select') {
+            const sel = row.locator('select').first()
+            const cur = await sel.inputValue()
+            const opts = await sel.locator('option').evaluateAll((os) => os.map((o) => o.value))
+            // Skip Storybook's "Choose option..." placeholder — selecting it just
+            // clears the arg and reads as a false effect/inert. Some options are
+            // designed visual no-ops (e.g. a legacy alias of the default), so a
+            // select counts as effective if ANY option changes the canvas.
+            const candidates = opts.filter((v) => v && !/^choose option/i.test(v) && v !== cur).slice(0, 5)
+            if (!candidates.length) return 'skipped'
+            for (const next of candidates) {
+                await sel.selectOption(next)
+                await page.waitForTimeout(900)
+                if ((await canvasHtml()) !== before) return 'effect'
+            }
+            return 'inert'
+        } else if (kind === 'checkbox') {
+            // The boolean control's input is visually hidden; the switch label is
+            // the click target a human uses.
+            await row.locator('label:has(input[type="checkbox"])').first().click()
+        } else if (kind === 'radio-group') {
+            // Same any-option rule as selects: the first unchecked radio can be
+            // the rendered default (e.g. tone "neutral"), a designed no-op.
+            // Click the label like a human — .check() asserts the input state
+            // synchronously and races Storybook's React-controlled radios.
+            const radioLabels = row.locator('label:has(input[type="radio"])')
+            const n = await radioLabels.count()
+            let tried = 0
+            for (let i = 0; i < n && tried < 5; i++) {
+                if (await radioLabels.nth(i).locator('input').isChecked()) continue
+                await radioLabels.nth(i).click()
+                tried++
+                await page.waitForTimeout(900)
+                if ((await canvasHtml()) !== before) return 'effect'
+            }
+            return tried ? 'inert' : 'skipped'
+        } else if (kind === 'text' || kind === 'textarea') {
+            const input = row.locator('input[type="text"], textarea').first()
+            const cur = await input.inputValue()
+            await input.fill(ICON_NAME_PROP.test(prop) ? TEXT_PROBE_ICON : `${cur}zprobe`)
+        } else if (kind === 'number' || kind === 'range') {
+            const input = row.locator('input[type="number"], input[type="range"]').first()
+            const cur = await input.inputValue()
+            await input.fill(String((Number(cur) || 0) + 3))
+        } else {
+            return 'skipped' // color/date pickers: rare, not probed yet
+        }
+    } catch (e) {
+        if (!JSON_OUT) console.error(`    [effects] ${prop}: ${String(e).split('\n')[0].slice(0, 140)}`)
+        return 'skipped'
+    }
+    await page.waitForTimeout(900)
+    const after = await canvasHtml()
+    return after === before ? 'inert' : 'effect'
+}
+
 for (const comp of components) {
     const id = storyIdFor(comp.name)
     if (!id) { results.push({ name: comp.name, status: comp.status, error: 'no story' }); continue }
@@ -107,11 +225,25 @@ for (const comp of components) {
         else { perProp[prop] = 'MISSING'; missing++ }
     }
     const denom = comp.props.length - handlers
+    let effects = null
+    if (EFFECTS) {
+        effects = { effect: 0, inert: [], exempt: [], skipped: [], unstable: [] }
+        const exempt = EFFECT_EXEMPT[comp.name] ?? {}
+        for (const prop of comp.props) {
+            const kind = widgets[prop]
+            if (perProp[prop] === 'handler' || !kind || !FUNCTIONAL.has(kind)) continue
+            if (exempt[prop]) { effects.exempt.push(prop); continue }
+            const outcome = await testEffect(`${URL}/?path=/story/${id}`, prop, kind)
+            if (outcome === 'effect') effects.effect++
+            else effects[outcome].push(prop)
+        }
+    }
     results.push({
         name: comp.name, status: comp.status,
         total: denom, operable, dead, missing, handlers,
         coverage: denom ? Math.round((operable / denom) * 100) : 100,
         failing: Object.entries(perProp).filter(([, v]) => v === 'DEAD' || v === 'MISSING').map(([k, v]) => `${k}:${v}`),
+        ...(effects ? { effects } : {}),
     })
 }
 
@@ -133,6 +265,24 @@ const pct = Math.round((totalOperable / totalProps) * 100)
 console.log(`\n${fullyOperable}/${results.filter((r) => !r.error).length} components fully operable`)
 console.log(`${totalOperable}/${totalProps} value props operable (${pct}%)`)
 console.log(`CONTROLS_OPERABLE_PCT=${pct}`)
+
+if (EFFECTS) {
+    let inertTotal = 0
+    console.log('\nEffect pass — perturbed each operable widget in the real panel; INERT = canvas DOM unchanged\n')
+    for (const r of results) {
+        if (!r.effects) continue
+        const e = r.effects
+        inertTotal += e.inert.length
+        const notes = []
+        if (e.inert.length) notes.push(`INERT: ${e.inert.join(', ')}`)
+        if (e.unstable.length) notes.push(`unstable canvas (not probed): ${e.unstable.join(', ')}`)
+        if (e.skipped.length) notes.push(`skipped: ${e.skipped.join(', ')}`)
+        if (e.exempt.length) notes.push(`exempt: ${e.exempt.join(', ')}`)
+        console.log(`  ${r.name.padEnd(24)} effect ${String(e.effect).padStart(2)}  ${notes.join('  |  ') || 'all effective'}`)
+    }
+    console.log(`\nCONTROLS_INERT_PROPS=${inertTotal}`)
+    if (inertTotal > 0) { console.error('FAIL: operable-but-inert props found — a widget that drives nothing is a lie'); process.exit(1) }
+}
 
 // --min <n>: fail when operable coverage drops below the ratchet (CI gate use).
 const minI = process.argv.indexOf('--min')


### PR DESCRIPTION
## Summary

Follow-through on the ButtonGroup finding: `audit:controls` proved a widget renders, not that it drives anything. This PR adds the missing measurement half (`--effects`) and fixes the two real defects an empirical effect sweep of all 15 batch-1 components surfaced.

## Instrument: `audit:controls --effects`

Perturbs every operable widget in the real Controls panel and diffs the rendered canvas DOM; identical DOM = INERT, and a nonzero `CONTROLS_INERT_PROPS` fails the run.

- Selects and radio groups use an any-option loop, because some options are designed visual no-ops (legacyStyle `solid` maps to the default weight; tone `neutral` adds no class).
- Booleans are toggled via the switch label, the way a human does (`.check()` races Storybook's React-controlled inputs).
- Unstable-at-rest canvases and color/date pickers are reported as not-probed, never silently passed.
- Exemptions require a written justification plus how the effect was verified instead. Current entries are behavior-verified: Avatar `clickable` (click navigates to `destinationUrl`), Button `clickAction` (click enters `aria-busy` pending state), SplitButton `options` (open menu shows the mapped entries) and `menuAlign` (collision-aware placement auto-flips at the canvas edge).

## Defects found and fixed

1. **Button attribute leak (shipped in #842)**: seeded link-only args rendered as literal `target="" rel=""` DOM attributes on the button form. The button branch now strips `href`/`target`/`rel`.
2. **Icon `legacyStyle` permanently masked**: `weight` was seeded `"regular"` and its select had no unset option, so `weight ?? legacyStyle` could never fall through. `weight` now offers "default (regular)", the seed is removed (rendered output identical), and `flip` gained an explicit none option.

## Verification

- `--effects` green on all 15 batch-1 components: zero inert props.
- Method notes: URL args are not a valid effect probe (Storybook silently rejects them for some enum props; only panel-driving is honest), and glyph comparison needs full path data (regular/fill share leading segments).
- AT compare mode passes in both modes with unchanged baselines; only the pre-existing Link/Footer staleness fails (tracked separately).
- Local gate: typecheck, lint, lint:css, vitest 1893/1893, build, all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button behavior so link-related values no longer appear on plain buttons in edge cases.
  * Refined the Icon Storybook controls so the default icon weight is clearer and easier to select.

* **Chores**
  * Enhanced the design-system audit tool to better detect controls that don’t visibly affect the UI, helping catch issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->