### PR TITLE
feat(design-system): controls autogen batch 4 — Layout + strays at 100% presence, 0 inert

### DIFF
--- a/.storybook/controls-autogen.json
+++ b/.storybook/controls-autogen.json
@@ -32,6 +32,23 @@
     "Spinner",
     "StatusDot",
     "Tabs",
-    "Toast"
+    "Toast",
+    "Accordion",
+    "AspectRatio",
+    "Card",
+    "Center",
+    "CodeBlockWindow",
+    "Container",
+    "Divider",
+    "ExpandableSection",
+    "FlexBox",
+    "Grid",
+    "MacWindowFrame",
+    "MarkdownMessage",
+    "NextLayout",
+    "Section",
+    "Spacer",
+    "Stack",
+    "ThemeProvider"
   ]
 }

--- a/nextjs-app/shared/components/Accordion/Accordion.stories.tsx
+++ b/nextjs-app/shared/components/Accordion/Accordion.stories.tsx
@@ -18,24 +18,46 @@ const meta: Meta<typeof Accordion> = {
     a11y: { test: "error" },
     llm: { schema },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // items keeps a mapping preset, defaultOpenId a radio over the preset's ids.
   argTypes: {
     items: {
-      control: "object",
-      description: "Accordion sections (id, title, content)",
+      control: { type: "select" },
+      options: ["faq", "twoItems"],
+      mapping: {
+        faq: [
+          {
+            id: "one",
+            title: "What is Digitaltableteur?",
+            content: "We are a design and engineering studio.",
+          },
+          {
+            id: "two",
+            title: "Do you work with AI?",
+            content: "Yes, responsibly—with human oversight.",
+          },
+          {
+            id: "three",
+            title: "How can I contact you?",
+            content: "Email mail@digitaltableteur.com.",
+          },
+        ],
+        twoItems: [
+          { id: "one", title: "First section", content: "First content." },
+          { id: "two", title: "Second section", content: "Second content." },
+        ],
+      },
+      description:
+        "Accordion sections (id, title, content). Pick a preset here; compose your own in code.",
+      table: { category: "Content", type: { summary: "AccordionItem[]" } },
     },
-
     defaultOpenId: {
-      control: "text",
-      description: "Initially expanded item id",
+      control: { type: "inline-radio" },
+      options: ["one", "two", "three"],
+      description: "Initially expanded item id (preset ids: one/two/three)",
+      table: { category: "Content" },
     },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
-      children: { table: { disable: true } },
-      className: { table: { disable: true } },
-      id: { table: { disable: true } },
-      ref: { table: { disable: true } },
-      style: { table: { disable: true } }
-},
+  },
 };
 
 export default meta;
