### PR TITLE
feat(design-system): promote Avatar beta→stable

### DIFF
--- a/nextjs-app/shared/components/Avatar/Avatar.contract.json
+++ b/nextjs-app/shared/components/Avatar/Avatar.contract.json
@@ -3,7 +3,7 @@
     "name": "Avatar",
     "tier": "atom",
     "group": "display",
-    "status": "beta",
+    "status": "stable",
     "description": "Profile image, initials, link, or menu trigger.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=369-8",
     "radixPrimitive": null,
@@ -15,6 +15,20 @@
                 "initials"
             ],
             "default": "image",
+            "propSourced": true
+        },
+        "size": {
+            "values": [
+                "2rem",
+                "2.5rem",
+                "3rem",
+                "4rem",
+                "5rem",
+                "6rem",
+                "7rem",
+                "8rem"
+            ],
+            "default": "2.5rem",
             "propSourced": true
         }
     },
@@ -35,7 +49,7 @@
         ],
         "reducedMotion": true,
         "reviewed": true,
-        "reviewedNote": "2026-05-26 — production behavior, keyboard, and forced-colors verified in Storybook.",
+        "reviewedNote": "2026-05-26 — production behavior, keyboard, and forced-colors verified in Storybook. 2026-07-05 (beta→stable) — re-verified independently: axe-clean, light + dark eyeballed (image ring + initials contrast), AT snapshots refreshed and compare-clean in all four modes (plain/light/dark/forced-colors), Controls 100% operable + 0 inert. Removed the dead avatarVariants cva stub and fixed the playground size default (was the non-length value \"md\", which produced an invalid --avatar-size).",
         "forcedColorsVerified": true,
         "accessibilityTreeVerified": true,
         "realBrowserForcedColorsVerified": true
@@ -45,7 +59,58 @@
         "spacing": []
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/BlogArticleMdxBody.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ServerArticleContent.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ServerArticleMain.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/index.ts",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "name": {
@@ -165,7 +230,7 @@
     "playground": {
         "defaults": {
             "name": "Petri Lahdelma",
-            "size": "md"
+            "size": "2.5rem"
         }
     }
 }

--- a/nextjs-app/shared/components/Avatar/Avatar.tsx
+++ b/nextjs-app/shared/components/Avatar/Avatar.tsx
@@ -1,10 +1,3 @@
-import { cva } from "class-variance-authority";
-
-export const avatarVariants = cva("", {
-  variants: { size: { sm: "", md: "", lg: "" } },
-  defaultVariants: { size: "md" },
-});
-
 import React from "react";
 import { useTranslation } from "react-i18next";
 import type { StaticImageData } from "next/image";

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--default-variant.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--default-variant.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - img "Petri Lahdelma"

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--default.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--default.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - img "Petri Lahdelma"

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--edge-detection.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--edge-detection.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open avatar menu":
   - img "Petri Lahdelma"
 - status: avatar.menuClosed

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--example.dark.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--example.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open avatar menu":
   - img "Petri Lahdelma"
 - status: avatar.menuClosed

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--example.forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open avatar menu":
   - img "Petri Lahdelma"
 - status: avatar.menuClosed

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--example.light.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--example.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open avatar menu":
   - img "Petri Lahdelma"
 - status: avatar.menuClosed

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--example.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--example.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open avatar menu":
   - img "Petri Lahdelma"
 - status: avatar.menuClosed

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--forced-colors.dark.yaml
@@ -1,1 +1,0 @@
-- status: Work in progress (beta)

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--forced-colors.forced-colors.yaml
@@ -1,1 +1,0 @@
-- status: Work in progress (beta)

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--forced-colors.light.yaml
@@ -1,1 +1,0 @@
-- status: Work in progress (beta)

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--forced-colors.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--forced-colors.yaml
@@ -1,1 +1,0 @@
-- status: Work in progress (beta)

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--playground.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--playground.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - img "Petri Lahdelma"

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--with-image.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--with-image.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - img "Avatar"

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--with-initials.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--with-initials.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: PL

--- a/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--with-menu.yaml
+++ b/nextjs-app/shared/components/Avatar/__a11y-snapshots__/content-avatar--with-menu.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open avatar menu":
   - img "Petri Lahdelma"
 - status: avatar.menuClosed

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -893,7 +893,7 @@
       "name": "Avatar",
       "group": "display",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "Profile image, initials, link, or menu trigger.",
       "dense": "Identity mark: image (srcSet/lazy) or initials from name; sm..xl sizes; optional link (clickable + destinationUrl) or dropdown menu (menuItems + menuLabel); variant forces image|initials",
       "keywords": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -2,6 +2,31 @@
 
 exports[`get > snapshot: get() shape per stable component (fields + example story names) 1`] = `
 {
+  "Avatar": {
+    "exampleStories": [
+      "WithImage",
+      "WithInitials",
+      "WithMenu",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "display",
+    "import": "import Avatar from "@dt/Avatar";",
+  },
   "Badge": {
     "exampleStories": [
       "Tones",


### PR DESCRIPTION
First **beta→stable** of the Phase 5 wave. Avatar carried every stable a11y flag and has genuine production consumers (blog article pages, author page, `ArticlePageTemplate` — 10 paths, populated by `audit:consumers`).

Per the "perfect component" bar I re-verified independently instead of trusting the May review note — which surfaced **two real defects**, now fixed:
- **Dead `avatarVariants` cva stub removed** — scaffolder leftover (sm/md/lg → empty strings), never applied; real sizing is the `--avatar-size` CSS var from the rem-based `size` prop.
- **Invalid playground `size` default fixed** — was `"md"` (not a valid `AvatarSize` length) → `--avatar-size: md` → avatar fell back to `auto`. Now `"2.5rem"`.
- Declared the `size` styling axis in `contract.variants` (`propSourced:true`) as the stable validator requires.

## Verification
- axe-clean; light + dark eyeballed (image ring + initials contrast)
- AT snapshots refreshed to current, compare-clean in all 4 modes (plain/light/dark/forced-colors)
- Controls 100% operable + 0 inert
- Gates: typecheck · lint · lint:css · validate:components · check:contract-props · check:contract-drift · check:consumers · vitest 1918/1918 · build

🤖 Generated with [Claude Code](https://claude.com/claude-code)