### PR TITLE
feat(design-system): controls autogen batch 2 — Forms at 100% presence, 0 inert

### DIFF
--- a/.storybook/controls-autogen.json
+++ b/.storybook/controls-autogen.json
@@ -1,4 +1,24 @@
 {
   "$comment": "Components whose Controls panel is DERIVED at runtime from the contract + docgen by .storybook/lib/controls-autogen.ts instead of hand-written meta.argTypes. validate:components skips its static argTypes gate for these; the enforcing instruments are audit:controls (presence, --min on the farm) and audit:controls --effects (0 inert). Append per remediation batch AFTER audits pass.",
-  "components": ["Title", "ButtonGroup", "CodeSnippet"]
+  "components": [
+    "Title",
+    "ButtonGroup",
+    "CodeSnippet",
+    "Checkbox",
+    "CheckboxGroup",
+    "Combobox",
+    "FileUpload",
+    "FormField",
+    "GroupLabel",
+    "HelperText",
+    "Label",
+    "MultiCombobox",
+    "PhoneInput",
+    "Radio",
+    "RadioGroup",
+    "Select",
+    "Switch",
+    "TextArea",
+    "TextInput"
+  ]
 }

--- a/nextjs-app/shared/components/Checkbox/Checkbox.stories.tsx
+++ b/nextjs-app/shared/components/Checkbox/Checkbox.stories.tsx
@@ -1,6 +1,7 @@
 import contract from "./Checkbox.contract.json";
 import React from "react";
 import { Meta, StoryFn } from "@storybook/react-vite";
+import { useArgs } from "storybook/preview-api";
 import { userEvent, within } from "storybook/test";
 import { useTranslation } from "react-i18next";
 import Icon from "@dt/Icon";
@@ -87,103 +88,7 @@ export default {
     a11y: { test: "error" },
     llm: { schema },
   },