@@ -94,9 +116,15 @@ Default.play = async ({ canvasElement }) => {
 
 const defaultItems = Default.args?.items ?? [];
 
+// defaultOpenId is mount-only state; keying the render on it remounts so the
+// radio actually drives the canvas. items arg is a mapping key.
 export const Playground: Story = {
   tags: ["beta-matrix"],
-  args: { items: defaultItems },
+  render: (args) => <Accordion key={`open-${args.defaultOpenId}`} {...args} />,
+  args: {
+    items: "faq" as unknown as typeof defaultItems,
+    defaultOpenId: "one",
+  },
 };
 
 export const Example: Story = {

--- a/nextjs-app/shared/components/Accordion/Accordion.tsx
+++ b/nextjs-app/shared/components/Accordion/Accordion.tsx
@@ -11,7 +11,9 @@ export type AccordionItem = {
 };
 
 export type AccordionProps = {
+  /** Accordion sections (id, title, content). */
   items: AccordionItem[];
+  /** Initially expanded item id. */
   defaultOpenId?: string;
 };
 

--- a/nextjs-app/shared/components/Accordion/__a11y-snapshots__/layout-accordion--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Accordion/__a11y-snapshots__/layout-accordion--playground.forced-colors.yaml
@@ -1,4 +1,5 @@
 - status: Work in progress (beta)
-- button "What is Digitaltableteur?"
+- button "What is Digitaltableteur?" [expanded]
+- region "What is Digitaltableteur?": We are a design and engineering studio.
 - button "Do you work with AI?"
 - button "How can I contact you?"

--- a/nextjs-app/shared/components/Accordion/__a11y-snapshots__/layout-accordion--playground.yaml
+++ b/nextjs-app/shared/components/Accordion/__a11y-snapshots__/layout-accordion--playground.yaml
@@ -1,4 +1,5 @@
 - status: Work in progress (beta)
-- button "What is Digitaltableteur?"
+- button "What is Digitaltableteur?" [expanded]
+- region "What is Digitaltableteur?": We are a design and engineering studio.
 - button "Do you work with AI?"
 - button "How can I contact you?"

--- a/nextjs-app/shared/components/AspectRatio/AspectRatio.stories.tsx
+++ b/nextjs-app/shared/components/AspectRatio/AspectRatio.stories.tsx
@@ -25,21 +25,12 @@ const meta = {
     a11y: { test: "error" },
     docs: { description: { component: contract.description } },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // children keeps an authored text control (content slot).
   argTypes: {
     children: {
-      control: false,
-      description: "Media or placeholder content inside the ratio box",
-    },
-    ratio: {
-      control: "select",
-      options: ["1:1", "4:3", "16:9", "21:9", "3:2", "2:3"],
-      description: "Width-to-height ratio token",
-      table: { defaultValue: { summary: "16:9" } },
-    },
-    className: {
       control: "text",
-      description: "Additional CSS class names",
-      table: { disable: true },
+      description: "Media or placeholder content inside the ratio box",
     },
   },
   args: defaultArgs,

--- a/nextjs-app/shared/components/AspectRatio/AspectRatio.tsx
+++ b/nextjs-app/shared/components/AspectRatio/AspectRatio.tsx
@@ -2,8 +2,11 @@ import { type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 export interface AspectRatioProps {
+  /** Media or placeholder content inside the ratio box. */
   children: ReactNode;
+  /** Width-to-height ratio token. @default "16:9" */
   ratio?: "1:1" | "4:3" | "16:9" | "21:9" | "3:2" | "2:3";
+  /** Additional CSS class names. */
   className?: string;
 }
 

--- a/nextjs-app/shared/components/Card/Card.stories.tsx
+++ b/nextjs-app/shared/components/Card/Card.stories.tsx
@@ -23,65 +23,48 @@ const meta = {
     contractStatus: contract.status,
     a11y: { test: "error" },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // authored entries cover judgment: children text control, mapping presets
+  // for the composite titleProps/descriptionProps/extra slots.
   argTypes: {
-    variant: {
-      control: { type: "select" },
-      options: ["default", "muted", "transparent"],
-      description:
-        "Background variant: default keeps the hairline border, muted recedes, transparent groups without weight",
-      table: { defaultValue: { summary: "default" } },
-    },
-    padding: {
-      control: { type: "select" },
-      options: ["none", "sm", "md", "lg"],
-      description: "Internal padding step on the space scale (12/16/24px)",
-      table: { defaultValue: { summary: "md" } },
-    },
-    as: {
-      control: { type: "select" },
-      options: ["div", "article", "section", "aside", "li"],
-      description: "Semantic element for the card surface",
-      table: { defaultValue: { summary: "div" } },
-    },
-    title: {
-      control: "text",
-      description: "Optional heading (Title xxs, real heading element)",
-    },
+    children: { control: "text", description: "Card body content" },
     titleProps: {
-      control: false,
-      description: "Heading configuration (level for the document outline)",
-      table: { category: "Advanced" },
-    },
-    description: {
-      control: "text",
-      description: "Supporting line under the title (Text s)",
+      control: { type: "select" },
+      options: ["default", "h2Outline", "largeSerif"],
+      mapping: {
+        default: undefined,
+        h2Outline: { level: 2 },
+        largeSerif: { size: "m", terminals: "serif" },
+      },
+      description:
+        "Heading configuration (level for the document outline). Pick a preset here; compose your own in code.",
+      table: { category: "Advanced", type: { summary: "CardTitleProps" } },
     },
     descriptionProps: {
-      control: false,
-      description: "Description configuration",
-      table: { category: "Advanced" },
+      control: { type: "select" },
+      options: ["default", "largeSpan"],
+      mapping: {
+        default: undefined,
+        largeSpan: { size: "m", as: "span" },
+      },
+      description:
+        "Description configuration. Pick a preset here; compose your own in code.",
+      table: { category: "Advanced", type: { summary: "CardDescriptionProps" } },
     },
     extra: {
-      control: false,
-      description: "Right-aligned header slot (badge, timestamp, small action)",
-    },
-    link: {
-      control: "text",
-      description: "Makes the whole card one link to this href",
-    },
-    linkLabel: {
-      control: "text",
-      description: "Accessible name when the title alone is ambiguous",
-    },
-    loading: {
-      control: "boolean",
-      description: "Skeleton loading state (role=status, aria-busy)",
-    },
-    children: { control: "text", description: "Card body content" },
-    className: {
-      control: false,
-      description: "Additional CSS classes on the card surface",
-      table: { category: "Advanced" },
+      control: { type: "select" },
+      options: ["none", "draftBadge"],
+      mapping: {
+        none: undefined,
+        draftBadge: (
+          <Badge tone="info" size="sm">
+            Draft
+          </Badge>
+        ),
+      },
+      description:
+        "Right-aligned header slot (badge, timestamp, small action). Pick a preset here; compose your own in code.",
+      table: { category: "Content", type: { summary: "React.ReactNode" } },
     },
   },
   args: {
@@ -111,13 +94,16 @@ export const Default: Story = {
   ),
 };
 
+// No hardcoded JSX children: they would override args.children and turn the
+// panel's body control into a liar. link seeded so linkLabel has an anchor
+// to name.
 export const Playground: Story = {
   tags: ["beta-matrix"],
-  render: (args) => (
-    <Card {...args} style={{ maxWidth: "20rem" }}>
-      <Text size="s">Body content flows in the card rhythm.</Text>
-    </Card>
-  ),
+  render: (args) => <Card {...args} style={{ maxWidth: "20rem" }} />,
+  args: {
+    children: "Body content flows in the card rhythm.",
+    link: "/work/dsharp-design-system",
+  },
 };
 
 /** Background swaps only — the border never moves. */

--- a/nextjs-app/shared/components/Card/__a11y-snapshots__/layout-card--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Card/__a11y-snapshots__/layout-card--playground.forced-colors.yaml
@@ -1,3 +1,5 @@
-- heading "Design tokens" [level=3]
+- heading "Design tokens" [level=3]:
+  - link "Design tokens":
+    - /url: /work/dsharp-design-system
 - paragraph: "Layer 0 of the system: DTCG JSON, transformed per platform."
-- paragraph: Body content flows in the card rhythm.
+- text: Body content flows in the card rhythm.

--- a/nextjs-app/shared/components/Card/__a11y-snapshots__/layout-card--playground.yaml
+++ b/nextjs-app/shared/components/Card/__a11y-snapshots__/layout-card--playground.yaml
@@ -1,3 +1,5 @@
-- heading "Design tokens" [level=3]
+- heading "Design tokens" [level=3]:
+  - link "Design tokens":
+    - /url: /work/dsharp-design-system
 - paragraph: "Layer 0 of the system: DTCG JSON, transformed per platform."
-- paragraph: Body content flows in the card rhythm.
+- text: Body content flows in the card rhythm.

--- a/nextjs-app/shared/components/Center/Center.stories.tsx
+++ b/nextjs-app/shared/components/Center/Center.stories.tsx
@@ -22,20 +22,12 @@ const meta = {
     a11y: { test: "error" },
     docs: { description: { component: contract.description } },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // children keeps an authored text control (content slot).
   argTypes: {
     children: {
-      control: false,
+      control: "text",
       description: "Content to center inside the flex container",
-    },
-    className: {
-      control: "text",
-      description: "Additional CSS class names (often a height constraint)",
-      table: { disable: true },
-    },
-    as: {
-      control: "text",
-      description: "Polymorphic wrapper element",
-      table: { disable: true },
     },
   },
   args: defaultArgs,
@@ -51,6 +43,9 @@ export const Default: Story = {
 export const Playground: Story = {
   tags: ["beta-matrix"],
   globals: { forcedColors: "none" },
+  // Plain-text children so the panel's text control matches what renders;
+  // className seeded with a height so centering is visible.
+  args: { children: "Centered content", className: "min-h-32" },
 };
 
 export const Example: Story = {

--- a/nextjs-app/shared/components/Center/Center.tsx
+++ b/nextjs-app/shared/components/Center/Center.tsx
@@ -2,8 +2,11 @@ import { type ReactNode, type ElementType } from "react";
 import { cn } from "@/lib/utils";
 
 export interface CenterProps {
+  /** Content to center inside the flex container. */
   children: ReactNode;
+  /** Additional CSS class names (often a height constraint). */
   className?: string;
+  /** Polymorphic wrapper element. @default "div" */
   as?: ElementType;
 }
 

--- a/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.stories.tsx
+++ b/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.stories.tsx
@@ -6,25 +6,10 @@ import { codeBlockFixtures } from "./codeBlockFixtures";
 import { renderCodeBlockFixtureNode } from "./CodeBlockFixtureRenderer";
 
 const meta: Meta<typeof CodeBlockWindow> = {
-  argTypes: {
-    context: {
-      control: "select",
-      options: ["default", "article"],
-      description: "Layout context for article vs default sizing",
-      table: { defaultValue: { summary: "default" } },
-    },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
-      caption: { control: "text", description: "Optional caption rendered below the code", table: { category: "Content" } },
-      children: { table: { disable: true } },
-      className: { control: "text", description: "Optional className passthrough", table: { category: "Advanced" } },
-      id: { table: { disable: true } },
-      language: { control: "text", description: "Language label shown in the header", table: { category: "Content" } },
-      ref: { table: { disable: true } },
-      showLineNumbers: { control: "boolean", description: "Force line numbers on/off (defaults to presence in Shiki output)", table: { category: "Content" } },
-      style: { table: { disable: true } },
-      title: { control: "text", description: "Optional title or filename shown in the header", table: { category: "Content" } }
-},
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // the composite children slot (pre-rendered Shiki output) keeps a mapping
+  // preset — defined on Playground below because the fixtures are built after
+  // this meta literal.
   title: "Content/CodeBlockWindow",
   component: CodeBlockWindow,
   parameters: {
@@ -101,7 +86,23 @@ export const DarkPreview: Story = {
   },
 };
 
-export const Playground = Default;
+export const Playground: Story = {
+  tags: ["beta-matrix"],
+  argTypes: {
+    children: {
+      control: { type: "select" },
+      options: ["tsx", "bash", "json", "longLine"],
+      mapping: fixture,
+      description:
+        "Pre-rendered Shiki code content. Pick a fixture here; compose your own in code.",
+      table: { category: "Content", type: { summary: "React.ReactNode" } },
+    },
+  },
+  args: {
+    ...Default.args,
+    children: "tsx" as unknown as React.ReactNode,
+  },
+};
 export const Example = {
   tags: ["beta-matrix"],
   parameters: { controls: { disable: true } },

--- a/nextjs-app/shared/components/Container/Container.stories.tsx
+++ b/nextjs-app/shared/components/Container/Container.stories.tsx
@@ -27,36 +27,14 @@ const meta = {
     a11y: { test: "error" },
     docs: { description: { component: contract.description } },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // children keeps an authored text control (content slot).
   argTypes: {
     children: {
-      control: false,
+      control: "text",
       description: "Page content inside the width constraint",
     },
-    size: {
-      control: "select",
-      options: ["sm", "md", "lg", "xl", "full"],
-      description: "Max-width token",
-      table: { defaultValue: { summary: "lg" } },
-    },
-    center: {
-      control: "boolean",
-      description: "Center the container horizontally",
-    },
-    className: {
-      control: "text",
-      description: "Wrapper class names",
-      table: { disable: true },
-    },
-    as: {
-      control: "text",
-      description: "Polymorphic element",
-      table: { disable: true },
-    },
-      asChild: { table: { disable: true } },
-      id: { table: { disable: true } },
-      ref: { table: { disable: true } },
-      style: { table: { disable: true } }
-},
+  },
   args: defaultArgs,
 } satisfies Meta<typeof Container>;
 

--- a/nextjs-app/shared/components/Container/Container.tsx
+++ b/nextjs-app/shared/components/Container/Container.tsx
@@ -4,10 +4,15 @@ import { cn } from "@/lib/utils";
 import styles from "./Container.module.css";
 
 export interface ContainerProps {
+  /** Page content inside the width constraint. */
   children: ReactNode;
+  /** Max-width token. @default "lg" */
   size?: "sm" | "md" | "lg" | "xl" | "full";
+  /** Center the container horizontally. */
   center?: boolean;
+  /** Wrapper class names. */
   className?: string;
+  /** Polymorphic element. @default "div" */
   as?: ElementType;
 }
 

--- a/nextjs-app/shared/components/Divider/Divider.stories.tsx
+++ b/nextjs-app/shared/components/Divider/Divider.stories.tsx
@@ -15,24 +15,7 @@ const meta = {
     contractStatus: contract.status,
     a11y: { test: "error" },
   },
-  argTypes: {
-    orientation: {
-      control: "radio",
-      options: ["horizontal", "vertical"],
-      description: "Layout axis of the separator",
-      table: { category: "Layout", defaultValue: { summary: "horizontal" } },
-    },
-    decorative: {
-      control: "boolean",
-      description: "When true, exposed as presentational only (role=none)",
-      table: { category: "Accessibility", defaultValue: { summary: "true" } },
-    },
-    className: {
-      control: false,
-      description: "Optional spacing/width utility classes",
-      table: { category: "Advanced" },
-    },
-  },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts).
   args: { orientation: "horizontal", decorative: true },
 } satisfies Meta<typeof Divider>;
 

--- a/nextjs-app/shared/components/ExpandableSection/ExpandableSection.contract.json
+++ b/nextjs-app/shared/components/ExpandableSection/ExpandableSection.contract.json
@@ -74,10 +74,6 @@
         "className": {
             "optional": true,
             "type": "string"
-        },
-        "staggerDelay": {
-            "optional": true,
-            "type": "number"
         }
     },
     "forbiddenUse": [
@@ -110,7 +106,7 @@
             },
             {
                 "guidance": true,
-                "description": "Keep the reveal short — a stagger over dozens of children reads as lag; tune staggerDelay down for long lists."
+                "description": "Keep the reveal short — dozens of children behind one disclosure read as lag; split long lists instead."
             },
             {
                 "guidance": false,

--- a/nextjs-app/shared/components/ExpandableSection/ExpandableSection.stories.tsx
+++ b/nextjs-app/shared/components/ExpandableSection/ExpandableSection.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import React, { useState } from "react";
-import { userEvent, within } from "storybook/test";
+import { useArgs } from "storybook/preview-api";
+import { expect, userEvent, within } from "storybook/test";
 import { ExpandableSection } from "./ExpandableSection";
 import contract from "./ExpandableSection.contract.json";
 
@@ -38,40 +39,12 @@ const meta = {
     a11y: { test: "error" },
     docs: { description: { component: contract.description } },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // children keeps an authored text control (content slot).
   argTypes: {
-    collapsedLabel: {
-      control: "text",
-      description: "Trigger label when collapsed",
-    },
-    expandedLabel: {
-      control: "text",
-      description: "Trigger label when expanded",
-    },
-    defaultExpanded: {
-      control: "boolean",
-      description: "Initial open state (uncontrolled)",
-    },
-    expanded: {
-      control: "boolean",
-      description: "Controlled open state",
-    },
-    onExpandedChange: {
-      action: "expandedChange",
-      description: "Open state change handler",
-    },
     children: {
-      control: false,
-      description: "Disclosed panel content",
-    },
-    className: {
       control: "text",
-      description: "Container class names",
-      table: { disable: true },
-    },
-    staggerDelay: {
-      control: "number",
-      description: "Child animation stagger in ms",
-      table: { defaultValue: { summary: "60" } },
+      description: "Disclosed panel content",
     },
   },
   args: defaultArgs,
@@ -83,15 +56,37 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   tags: ["beta-matrix"],
   render: (args) => <ExpandableSectionDemo {...args} />,
+  // Keyboard contract: the trigger is a real button — click toggles and
+  // aria-expanded follows. (Kept off Playground so its seeded expanded state
+  // stays untouched for the controls effects audit.)
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole("button");
+    await userEvent.click(trigger);
+    await expect(trigger).toHaveAttribute("aria-expanded", "true");
+  },
 };
 export const Playground: Story = {
   tags: ["beta-matrix"],
-  render: (args) => <ExpandableSectionDemo {...args} />,
-};
-
-Playground.play = async ({ canvasElement }) => {
-  const canvas = within(canvasElement);
-  await userEvent.click(canvas.getByRole("button"));
+  /**
+   * Args-driven controlled state (useArgs writeback): the expanded toggle
+   * drives the canvas AND clicking the trigger updates the panel. useArgs must
+   * run in the story render itself, not a nested component. Seeded expanded so
+   * the content is visible; expandedLabel seeded "" so BOTH label props are
+   * live (a set expandedLabel would mask collapsedLabel entirely while open).
+   */
+  render: function PlaygroundRender(args) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- Storybook render context
+    const [{ expanded }, updateArgs] = useArgs();
+    return (
+      <ExpandableSection
+        {...args}
+        expanded={Boolean(expanded)}
+        onExpandedChange={(next) => updateArgs({ expanded: next })}
+      />
+    );
+  },
+  args: { ...defaultArgs, expanded: true, expandedLabel: "" },
 };
 
 export const Example: Story = {

--- a/nextjs-app/shared/components/ExpandableSection/ExpandableSection.tsx
+++ b/nextjs-app/shared/components/ExpandableSection/ExpandableSection.tsx
@@ -20,8 +20,6 @@ export interface ExpandableSectionProps {
   children: ReactNode;
   /** Additional className for the container */
   className?: string;
-  /** Stagger delay for child animations (ms) */
-  staggerDelay?: number;
 }
 
 export function ExpandableSection({
@@ -32,7 +30,6 @@ export function ExpandableSection({
   onExpandedChange,
   children,
   className,
-  staggerDelay = 60,
 }: ExpandableSectionProps) {
   const [internalExpanded, setInternalExpanded] = useState(defaultExpanded);
   const isControlled = controlledExpanded !== undefined;

--- a/nextjs-app/shared/components/FlexBox/FlexBox.stories.tsx
+++ b/nextjs-app/shared/components/FlexBox/FlexBox.stories.tsx
@@ -36,69 +36,30 @@ const meta = {
     a11y: { test: "error" },
     docs: { description: { component: contract.description } },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // the composite children slot keeps a mapping preset.
   argTypes: {
-    children: { control: false, description: "Flex items" },
-    direction: {
-      control: "select",
-      options: ["row", "row-reverse", "column", "column-reverse"],
-      description: "flex-direction",
-      table: { defaultValue: { summary: "row" } },
+    children: {
+      control: { type: "select" },
+      options: ["threeLabels", "sixLabels"],
+      mapping: {
+        threeLabels: defaultArgs.children,
+        sixLabels: (
+          <>
+            {["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta"].map(
+              (label) => (
+                <Text key={label} as="span" terminals="sans">
+                  {label}
+                </Text>
+              ),
+            )}
+          </>
+        ),
+      },
+      description: "Flex items. Pick a preset here; compose your own in code.",
+      table: { category: "Content", type: { summary: "React.ReactNode" } },
     },
-    wrap: {
-      control: "select",
-      options: ["nowrap", "wrap", "wrap-reverse"],
-      description: "flex-wrap",
-      table: { defaultValue: { summary: "nowrap" } },
-    },
-    justify: {
-      control: "select",
-      options: [
-        "flex-start",
-        "flex-end",
-        "center",
-        "space-between",
-        "space-around",
-        "space-evenly",
-      ],
-      description: "justify-content",
-    },
-    align: {
-      control: "select",
-      options: ["stretch", "flex-start", "flex-end", "center", "baseline"],
-      description: "align-items",
-      table: { defaultValue: { summary: "stretch" } },
-    },
-    gap: { control: "text", description: "Shorthand gap" },
-    rowGap: {
-      control: "text",
-      description: "Row gap override",
-      table: { disable: true },
-    },
-    columnGap: {
-      control: "text",
-      description: "Column gap override",
-      table: { disable: true },
-    },
-    alignContent: {
-      control: "text",
-      description: "align-content",
-      table: { disable: true },
-    },
-    className: {
-      control: "text",
-      description: "Wrapper class names",
-      table: { disable: true },
-    },
-    style: {
-      control: "object",
-      description: "Inline style override",
-      table: { disable: true },
-    },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
-      id: { table: { disable: true } },
-      ref: { table: { disable: true } }
-},
+  },
   args: defaultArgs,
 } satisfies Meta<typeof FlexBox>;
 
@@ -108,8 +69,15 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   tags: ["beta-matrix"],
 };
+// Gap overrides seeded with valid lengths so the effects probe's appended
+// characters produce a measurable valid->invalid style change.
 export const Playground: Story = {
   tags: ["beta-matrix"],
+  args: {
+    children: "threeLabels" as unknown as typeof defaultArgs.children,
+    rowGap: "1rem",
+    columnGap: "1rem",
+  },
 };
 
 export const Example: Story = {

--- a/nextjs-app/shared/components/FlexBox/FlexBox.tsx
+++ b/nextjs-app/shared/components/FlexBox/FlexBox.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 
 export interface FlexBoxProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** flex-direction. @default "row" */
   direction?: "row" | "row-reverse" | "column" | "column-reverse";
+  /** flex-wrap. @default "nowrap" */
   wrap?: "nowrap" | "wrap" | "wrap-reverse";
   justify?:
     | "flex-start"
@@ -18,8 +20,11 @@ export interface FlexBoxProps extends React.HTMLAttributes<HTMLDivElement> {
     | "center"
     | "space-between"
     | "space-around";
+  /** Shorthand gap (CSS length or number of px). */
   gap?: string | number;
+  /** Row gap override. */
   rowGap?: string | number;
+  /** Column gap override. */
   columnGap?: string | number;
   style?: React.CSSProperties;
   children: React.ReactNode;

--- a/nextjs-app/shared/components/Grid/Grid.stories.tsx
+++ b/nextjs-app/shared/components/Grid/Grid.stories.tsx
@@ -46,53 +46,33 @@ const meta = {
     a11y: { test: "error" },
     docs: { description: { component: contract.description } },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // the composite children slot keeps a mapping preset, and columns keeps a
+  // bespoke number knob (number-or-template union derives as free text).
   argTypes: {
     children: {
-      control: false,
-      description: "Grid cells (supports span on child props)",
+      control: { type: "select" },
+      options: ["fourCells", "sixCells"],
+      mapping: {
+        fourCells: defaultArgs.children,
+        sixCells: (
+          <>
+            {["A", "B", "C", "D", "E", "F"].map((cell) => (
+              <div key={cell}>
+                <Text as="p" terminals="sans">
+                  Cell {cell}
+                </Text>
+              </div>
+            ))}
+          </>
+        ),
+      },
+      description:
+        "Grid cells (supports span on child props). Pick a preset here; compose your own in code.",
+      table: { category: "Content", type: { summary: "ReactNode" } },
     },
     columns: { control: "number", description: "Column count or template" },
-    rows: {
-      control: "text",
-      description: "Row count or template",
-      table: { disable: true },
-    },
-    gap: {
-      control: "text",
-      description: "Grid gap",
-      table: { defaultValue: { summary: "1rem" } },
-    },
-    rowGap: {
-      control: "text",
-      description: "Row gap override",
-      table: { disable: true },
-    },
-    colGap: {
-      control: "text",
-      description: "Column gap override",
-      table: { disable: true },
-    },
-    align: {
-      control: "text",
-      description: "align-items",
-      table: { disable: true, defaultValue: { summary: "inherit" } },
-    },
-    justify: {
-      control: "text",
-      description: "justify-items",
-      table: { disable: true },
-    },
-    className: {
-      control: "text",
-      description: "Grid class names",
-      table: { disable: true },
-    },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
-      id: { table: { disable: true } },
-      ref: { table: { disable: true } },
-      style: { table: { disable: true } }
-},
+  },
   args: defaultArgs,
 } satisfies Meta<typeof Grid>;
 
@@ -102,8 +82,16 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   tags: ["beta-matrix"],
 };
+// Free-length props are seeded with VALID values: the effects probe appends
+// characters, and only a valid->invalid transition shows in the style attr.
 export const Playground: Story = {
   tags: ["beta-matrix"],
+  args: {
+    children: "fourCells" as unknown as typeof defaultArgs.children,
+    rows: "2",
+    rowGap: "1rem",
+    colGap: "1rem",
+  },
 };
 
 export const Example: Story = {

--- a/nextjs-app/shared/components/Grid/Grid.tsx
+++ b/nextjs-app/shared/components/Grid/Grid.tsx
@@ -8,15 +8,24 @@ import React, {
 import styles from "./Grid.module.css";
 
 export interface GridProps {
+  /** Grid cells (supports span on child props). */
   children: ReactNode;
+  /** Column count or grid-template-columns string. */
   columns?: number | string;
+  /** Row count or grid-template-rows string. */
   rows?: number | string;
+  /** Grid gap. @default "1rem" */
   gap?: string;
+  /** Row gap override. */
   rowGap?: string;
+  /** Column gap override. */
   colGap?: string;
+  /** align-items. */
   align?: CSSProperties["alignItems"];
+  /** justify-items. */
   justify?: CSSProperties["justifyItems"];
   style?: CSSProperties;
+  /** Grid class names. */
   className?: string;
   [key: string]: any; // Allow passing any grid CSS prop
 }

--- a/nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.stories.tsx
+++ b/nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.stories.tsx
@@ -1,26 +1,14 @@
 import contract from "./MacWindowFrame.contract.json";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
 import MacWindowFrame from "@dt/MacWindowFrame";
 
 const meta: Meta<typeof MacWindowFrame> = {
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // children keeps an authored text control (content slot).
   argTypes: {
-    density: {
-      control: { type: "select" },
-      options: ["compact", "comfortable"],
-      description: "Chrome density inside the window frame",
-      table: { defaultValue: { summary: "compact" } },
-    },
-      actionLabelKey: { control: "text", description: "Optional label for the action button", table: { category: "Accessibility" } },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
-      children: { table: { disable: true } },
-      className: { control: "text", description: "Optional className passthrough", table: { category: "Advanced" } },
-      id: { table: { disable: true } },
-      onAction: { action: "onAction", table: { disable: true } },
-      ref: { table: { disable: true } },
-      style: { table: { disable: true } },
-      titleKey: { control: "text", description: "Translation key for the window title", table: { category: "Content" } }
-},
+    children: { control: "text", description: "Content to render inside the frame" },
+  },
   title: "Layout/MacWindowFrame",
   component: MacWindowFrame,
   parameters: {
@@ -98,7 +86,12 @@ export const Compact: Story = {
   args: { density: "compact", children: sampleContent },
 };
 
-export const Playground = Default;
+// onAction is seeded so the action button exists and actionLabelKey can
+// drive it from the panel (the button hides itself without a callback).
+export const Playground: Story = {
+  tags: ["beta-matrix"],
+  args: { children: sampleContent, onAction: fn() },
+};
 export const Example = {
   tags: ["beta-matrix"],
   parameters: { controls: { disable: true } },

--- a/nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.tsx
+++ b/nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.tsx
@@ -74,16 +74,18 @@ export const MacWindowFrame: React.FC<MacWindowFrameProps> = ({
           <span className={`${styles.dot} ${styles.maximize}`} />
         </div>
         <Title as="h3" level={3} size="m" className={styles.title}>
-          {t(titleKey)}
+          {/* || not just the destructure defaults: a cleared/seeded Controls
+              text field passes "" and must fall back the same way */}
+          {t(titleKey || "macWindowFrame.title")}
         </Title>
         {hasAction ? (
           <Button
             variant="tertiary"
             className={styles.action}
             onClick={onAction}
-            accessibleName={t(actionLabelKey)}
+            accessibleName={t(actionLabelKey || "macWindowFrame.action")}
           >
-            {t(actionLabelKey)}
+            {t(actionLabelKey || "macWindowFrame.action")}
           </Button>
         ) : (
           <span className={styles.actionPlaceholder} aria-hidden="true" />

--- a/nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.stories.tsx
+++ b/nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.stories.tsx
@@ -4,27 +4,19 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import MarkdownMessage from "@dt/MarkdownMessage";
 
 const meta: Meta<typeof MarkdownMessage> = {
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // designSystemTextSize keeps an authored select (its type is an alias the
+  // contract cannot expand). fallback is effect-exempt (masked while content
+  // renders; unit-tested).
   argTypes: {
-    density: {
-      control: "select",
-      options: ["default", "chat"],
+    designSystemTextSize: {
+      control: { type: "select" },
+      options: ["xxs", "xs", "s", "m", "l", "xl", "xxl"],
       description:
-        "Typography density for chat bubbles vs default markdown blocks",
-      table: { defaultValue: { summary: "default" } },
+        "When `renderWithDesignSystem` is enabled, use this as the base size for paragraph and inline emphasis text (e.g. `p`, `strong`, `em`).",
+      table: { category: "Content", type: { summary: "TextProps[\"size\"]" } },
     },
-      "data-role": { table: { disable: true } },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
-      children: { table: { disable: true } },
-      className: { table: { disable: true } },
-      content: { control: "text", description: "Markdown source rendered through DS typography.", table: { category: "Content" } },
-      designSystemTextSize: { control: false, description: "When `renderWithDesignSystem` is enabled, use this as the base size for paragraph and inline emphasis text (e.g. `p`, `strong`, `em`).", table: { category: "Content" } },
-      fallback: { control: "text", description: "Plain text shown when content fails to parse.", table: { category: "Content" } },
-      id: { table: { disable: true } },
-      ref: { table: { disable: true } },
-      renderWithDesignSystem: { control: "boolean", description: "Render markdown using the design system components (Title/Text/Link). Useful for long-form content pages to ensure consistent styling.", table: { category: "Content" } },
-      style: { table: { disable: true } }
-},
+  },
   title: "Site/Chat/MarkdownMessage",
   component: MarkdownMessage,
   tags: ["beta", "!autodocs"],
@@ -66,7 +58,12 @@ export const LinkAndImage: Story = {
   },
 };
 
-export const Playground = Default;
+// renderWithDesignSystem seeded true so designSystemTextSize has a live path.
+export const Playground: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "none" },
+  args: { renderWithDesignSystem: true, designSystemTextSize: "m" },
+};
 export const Example = {
   tags: ["beta-matrix"],
   parameters: { controls: { disable: true } },

--- a/nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.tsx
+++ b/nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.tsx
@@ -9,7 +9,9 @@ import Link from "@dt/Link";
 type DesignSystemTextSize = NonNullable<TextProps["size"]>;
 
 export interface MarkdownMessageProps {
+  /** Markdown source rendered through DS typography. */
   content: string;
+  /** Plain text shown when content is empty or fails to parse. */
   fallback?: string;
   "data-role"?: string;
   /**

--- a/nextjs-app/shared/components/NextLayout/NextLayout.contract.json
+++ b/nextjs-app/shared/components/NextLayout/NextLayout.contract.json
@@ -37,6 +37,10 @@
         "className": {
             "optional": true,
             "type": "string"
+        },
+        "children": {
+            "optional": false,
+            "type": "React.ReactNode"
         }
     },
     "forbiddenUse": [

--- a/nextjs-app/shared/components/NextLayout/NextLayout.stories.tsx
+++ b/nextjs-app/shared/components/NextLayout/NextLayout.stories.tsx
@@ -30,19 +30,7 @@ const meta = {
     a11y: { test: "error" },
     docs: { description: { component: contract.description } },
   },
-  argTypes: {
-    className: {
-      control: "text",
-      description: "Layout wrapper class names",
-      table: { disable: true },
-    },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
-      children: { table: { disable: true } },
-      id: { table: { disable: true } },
-      ref: { table: { disable: true } },
-      style: { table: { disable: true } }
-},
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts).
   args: {},
 } satisfies Meta<typeof NextLayout>;
 
@@ -53,9 +41,14 @@ export const Default: Story = {
   tags: ["beta-matrix"],
   render: () => <NextLayout>{sampleMain}</NextLayout>,
 };
+// Args-driven children (no hardcoded JSX children, which would override the
+// panel's text control and turn it into a liar).
 export const Playground: Story = {
   tags: ["beta-matrix"],
-  ...Default,
+  render: (args) => <NextLayout {...args} />,
+  args: {
+    children: "Page content rendered inside the production shell.",
+  },
 };
 
 Playground.play = async ({ canvasElement }) => {

--- a/nextjs-app/shared/components/NextLayout/NextLayout.tsx
+++ b/nextjs-app/shared/components/NextLayout/NextLayout.tsx
@@ -19,17 +19,23 @@ const CookieConsentModal = dynamic(
 
 /** Props for NextLayout. */
 export interface NextLayoutProps {
+  /** Additional class names on the layout wrapper. */
   className?: string;
+  children: React.ReactNode;
 }
 
 /**
  * NextLayout component.
  */
-export function NextLayout({ children }: { children: React.ReactNode }) {
+export function NextLayout({ children, className }: NextLayoutProps) {
   return (
     <>
       <DonnyActionProvider>
-        <div className={styles.layout}>
+        <div
+          className={
+            className ? `${styles.layout} ${className}` : styles.layout
+          }
+        >
           <SkipLink href="#main-content" />
           <SiteHeader />
           <main id="main-content" className={styles.main}>

--- a/nextjs-app/shared/components/Section/Section.stories.tsx
+++ b/nextjs-app/shared/components/Section/Section.stories.tsx
@@ -27,40 +27,11 @@ const meta = {
     a11y: { test: "error" },
     docs: { description: { component: contract.description } },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // children keeps an authored text control (content slot).
   argTypes: {
-    children: { control: false, description: "Section content" },
-    spacing: {
-      control: "select",
-      options: ["none", "sm", "md", "lg", "xl", "hero", "follow"],
-      description: "Block padding scale",
-      table: { defaultValue: { summary: "md" } },
-    },
-    background: {
-      control: "select",
-      options: ["default", "muted", "accent", "inverse"],
-      description: "Surface background token",
-      table: { defaultValue: { summary: "default" } },
-    },
-    className: {
-      control: "text",
-      description: "Section class names",
-      table: { disable: true },
-    },
-    id: {
-      control: "text",
-      description: "Section id",
-      table: { disable: true },
-    },
-    donnyTarget: {
-      control: "text",
-      description: "Donny spotlight target id",
-      table: { disable: true },
-    },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
-      ref: { table: { disable: true } },
-      style: { table: { disable: true } }
-},
+    children: { control: "text", description: "Section content" },
+  },
   args: defaultArgs,
 } satisfies Meta<typeof Section>;
 

--- a/nextjs-app/shared/components/Section/Section.tsx
+++ b/nextjs-app/shared/components/Section/Section.tsx
@@ -4,10 +4,15 @@ import { type ReactNode, forwardRef } from "react";
 import { cn } from "@/lib/utils";
 
 export interface SectionProps {
+  /** Section content. */
   children: ReactNode;
+  /** Block padding scale. @default "md" */
   spacing?: "none" | "sm" | "md" | "lg" | "xl" | "hero" | "follow";
+  /** Surface background token. @default "default" */
   background?: "default" | "muted" | "accent" | "inverse";
+  /** Section class names. */
   className?: string;
+  /** Section id (anchor target). */
   id?: string;
   /** Whitelisted Donny spotlight / navigation target id */
   donnyTarget?: string;

--- a/nextjs-app/shared/components/Spacer/Spacer.stories.tsx
+++ b/nextjs-app/shared/components/Spacer/Spacer.stories.tsx
@@ -21,25 +21,7 @@ const meta = {
     a11y: { test: "error" },
     docs: { description: { component: contract.description } },
   },
-  argTypes: {
-    size: {
-      control: "select",
-      options: ["xs", "sm", "md", "lg", "xl", "2xl"],
-      description: "Tokenized gap size",
-      table: { defaultValue: { summary: "md" } },
-    },
-    axis: {
-      control: "select",
-      options: ["vertical", "horizontal"],
-      description: "Block (vertical) or inline (horizontal) axis",
-      table: { defaultValue: { summary: "vertical" } },
-    },
-    className: {
-      control: "text",
-      description: "Additional CSS class names",
-      table: { disable: true },
-    },
-  },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts).
   args: defaultArgs,
 } satisfies Meta<typeof Spacer>;
 

--- a/nextjs-app/shared/components/Spacer/Spacer.tsx
+++ b/nextjs-app/shared/components/Spacer/Spacer.tsx
@@ -1,8 +1,11 @@
 import { cn } from "@/lib/utils";
 
 export interface SpacerProps {
+  /** Tokenized gap size. @default "md" */
   size?: "xs" | "sm" | "md" | "lg" | "xl" | "2xl";
+  /** Block (vertical) or inline (horizontal) axis. @default "vertical" */
   axis?: "vertical" | "horizontal";
+  /** Additional CSS class names. */
   className?: string;
 }
 

--- a/nextjs-app/shared/components/Stack/Stack.stories.tsx
+++ b/nextjs-app/shared/components/Stack/Stack.stories.tsx
@@ -32,50 +32,31 @@ const meta = {
     a11y: { test: "error" },
     docs: { description: { component: contract.description } },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // the composite children slot keeps a mapping preset.
   argTypes: {
-    children: { control: false, description: "Stacked children" },
-    direction: {
-      control: "select",
-      options: ["vertical", "horizontal"],
-      description: "Stack axis",
-      table: { defaultValue: { summary: "vertical" } },
+    children: {
+      control: { type: "select" },
+      options: ["twoItems", "fourItems"],
+      mapping: {
+        twoItems: defaultArgs.children,
+        fourItems: (
+          <>
+            {["First item", "Second item", "Third item", "Fourth item"].map(
+              (label) => (
+                <Text key={label} as="p" terminals="sans">
+                  {label}
+                </Text>
+              ),
+            )}
+          </>
+        ),
+      },
+      description:
+        "Stacked children. Pick a preset here; compose your own in code.",
+      table: { category: "Content", type: { summary: "ReactNode" } },
     },
-    gap: {
-      control: "select",
-      options: ["none", "xs", "sm", "md", "lg", "xl"],
-      description: "Gap token between items",
-      table: { defaultValue: { summary: "md" } },
-    },
-    align: {
-      control: "select",
-      options: ["start", "center", "end", "stretch"],
-      description: "Cross-axis alignment",
-      table: { defaultValue: { summary: "center" } },
-    },
-    justify: {
-      control: "select",
-      options: ["start", "center", "end", "between", "around"],
-      description: "Main-axis distribution",
-    },
-    wrap: {
-      control: "boolean",
-      description: "Allow wrapping on horizontal stacks",
-    },
-    className: {
-      control: "text",
-      description: "Stack class names",
-      table: { disable: true },
-    },
-    as: {
-      control: "text",
-      description: "Polymorphic element",
-      table: { disable: true },
-    },
-      asChild: { table: { disable: true } },
-      id: { table: { disable: true } },
-      ref: { table: { disable: true } },
-      style: { table: { disable: true } }
-},
+  },
   args: defaultArgs,
 } satisfies Meta<typeof Stack>;
 
@@ -87,6 +68,9 @@ export const Default: Story = {
 };
 export const Playground: Story = {
   tags: ["beta-matrix"],
+  args: {
+    children: "twoItems" as unknown as typeof defaultArgs.children,
+  },
 };
 
 export const Example: Story = {

--- a/nextjs-app/shared/components/Stack/Stack.tsx
+++ b/nextjs-app/shared/components/Stack/Stack.tsx
@@ -2,13 +2,21 @@ import { type ReactNode, type ElementType } from "react";
 import { cn } from "@/lib/utils";
 
 export interface StackProps {
+  /** Stacked children. */
   children: ReactNode;
+  /** Stack axis. @default "vertical" */
   direction?: "vertical" | "horizontal";
+  /** Gap token between items. @default "md" */
   gap?: "none" | "xs" | "sm" | "md" | "lg" | "xl";
+  /** Cross-axis alignment. @default "center" */
   align?: "start" | "center" | "end" | "stretch";
+  /** Main-axis distribution. */
   justify?: "start" | "center" | "end" | "between" | "around";
+  /** Allow wrapping on horizontal stacks. */
   wrap?: boolean;
+  /** Stack class names. */
   className?: string;
+  /** Polymorphic element. @default "div" */
   as?: ElementType;
 }
 

--- a/nextjs-app/shared/components/ThemeProvider/ThemeProvider.contract.json
+++ b/nextjs-app/shared/components/ThemeProvider/ThemeProvider.contract.json
@@ -34,9 +34,14 @@
     "slots": [],
     "schemaVersion": 2,
     "props": {
-        "className": {
+        "children": {
+            "optional": false,
+            "type": "React.ReactNode"
+        },
+        "forcedTheme": {
             "optional": true,
-            "type": "string"
+            "type": "union",
+            "values": ["light", "dark", "hcb", "hcw"]
         }
     },
     "forbiddenUse": [

--- a/nextjs-app/shared/components/ThemeProvider/ThemeProvider.stories.tsx
+++ b/nextjs-app/shared/components/ThemeProvider/ThemeProvider.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
 import { userEvent, within } from "storybook/test";
 import Button from "@dt/Button";
 import Text from "@dt/Text";
@@ -33,19 +34,22 @@ const meta = {
     a11y: { test: "error" },
     docs: { description: { component: contract.description } },
   },
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts);
+  // the children slot keeps a mapping preset so the theme-reading demo stays
+  // available in the panel.
   argTypes: {
-    className: {
-      control: "text",
-      description: "Provider wrapper class names",
-      table: { disable: true },
+    children: {
+      control: { type: "select" },
+      options: ["toggleDemo", "plainText"],
+      mapping: {
+        toggleDemo: <ThemeToggleDemo />,
+        plainText: "Themed subtree content",
+      },
+      description:
+        "Subtree that receives the theme context. Pick a preset here; compose your own in code.",
+      table: { category: "Content", type: { summary: "React.ReactNode" } },
     },
-      as: { table: { disable: true } },
-      asChild: { table: { disable: true } },
-      children: { table: { disable: true } },
-      id: { table: { disable: true } },
-      ref: { table: { disable: true } },
-      style: { table: { disable: true } }
-},
+  },
   args: {},
 } satisfies Meta<typeof ThemeProvider>;
 
@@ -60,9 +64,14 @@ export const Default: Story = {
     </ThemeProvider>
   ),
 };
+// Args-driven so forcedTheme and the children preset actually drive the
+// canvas (the shared render hardcodes its subtree).
 export const Playground: Story = {
   tags: ["beta-matrix"],
-  ...Default,
+  render: (args) => <ThemeProvider {...args} />,
+  args: {
+    children: "toggleDemo" as unknown as ReactNode,
+  },
 };
 
 Playground.play = async ({ canvasElement }) => {

--- a/nextjs-app/shared/components/ThemeProvider/ThemeProvider.tsx
+++ b/nextjs-app/shared/components/ThemeProvider/ThemeProvider.tsx
@@ -1,9 +1,4 @@
 
-/** Props for ThemeProvider. */
-export interface ThemeProviderProps {
-  className?: string;
-}
-
 import React, {
   createContext,
   useCallback,
@@ -14,6 +9,14 @@ import React, {
 } from "react";
 
 export type Theme = "light" | "dark" | "hcb" | "hcw";
+
+/** Props for ThemeProvider. */
+export interface ThemeProviderProps {
+  /** Subtree that receives the theme context. */
+  children: React.ReactNode;
+  /** Pin the theme regardless of stored/system preference (e.g. external embeds). */
+  forcedTheme?: Theme;
+}
 
 const THEME_SEQUENCE: Theme[] = ["light", "dark", "hcb", "hcw"];
 const DEFAULT_THEME: Theme = "light";
@@ -186,10 +189,10 @@ export const useTheme = () => useContext(ThemeContext);
 /**
  * ThemeProvider component.
  */
-export const ThemeProvider: React.FC<{
-  children: React.ReactNode;
-  forcedTheme?: Theme;
-}> = ({ children, forcedTheme }) => {
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({
+  children,
+  forcedTheme,
+}) => {
   const [theme, setThemeState] = useState<Theme>(DEFAULT_THEME);
   const [systemPreference, setSystemPreference] = useState<"light" | "dark">(
     "light"

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -5423,10 +5423,6 @@
         "className": {
           "optional": true,
           "type": "string"
-        },
-        "staggerDelay": {
-          "optional": true,
-          "type": "number"
         }
       },
       "composesWith": [
@@ -5455,7 +5451,7 @@
           },
           {
             "guidance": true,
-            "description": "Keep the reveal short — a stagger over dozens of children reads as lag; tune staggerDelay down for long lists."
+            "description": "Keep the reveal short — dozens of children behind one disclosure read as lag; split long lists instead."
           },
           {
             "guidance": false,
@@ -8423,7 +8419,7 @@
         {
           "story": "Compact",
           "description": "density compact tightens the chrome for dense grids of demo windows.",
-          "source": "export const Compact: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: {\n      description: {\n        story:\n          \"density compact tightens the chrome for dense grids of demo windows.\",\n      },\n    },\n  },\n  args: { density: \"compact\", children: sampleContent },\n};"
+          "source": "export const Compact: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: {\n      description: {\n        story:\n          \"density compact tightens the chrome for dense grids of demo windows.\",\n      },\n    },\n  },\n  args: { density: \"compact\", children: sampleContent },\n};\n\n// onAction is seeded so the action button exists and actionLabelKey can\n// drive it from the panel (the button hides itself without a callback)."
         }
       ]
     },
@@ -9298,6 +9294,11 @@
       "importLine": "import { NextLayout } from \"@dt/NextLayout\";",
       "keyProps": [
         {
+          "name": "children",
+          "type": "React.ReactNode",
+          "required": true
+        },
+        {
           "name": "className",
           "type": "string",
           "required": false
@@ -9307,6 +9308,10 @@
         "className": {
           "optional": true,
           "type": "string"
+        },
+        "children": {
+          "optional": false,
+          "type": "React.ReactNode"
         }
       },
       "composesWith": [],
@@ -13992,15 +13997,30 @@
       "importLine": "import { ThemeProvider } from \"@dt/ThemeProvider\";",
       "keyProps": [
         {
-          "name": "className",
-          "type": "string",
+          "name": "children",
+          "type": "React.ReactNode",
+          "required": true
+        },
+        {
+          "name": "forcedTheme",
+          "type": "light | dark | hcb | hcw",
           "required": false
         }
       ],
       "props": {
-        "className": {
+        "children": {
+          "optional": false,
+          "type": "React.ReactNode"
+        },
+        "forcedTheme": {
           "optional": true,
-          "type": "string"
+          "type": "union",
+          "values": [
+            "light",
+            "dark",
+            "hcb",
+            "hcw"
+          ]
         }
       },
       "composesWith": [

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "report:doc-coverage": "node scripts/design-system/report-doc-coverage.mjs",
     "audit:catalog": "node scripts/design-system/audit-catalog-coverage.mjs",
     "audit:controls": "node scripts/design-system/audit-controls.mjs",
-    "audit:controls:ci": "concurrently -k -s first -n SB,AUDIT \"npm run storybook -- --ci --no-open --quiet\" \"npm run storybook:wait && node scripts/design-system/audit-controls.mjs --min 65\"",
+    "audit:controls:ci": "concurrently -k -s first -n SB,AUDIT \"npm run storybook -- --ci --no-open --quiet\" \"npm run storybook:wait && node scripts/design-system/audit-controls.mjs --min 71\"",
     "new-component": "node scripts/design-system/scaffold-component.mjs",
     "bootstrap:contracts": "node scripts/design-system/bootstrap-contracts.mjs",
     "elevate:storybook": "python3 scripts/design-system/elevate_storybook_beta.py",

--- a/scripts/design-system/audit-controls.mjs
+++ b/scripts/design-system/audit-controls.mjs
@@ -82,12 +82,24 @@ const EFFECT_EXEMPT = {
         floatedButtonClassName: 'open-tray only: the fanned option buttons exist only while the tray is open; verified by unit test (open tray applies the class)',
         openTriggerClassName: 'open-tray only: applied to the trigger while expanded; verified by unit test (open tray applies the class)',
     },
+    ExpandableSection: {
+        defaultExpanded: 'uncontrolled-only initial state, masked while the seeded controlled `expanded` arg drives the Playground; verified by unit test (respects defaultExpanded)',
+    },
+    MarkdownMessage: {
+        fallback: 'masked while content renders (shown only when content sanitizes to empty); verified by unit test (renders fallback when content empty)',
+    },
 }
 
 // Icon-name text knobs: appending characters makes an UNKNOWN icon (renders
 // nothing = false inert). Perturb them to a known registry icon instead.
 const ICON_NAME_PROP = /icon|^name$/i
 const TEXT_PROBE_ICON = 'check'
+
+// CSS-length text knobs (gap/width/etc.): appending characters makes an
+// INVALID value, and the CSSOM rejects invalid assignments while KEEPING the
+// previous value — a false inert. Perturb to a different valid length instead.
+const CSS_LENGTH = /^-?\d+(\.\d+)?(px|rem|em|%|ch|vw|vh|fr)$/
+const LENGTH_PROBE = (cur) => (cur === '17px' ? '23px' : '17px')
 
 const ROOTS = [
     resolve(__dirname, '../../nextjs-app/shared/components'),
@@ -156,7 +168,12 @@ const canvasHtml = async () => {
                 .filter((el) => el !== root && !/^(SCRIPT|STYLE|LINK)$/.test(el.tagName))
                 .map((el) => el.outerHTML)
                 .join('')
-            return root.innerHTML + portals
+            // Theme plumbing (ThemeProvider forcedTheme) writes classes and
+            // data attributes onto <html>/<body> — canvas-visible, but not in
+            // any innerHTML. Serialize their attributes into the fingerprint.
+            const attrs = (el) =>
+                el.getAttributeNames().sort().map((n) => `${n}=${el.getAttribute(n)}`).join(';')
+            return `${attrs(document.documentElement)}|${attrs(document.body)}|${root.innerHTML}${portals}`
         })
     } catch { return null }
 }
@@ -171,11 +188,19 @@ const rowFor = async (prop) => {
     return null
 }
 
+// Storybook's "unsaved changes" save-from-controls bar appears after the
+// first arg edit and INTERCEPTS pointer events over the panel's bottom rows —
+// the second click of a radio/checkbox probe times out and reads as a silent
+// skip. It is dev chrome, not a control; hide it for the probe session.
+const hideSaveBar = () =>
+    page.addStyleTag({ content: '#save-from-controls{display:none!important}' }).catch(() => {})
+
 // Perturb one operable widget and report whether the canvas DOM changed.
 // Returns 'effect' | 'inert' | 'skipped' | 'unstable'.
 async function testEffect(storyUrl, prop, kind) {
     await page.goto(storyUrl, { waitUntil: 'domcontentloaded' })
     await page.waitForSelector('tr td', { timeout: 9000 }).catch(() => {})
+    await hideSaveBar()
     await page.waitForTimeout(800)
     const before1 = await canvasHtml()
     await page.waitForTimeout(300)
@@ -224,7 +249,12 @@ async function testEffect(storyUrl, prop, kind) {
         } else if (kind === 'text' || kind === 'textarea') {
             const input = row.locator('input[type="text"], textarea').first()
             const cur = await input.inputValue()
-            await input.fill(ICON_NAME_PROP.test(prop) ? TEXT_PROBE_ICON : `${cur}zprobe`)
+            const next = ICON_NAME_PROP.test(prop)
+                ? TEXT_PROBE_ICON
+                : CSS_LENGTH.test(cur)
+                    ? LENGTH_PROBE(cur)
+                    : `${cur}zprobe`
+            await input.fill(next)
         } else if (kind === 'number' || kind === 'range') {
             const input = row.locator('input[type="number"], input[type="range"]').first()
             const cur = await input.inputValue()


### PR DESCRIPTION
Registers all 13 Layout components plus CodeBlockWindow, MarkdownMessage,
NextLayout, and ThemeProvider in the controls-autogen registry and deletes
their hand-written argTypes (~460 lines). Stories keep only judgment:
children mapping presets for the composite layout slots (Grid cells,
FlexBox/Stack items, Accordion items + defaultOpenId radio, CodeBlockWindow
Shiki fixtures, Card titleProps/descriptionProps/extra, ThemeProvider demo
subtree) and text controls for content slots.

Dead contract props found and fixed at the root:
- ExpandableSection staggerDelay: destructured, documented, never used, zero
  consumers — REMOVED (contract + component + usage bullet reworded).
- ThemeProvider className: scaffolder artifact on a pure context provider
  with no DOM — REMOVED; the contract now declares what the component
  actually has (children + the previously undeclared forcedTheme union).
- NextLayout className: interface existed but the component never accepted
  it — WIRED onto the layout wrapper.

Playground fixes in the render-closure class: Card Playground hardcoded JSX
children over args (body control was a liar); NextLayout ditto;
ExpandableSection gets a useArgs writeback for its controlled expanded prop
(hook must run in the story render itself, not a nested component — a nested
useArgs renders a frozen canvas where EVERYTHING reads inert); Accordion
remounts on defaultOpenId; MacWindowFrame seeds onAction so the action
button exists; MarkdownMessage seeds renderWithDesignSystem so
designSystemTextSize has a live path; ExpandableSection seeds expandedLabel
"" so both label props stay live.

MacWindowFrame ""-normalization: cleared titleKey/actionLabelKey text
fields now fall back to the default i18n keys at the use sites.

Instrument changes (audit-controls.mjs):
- CSS-length text knobs (gap/width/rowGap...) are now perturbed to a
  DIFFERENT VALID length: the CSSOM rejects invalid assignments while
  keeping the previous value, so the old append-probe read valid length
  props as false inerts (caught on Grid gap/rowGap/colGap).
- Storybook's "unsaved changes" save-from-controls bar is hidden during
  probes: it appears after the first arg edit and intercepts pointer events
  over the panel's bottom rows — the second click of a radio probe timed
  out and read as a silent skip (caught on MarkdownMessage density).
- The canvas fingerprint now includes <html>/<body> attribute serialization:
  ThemeProvider forcedTheme writes theme classes there, which no innerHTML
  measurement can see.
- New justified exemptions: ExpandableSection defaultExpanded (masked by the
  seeded controlled expanded; unit-tested), MarkdownMessage fallback (masked
  while content renders; unit-tested).

JSDoc backfilled on 10 layout prop interfaces so docgen carries the
descriptions the deleted argTypes used to hold. ExpandableSection Default
gained the keyboard-contract play the validator requires (kept off
Playground so its seeded state survives the effects probe).

AT baselines regenerated (default + forced colors), both passes green.
Batch 3 components re-verified 0 inert under the new instrument.

Global controls presence 67% -> 73% (63/125 components fully operable);
farm ratchet raised to --min 71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Storybook controls for multiple components, making more content and layout options editable in the preview.
  * Added clearer default examples for several components, including interactive playgrounds and preset content selections.

* **Bug Fixes**
  * Improved accordion and disclosure behavior in previews so expanded states are reflected correctly in accessibility snapshots.
  * Added fallback handling for empty translation values in the window-frame component.

* **Documentation**
  * Added or improved prop descriptions across several components to make usage clearer.
  * Updated generated control data and related preview content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->