### PR TITLE
fix(design-system): docs status pill fully consumes Badge sm variant

### DIFF
--- a/.storybook/blocks/StatusPill.module.css
+++ b/.storybook/blocks/StatusPill.module.css
@@ -1,7 +1,15 @@
-.pill {
+/* Doubled .pill.pill raises specificity above Storybook's global `.sbdocs`
+   font-size so the docs pill fully matches a <Badge size="sm">. The label is
+   targeted explicitly because `.sbdocs :where(span)` sets 16px directly on the
+   label span (overriding inheritance from the pill root's 0.75rem). */
+.pill.pill {
   text-transform: lowercase;
   letter-spacing: 0.02em;
-  font-size: var(--font-size-text-s);
+  font-size: 0.75rem;
+}
+
+.pill.pill :global(.badge__content) {
+  font-size: 0.75rem;
 }
 
 .stable {


### PR DESCRIPTION
The docs StatusPill passed size=sm but its label rendered at 16px because Storybook's global `.sbdocs :where(span)` sets font-size directly on the label span, overriding Badge's native sm 0.75rem. Raised specificity so the pill matches a real Badge size=sm — 12px label at 32px height. Verified live; lint/css/StatusPill tests/typecheck/docs-smoke green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)