### PR TITLE
feat(design-system): stack the docs-page header + color-coded lifecycle dot

### DIFF
--- a/.storybook/blocks/DocHeader.module.css
+++ b/.storybook/blocks/DocHeader.module.css
@@ -1,10 +1,19 @@
 .header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-internal-8);
   margin-block-end: var(--space-layout-24);
+}
+
+.group {
+  color: var(--color-muted);
+  text-transform: lowercase;
 }
 
 .titleRow {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: var(--space-internal-12);
   flex-wrap: wrap;
 }
@@ -13,21 +22,25 @@
   margin: 0;
 }
 
-.group {
-  color: var(--color-muted);
-  text-transform: lowercase;
+/* View in Figma sits on its own row; a touch more air above it than the
+   tight group -> title gap. Plain link, no wavy underline (underline="none"),
+   no icon. The doubled class (.figma.figma) raises specificity above
+   Storybook's global `.sbdocs a` rule, which otherwise bleeds a plain
+   text-decoration: underline onto the link. */
+.figma.figma {
+  margin-block-start: var(--space-internal-4);
+  white-space: nowrap;
+  text-decoration: none;
 }
 
-.figma {
-  margin-inline-start: auto;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-internal-4);
-  white-space: nowrap;
+/* @dt/Link auto-appends an external-link arrow for external hrefs; the mock
+   wants a plain "View in Figma" text link, so hide it here. */
+.figma [class*="externalIcon"] {
+  display: none;
 }
 
 .standfirst {
-  margin-block: var(--space-internal-12) 0;
+  margin: 0;
   max-inline-size: 70ch;
   color: var(--color-text);
 }

--- a/.storybook/blocks/DocHeader.tsx
+++ b/.storybook/blocks/DocHeader.tsx
@@ -2,14 +2,15 @@ import React from "react";
 import Title from "@dt/Title";
 import Text from "@dt/Text";
 import Link from "@dt/Link";
-import Icon from "@dt/Icon";
 import type { DtContract } from "../lib/contracts";
 import { StatusPill } from "./StatusPill";
 import styles from "./DocHeader.module.css";
 
 /**
- * Docs-page masthead: component name, lifecycle status, group and the Figma
- * source link. The contract's `description` doubles as the standfirst.
+ * Docs-page masthead, stacked: the component group on its own row, then the
+ * name with its lifecycle status, then the Figma source link. The contract's
+ * `description` doubles as the standfirst and sits above the Figma link so the
+ * link stays last.
  */
 export function DocHeader({ contract }: { contract: DtContract }) {
   const figma =
@@ -19,26 +20,31 @@ export function DocHeader({ contract }: { contract: DtContract }) {
 
   return (
     <header className={styles.header} data-doc-block="doc-header">
+      {contract.group ? (
+        <Text as="span" size="s" className={styles.group}>
+          {contract.group}
+        </Text>
+      ) : null}
       <div className={styles.titleRow}>
         <Title as="h1" size="l" className={styles.title}>
           {contract.displayName ?? contract.name}
         </Title>
         <StatusPill status={contract.status} />
-        {contract.group ? (
-          <Text as="span" size="s" className={styles.group}>
-            {contract.group}
-          </Text>
-        ) : null}
-        {figma ? (
-          <Link href={figma} target="_blank" className={styles.figma}>
-            <Icon name="figma-logo" decorative /> Figma
-          </Link>
-        ) : null}
       </div>
       {contract.description ? (
         <Text as="p" size="l" lineHeight="relaxed" className={styles.standfirst}>
           {contract.description}
         </Text>
+      ) : null}
+      {figma ? (
+        <Link
+          href={figma}
+          target="_blank"
+          underline="none"
+          className={styles.figma}
+        >
+          View in Figma
+        </Link>
       ) : null}
     </header>
   );

--- a/.storybook/blocks/StatusPill.tsx
+++ b/.storybook/blocks/StatusPill.tsx
@@ -17,7 +17,8 @@ const TONE_BY_STATUS: Record<
 /**
  * Component lifecycle pill for the docs frame header and the landing gallery.
  * Dogfoods Badge; tone mapping mirrors the WipBadge status semantics
- * (stable = success, beta = info, alpha = warning, deprecated = error).
+ * (stable = success, beta = info, alpha = warning, deprecated = error). The
+ * `dot` prop renders a color-coded StatusDot in place of the semantic icon.
  */
 export function StatusPill({ status }: { status: ComponentStatus }) {
   return (
@@ -25,6 +26,7 @@ export function StatusPill({ status }: { status: ComponentStatus }) {
       variant="secondary"
       tone={TONE_BY_STATUS[status]}
       size="sm"
+      dot
       className={`${styles.pill} ${styles[status]}`}
     >
       {status}

--- a/nextjs-app/shared/components/Badge/Badge.contract.json
+++ b/nextjs-app/shared/components/Badge/Badge.contract.json
@@ -178,6 +178,10 @@
             "optional": true,
             "type": "React.ReactNode"
         },
+        "dot": {
+            "optional": true,
+            "type": "boolean"
+        },
         "square": {
             "optional": true,
             "type": "boolean"

--- a/nextjs-app/shared/components/Badge/Badge.stories.tsx
+++ b/nextjs-app/shared/components/Badge/Badge.stories.tsx
@@ -61,6 +61,13 @@ const meta: Meta<typeof Badge> = {
       },
     },
 
+    dot: {
+      control: "boolean",
+      description:
+        "Render a leading color-coded StatusDot (from tone) instead of the semantic icon — e.g. lifecycle badges.",
+      table: { category: "Content", defaultValue: { summary: "false" } },
+    },
+
     // Appearance
     variant: {
       control: { type: "inline-radio" },
@@ -242,6 +249,35 @@ export const WithIcon: Story = {
   parameters: { docs: { description: { story: "Custom icon next to the label via the icon slot." } } },
   render: Template,
   args: { variant: "primary", tone: "info", children: "badgeInfo", iconName: "info" },
+};
+
+/** `dot` swaps the semantic icon for a color-coded StatusDot — lifecycle labels. */
+export const LifecycleDots: Story = {
+  tags: ["example"],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "dot renders a leading StatusDot colored by tone instead of the semantic icon — the pattern the docs-header status pill uses for alpha (warning), beta (info), stable (success), and deprecated (error).",
+      },
+    },
+  },
+  render: () => (
+    <div style={{ display: "flex", gap: "0.75rem", alignItems: "center", flexWrap: "wrap" }}>
+      <Badge variant="secondary" tone="warning" size="sm" dot>
+        alpha
+      </Badge>
+      <Badge variant="secondary" tone="info" size="sm" dot>
+        beta
+      </Badge>
+      <Badge variant="secondary" tone="success" size="sm" dot>
+        stable
+      </Badge>
+      <Badge variant="secondary" tone="error" size="sm" dot>
+        deprecated
+      </Badge>
+    </div>
+  ),
 };
 
 const SizesContent: React.FC = () => {

--- a/nextjs-app/shared/components/Badge/Badge.test.tsx
+++ b/nextjs-app/shared/components/Badge/Badge.test.tsx
@@ -48,4 +48,27 @@ describe("Badge", () => {
     // Ensure no nested svg created for invalid icon
     expect(container.querySelector("svg")).not.toBeInTheDocument();
   });
+
+  it("renders a color-coded StatusDot instead of the semantic icon when dot is set", () => {
+    const { container } = render(
+      <Badge tone="success" dot>
+        Stable
+      </Badge>,
+    );
+    // StatusDot renders a styled dot span (tone-classed), not the semantic icon svg.
+    const dot = container.querySelector('[class*="dot"]');
+    expect(dot).not.toBeNull();
+    expect(dot?.className).toMatch(/success/);
+    expect(container.querySelector("svg")).not.toBeInTheDocument();
+  });
+
+  it("lets an explicit icon win over dot", () => {
+    const { container } = render(
+      <Badge tone="info" dot icon={<span data-testid="custom-icon" />}>
+        Beta
+      </Badge>,
+    );
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+    expect(container.querySelector('[class*="dot"]')).toBeNull();
+  });
 });

--- a/nextjs-app/shared/components/Badge/Badge.tsx
+++ b/nextjs-app/shared/components/Badge/Badge.tsx
@@ -14,6 +14,7 @@ export const badgeVariants = cva(styles.badge, {
 
 import React, { isValidElement, useState } from "react";
 import Icon from "@dt/Icon";
+import StatusDot from "@dt/StatusDot";
 import { useTranslation } from "react-i18next";
 import { type SemanticStatus, STATUS_ICON_NAMES } from "../../utils/semanticIcons";
 
@@ -48,6 +49,12 @@ export interface BadgeProps {
   onRemove?: () => void;
   /** Leading icon; a semantic icon is supplied automatically for non-neutral tones. */
   icon?: React.ReactNode;
+  /**
+   * Render a leading color-coded {@link StatusDot} (from `tone`) instead of the
+   * semantic icon — e.g. lifecycle badges (alpha/beta/stable/deprecated). An
+   * explicit `icon` still wins.
+   */
+  dot?: boolean;
   /** Square (non-pill) corners. */
   square?: boolean;
   /**
@@ -67,6 +74,7 @@ export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
       removable = false,
       onRemove,
       icon,
+      dot = false,
       className,
       square = false,
       size = "md",
@@ -82,9 +90,15 @@ export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
 
     // Icons track the badge's size step: sm 16px, md 24px, lg 32px.
     const badgeIconSize = { sm: "xs", md: "md", lg: "lg" } as const;
+    // StatusDot follows the badge size step so lifecycle dots scale with sm/md/lg.
+    const badgeDotSize = { sm: "sm", md: "md", lg: "lg" } as const;
 
     let resolvedIcon: React.ReactNode = icon;
-    if (resolvedIcon == null && tone && semanticStatus) {
+    if (resolvedIcon == null && dot) {
+      // Leading color-coded dot instead of the semantic icon (tone drives the
+      // color; undefined tone falls back to StatusDot's neutral).
+      resolvedIcon = <StatusDot tone={tone} size={badgeDotSize[size]} />;
+    } else if (resolvedIcon == null && tone && semanticStatus) {
       // The badge already sets a contrast-correct text color per variant×tone,
       // so the semantic icon inherits it via currentColor.
       resolvedIcon = (

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -1316,6 +1316,10 @@
           "optional": true,
           "type": "React.ReactNode"
         },
+        "dot": {
+          "optional": true,
+          "type": "boolean"
+        },
         "square": {
           "optional": true,
           "type": "boolean"
@@ -1414,7 +1418,12 @@
         {
           "story": "WithIcon",
           "description": "Custom icon next to the label via the icon slot.",
-          "source": "export const WithIcon: Story = {\n  tags: [\"example\"],\n  parameters: { docs: { description: { story: \"Custom icon next to the label via the icon slot.\" } } },\n  render: Template,\n  args: { variant: \"primary\", tone: \"info\", children: \"badgeInfo\", iconName: \"info\" },\n};\n\nconst SizesContent: React.FC = () => {\n  const { t } = useTranslation();\n  return (\n    <div style={{ display: \"flex\", gap: \"1rem\", alignItems: \"center\" }}>\n      <Badge size=\"sm\">{t(\"badgeSmall\")}</Badge>\n      <Badge size=\"md\">{t(\"badgeMedium\")}</Badge>\n      <Badge size=\"lg\">{t(\"badgeLarge\")}</Badge>\n    </div>\n  );\n};"
+          "source": "export const WithIcon: Story = {\n  tags: [\"example\"],\n  parameters: { docs: { description: { story: \"Custom icon next to the label via the icon slot.\" } } },\n  render: Template,\n  args: { variant: \"primary\", tone: \"info\", children: \"badgeInfo\", iconName: \"info\" },\n};\n\n/** `dot` swaps the semantic icon for a color-coded StatusDot — lifecycle labels. */"
+        },
+        {
+          "story": "LifecycleDots",
+          "description": "dot renders a leading StatusDot colored by tone instead of the semantic icon — the pattern the docs-header status pill uses for alpha (warning), beta (info), stable (success), and deprecated (error).",
+          "source": "export const LifecycleDots: Story = {\n  tags: [\"example\"],\n  parameters: {\n    docs: {\n      description: {\n        story:\n          \"dot renders a leading StatusDot colored by tone instead of the semantic icon — the pattern the docs-header status pill uses for alpha (warning), beta (info), stable (success), and deprecated (error).\",\n      },\n    },\n  },\n  render: () => (\n    <div style={{ display: \"flex\", gap: \"0.75rem\", alignItems: \"center\", flexWrap: \"wrap\" }}>\n      <Badge variant=\"secondary\" tone=\"warning\" size=\"sm\" dot>\n        alpha\n      </Badge>\n      <Badge variant=\"secondary\" tone=\"info\" size=\"sm\" dot>\n        beta\n      </Badge>\n      <Badge variant=\"secondary\" tone=\"success\" size=\"sm\" dot>\n        stable\n      </Badge>\n      <Badge variant=\"secondary\" tone=\"error\" size=\"sm\" dot>\n        deprecated\n      </Badge>\n    </div>\n  ),\n};\n\nconst SizesContent: React.FC = () => {\n  const { t } = useTranslation();\n  return (\n    <div style={{ display: \"flex\", gap: \"1rem\", alignItems: \"center\" }}>\n      <Badge size=\"sm\">{t(\"badgeSmall\")}</Badge>\n      <Badge size=\"md\">{t(\"badgeMedium\")}</Badge>\n      <Badge size=\"lg\">{t(\"badgeLarge\")}</Badge>\n    </div>\n  );\n};"
         },
         {
           "story": "Sizes",

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -8,6 +8,7 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
       "SecondaryVariants",
       "Removable",
       "WithIcon",
+      "LifecycleDots",
       "Sizes",
       "AsCount",
       "InButtonEndSlot",


### PR DESCRIPTION
Restyles the Storybook docs masthead (DocHeader) from one long row into a
stack, per the Figma direction:
- Row 1: the component group/class (e.g. "feedback"), muted + lowercase.
- Row 2: the component name + its lifecycle StatusPill (unchanged tag).
- The contract description sits below, then last:
- Row 3: a plain "View in Figma" link — underline="none" (no wavy underline),
  no figma-logo icon, and the auto external-arrow suppressed so it matches the
  mock's clean text link. The doubled .figma.figma selector beats Storybook's
  global `.sbdocs a` underline bleed.

Extends Badge with a `dot` prop: when set it renders a leading color-coded
StatusDot (from `tone`) in place of the auto semantic icon — an explicit
`icon` still wins, and `dot` defaults false so every existing Badge usage is
unchanged. StatusPill now passes `dot`, so the lifecycle pills show a
color-coded dot instead of the info glyph: alpha = warning (amber), beta =
info (teal), stable = success (green), deprecated = error (red).

Badge is stable: additive prop only. Contract + docgen updated (new `dot`
prop, LifecycleDots example story), unit tests cover dot-vs-icon precedence,
and the docs-registry get-shape snapshot picks up the new example. Full local
gate green (typecheck, lint, css, contract-props, consumers, tests, build,
docs-smoke); no AT snapshots change (dot defaults off, so beta-matrix Badge
stories render identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)