-  argTypes: {
-    // Content
-
-    label: {
-      control: "text",
-      description: "Label text displayed next to the checkbox",
-      table: { category: "Content", type: { summary: "string" } },
-    },
-
-    error: {
-      control: "text",
-      description: "Error message under the control; wires aria-invalid + role=alert.",
-      table: { category: "State", type: { summary: "string" } },
-    },
-    helperText: {
-      control: "text",
-      description: "Supporting text under the control; suppressed while error is set.",
-      table: { category: "Content", type: { summary: "string" } },
-    },
-    showLabel: {
-      control: "boolean",
-      description: "Whether to show the label text",
-      table: {
-        category: "Content",
-        type: { summary: "boolean" },
-        defaultValue: { summary: "true" },
-      },
-    },
-
-    // State (v1.1.0)
-
-    checked: {
-      control: "boolean",
-      description: "Checked state (controlled) (v1.1.0+)",
-      table: { category: "State", type: { summary: "boolean" } },
-    },
-
-    indeterminate: {
-      control: "boolean",
-      description: "Indeterminate state (v1.1.0+)",
-      table: { category: "State", type: { summary: "boolean" } },
-    },
-
-    disabled: {
-      control: "boolean",
-      description: "Disables the checkbox (v1.1.0+)",
-      table: { category: "State", type: { summary: "boolean" } },
-    },
-
-    defaultChecked: {
-      control: "boolean",
-      description: "Initial checked state for uncontrolled component (v1.1.0+)",
-      table: { category: "State", type: { summary: "boolean" } },
-    },
-
-    // Appearance
-
-    size: {
-      control: { type: "select" },
-      options: ["sm", "md", "lg"],
-      description: "Size variant (v1.1.0+)",
-      table: {
-        category: "Appearance",
-        type: { summary: "sm | md | lg" },
-        defaultValue: { summary: "md" },
-      },
-    },
-
-    // Behavior
-    onCheckedChange: {
-      action: "checkedChanged",
-      description: "Checked change handler (v1.1.0+)",
-      table: {
-        category: "Behavior",
-        type: { summary: "(checked: boolean) => void" },
-      },
-    },
-
-    // Accessibility
-
-    id: {
-      control: "text",
-      description: "Custom ID for the checkbox element",
-      table: { category: "Accessibility", type: { summary: "string" } },
-    },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
-      children: { table: { disable: true } },
-      className: { table: { disable: true } },
-      isChecked: { table: { disable: true } },
-      isDisabled: { table: { disable: true } },
-      isIndeterminate: { table: { disable: true } },
-      name: { table: { disable: true } },
-      ref: { table: { disable: true } },
-      style: { table: { disable: true } },
-      value: { table: { disable: true } }
-},
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts).
 } as Meta<CheckboxProps>;
 
 const StoryLabel = ({ tKey }: { tKey: string }) => {
@@ -388,7 +293,29 @@ export const Z_CheckboxCompliance: StoryFn = () => (
   />
 );
 Z_CheckboxCompliance.parameters = { docs: { disable: true } };
-export const Playground = Default;
+// Playground keeps the canvas interactive while `checked` is seeded (controlled):
+// toggling in the canvas writes the arg back so panel and canvas stay in sync.
+const PlaygroundRender: StoryFn<CheckboxProps> = (args) => {
+  const [, updateArgs] = useArgs();
+  const label =
+    typeof args.label === "string" ? (
+      <StoryLabel tKey={args.label} />
+    ) : (
+      args.label
+    );
+  return (
+    <Checkbox
+      {...args}
+      label={label as any}
+      onCheckedChange={(next) => {
+        args.onCheckedChange?.(next);
+        updateArgs({ checked: next });
+      }}
+    />
+  );
+};
+export const Playground = PlaygroundRender.bind({});
+Playground.args = { id: "newsletter", label: "storyCheckboxLabel" };
 
 export const Example: Story = {
   globals: { forcedColors: "none" },

--- a/nextjs-app/shared/components/Checkbox/Checkbox.tsx
+++ b/nextjs-app/shared/components/Checkbox/Checkbox.tsx
@@ -8,7 +8,9 @@ export interface CheckboxProps
     React.InputHTMLAttributes<HTMLInputElement>,
     "onChange" | "checked" | "size"
   > {
+  /** Label text displayed next to the checkbox */
   label?: string;
+  /** Whether to show the label text. @default true */
   showLabel?: boolean;
   /** Checked state (controlled). */
   checked?: boolean;
@@ -22,6 +24,7 @@ export interface CheckboxProps
   size?: "sm" | "md" | "lg";
   /** Called with the next checked value when toggled. */
   onCheckedChange?: (checked: boolean) => void;
+  /** Custom ID for the checkbox element; auto-generated when omitted */
   id?: string;
   /** Error message under the control; sets aria-invalid and aria-describedby. */
   error?: string;

--- a/nextjs-app/shared/components/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/nextjs-app/shared/components/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -86,31 +86,47 @@ export default {
     a11y: { test: "error" },
     llm: { schema },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // the composite options and defaultSelected slots keep authored mapping presets.
   argTypes: {
-    label: { control: "text", description: "Legend text for the group" },
-
     options: {
-      control: "object",
-      description: "Checkbox options (label, value)",
+      control: { type: "select" },
+      options: ["five", "four", "two"],
+      mapping: {
+        five: [
+          { label: "storyCheckboxOption1", value: "option1" },
+          { label: "storyCheckboxOption2", value: "option2" },
+          { label: "storyCheckboxOption3", value: "option3" },
+          { label: "storyCheckboxOption4", value: "option4" },
+          { label: "storyCheckboxOption5", value: "option5" },
+        ],
+        four: [
+          { label: "storyCheckboxOption1", value: "option1" },
+          { label: "storyCheckboxOption2", value: "option2" },
+          { label: "storyCheckboxOption3", value: "option3" },
+          { label: "storyCheckboxOption4", value: "option4" },
+        ],
+        two: [
+          { label: "storyCheckboxOption1", value: "option1" },
+          { label: "storyCheckboxOption2", value: "option2" },
+        ],
+      },
+      description:
+        "Checkbox options (label, value). Pick a preset here; compose your own in code.",
+      table: { category: "Content" },
     },
-
-    id: { control: "text", description: "Base id for checkbox inputs" },
-
-    showMasterCheckbox: {
-      control: "boolean",
-      description: "Shows select-all master checkbox",
-      table: { defaultValue: { summary: "true" } },
+    defaultSelected: {
+      control: { type: "select" },
+      options: ["none", "firstTwo", "first"],
+      mapping: {
+        none: [],
+        firstTwo: ["option1", "option2"],
+        first: ["option1"],
+      },
+      description: "Initially selected option values (uncontrolled).",
+      table: { category: "Content" },
     },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
-      children: { table: { disable: true } },
-      className: { control: "text", description: "Additional CSS classes on the group.", table: { category: "Advanced" } },
-      defaultSelected: { control: "object", description: "Initially selected option values (uncontrolled).", table: { category: "Content" } },
-      masterLabel: { control: "text", description: "Label for the select-all master checkbox.", table: { category: "Accessibility" } },
-      onChange: { action: "onChange", table: { disable: true } },
-      ref: { table: { disable: true } },
-      style: { table: { disable: true } }
-},
+  },
 } as Meta<CheckboxGroupProps>;
 
 const CheckboxGroupStory: React.FC<CheckboxGroupProps> = (args) => {
@@ -257,6 +273,16 @@ WithIndeterminateState.parameters = {
 export const Playground: Story = {
   parameters: { a11y: { disable: true, test: "off" } },
   tags: ["beta-matrix"],
+  // options/defaultSelected args are mapping keys resolved by the presets above.
+  args: {
+    id: "interests",
+    label: "storyCheckboxGroupLabel",
+    masterLabel: "storyCheckboxGroupMasterLabel",
+    showMasterCheckbox: true,
+    options: "five" as unknown as CheckboxGroupProps["options"],
+    defaultSelected: "firstTwo" as unknown as CheckboxGroupProps["defaultSelected"],
+  },
+  render: (args) => <CheckboxGroupStory {...args} />,
 };
 
 export const Example: Story = {

--- a/nextjs-app/shared/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/nextjs-app/shared/components/CheckboxGroup/CheckboxGroup.tsx
@@ -5,13 +5,19 @@ import GroupLabel from "@dt/GroupLabel/GroupLabel";
 import styles from "./CheckboxGroup.module.css";
 
 export interface CheckboxGroupProps {
+  /** Base id for the checkbox inputs */
   id?: string;
+  /** Legend text for the group */
   label: string;
+  /** Additional CSS classes on the group */
   className?: string;
+  /** Checkbox options (label, value) */
   options: { label: string; value: string }[];
+  /** Shows the select-all master checkbox. @default true */
   showMasterCheckbox?: boolean;
+  /** Label for the select-all master checkbox */
   masterLabel?: string;
-  // initial selected option values
+  /** Initially selected option values (uncontrolled) */
   defaultSelected?: string[];
   // eslint-disable-next-line no-unused-vars
   onChange?: (selectedOptions: string[]) => void;

--- a/nextjs-app/shared/components/Combobox/Combobox.stories.tsx
+++ b/nextjs-app/shared/components/Combobox/Combobox.stories.tsx
@@ -1,5 +1,6 @@
 import contract from "./Combobox.contract.json";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useArgs } from "storybook/preview-api";
 import React, { useState } from "react";
 import { expect, screen, userEvent, waitFor, within } from "storybook/test";
 import Combobox, { type ComboboxOption } from "./Combobox";
@@ -34,61 +35,32 @@ const meta = {
     a11y: { test: "error" },
     layout: "padded",
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // options keeps a mapping preset and value a select of valid option values
+  // (a free-text value would match no option and read as a no-op).
   argTypes: {
-    label: {
-      control: "text",
-      description: "Field label (associates the trigger)",
-      table: { category: "Content" },
-    },
     options: {
-      control: "object",
-      description: "Selectable options",
+      control: { type: "select" },
+      options: ["timeline", "twoOptions", "withDisabled"],
+      mapping: {
+        timeline: OPTIONS,
+        twoOptions: OPTIONS.slice(0, 2),
+        withDisabled: [
+          ...OPTIONS.slice(0, 2),
+          { value: "later", label: "Later this year", disabled: true },
+        ],
+      },
+      description:
+        "Selectable options. Pick a preset here; compose your own in code.",
       table: { category: "Content" },
     },
     value: {
-      control: "text",
-      description: "Selected option value (controlled)",
+      control: { type: "select" },
+      options: ["", ...OPTIONS.map((o) => o.value)],
+      description: "Selected option value (controlled); \"\" shows the placeholder",
       table: { category: "State" },
     },
-    onValueChange: {
-      description: "Called with the chosen value",
-      table: {
-        category: "Events",
-        type: { summary: "(value: string) => void" },
-      },
-    },
-    placeholder: {
-      control: "text",
-      description: "Shown when no value is selected",
-      table: { category: "Content" },
-    },
-    helperText: {
-      control: "text",
-      description: "Assistive text below the field",
-      table: { category: "Content" },
-    },
-    error: {
-      control: "text",
-      description: "Error message; sets aria-invalid",
-      table: { category: "Validation" },
-    },
-    required: {
-      control: "boolean",
-      description: "Marks the field required",
-      table: { category: "Validation" },
-    },
-    disabled: {
-      control: "boolean",
-      description: "Disables the control",
-      table: { category: "State" },
-    },
-    className: {
-      control: false,
-      description: "Classes on the field wrapper",
-      table: { category: "Advanced" },
-    },
-      id: { control: "text", description: "Explicit control id (wires the label); auto-generated when omitted.", table: { category: "Advanced" } }
-},
+  },
 } satisfies Meta<typeof Combobox>;
 
 export default meta;
@@ -99,14 +71,28 @@ export const Default: Story = {
   render: () => <ComboboxDemo />,
 };
 
+// Playground keeps the canvas interactive while `value` is seeded (controlled):
+// choosing in the canvas writes the arg back so panel and canvas stay in sync.
 export const Playground: Story = {
   tags: ["beta-matrix"],
   args: {
     label: "Timeline",
-    options: OPTIONS,
+    options: "timeline" as unknown as ComboboxOption[],
     value: "",
     placeholder: "Select…",
     onValueChange: () => {},
+  },
+  render: function PlaygroundStory(args) {
+    const [, updateArgs] = useArgs();
+    return (
+      <Combobox
+        {...args}
+        onValueChange={(next) => {
+          args.onValueChange?.(next);
+          updateArgs({ value: next });
+        }}
+      />
+    );
   },
 };
 

--- a/nextjs-app/shared/components/Combobox/Combobox.tsx
+++ b/nextjs-app/shared/components/Combobox/Combobox.tsx
@@ -23,16 +23,27 @@ export interface ComboboxOption {
 }
 
 export interface ComboboxProps {
+  /** Field label; associates the trigger */
   label: string;
+  /** Selectable options */
   options: ComboboxOption[];
+  /** Selected option value (controlled); "" shows the placeholder */
   value: string;
+  /** Called with the chosen value */
   onValueChange: (value: string) => void;
+  /** Explicit control id (wires the label); auto-generated when omitted */
   id?: string;
+  /** Shown when no value is selected */
   placeholder?: string;
+  /** Assistive text below the field */
   helperText?: string;
+  /** Error message; replaces the helper line and sets aria-invalid */
   error?: string;
+  /** Marks the field required. @default false */
   required?: boolean;
+  /** Disables the control. @default false */
   disabled?: boolean;
+  /** Classes on the field wrapper */
   className?: string;
 }
 

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--default.forced-colors.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": Select…
+- button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--default.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--default.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": Select…
+- button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--example.forced-colors.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": 1–2 months
+- button "Toggle options"
+- paragraph: When should the project start?

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--example.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--example.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": 1–2 months
+- button "Toggle options"
+- paragraph: When should the project start?

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--forced-colors.forced-colors.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": ASAP
+- button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--forced-colors.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--forced-colors.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": ASAP
+- button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--keyboard-selection.forced-colors.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--keyboard-selection.forced-colors.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": 1–2 months
+- button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--keyboard-selection.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--keyboard-selection.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": 1–2 months
+- button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--playground.forced-colors.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": Select…
+- button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--playground.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--playground.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Timeline
+- combobox "Timeline": Select…
+- button "Toggle options"

--- a/nextjs-app/shared/components/FileUpload/FileUpload.stories.tsx
+++ b/nextjs-app/shared/components/FileUpload/FileUpload.stories.tsx
@@ -18,75 +18,46 @@ export default {
     a11y: { test: "error" },
     llm: { schema },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // the File-typed value slot keeps an authored mapping preset.
   argTypes: {
-    label: { control: "text", description: "Field label" },
-
-    placeholder: {
-      control: "text",
-      description: "Placeholder when no file selected",
-    },
-
-    helperText: {
-      control: "text",
-      description: "Helper copy below the control",
-    },
-
-    uploadButtonLabel: { control: "text", description: "Upload button label" },
-
-    clearButtonLabel: {
-      control: "text",
-      description: "Clear/remove button label",
-    },
-
-    accept: { control: "text", description: "Accepted file extensions/MIME" },
-
-    maxSizeInBytes: {
-      control: "number",
-      description: "Maximum file size in bytes",
-    },
-
-    sizeErrorMessage: {
-      control: "text",
-      description: "Error when file exceeds max size",
-    },
-
-    error: { control: "text", description: "External error message" },
-
-    disabled: { control: "boolean", description: "Disables the control" },
-
-    required: { control: "boolean", description: "Marks field as required" },
-
-    appearance: {
-      control: "select",
-      options: ["default", "editorial"],
-      description:
-        "Visual variant — editorial matches FormFieldEditorial / Combobox",
-    },
     value: {
-      table: { disable: true },
-      description: "Controlled File value (managed in stories)",
+      control: { type: "select" },
+      options: ["none", "samplePdf", "largePng"],
+      mapping: {
+        none: null,
+        samplePdf: new File([new Uint8Array(48 * 1024)], "project-brief.pdf", {
+          type: "application/pdf",
+        }),
+        largePng: new File([new Uint8Array(160 * 1024)], "moodboard.png", {
+          type: "image/png",
+        }),
+      },
+      description:
+        "Controlled File value. Pick a preset here; real picks use the button.",
+      table: { category: "Content" },
     },
-    onFileChange: {
-      action: "file change",
-      description: "Called when a file is selected or cleared",
-    },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
-      children: { table: { disable: true } },
-      className: { control: "text", description: "Additional CSS classes on the field.", table: { category: "Advanced" } },
-      id: { table: { disable: true } },
-      ref: { table: { disable: true } },
-      style: { table: { disable: true } }
-},
+  },
 } as Meta<typeof FileUpload>;
 
 const Template: StoryFn<typeof FileUpload> = (
   args: React.ComponentProps<typeof FileUpload>,
 ) => {
-  const [file, setFile] = useState<File | null>(null);
+  const [file, setFile] = useState<File | null>(args.value ?? null);
+  // Panel edits to the value arg drive the canvas; button picks still work.
+  React.useEffect(() => {
+    setFile(args.value ?? null);
+  }, [args.value]);
   return (
     <div style={{ maxWidth: "28rem" }}>
-      <FileUpload {...args} value={file} onFileChange={setFile} />
+      <FileUpload
+        {...args}
+        value={file}
+        onFileChange={(next) => {
+          args.onFileChange?.(next);
+          setFile(next);
+        }}
+      />
     </div>
   );
 };
@@ -212,7 +183,11 @@ export const Playground: Story = {
   parameters: { a11y: { disable: true, test: "off" } },
   tags: ["beta-matrix"],
   render: Template,
-  args: Default.args,
+  // value arg is a mapping key; a preset file keeps the clear button visible.
+  args: {
+    ...Default.args,
+    value: "samplePdf" as unknown as File,
+  },
 };
 
 export const Example: Story = {

--- a/nextjs-app/shared/components/FileUpload/FileUpload.tsx
+++ b/nextjs-app/shared/components/FileUpload/FileUpload.tsx
@@ -8,18 +8,31 @@ import Button from "@dt/Button";
 import HelperText from "@dt/HelperText";
 
 export interface FileUploadProps {
+  /** Field label */
   label: string;
+  /** Placeholder shown when no file is selected */
   placeholder?: string;
+  /** Helper copy below the control */
   helperText?: string;
+  /** Upload button label */
   uploadButtonLabel: string;
+  /** Clear/remove button label; the button shows only while a file is set */
   clearButtonLabel?: string;
+  /** Accepted file extensions/MIME types for the native picker */
   accept?: string;
+  /** Maximum file size in bytes; checked when a file is picked */
   maxSizeInBytes?: number;
+  /** Error shown when a picked file exceeds maxSizeInBytes */
   sizeErrorMessage?: string;
+  /** External error message; replaces the helper line */
   error?: string;
+  /** Controlled File value */
   value?: File | null;
+  /** Called when a file is selected or cleared */
   onFileChange?: (file: File | null) => void;
+  /** Disables the control. @default false */
   disabled?: boolean;
+  /** Marks the field required. @default false */
   required?: boolean;
   /** Match FormFieldEditorial / Combobox styling on editorial forms. */
   appearance?: "default" | "editorial";

--- a/nextjs-app/shared/components/FormField/FormField.stories.tsx
+++ b/nextjs-app/shared/components/FormField/FormField.stories.tsx
@@ -6,6 +6,28 @@ import Radio from "@dt/Radio";
 import TextInput from "@dt/TextInput";
 import contract from "./FormField.contract.json";
 
+const channels = (
+  <>
+    <Checkbox label="Email" defaultChecked />
+    <Checkbox label="SMS" />
+    <Checkbox label="Push" />
+  </>
+);
+
+const radioSet = (
+  <>
+    <Radio name="pref" value="email" label="Email" defaultChecked />
+    <Radio name="pref" value="phone" label="Phone" />
+  </>
+);
+
+const textPair = (
+  <div style={{ display: "flex", gap: "1rem", alignItems: "flex-end" }}>
+    <TextInput label="Opens" type="text" placeholder="09:00" />
+    <TextInput label="Closes" type="text" placeholder="17:00" />
+  </div>
+);
+
 const meta = {
   title: "Forms/FormField",
   component: FormField,
@@ -19,64 +41,31 @@ const meta = {
     contractStatus: contract.status,
     a11y: { test: "error" },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // only the composite children slot needs an authored mapping preset.
   argTypes: {
-    legend: {
-      control: "text",
-      description: "Accessible name for the group; rendered as the fieldset legend.",
-      table: { category: "Content", type: { summary: "string" } },
-    },
     children: {
-      control: false,
-      description: "The grouped controls; each keeps its own label.",
+      control: { type: "select" },
+      options: ["checkboxCluster", "radioSet", "textPair"],
+      mapping: { checkboxCluster: channels, radioSet, textPair },
+      description:
+        "The grouped controls; each keeps its own label. Pick a preset here; compose your own in code.",
       table: { category: "Content", type: { summary: "ReactNode" } },
-    },
-    groupDescription: {
-      control: "text",
-      description: "Helper text for the whole set, shown under the legend.",
-      table: { category: "Content", type: { summary: "string" } },
-    },
-    error: {
-      control: "text",
-      description: "Group-level error shown after the controls with role=alert.",
-      table: { category: "State", type: { summary: "string" } },
-    },
-    required: {
-      control: "boolean",
-      description: "Appends a visual asterisk to the legend.",
-      table: { category: "State", type: { summary: "boolean" } },
-    },
-    disabled: {
-      control: "boolean",
-      description: "Disables every contained control via the fieldset.",
-      table: { category: "State", type: { summary: "boolean" } },
-    },
-    className: {
-      control: "text",
-      description: "Merged onto the fieldset.",
-      table: { category: "Advanced", type: { summary: "string" } },
     },
   },
   args: {
     legend: "Notification channels",
     groupDescription: "Pick at least one",
+    children: "checkboxCluster",
   },
 } satisfies Meta<typeof FormField>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const channels = (
-  <>
-    <Checkbox label="Email" defaultChecked />
-    <Checkbox label="SMS" />
-    <Checkbox label="Push" />
-  </>
-);
-
 export const Default: Story = {
   tags: ["beta-matrix"],
   globals: { forcedColors: "none" },
-  render: (args) => <FormField {...args}>{channels}</FormField>,
 };
 
 export const CheckboxCluster: Story = {
@@ -159,7 +148,6 @@ export const CustomRadioSet: Story = {
 export const Playground: Story = {
   parameters: { a11y: { disable: true, test: "off" } },
   tags: ["beta-matrix"],
-  render: (args) => <FormField {...args}>{channels}</FormField>,
 };
 
 export const Example: Story = {
@@ -176,5 +164,4 @@ export const Example: Story = {
 export const ForcedColors: Story = {
   tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
-  render: (args) => <FormField {...args}>{channels}</FormField>,
 };

--- a/nextjs-app/shared/components/FormField/FormField.tsx
+++ b/nextjs-app/shared/components/FormField/FormField.tsx
@@ -10,13 +10,17 @@ export interface FormFieldProps {
    * `<legend>`.
    */
   legend: string;
+  /** The grouped controls; each keeps its own label. */
   children: ReactNode;
   /** Helper text shown under the legend. */
   groupDescription?: string;
   /** Group-level error message shown after the controls. */
   error?: string;
+  /** Appends a visual asterisk to the legend. */
   required?: boolean;
+  /** Disables every contained control via the fieldset. */
   disabled?: boolean;
+  /** Merged onto the fieldset. */
   className?: string;
 }
 

--- a/nextjs-app/shared/components/GroupLabel/GroupLabel.stories.tsx
+++ b/nextjs-app/shared/components/GroupLabel/GroupLabel.stories.tsx
@@ -23,36 +23,13 @@ const meta = {
     a11y: { test: "error" },
     docs: { description: { component: contract.description } },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // children is not on the contract (native passthrough) so it keeps a text knob.
   argTypes: {
-    htmlFor: {
-      control: "text",
-      description: "ID of the grouped control for label association",
-    },
     children: {
-      control: "text",
+      control: { type: "text" },
       description: "Group legend text",
-    },
-    tooltipText: {
-      control: "text",
-      description: "Optional browser tooltip",
-    },
-    required: {
-      control: "boolean",
-      description: "Shows required asterisk",
-    },
-    disabled: {
-      control: "boolean",
-      description: "Muted disabled styling",
-    },
-    title: {
-      control: "text",
-      description: "Native title attribute override",
-      table: { disable: true },
-    },
-    className: {
-      control: "text",
-      description: "Additional CSS class names",
-      table: { disable: true },
+      table: { category: "Content" },
     },
   },
   args: defaultArgs,

--- a/nextjs-app/shared/components/GroupLabel/GroupLabel.tsx
+++ b/nextjs-app/shared/components/GroupLabel/GroupLabel.tsx
@@ -2,11 +2,16 @@ import React from "react";
 import styles from "./GroupLabel.module.css";
 
 export interface GroupLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  /** ID of the grouped control for label association */
   htmlFor: string;
+  /** Optional browser tooltip; fallback when title is not set */
   tooltipText?: string;
+  /** Shows the required asterisk. @default false */
   required?: boolean;
+  /** Muted disabled styling. @default false */
   disabled?: boolean;
-  title?: string; // Add title for browser tooltips
+  /** Native title attribute override */
+  title?: string;
 }
 
 /**

--- a/nextjs-app/shared/components/HelperText/HelperText.stories.tsx
+++ b/nextjs-app/shared/components/HelperText/HelperText.stories.tsx
@@ -18,26 +18,7 @@ const meta: Meta<typeof HelperText> = {
     a11y: { test: "error" },
     llm: { schema },
   },
-  argTypes: {
-    state: {
-      control: "select",
-      options: ["error", "warning", "success", "info", undefined],
-      description: "Semantic state of the helper text",
-    },
-
-    children: { control: "text", description: "The helper text content" },
-
-    id: {
-      control: "text",
-      description: "Optional ID for aria-describedby association",
-    },
-
-    className: { control: "text", description: "Additional CSS class name" },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
-      ref: { table: { disable: true } },
-      style: { table: { disable: true } }
-},
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts).
 };
 
 export default meta;

--- a/nextjs-app/shared/components/Label/Label.stories.tsx
+++ b/nextjs-app/shared/components/Label/Label.stories.tsx
@@ -86,40 +86,15 @@ export default {
     a11y: { test: "error" },
     llm: { schema },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // children is not on the contract (native passthrough) so it keeps a text knob.
   argTypes: {
-    htmlFor: {
-      control: "text",
-      description: "ID of the associated form control (for/id pairing)",
-    },
-
     children: {
-      control: "text",
+      control: { type: "text" },
       description: "Visible label text (translation key in stories)",
+      table: { category: "Content" },
     },
-
-    tooltipText: {
-      control: "text",
-      description: "Optional tooltip content beside the label",
-    },
-
-    required: {
-      control: "boolean",
-      description: "Shows the required indicator when true",
-      table: { defaultValue: { summary: "false" } },
-    },
-
-    disabled: {
-      control: "boolean",
-      description: "Muted style when the labeled control is disabled",
-      table: { defaultValue: { summary: "false" } },
-    },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
-      className: { table: { disable: true } },
-      id: { table: { disable: true } },
-      ref: { table: { disable: true } },
-      style: { table: { disable: true } }
-},
+  },
 } as Meta;
 
 type Story = StoryObj<typeof Label>;
@@ -144,11 +119,13 @@ export const Z_LabelCompliance: StoryFn = () => (
 );
 
 export const Default = Template.bind({});
-export const Playground = Template.bind({});
-Playground.args = Default.args;
-
 Default.args = { htmlFor: "field", children: "storyLabelDefault" };
 Default.parameters = {};
+
+// NOTE: assigned after Default.args — the previous ordering copied `undefined`
+// and left the Playground with no seeded args (every control rendered dead).
+export const Playground = Template.bind({});
+Playground.args = Default.args;
 
 export const WithTooltip = Template.bind({});
 WithTooltip.args = {

--- a/nextjs-app/shared/components/MultiCombobox/MultiCombobox.stories.tsx
+++ b/nextjs-app/shared/components/MultiCombobox/MultiCombobox.stories.tsx
@@ -1,5 +1,6 @@
 import contract from "./MultiCombobox.contract.json";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useArgs } from "storybook/preview-api";
 import React, { useState } from "react";
 import { expect, screen, userEvent, waitFor, within } from "storybook/test";
 import { MultiCombobox, type MultiComboboxOption } from "./MultiCombobox";
@@ -37,61 +38,36 @@ const meta = {
     a11y: { test: "error" },
     layout: "padded",
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // the composite options and value slots keep authored mapping presets.
   argTypes: {
-    label: {
-      control: "text",
-      description: "Field label (associates the input)",
-      table: { category: "Content" },
-    },
     options: {
-      control: "object",
-      description: "Selectable options",
+      control: { type: "select" },
+      options: ["disciplines", "twoOptions", "withDisabled"],
+      mapping: {
+        disciplines: OPTIONS,
+        twoOptions: OPTIONS.slice(0, 2),
+        withDisabled: [
+          ...OPTIONS.slice(0, 2),
+          { value: "ops", label: "DesignOps", disabled: true },
+        ],
+      },
+      description:
+        "Selectable options. Pick a preset here; compose your own in code.",
       table: { category: "Content" },
     },
     value: {
-      control: "object",
+      control: { type: "select" },
+      options: ["none", "one", "two"],
+      mapping: {
+        none: [],
+        one: ["research"],
+        two: ["research", "design"],
+      },
       description: "Selected values (controlled string[])",
       table: { category: "State" },
     },
-    onValueChange: {
-      description: "Called with the next selected values",
-      table: {
-        category: "Events",
-        type: { summary: "(value: string[]) => void" },
-      },
-    },
-    placeholder: {
-      control: "text",
-      description: "Shown when nothing is selected",
-      table: { category: "Content" },
-    },
-    helperText: {
-      control: "text",
-      description: "Assistive text below the field",
-      table: { category: "Content" },
-    },
-    error: {
-      control: "text",
-      description: "Error message; sets aria-invalid",
-      table: { category: "Validation" },
-    },
-    required: {
-      control: "boolean",
-      description: "Marks the field required",
-      table: { category: "Validation" },
-    },
-    disabled: {
-      control: "boolean",
-      description: "Disables the control",
-      table: { category: "State" },
-    },
-    className: {
-      control: false,
-      description: "Classes on the field wrapper",
-      table: { category: "Advanced" },
-    },
-      id: { control: "text", description: "Explicit control id (wires the label); auto-generated when omitted.", table: { category: "Advanced" } }
-},
+  },
 } satisfies Meta<typeof MultiCombobox>;
 
 export default meta;
@@ -102,14 +78,28 @@ export const Default: Story = {
   render: () => <MultiComboboxDemo />,
 };
 
+// Playground keeps the canvas interactive while `value` is seeded (controlled):
+// picking in the canvas writes the arg back so panel and canvas stay in sync.
 export const Playground: Story = {
   tags: ["beta-matrix"],
   args: {
     label: "Disciplines",
-    options: OPTIONS,
-    value: [],
+    options: "disciplines" as unknown as MultiComboboxOption[],
+    value: "none" as unknown as string[],
     placeholder: "Add disciplines…",
     onValueChange: () => {},
+  },
+  render: function PlaygroundStory(args) {
+    const [, updateArgs] = useArgs();
+    return (
+      <MultiCombobox
+        {...args}
+        onValueChange={(next) => {
+          args.onValueChange?.(next);
+          updateArgs({ value: next });
+        }}
+      />
+    );
   },
 };
 

--- a/nextjs-app/shared/components/MultiCombobox/MultiCombobox.tsx
+++ b/nextjs-app/shared/components/MultiCombobox/MultiCombobox.tsx
@@ -24,16 +24,27 @@ export interface MultiComboboxOption {
 }
 
 export interface MultiComboboxProps {
+  /** Field label; associates the input */
   label: string;
+  /** Selectable options */
   options: MultiComboboxOption[];
+  /** Selected values (controlled) */
   value: string[];
+  /** Called with the next selected values */
   onValueChange: (value: string[]) => void;
+  /** Explicit control id (wires the label); auto-generated when omitted */
   id?: string;
+  /** Shown when nothing is selected */
   placeholder?: string;
+  /** Assistive text below the field */
   helperText?: string;
+  /** Error message; replaces the helper line and sets aria-invalid */
   error?: string;
+  /** Marks the field required. @default false */
   required?: boolean;
+  /** Disables the control. @default false */
   disabled?: boolean;
+  /** Classes on the field wrapper */
   className?: string;
 }
 

--- a/nextjs-app/shared/components/PhoneInput/PhoneInput.stories.tsx
+++ b/nextjs-app/shared/components/PhoneInput/PhoneInput.stories.tsx
@@ -20,43 +20,8 @@ const meta: Meta<typeof PhoneInput> = {
     a11y: { test: "error" },
     llm: { schema },
   },
-  argTypes: {
-    label: { control: "text", description: "Label text" },
-
-    value: {
-      control: "text",
-      description: "Phone number value (E.164 format)",
-    },
-
-    placeholder: { control: "text", description: "Placeholder text" },
-
-    helperText: { control: "text", description: "Helper text below input" },
-
-    error: { control: "text", description: "Error message" },
-
-    disabled: { control: "boolean", description: "Disabled state" },
-
-    required: {
-      control: "boolean",
-      description: "Shows the required marker on the label",
-      table: { defaultValue: { summary: "false" } },
-    },
-
-    defaultCountry: {
-      control: "text",
-      description: "ISO country used when the value has no prefix",
-      table: { defaultValue: { summary: "FI" } },
-    },
-
-    onChange: { action: "phone change", description: "Change handler" },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
-      children: { table: { disable: true } },
-      className: { table: { disable: true } },
-      id: { control: "text", description: "Explicit control id (wires the label); auto-generated when omitted.", table: { category: "Advanced" } },
-      ref: { table: { disable: true } },
-      style: { table: { disable: true } }
-},
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // defaultCountry renders a select from the contract's ISO-code union.
 };
 
 export default meta;
@@ -71,6 +36,11 @@ type PhoneInputStoryArgs = React.ComponentProps<typeof PhoneInput> & {
 const PhoneInputStory: React.FC<PhoneInputStoryArgs> = (args) => {
   const { t } = useTranslation();
   const [value, setValue] = useState<string | undefined>(args.value);
+
+  // Panel edits to the value arg drive the canvas; typing still updates local state.
+  React.useEffect(() => {
+    if (args.value) setValue(args.value);
+  }, [args.value]);
 
   return (
     <div className={styles.storyContainer}>

--- a/nextjs-app/shared/components/PhoneInput/PhoneInput.tsx
+++ b/nextjs-app/shared/components/PhoneInput/PhoneInput.tsx
@@ -7,13 +7,21 @@ import Label from "@dt/Label/Label";
 import HelperText from "@dt/HelperText/HelperText";
 
 export interface PhoneInputProps {
+  /** Label text */
   label: string;
+  /** Phone number value (E.164 format) */
   value?: string;
+  /** Error message; replaces the helper line */
   error?: string;
+  /** Helper text below the input */
   helperText?: string;
+  /** Placeholder text */
   placeholder?: string;
+  /** Disabled state. @default false */
   disabled?: boolean;
+  /** Shows the required marker on the label. @default false */
   required?: boolean;
+  /** Explicit control id (wires the label); auto-generated when omitted */
   id?: string;
   /** ISO 3166-1 alpha-2 code used when the value has no country prefix. @default "FI" */
   defaultCountry?: Country;

--- a/nextjs-app/shared/components/Radio/Radio.stories.tsx
+++ b/nextjs-app/shared/components/Radio/Radio.stories.tsx
@@ -15,59 +15,7 @@ const meta = {
     contractStatus: contract.status,
     a11y: { test: "error" },
   },
-  argTypes: {
-    label: {
-      control: "text",
-      description: "Option label",
-      table: { category: "Content" },
-    },
-    value: {
-      control: "text",
-      description: "Submitted value when selected",
-      table: { category: "Value" },
-    },
-    name: {
-      control: "text",
-      description: "Group name (must match siblings)",
-      table: { category: "Form" },
-    },
-    checked: {
-      control: "boolean",
-      description: "Controlled checked state",
-      table: { category: "State" },
-    },
-    disabled: {
-      control: "boolean",
-      description: "Disable this option",
-      table: { category: "State", defaultValue: { summary: "false" } },
-    },
-    defaultChecked: {
-      control: false,
-      description: "Initial checked state (uncontrolled mode only)",
-      table: { category: "State", disable: true },
-    },
-    size: {
-      control: "select",
-      options: ["sm", "md", "lg"],
-      description: "Control hit area",
-      table: { category: "Appearance", defaultValue: { summary: "md" } },
-    },
-    showLabel: {
-      control: "boolean",
-      description: "Render visible label",
-      table: { category: "Content", defaultValue: { summary: "true" } },
-    },
-    onCheckedChange: {
-      description: "Fired when selection changes",
-      action: "checkedChange",
-      table: { category: "Events" },
-    },
-    className: {
-      control: false,
-      description: "Optional utility classes",
-      table: { category: "Advanced" },
-    },
-  },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts).
   args: {
     label: "Email updates",
     value: "email",

--- a/nextjs-app/shared/components/Radio/Radio.test.tsx
+++ b/nextjs-app/shared/components/Radio/Radio.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import Radio from "./Radio";
 
@@ -6,5 +6,12 @@ describe("Radio", () => {
   it("renders", () => {
     render(<Radio name="n" value="v" label="Opt" />);
     expect(document.body).toBeTruthy();
+  });
+
+  // Backs the audit-controls effect exemption: defaultChecked only applies on
+  // the uncontrolled path (no `checked`), invisible in the controlled Playground.
+  it("preselects via defaultChecked on the uncontrolled path", () => {
+    render(<Radio name="n" value="v" label="Opt" defaultChecked />);
+    expect(screen.getByRole("radio")).toBeChecked();
   });
 });

--- a/nextjs-app/shared/components/Radio/Radio.tsx
+++ b/nextjs-app/shared/components/Radio/Radio.tsx
@@ -5,16 +5,23 @@ import { normalizeSizeProp, type SizeUnified } from "../../utils/sizeNormalizati
 
 export interface RadioProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size" | "type" | "onChange"> {
+  /** Option label */
   label: string;
+  /** Submitted value when selected */
   value: string;
+  /** Group name; must match siblings to form the exclusive set */
   name: string;
   /** Checked state (controlled); use inside RadioGroup for sets. */
   checked?: boolean;
+  /** Initial checked state (uncontrolled mode only) */
   defaultChecked?: boolean;
   /** Disables interaction and dims the control. @default false */
   disabled?: boolean;
+  /** Control hit area. @default "md" */
   size?: SizeUnified;
+  /** Fired with the next checked value when selection changes */
   onCheckedChange?: (checked: boolean) => void;
+  /** Render the visible label. @default true */
   showLabel?: boolean;
 }
 
@@ -50,6 +57,9 @@ const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
         name={name}
         value={value}
         checked={checked}
+        // React syncs the checked PROPERTY only; expose the controlled state as
+        // an attribute so CSS/tests (and the controls effect audit) can see it.
+        data-checked={checked === undefined ? undefined : String(checked)}
         defaultChecked={defaultChecked}
         disabled={disabled}
         className={[styles.input, styles[`input--${normalizedSize}`]].join(" ")}

--- a/nextjs-app/shared/components/Radio/__a11y-snapshots__/forms-radio--forced-colors.yaml
+++ b/nextjs-app/shared/components/Radio/__a11y-snapshots__/forms-radio--forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- radio "Email updates" [checked]
+- text: Email updates

--- a/nextjs-app/shared/components/RadioGroup/RadioGroup.stories.tsx
+++ b/nextjs-app/shared/components/RadioGroup/RadioGroup.stories.tsx
@@ -21,68 +21,28 @@ const meta = {
     contractStatus: contract.status,
     a11y: { test: "error" },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // only the composite options slot needs an authored mapping preset.
   argTypes: {
-    legend: {
-      control: "text",
-      description: "Group label (fieldset legend)",
-      table: { category: "Content" },
-    },
     options: {
-      control: false,
-      description: "Radio options array",
+      control: { type: "select" },
+      options: ["expertise", "delivery", "plans"],
+      mapping: {
+        expertise: OPTIONS,
+        delivery: [
+          { value: "standard", label: "Standard (3-5 days)" },
+          { value: "express", label: "Express (1-2 days)" },
+          { value: "pickup", label: "Pickup point" },
+        ],
+        plans: [
+          { value: "free", label: "Free" },
+          { value: "pro", label: "Pro" },
+          { value: "enterprise", label: "Enterprise (contact sales)", disabled: true },
+        ],
+      },
+      description:
+        "Radio options array. Pick a preset here; compose your own in code.",
       table: { category: "Content" },
-    },
-    value: {
-      control: "text",
-      description: "Controlled selected value",
-      table: { category: "Value" },
-    },
-    name: {
-      control: "text",
-      description: "Native form field name for the group",
-      table: { category: "Form" },
-    },
-    defaultValue: {
-      control: "text",
-      description: "Initial value when uncontrolled",
-      table: { category: "Value" },
-    },
-    orientation: {
-      control: "radio",
-      options: ["vertical", "horizontal"],
-      description: "Stack direction",
-      table: { category: "Layout", defaultValue: { summary: "vertical" } },
-    },
-    size: {
-      control: "select",
-      options: ["sm", "md", "lg"],
-      description: "Radio control size",
-      table: { category: "Appearance", defaultValue: { summary: "md" } },
-    },
-    helperText: {
-      control: "text",
-      description: "Helper copy below the group",
-      table: { category: "Content" },
-    },
-    error: {
-      control: "text",
-      description: "Error message",
-      table: { category: "Validation" },
-    },
-    disabled: {
-      control: "boolean",
-      description: "Disable entire group",
-      table: { category: "State", defaultValue: { summary: "false" } },
-    },
-    onValueChange: {
-      description: "On Value Change",
-      action: "valueChanged",
-      table: { category: "Events" },
-    },
-    className: {
-      description: "Class Name",
-      control: false,
-      table: { category: "Advanced" },
     },
   },
   args: {
@@ -102,6 +62,13 @@ type Story = StoryObj<typeof meta>;
 export const Playground: Story = {
   tags: ["beta-matrix"],
   globals: { forcedColors: "none" },
+  args: {
+    options: "expertise" as unknown as typeof OPTIONS,
+  },
+  // defaultValue is consumed once at mount — remount on change so the control drives the canvas.
+  render: (args) => (
+    <RadioGroup key={`remount-${args.defaultValue ?? ""}`} {...args} />
+  ),
 };
 export const Default: Story = {
   tags: ["beta-matrix"],

--- a/nextjs-app/shared/components/RadioGroup/RadioGroup.tsx
+++ b/nextjs-app/shared/components/RadioGroup/RadioGroup.tsx
@@ -11,18 +11,29 @@ export type RadioGroupOption = {
 };
 
 export interface RadioGroupProps {
+  /** Native form field name shared by the set; auto-generated when omitted */
   name?: string;
+  /** Group label rendered as the fieldset legend */
   legend: string;
+  /** Radio options; per-option disabled keeps the choice visible */
   options: RadioGroupOption[];
+  /** Controlled selected value; "" is treated as absent (uncontrolled) */
   value?: string;
+  /** Initial value when uncontrolled */
   defaultValue?: string;
+  /** Fired with the next value when selection changes */
   onValueChange?: (value: string) => void;
+  /** Stack direction. @default "vertical" */
   orientation?: "vertical" | "horizontal";
+  /** Radio control size. @default "md" */
   size?: SizeUnified;
   /** Disables the whole set. @default false */
   disabled?: boolean;
+  /** Error message; announces via role=alert and sets aria-invalid */
   error?: string;
+  /** Helper copy below the group; suppressed while error is set */
   helperText?: string;
+  /** Merged onto the fieldset */
   className?: string;
 }
 
@@ -42,10 +53,13 @@ const RadioGroup: React.FC<RadioGroupProps> = ({
   className,
 }) => {
   const autoName = useId();
-  const name = nameProp ?? `radio-group-${autoName}`;
+  // Controls convention: "" means absent — empty name falls back to the
+  // generated one, empty value keeps the group uncontrolled and clickable.
+  const name = nameProp || `radio-group-${autoName}`;
+  const controlledValue = value === "" ? undefined : value;
   const [internal, setInternal] = useState(defaultValue ?? "");
-  const isControlled = value !== undefined;
-  const selected = isControlled ? value : internal;
+  const isControlled = controlledValue !== undefined;
+  const selected = isControlled ? controlledValue : internal;
   const helperId = `${name}-helper`;
   const errorId = `${name}-error`;
 

--- a/nextjs-app/shared/components/Select/Select.stories.tsx
+++ b/nextjs-app/shared/components/Select/Select.stories.tsx
@@ -88,117 +88,33 @@ export default {
     a11y: { test: "error" },
     llm: { schema },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // only the composite options slot needs an authored mapping preset.
   argTypes: {
-    // Content
-
-    label: {
-      control: "text",
-      description: "Label text displayed above the select dropdown",
-      table: { category: "Content", type: { summary: "string" } },
-    },
-
     options: {
-      control: "object",
+      control: { type: "select" },
+      options: ["basic", "withDisabled", "many"],
+      mapping: {
+        basic: [
+          { value: "option1", label: "storyCheckboxOption1" },
+          { value: "option2", label: "storyCheckboxOption2" },
+          { value: "option3", label: "storyCheckboxOption3" },
+        ],
+        withDisabled: [
+          { value: "option1", label: "storyCheckboxOption1" },
+          { value: "option2", label: "storyCheckboxOption2", disabled: true },
+          { value: "option3", label: "storyCheckboxOption3" },
+        ],
+        many: Array.from({ length: 8 }, (_, i) => ({
+          value: `option${i + 1}`,
+          label: `Option ${i + 1}`,
+        })),
+      },
       description:
-        "Array of option objects with value, label, and optional disabled",
+        "Array of option objects with value, label, and optional disabled. Pick a preset here; compose your own in code.",
       table: { category: "Content", type: { summary: "SelectOptionItem[]" } },
     },
-
-    helperText: {
-      control: "text",
-      description:
-        "Helper text displayed below the select (hidden if error is set)",
-      table: { category: "Content", type: { summary: "string" } },
-    },
-
-    children: {
-      control: false,
-      description: "Custom SelectOption children (overrides options prop)",
-      table: { category: "Content", type: { summary: "ReactNode" } },
-    },
-
-    // Appearance
-
-    size: {
-      control: { type: "select" },
-      options: ["sm", "md", "lg"],
-      description: "Size variant (v1.1.0+)",
-      table: {
-        category: "Appearance",
-        type: { summary: "SizeUnified" },
-        defaultValue: { summary: "md" },
-      },
-    },
-
-    error: {
-      control: "text",
-      description:
-        "Error message to display (changes border color and shows error HelperText)",
-      table: { category: "Appearance", type: { summary: "string" } },
-    },
-
-    // State
-
-    disabled: {
-      control: "boolean",
-      description: "Disables the select",
-      table: { category: "State", type: { summary: "boolean" } },
-    },
-
-    value: {
-      control: "text",
-      description: "Controlled value (requires onValueChange)",
-      table: { category: "State", type: { summary: "string" } },
-    },
-
-    defaultValue: {
-      control: "text",
-      description: "Initial value for uncontrolled component",
-      table: { category: "State", type: { summary: "string" } },
-    },
-
-    // Behavior
-    onValueChange: {
-      action: "valueChanged",
-      description: "Value change handler (v1.1.0+)",
-      table: {
-        category: "Behavior",
-        type: { summary: "(value: string) => void" },
-      },
-    },
-
-    // Accessibility
-
-    id: {
-      control: "text",
-      description: "Custom ID for the select element",
-      table: { category: "Accessibility", type: { summary: "string" } },
-    },
-
-    // Advanced
-
-    className: {
-      control: "text",
-      description: "Additional CSS classes",
-      table: { category: "Advanced", type: { summary: "string" } },
-    },
-
-    // Deprecated
-
-    onChange: {
-      action: "changed",
-      description:
-        "⚠️ Deprecated: Use onValueChange instead. Will be removed in v2.0.0",
-      table: {
-        category: "Deprecated",
-        type: { summary: "(value: string) => void" },
-      },
-    },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
-      ref: { table: { disable: true } },
-      style: { table: { disable: true } }
-},
+  },
 } as Meta;
 
 export const Z_SelectCompliance: StoryFn = () => (
@@ -401,6 +317,14 @@ Disabled.play = async ({ canvasElement }) => {
 export const Playground: Story = {
   parameters: { a11y: { disable: true, test: "off" } },
   tags: ["beta-matrix"],
+  // options arg is a mapping key; uncontrolled (no value) so the canvas select stays interactive.
+  args: {
+    label: "storySelectLabel",
+    options: "basic" as unknown as React.ComponentProps<
+      typeof Select
+    >["options"],
+  },
+  render: (args) => <SelectStory {...args} />,
 };
 
 export const Example: Story = {

--- a/nextjs-app/shared/components/Select/Select.tsx
+++ b/nextjs-app/shared/components/Select/Select.tsx
@@ -16,7 +16,9 @@ interface SelectOptionItem {
 
 export interface SelectProps
   extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, "onChange" | "size"> {
+  /** Label text displayed above the select dropdown */
   label: string;
+  /** Option objects with value, label, and optional disabled; children override this */
   options?: SelectOptionItem[];
   /** Supporting text under the control; suppressed while `error` is set. */
   helperText?: string;

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--playground.forced-colors.yaml
@@ -1,3 +1,7 @@
 - status: Work in progress (beta)
-- combobox
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1" [selected]
+  - option "Option 2"
+  - option "Option 3"
 - img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--playground.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--playground.yaml
@@ -1,3 +1,7 @@
 - status: Work in progress (beta)
-- combobox
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1" [selected]
+  - option "Option 2"
+  - option "Option 3"
 - img "Toggle options"

--- a/nextjs-app/shared/components/Switch/Switch.stories.tsx
+++ b/nextjs-app/shared/components/Switch/Switch.stories.tsx
@@ -86,104 +86,16 @@ const meta: Meta<typeof Switch> = {
     a11y: { test: "error" },
     llm: { schema },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // label is ReactNode on the contract (autogen hides those) but accepts plain
+  // text, so it keeps an authored text control.
   argTypes: {
-    // Content
-
     label: {
-      control: "text",
+      control: { type: "text" },
       description: "Label text displayed next to the switch",
       table: { category: "Content", type: { summary: "React.ReactNode" } },
     },
-
-    helperText: {
-      control: "text",
-      description: "Helper text displayed below the switch",
-      table: { category: "Content", type: { summary: "string" } },
-    },
-
-    error: {
-      control: "text",
-      description: "Error message beneath the control; wires aria-invalid + role=alert.",
-      table: { category: "State", type: { summary: "string" } },
-    },
-
-    // State (v2.0.0)
-
-    checked: {
-      control: "boolean",
-      description: "Checked state (controlled) (v2.0.0+)",
-      table: { category: "State", type: { summary: "boolean" } },
-    },
-
-    disabled: {
-      control: "boolean",
-      description: "Disables the switch (v2.0.0+)",
-      table: { category: "State", type: { summary: "boolean" } },
-    },
-
-    loading: {
-      control: "boolean",
-      description: "Shows loading state with spinner (v2.0.0+)",
-      table: { category: "State", type: { summary: "boolean" } },
-    },
-
-    defaultChecked: {
-      control: "boolean",
-      description: "Initial checked state for uncontrolled component (v2.0.0+)",
-      table: { category: "State", type: { summary: "boolean" } },
-    },
-
-    // Appearance
-
-    size: {
-      control: { type: "select" },
-      options: ["sm", "md", "lg"],
-      description: "Size variant",
-      table: {
-        category: "Appearance",
-        type: { summary: "sm | md | lg" },
-        defaultValue: { summary: "md" },
-      },
-    },
-
-    labelPlacement: {
-      control: { type: "select" },
-      options: ["right", "left", "top"],
-      description: "Label position relative to switch",
-      table: {
-        category: "Appearance",
-        type: { summary: "\"right\" | \"left\" | \"top\"" },
-        defaultValue: { summary: "right" },
-      },
-    },
-
-    // Behavior
-    onCheckedChange: {
-      action: "checkedChanged",
-      description: "Checked change handler (v2.0.0+)",
-      table: {
-        category: "Behavior",
-        type: { summary: "(checked: boolean) => void" },
-      },
-    },
-
-    // Accessibility
-
-    id: {
-      control: "text",
-      description: "Custom ID for the switch element",
-      table: { category: "Accessibility", type: { summary: "string" } },
-    },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
-      children: { table: { disable: true } },
-      className: { table: { disable: true } },
-      isChecked: { table: { disable: true } },
-      isDisabled: { table: { disable: true } },
-      isLoading: { table: { disable: true } },
-      ref: { table: { disable: true } },
-      style: { table: { disable: true } }
-},
+  },
   args: {
     checked: false,
     loading: false,

--- a/nextjs-app/shared/components/TextArea/TextArea.stories.tsx
+++ b/nextjs-app/shared/components/TextArea/TextArea.stories.tsx
@@ -17,35 +17,13 @@ const meta = {
     contractStatus: contract.status,
     a11y: { test: "error" },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // rows is a native passthrough (not on the contract) so it keeps a bespoke knob.
   argTypes: {
-    label: { control: "text", description: "Visible field label" },
-    placeholder: { control: "text", description: "Placeholder text" },
-    error: { control: "text", description: "Validation error message" },
-    helperText: { control: "text", description: "Helper copy below the field" },
     rows: {
       control: { type: "number", min: 2, max: 20 },
       description: "Static row count (ignored when animateResize is on)",
-      table: { defaultValue: { summary: "4" } },
-    },
-    animateResize: {
-      control: "boolean",
-      description: "Enable smooth animated auto-growing",
-      table: { defaultValue: { summary: "false" } },
-    },
-    minRows: {
-      control: { type: "number", min: 1, max: 10 },
-      description: "Minimum rows when animateResize is enabled",
-      table: { defaultValue: { summary: "2" } },
-    },
-    maxRows: {
-      control: { type: "number", min: 1, max: 20 },
-      description: "Maximum rows when animateResize is enabled",
-      table: { defaultValue: { summary: "10" } },
-    },
-    disabled: {
-      control: "boolean",
-      description: "Disables the textarea",
-      table: { defaultValue: { summary: "false" } },
+      table: { defaultValue: { summary: "4" }, category: "Appearance" },
     },
   },
 } satisfies Meta<typeof TextArea>;
@@ -139,7 +117,17 @@ AnimatedResize.parameters = {
 export const Playground: Story = {
   parameters: { a11y: { disable: true, test: "off" } },
   tags: ["beta-matrix"],
-  render: () => <TextAreaStory {...Default.args} />,
+  // Animated defaults with overflowing content so minRows/maxRows visibly
+  // drive the canvas (they only apply while animateResize is on).
+  args: {
+    label: "storyTextAreaLabel",
+    placeholder: "storyTextAreaPlaceholder",
+    animateResize: true,
+    minRows: 3,
+    maxRows: 6,
+    value: Array.from({ length: 10 }, (_, i) => `Line ${i + 1}`).join("\n"),
+  },
+  render: (args) => <TextAreaStory {...args} />,
 };
 export const Example: Story = {
   globals: { forcedColors: "none" },

--- a/nextjs-app/shared/components/TextArea/TextArea.tsx
+++ b/nextjs-app/shared/components/TextArea/TextArea.tsx
@@ -5,10 +5,15 @@ import HelperText from "@dt/HelperText";
 
 export interface TextAreaProps
   extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, "onChange"> {
+  /** Visible field label */
   label: string;
+  /** Value synced into the field; typing still works after it is set */
   value?: string;
+  /** Validation error message; replaces the helper line */
   error?: string;
+  /** Helper copy below the field */
   helperText?: string;
+  /** Change handler receiving the raw string value */
   onChange?: (value: string) => void;
   /** Enable smooth animated auto-growing (default: false) */
   animateResize?: boolean;

--- a/nextjs-app/shared/components/TextInput/TextInput.stories.tsx
+++ b/nextjs-app/shared/components/TextInput/TextInput.stories.tsx
@@ -18,49 +18,7 @@ const meta = {
     a11y: { test: "error" },
     llm: { schema },
   },
-  argTypes: {
-    size: {
-      control: { type: "select" },
-      options: ["sm", "md", "lg"],
-      description: "Input size token (v1.1.0+)",
-      table: { defaultValue: { summary: "md" } },
-    },
-
-    type: {
-      control: {
-        type: "select",
-        options: ["text", "number", "email", "password", "search", "tel"],
-      },
-      description: "HTML input type",
-      table: { defaultValue: { summary: "text" } },
-    },
-
-    label: { control: "text", description: "Visible field label" },
-
-    placeholder: { control: "text", description: "Placeholder text" },
-
-    error: { control: "text", description: "Validation error message" },
-
-    helperText: { control: "text", description: "Helper copy below the field" },
-
-    disabled: {
-      control: "boolean",
-      description: "Disables the input",
-      table: { defaultValue: { summary: "false" } },
-    },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
-      children: { table: { disable: true } },
-      className: { table: { disable: true } },
-      defaultValue: { control: "text", description: "Initial value for uncontrolled component", table: { category: "Content" } },
-      id: { table: { disable: true } },
-      isDisabled: { table: { disable: true } },
-      onChange: { action: "onChange", table: { disable: true } },
-      onValueChange: { action: "onValueChange", table: { disable: true } },
-      ref: { table: { disable: true } },
-      style: { table: { disable: true } },
-      value: { control: "text", description: "Controlled value; pair with onChange.", table: { category: "State" } }
-},
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts).
 } satisfies Meta<typeof TextInput>;
 
 export default meta;
@@ -174,7 +132,15 @@ export const Default = TextInputStory;
 export const Playground: Story = {
   parameters: { a11y: { disable: true, test: "off" } },
   tags: ["beta-matrix"],
-  render: () => <InputStory {...TextInputStory.args} />,
+  args: {
+    label: "storyInputTextLabel",
+    type: "text",
+    placeholder: "storyInputTextPlaceholder",
+  },
+  // defaultValue is consumed once at mount — remount on change so the control drives the canvas.
+  render: (args) => (
+    <InputStory key={`remount-${args.defaultValue ?? ""}`} {...args} />
+  ),
 };
 export const Example: Story = {
   globals: { forcedColors: "none" },

--- a/nextjs-app/shared/components/TextInput/TextInput.tsx
+++ b/nextjs-app/shared/components/TextInput/TextInput.tsx
@@ -5,7 +5,7 @@ export const textInputVariants = cva("", {
   defaultVariants: { size: "md" },
 });
 
-import React, { useEffect, useId, useState } from "react";
+import React, { useEffect, useId, useRef, useState } from "react";
 import styles from "./TextInput.module.css";
 import Label from "@dt/Label";
 import HelperText from "@dt/HelperText";
@@ -20,7 +20,9 @@ import { suggestEmailCorrection } from "../../utils/emailSuggestion";
 
 export interface TextInputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange" | "size"> {
+  /** Visible field label; also feeds the input name */
   label: string;
+  /** HTML input type; tel formats and email validates as you type */
   type: "text" | "number" | "email" | "password" | "search" | "tel";
 
   // NEW PROPS (v1.1.0)
@@ -32,8 +34,11 @@ export interface TextInputProps
   defaultValue?: string | number;
 
   // EXISTING PROPS
+  /** Controlled value; an initial "" is treated as absent (uncontrolled), later changes always sync in */
   value?: string | number;
+  /** Validation error message; replaces the helper line and sets aria-invalid */
   error?: string;
+  /** Helper copy below the field */
   helperText?: string;
   /** Disables the input. Declared explicitly (not just via the native attribute extension) so the agent-blocks prop extraction sees it. */
   disabled?: boolean;
@@ -77,9 +82,14 @@ const TextInput: React.FC<TextInputProps> = ({
   const effectiveOnChange = onValueChange ?? onChange;
   const normalizedSize = normalizeSizeProp(size);
 
+  // Controls convention: "" means absent AT MOUNT — an initial empty string
+  // yields the uncontrolled path so defaultValue and canvas typing keep
+  // working. Later value changes (including back to "") still sync in, so
+  // consumers that clear a field by setting value="" keep that behavior.
   const [inputValue, setInputValue] = useState<string | number>(
-    value ?? defaultValue ?? ""
+    (value === "" ? undefined : value) ?? defaultValue ?? ""
   );
+  const syncedOnce = useRef(false);
   const [phoneError, setPhoneError] = useState("");
   const [emailError, setEmailError] = useState("");
 
@@ -94,7 +104,12 @@ const TextInput: React.FC<TextInputProps> = ({
   ].filter(Boolean).join(' ') || undefined;
 
   useEffect(() => {
-    setInputValue(value ?? "");
+    // Skip the mount run so an initial "" doesn't clobber defaultValue.
+    if (!syncedOnce.current) {
+      syncedOnce.current = true;
+      return;
+    }
+    if (value !== undefined) setInputValue(value);
   }, [value]);
 
   const validatePhoneNumber = (phone: string) => {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "report:doc-coverage": "node scripts/design-system/report-doc-coverage.mjs",
     "audit:catalog": "node scripts/design-system/audit-catalog-coverage.mjs",
     "audit:controls": "node scripts/design-system/audit-controls.mjs",
-    "audit:controls:ci": "concurrently -k -s first -n SB,AUDIT \"npm run storybook -- --ci --no-open --quiet\" \"npm run storybook:wait && node scripts/design-system/audit-controls.mjs --min 50\"",
+    "audit:controls:ci": "concurrently -k -s first -n SB,AUDIT \"npm run storybook -- --ci --no-open --quiet\" \"npm run storybook:wait && node scripts/design-system/audit-controls.mjs --min 60\"",
     "new-component": "node scripts/design-system/scaffold-component.mjs",
     "bootstrap:contracts": "node scripts/design-system/bootstrap-contracts.mjs",
     "elevate:storybook": "python3 scripts/design-system/elevate_storybook_beta.py",

--- a/scripts/design-system/audit-controls.mjs
+++ b/scripts/design-system/audit-controls.mjs
@@ -49,6 +49,25 @@ const EFFECT_EXEMPT = {
         options: 'menu content: visible only while open; verified by open-menu interaction (basic preset -> 2 menuitems)',
         menuAlign: 'collision-aware placement (resolvedAlign) auto-flips near viewport edges; Playground pins the trigger at the left edge so start/end resolve identically there',
     },
+    Checkbox: {
+        defaultChecked: 'uncontrolled-only initial state, masked while the seeded `checked` arg keeps the control controlled; verified by unit test (uncontrolled toggle path)',
+    },
+    Combobox: {
+        options: 'dropdown content: portaled to document.body and visible only while open; verified by the KeyboardSelection play story (ArrowDown opens, options render, Enter selects)',
+    },
+    MultiCombobox: {
+        options: 'dropdown content: portaled to document.body and visible only while open; verified by the play story that opens the listbox and picks options',
+    },
+    Switch: {
+        defaultChecked: 'uncontrolled-only initial state, masked by the controlled Playground template; verified by unit test (uncontrolled toggle path)',
+    },
+    Radio: {
+        defaultChecked: 'uncontrolled-only initial state, masked while the seeded `checked` arg keeps the control controlled; verified by unit test',
+    },
+    FileUpload: {
+        maxSizeInBytes: 'validation-time only: applied when a file is picked, no DOM signature at rest; verified by oversize-pick unit test',
+        sizeErrorMessage: 'validation-time only: rendered when a picked file exceeds maxSizeInBytes; verified by oversize-pick unit test',
+    },
 }
 
 // Icon-name text knobs: appending characters makes an UNKNOWN icon (renders
@@ -62,7 +81,10 @@ const ROOTS = [
 ]
 
 // Public props worth a control (skip pure DOM/React plumbing a human never sets).
-const SKIP = new Set(['ref', 'style', 'key', 'asChild', 'as', 'data-role', 'aria-label'])
+// Keep in sync with HIDDEN in .storybook/lib/controls-autogen.ts — `id` is
+// plumbing of the same class as aria-label: contracts expose it, no human
+// drives a canvas from an id text field.
+const SKIP = new Set(['ref', 'style', 'key', 'asChild', 'as', 'data-role', 'aria-label', 'id'])
 
 function contractProps(dir, root) {
     const p = `${root}/${dir}/${dir}.contract.json`


### PR DESCRIPTION
## Summary
- Registers all **16 Forms components** in the controls-autogen registry (`.storybook/controls-autogen.json`) and deletes their hand-written argTypes (~700 lines); stories keep only mapping presets for composite slots and bespoke knobs for native passthroughs.
- Fixes the root causes of dead panels, not just seeding: Playgrounds that ignored args (static-render closures, `Playground.args` copied before `Default.args` existed, no args at all), controlled props freezing the canvas (`useArgs` writeback), mount-only props (remount keys), and empty-string normalization so enhancer seeds never render controlled-frozen.
- `Radio.checked` was operable-but-inert (React syncs the checked *property*; no DOM signature) — added a `data-checked` attribute.
- Instrument: `id` added to the audit SKIP set (matches enhancer HIDDEN); documented effect exemptions each backed by a play story or unit test (one new Radio test added).
- JSDoc prop descriptions on all 16 Props interfaces (single docgen/IDE/agent-manifest source).

## Results
- **Global controls operability 50% → 61%** (457/751); farm ratchet raised to `--min 60`.
- All 16 components: **100% presence, 0 inert** via `audit:controls --effects`; batch-1 components re-verified, no regression.
- One consumer regression caught and fixed during verification: ContactForm clears fields via `value=""` — TextInput's normalization is mount-only so clearing still works (covered by the existing test).

## Verification (local, full gate)
typecheck ✓ · lint ✓ · vitest 1894/1894 ✓ · build ✓ · build:tokens ✓ · check:contract-props ✓ · check:consumers ✓ · a11y-snapshot suites green in both modes (451 passed) · AT baselines updated only where trees changed (Select playground gained its label/options; Combobox/Radio baselines that were missing on main). Link/Footer refreshes excluded — tracked by the spawned stale-baseline task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Storybook demos now use smarter preset-based controls for several form components, making examples easier to explore.
  * Added clearer prop descriptions across form components to improve in-product documentation.

* **Bug Fixes**
  * Improved controlled/uncontrolled behavior in text inputs, radios, comboboxes, and file uploads so canvas examples stay in sync with user actions and panel edits.
  * Updated accessibility snapshots and forced-colors coverage for several forms components.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->