### PR TITLE
feat(design-system): contract-driven Controls autogen — argTypes derived, not authored

### DIFF
--- a/.storybook/controls-autogen.json
+++ b/.storybook/controls-autogen.json
@@ -1,0 +1,4 @@
+{
+  "$comment": "Components whose Controls panel is DERIVED at runtime from the contract + docgen by .storybook/lib/controls-autogen.ts instead of hand-written meta.argTypes. validate:components skips its static argTypes gate for these; the enforcing instruments are audit:controls (presence, --min on the farm) and audit:controls --effects (0 inert). Append per remediation batch AFTER audits pass.",
+  "components": ["Title", "ButtonGroup", "CodeSnippet"]
+}

--- a/.storybook/lib/controls-autogen.ts
+++ b/.storybook/lib/controls-autogen.ts
@@ -1,0 +1,172 @@
+/**
+ * Contract-driven Controls: derives the argTypes treatment table at runtime
+ * for components registered in .storybook/controls-autogen.json, instead of
+ * hand-maintaining ~equivalent argTypes blocks in 125 story files.
+ *
+ * Sources, in priority order:
+ *   1. Hand-written story argTypes/args — always win (presets, bespoke knobs).
+ *   2. Docgen inference (JSDoc descriptions, extracted default values).
+ *   3. The component contract (machine-checked prop set + union values).
+ *
+ * The treatment table implemented here is the one documented in
+ * nextjs-app/shared/components/AGENTS.md ("Storybook Controls quality bar"):
+ *   union            -> inline-radio (<=4 options) / select, options from contract
+ *   boolean          -> boolean toggle, seeded to its default (unseeded = dead Set-button)
+ *   string           -> text input, seeded "" (component must treat "" as absent)
+ *   number           -> number input, seeded to its default (else 0)
+ *   on* / function   -> action + hidden row (Actions pane covers it)
+ *   ReactNode/object -> hidden row; stories override with mapping presets
+ *   children         -> text control (label-like slots); stories override with
+ *                       mapping presets when children are composite
+ *
+ * Enforcement: validate:components skips its static argTypes gate for
+ * registered components; the rendered truth is measured by audit:controls
+ * (presence, farm --min ratchet) and audit:controls --effects (0 inert).
+ */
+import type { ArgTypesEnhancer, ArgsEnhancer } from "storybook/internal/types";
+import registry from "../controls-autogen.json";
+
+type ContractProp = {
+  optional?: boolean;
+  type?: string;
+  values?: (string | number)[];
+};
+type Contract = { props?: Record<string, ContractProp> };
+
+const contractModules = import.meta.glob<{ default: Contract }>(
+  "../../nextjs-app/shared/{components,patterns}/*/*.contract.json",
+  { eager: true },
+);
+
+const contracts = new Map<string, Contract>();
+for (const [path, mod] of Object.entries(contractModules)) {
+  const name = path.split("/").pop()?.replace(".contract.json", "");
+  if (name) contracts.set(name, mod.default ?? (mod as unknown as Contract));
+}
+
+const AUTOGEN = new Set<string>(registry.components);
+
+// Plumbing a human never sets from a panel — hidden, same set audit:controls skips.
+const HIDDEN = new Set(["ref", "style", "key", "asChild", "as", "data-role", "aria-label", "id"]);
+
+const componentNameFor = (title?: string) => title?.split("/").pop() ?? "";
+
+const categoryFor = (name: string): string => {
+  if (/^on[A-Z]/.test(name)) return "Behavior";
+  if (/^aria|^role$|label|accessible|tooltip/i.test(name)) return "Accessibility";
+  if (/^(id|className|style|ref)$/.test(name)) return "Advanced";
+  if (/variant|tone|size|surface|rounded|square|attached|align|spacing|lineHeight|terminals|weight|color/i.test(name))
+    return "Appearance";
+  return "Content";
+};
+
+/** Literal unions the extractor left as a type string: `"a" | "b"` or `1 | 2`. */
+const literalUnionValues = (type: string): (string | number)[] | null => {
+  const parts = type.split("|").map((p) => p.trim());
+  if (parts.length < 2) return null;
+  const values: (string | number)[] = [];
+  for (const part of parts) {
+    if (/^["'].*["']$/.test(part)) values.push(part.slice(1, -1));
+    else if (/^-?\d+$/.test(part)) values.push(Number(part));
+    else if (part === "undefined") continue;
+    else return null;
+  }
+  return values.length >= 2 ? values : null;
+};
+
+const isStringish = (type: string) =>
+  /\bstring\b/.test(type) && !/ReactNode|Element|Children/i.test(type);
+const isFunction = (type: string) => type.includes("=>") || /^\(/.test(type);
+
+type AnyArgType = Record<string, unknown> & { table?: Record<string, unknown> };
+
+function deriveEntry(prop: string, spec: ContractProp, inherited: AnyArgType | undefined): AnyArgType {
+  const type = spec.type ?? "";
+  const table = { category: categoryFor(prop), ...(inherited?.table ?? {}) };
+
+  if (HIDDEN.has(prop)) return { table: { ...table, disable: true } };
+  if (/^on[A-Z]/.test(prop) || isFunction(type)) {
+    return { action: prop, table: { ...table, disable: true } };
+  }
+
+  const unionValues =
+    spec.values ?? (type !== "union" ? literalUnionValues(type) : null);
+  if (unionValues) {
+    return {
+      ...inherited,
+      control: { type: unionValues.length <= 4 ? "inline-radio" : "select" },
+      options: unionValues,
+      table,
+    };
+  }
+  // Object form only: CSF shorthand normalization (control: "text") runs
+  // BEFORE argTypes enhancers, so shorthands emitted here render no widget.
+  if (/^boolean\b/.test(type)) return { ...inherited, control: { type: "boolean" }, table };
+  if (/^number\b/.test(type)) return { ...inherited, control: { type: "number" }, table };
+  if (prop === "children" || isStringish(type)) {
+    return { ...inherited, control: { type: "text" }, table };
+  }
+  // ReactNode / arrays / objects: a "Set object" button helps nobody — hidden
+  // unless the story supplies a mapping preset entry (which wins wholesale).
+  return { table: { ...table, disable: true } };
+}
+
+/** Seed a no-op default so text/boolean/number controls render operable widgets. */
+function seedFor(spec: ContractProp, inherited: AnyArgType | undefined): unknown {
+  const type = spec.type ?? "";
+  const summary = (inherited?.table as { defaultValue?: { summary?: string } } | undefined)
+    ?.defaultValue?.summary;
+  if (/^boolean\b/.test(type)) {
+    return summary === "true";
+  }
+  if (/^number\b/.test(type)) {
+    const n = Number(summary);
+    return Number.isFinite(n) ? n : 0;
+  }
+  if (isStringish(type) && !(spec.values || literalUnionValues(type))) {
+    return "";
+  }
+  return undefined; // enums/unions render operable unseeded; ReactNode stays unset
+}
+
+export const autogenArgTypes: ArgTypesEnhancer = (context) => {
+  const name = componentNameFor(context.title);
+  if (!AUTOGEN.has(name)) return context.argTypes;
+  const contract = contracts.get(name);
+  if (!contract?.props) return context.argTypes;
+
+  const out = { ...context.argTypes } as Record<string, AnyArgType>;
+  for (const [prop, spec] of Object.entries(contract.props)) {
+    const existing = out[prop];
+    // A story-authored entry (control/options/mapping/action or explicit hide)
+    // is deliberate — leave it alone. Docgen-inferred entries carry name/type/
+    // description but none of those fields.
+    const authored =
+      existing &&
+      ("control" in existing ||
+        "options" in existing ||
+        "mapping" in existing ||
+        "action" in existing ||
+        (existing.table as { disable?: boolean } | undefined)?.disable === true);
+    if (authored) continue;
+    out[prop] = { ...existing, ...deriveEntry(prop, spec, existing) };
+  }
+  return out;
+};
+
+export const autogenArgs: ArgsEnhancer = (context) => {
+  const name = componentNameFor(context.title);
+  if (!AUTOGEN.has(name)) return context.initialArgs;
+  const contract = contracts.get(name);
+  if (!contract?.props) return context.initialArgs;
+
+  const seeds: Record<string, unknown> = {};
+  for (const [prop, spec] of Object.entries(contract.props)) {
+    if (HIDDEN.has(prop) || /^on[A-Z]/.test(prop) || prop === "children") continue;
+    const argType = (context.argTypes as Record<string, AnyArgType>)[prop];
+    if (argType && "mapping" in argType) continue; // preset selects stay unset
+    const seed = seedFor(spec, argType);
+    if (seed !== undefined) seeds[prop] = seed;
+  }
+  return { ...seeds, ...context.initialArgs }; // story args always win
+};

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -21,6 +21,7 @@ import sv from "@dt/../locales/sv/translation.json";
 import { WipBadge } from "@dt/WipBadge";
 import { CookieConsentProvider } from "../nextjs-app/shared/lib/cookieConsent/CookieConsentContext";
 import { resolveDesignParameters } from "./lib/resolve-figma-from-contract";
+import { autogenArgTypes, autogenArgs } from "./lib/controls-autogen";
 import { DtDocsPage } from "./blocks/DtDocsPage";
 import { dtSourceTransform } from "./blocks/sourceTransform";
 
@@ -447,6 +448,10 @@ const detectVisualRegression = () => {
 const isVisualRegression = detectVisualRegression();
 
 const preview: Preview = {
+  // Contract-driven Controls for components registered in
+  // .storybook/controls-autogen.json — see lib/controls-autogen.ts.
+  argTypesEnhancers: [autogenArgTypes],
+  argsEnhancers: [autogenArgs],
   initialGlobals: {
     forcedColors: "none",
     // When the iframe boots under Playwright's `emulateMedia({ forcedColors: "active" })`,

--- a/nextjs-app/shared/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/nextjs-app/shared/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -25,13 +25,9 @@ const meta = {
     a11y: { test: "error" },
     contractStatus: contract.status,
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // only the composite children slot needs an authored mapping preset.
   argTypes: {
-    ariaLabel: { control: "text", description: "Accessible group name" },
-    attached: {
-      control: "boolean",
-      description: "Fuse children into one segmented surface",
-      table: { defaultValue: { summary: "true" } },
-    },
     children: {
       control: {
         type: "select",

--- a/nextjs-app/shared/components/CodeSnippet/CodeSnippet.stories.tsx
+++ b/nextjs-app/shared/components/CodeSnippet/CodeSnippet.stories.tsx
@@ -55,27 +55,11 @@ export function DemoComponent({ title, description }: DemoProps) { const [count,
 }`;
 
 const meta: Meta<typeof CodeSnippet> = {
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // non-contract passthroughs that docgen would otherwise surface stay hidden.
   argTypes: {
-    variant: {
-      control: { type: "select" },
-      options: ["inline", "single", "multi"],
-      description: "Code snippet layout variant",
-      table: { defaultValue: { summary: "inline" } },
-    },
-      "aria-label": { table: { disable: true } },
-      allowCopy: { control: "boolean", description: "Show the copy button; keep on for reusable code.", table: { category: "Content" } },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
       children: { table: { disable: true } },
       className: { table: { disable: true } },
-      code: { control: "text", description: "The code string to highlight.", table: { category: "Content" } },
-      id: { table: { disable: true } },
-      language: { control: "text", description: "Highlighting grammar (typescript, bash, python, ...).", table: { category: "Content" } },
-      maxLines: { control: { type: "number", min: 0 }, description: "Clamp height to this many lines; longer code scrolls. 0 disables the clamp.", table: { category: "Content", defaultValue: { summary: "0" } } },
-      onCopy: { action: "onCopy", table: { disable: true } },
-      ref: { table: { disable: true } },
-      showLineNumbers: { control: "boolean", description: "Render a line-number gutter.", table: { category: "Content" } },
-      style: { table: { disable: true } }
 },
   title: "Content/CodeSnippet",
   component: CodeSnippet,

--- a/nextjs-app/shared/components/CodeSnippet/CodeSnippet.tsx
+++ b/nextjs-app/shared/components/CodeSnippet/CodeSnippet.tsx
@@ -31,13 +31,21 @@ export type SupportedLanguage =
 export type CodeSnippetVariant = "inline" | "single" | "multi";
 
 export interface CodeSnippetProps {
+  /** The code string to highlight. */
   code: string;
+  /** Highlighting grammar. */
   language?: SupportedLanguage;
+  /** Render a line-number gutter. */
   showLineNumbers?: boolean;
+  /** Accessible name for the snippet region. */
   "aria-label"?: string;
+  /** Show the copy button; keep on for reusable code. */
   allowCopy?: boolean;
+  /** Layout variant: inline token, single line, or multi-line window. */
   variant?: CodeSnippetVariant;
+  /** Clamp height to this many lines; longer code scrolls. 0 disables the clamp. */
   maxLines?: number;
+  /** Fires after the code is copied to the clipboard. */
   onCopy?: () => void;
 }
 

--- a/nextjs-app/shared/components/Title/Title.stories.tsx
+++ b/nextjs-app/shared/components/Title/Title.stories.tsx
@@ -101,69 +101,9 @@ export default {
     a11y: { test: "error" },
     llm: { schema },
   },
-  argTypes: {
-    level: {
-      control: { type: "select" },
-      options: [1, 2, 3, 4, 5, 6],
-      description: "Semantic heading level (maps to h1–h6 when as is unset)",
-      table: { defaultValue: { summary: "2" } },
-    },
-
-    size: {
-      control: { type: "select" },
-      options: ["xxs", "xs", "s", "m", "l", "xl", "xxl"],
-      description: "Display size token for the heading",
-      table: { defaultValue: { summary: "l" } },
-    },
-
-    children: {
-      control: "text",
-      description: "Heading text (translation key in stories)",
-    },
-
-    className: {
-      control: "text",
-      description: "Additional CSS class names",
-      table: { category: "Advanced" },
-    },
-
-    terminals: {
-      control: { type: "select" },
-      options: ["serif", "sans"],
-      description: "Type family: serif (display) or sans (UI)",
-      table: { defaultValue: { summary: "serif" } },
-    },
-
-    lineHeight: {
-      control: { type: "select" },
-      options: ["tight", "snug", "normal", "relaxed", "loose"],
-      description: "Line height variant",
-      table: { defaultValue: { summary: "normal" } },
-    },
-
-    as: {
-      control: "text",
-      description: "Override the rendered element (h1–h6)",
-      table: { disable: true },
-    },
-
-    unstyled: {
-      control: "boolean",
-      description:
-        "Render only the heading tag and className (no Title size/terminal tokens)",
-      table: { defaultValue: { summary: "false" } },
-    },
-      asChild: { table: { disable: true } },
-      id: { table: { disable: true } },
-      ref: { table: { disable: true } },
-      style: { table: { disable: true } }
-},
-  // Seeded to the component defaults so the text/boolean controls render
-  // operable widgets instead of Set-buttons.
-  args: {
-    className: "",
-    unstyled: false,
-  },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts,
+  // registered in .storybook/controls-autogen.json). Author argTypes here only
+  // for bespoke knobs or mapping presets — authored entries win over autogen.
 } as Meta<typeof Title>;
 
 export const AllSizes = () => {

--- a/nextjs-app/shared/components/Title/Title.tsx
+++ b/nextjs-app/shared/components/Title/Title.tsx
@@ -8,14 +8,21 @@ type LineHeight = "tight" | "snug" | "normal" | "relaxed" | "loose";
 type HeadingTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 
 export type TitleProps = {
+  /** Heading text. */
   children: React.ReactNode;
+  /** Override the rendered element (h1-h6); wins over level. */
   as?: HeadingTag;
+  /** Additional CSS class names. */
   className?: string;
   /** When true, only sets the heading tag + className (no Title token typography). Use in patterns/pages that already define font/size in CSS or Tailwind. */
   unstyled?: boolean;
+  /** Display size token for the heading. */
   size?: TitleSize;
+  /** Semantic heading level (maps to h1-h6 when as is unset). */
   level?: 1 | 2 | 3 | 4 | 5 | 6;
+  /** Type family: serif (display) or sans (UI). */
   terminals?: TitleTerminals;
+  /** Line height variant. */
   lineHeight?: LineHeight;
 } & React.HTMLAttributes<HTMLHeadingElement>;
 

--- a/scripts/design-system/validate-components.ts
+++ b/scripts/design-system/validate-components.ts
@@ -17,6 +17,18 @@ import { docTierFor } from './doc-tiers.mjs'
 
 type VariantMap = Record<string, { values: string[]; default: string | null }>
 
+// Components whose Controls panel is derived at runtime by the preview-level
+// enhancers (.storybook/lib/controls-autogen.ts). The static argTypes gate
+// does not apply to them; audit:controls (+ --effects) enforces the surface.
+const CONTROLS_AUTOGEN: Set<string> = (() => {
+    try {
+        const p = resolve(dirname(fileURLToPath(import.meta.url)), '../../.storybook/controls-autogen.json')
+        return new Set(JSON.parse(readFileSync(p, 'utf8')).components as string[])
+    } catch {
+        return new Set()
+    }
+})()
+
 function normalizeVariantToken(value: string | null | undefined): string | null {
     if (value == null) return null
     return String(value).replace(/^["']+|["']+$/g, '')
@@ -1074,7 +1086,14 @@ export function validateComponentsDir(root: string): ValidationResult {
             // 3. Each control needs `description`; variant axes need table.defaultValue.summary.
             //
             // Alpha components may ship before the Controls/docs surface is complete.
-            if (manifest.status === 'beta' || manifest.status === 'stable') {
+            //
+            // Components registered in .storybook/controls-autogen.json derive
+            // argTypes at runtime from the contract + docgen
+            // (.storybook/lib/controls-autogen.ts) — there is no static
+            // meta.argTypes block to parse. Their Controls surface is enforced
+            // by the STRONGER runtime instruments instead: audit:controls
+            // (presence, farm --min ratchet) and --effects (0 inert props).
+            if ((manifest.status === 'beta' || manifest.status === 'stable') && !CONTROLS_AUTOGEN.has(name)) {
                 const declaredVariants = Object.keys(manifest.variants ?? {})
                 const metaObj = extractMetaObject(storiesSf)
                 const argTypesObj = metaObj ? extractArgTypesObject(metaObj) : null


### PR DESCRIPTION
## Summary

Spike proving the scale route for the controls-operability sweep: derive argTypes instead of authoring them. A preview-level enhancer implements the AGENTS.md treatment table at runtime from two machine-checked sources: the contract (public prop set, union values — `check:contract-props` guarantees truthfulness) and docgen (JSDoc descriptions, extracted destructured defaults). An args enhancer seeds no-op defaults so text/boolean/number controls render operable widgets instead of Set-buttons.

Story files keep only genuine judgment — mapping presets and bespoke knobs — and authored entries always win over autogen.

## Mechanism

- `.storybook/lib/controls-autogen.ts`: `argTypesEnhancers` + `argsEnhancers`, scoped to an explicit registry (`.storybook/controls-autogen.json`). Batches append to the registry after their audits pass.
- `validate:components` skips its static argTypes gate for registered components; their Controls surface is enforced by the stronger runtime instruments: `audit:controls` (presence, farm `--min` ratchet) and `--effects` (0 inert).
- Prop descriptions live in JSDoc on the Props interface — one source feeding docgen, the IDE, and the agent manifest (per Storybook's AI best-practices guidance). Ported for Title and CodeSnippet; ButtonGroup already had them.

## Proof (hand-written argTypes deleted on 3 representative components)

| Component | What it exercises | Story-side code left |
|---|---|---|
| Title | unions, literal-union `level`, strings, boolean | none |
| ButtonGroup | composite `children` | 8-line mapping preset only |
| CodeSnippet | handler, number clamp, hidden passthroughs | 2 hidden non-contract rows |

Free upgrade found: `CodeSnippet.language` was a hand-written free-text control, but the contract knows it is a 10-value union — autogen renders a grammar select.

## Verification

- `audit:controls` 100% presence and `--effects` 0 inert on all three.
- Docs table quality preserved: descriptions from JSDoc, defaults from docgen (`"l"`, `"serif"`, `false`), category grouping intact.
- AT compare unchanged in both modes (only the known pre-existing Link/Footer staleness fails).
- Static Storybook build exit 0 (the #812 lesson); validate:components, contract gates, typecheck, lint, vitest 1893/1893, build all green.
- Gotcha encoded in the module: CSF control shorthands normalize BEFORE enhancers run — enhancer output must use `{ type }` object form or the widget silently does not render.

## What this changes for batches 2+

Per component: fix empty-string handling if needed, add JSDoc where missing, author mapping presets for composite slots, append to the registry, delete the argTypes block, run presence + effects + AT compare. Story surgery becomes data entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Storybook controls are now generated automatically for selected components, with default args and control types derived at runtime.
  * Updated component stories to use the new auto-generated controls for a cleaner, more consistent Storybook experience.

* **Documentation**
  * Added and expanded component prop descriptions to improve Storybook and code reference clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->