### PR TITLE
fix(design-system): Breadcrumb defers all underlining to Link (underline prop)

### DIFF
--- a/nextjs-app/shared/components/Breadcrumb/Breadcrumb.contract.json
+++ b/nextjs-app/shared/components/Breadcrumb/Breadcrumb.contract.json
@@ -48,6 +48,15 @@
         "aria-label": {
             "optional": true,
             "type": "string"
+        },
+        "underline": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "always",
+                "hover",
+                "none"
+            ]
         }
     },
     "forbiddenUse": [

--- a/nextjs-app/shared/components/Breadcrumb/Breadcrumb.module.css
+++ b/nextjs-app/shared/components/Breadcrumb/Breadcrumb.module.css
@@ -28,15 +28,8 @@
   color: var(--color-border);
 }
 
-.link {
-  text-decoration: none;
-  color: var(--link-color);
-}
-
-.link:hover,
-.link:focus-visible {
-  text-decoration: underline;
-}
+/* Link owns all color + underline behavior (color, wavy underline, focus ring)
+   via the underline prop; Breadcrumb must not re-decorate it. */
 
 .current {
   font-weight: 600;

--- a/nextjs-app/shared/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/nextjs-app/shared/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -94,6 +94,34 @@ export const ForcedColors: Story = {
   globals: { forcedColors: "active" },
 };
 
+/** Underline follows the Link contract: always, hover, or none. */
+export const UnderlineModes: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story:
+          "The underline prop is forwarded straight to each Link, so the trail behaves exactly like a Link: `always` keeps the wavy underline on, `hover` reveals it on hover and keyboard focus, and `none` omits it. There is no separate breadcrumb underline — Link owns it entirely.",
+      },
+    },
+  },
+  render: () => {
+    const items = [
+      { label: "Home", href: "/" },
+      { label: "Blog", href: "/blog" },
+      { label: "Article" },
+    ];
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+        <Breadcrumb items={items} underline="always" aria-label="Always" />
+        <Breadcrumb items={items} underline="hover" aria-label="Hover" />
+        <Breadcrumb items={items} underline="none" aria-label="None" />
+      </div>
+    );
+  },
+};
+
 /** A four-level trail: every level except the current one is a link. */
 export const DeepTrail: Story = {
   tags: ["example"],

--- a/nextjs-app/shared/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/nextjs-app/shared/components/Breadcrumb/Breadcrumb.test.tsx
@@ -58,6 +58,29 @@ describe("Breadcrumb", () => {
     expect(screen.getByLabelText("Breadcrumb")).toBeInTheDocument();
   });
 
+  it("forwards the underline prop to each link (default always → wavy underline)", () => {
+    const items: BreadcrumbItem[] = [
+      { label: "Home", href: "/" },
+      { label: "Current" },
+    ];
+    render(<Breadcrumb items={items} />);
+    // Link owns the wavy underline via its underline="always" default.
+    expect(screen.getByRole("link", { name: "Home" }).className).toContain(
+      "wavyUnderline",
+    );
+  });
+
+  it("omits the underline entirely when underline is none", () => {
+    const items: BreadcrumbItem[] = [
+      { label: "Home", href: "/" },
+      { label: "Current" },
+    ];
+    render(<Breadcrumb items={items} underline="none" />);
+    expect(
+      screen.getByRole("link", { name: "Home" }).className,
+    ).not.toContain("wavyUnderline");
+  });
+
   it("renders last item as current page without href", () => {
     const items: BreadcrumbItem[] = [
       { label: "Home", href: "/" },

--- a/nextjs-app/shared/components/Breadcrumb/Breadcrumb.tsx
+++ b/nextjs-app/shared/components/Breadcrumb/Breadcrumb.tsx
@@ -14,12 +14,19 @@ export type BreadcrumbProps = {
   items: BreadcrumbItem[];
   /** Accessible name for the nav landmark. @default "Breadcrumb" */
   "aria-label"?: string;
+  /**
+   * Underline mode forwarded to the Link for each trail item — the same
+   * contract as Link: "always" shows the wavy underline permanently, "hover"
+   * reveals it on hover and keyboard focus, "none" omits it. @default "always"
+   */
+  underline?: "always" | "hover" | "none";
 };
 
 /** Breadcrumb navigation trail with current page indication. */
 const Breadcrumb: React.FC<BreadcrumbProps> = ({
   items,
   "aria-label": ariaLabel = "Breadcrumb",
+  underline = "always",
 }) => {
   if (!items?.length) return null;
   const lastIndex = items.length - 1;
@@ -32,7 +39,7 @@ const Breadcrumb: React.FC<BreadcrumbProps> = ({
           return (
             <li key={`${item.label}-${idx}`} className={styles.item}>
               {item.href && !isLast ? (
-                <Link href={item.href} size="sm" className={styles.link}>
+                <Link href={item.href} size="sm" underline={underline}>
                   {item.label}
                 </Link>
               ) : (

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -1817,6 +1817,11 @@
           "required": true
         },
         {
+          "name": "underline",
+          "type": "always | hover | none",
+          "required": false
+        },
+        {
           "name": "aria-label",
           "type": "string",
           "required": false
@@ -1830,6 +1835,15 @@
         "aria-label": {
           "optional": true,
           "type": "string"
+        },
+        "underline": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "always",
+            "hover",
+            "none"
+          ]
         }
       },
       "composesWith": [
@@ -1902,6 +1916,11 @@
         "spacing": []
       },
       "examples": [
+        {
+          "story": "UnderlineModes",
+          "description": "The underline prop is forwarded straight to each Link, so the trail behaves exactly like a Link: `always` keeps the wavy underline on, `hover` reveals it on hover and keyboard focus, and `none` omits it. There is no separate breadcrumb underline — Link owns it entirely.",
+          "source": "export const UnderlineModes: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: {\n      description: {\n        story:\n          \"The underline prop is forwarded straight to each Link, so the trail behaves exactly like a Link: `always` keeps the wavy underline on, `hover` reveals it on hover and keyboard focus, and `none` omits it. There is no separate breadcrumb underline — Link owns it entirely.\",\n      },\n    },\n  },\n  render: () => {\n    const items = [\n      { label: \"Home\", href: \"/\" },\n      { label: \"Blog\", href: \"/blog\" },\n      { label: \"Article\" },\n    ];\n    return (\n      <div style={{ display: \"flex\", flexDirection: \"column\", gap: \"1rem\" }}>\n        <Breadcrumb items={items} underline=\"always\" aria-label=\"Always\" />\n        <Breadcrumb items={items} underline=\"hover\" aria-label=\"Hover\" />\n        <Breadcrumb items={items} underline=\"none\" aria-label=\"None\" />\n      </div>\n    );\n  },\n};\n\n/** A four-level trail: every level except the current one is a link. */"
+        },
         {
           "story": "DeepTrail",
           "description": "Items render in root-to-current order; the last one is always plain text with no self-link. Keep labels short — the trail is orientation, not headline copy.",


### PR DESCRIPTION
## Bug: Breadcrumb stacked two underlines

The trail rendered `<Link>` **without** an `underline` prop, so Link's `"always"` default kept the wavy underline on permanently — and `Breadcrumb.module.css` added its **own** `text-decoration: underline` on `:hover`/`:focus-visible`, a second normal underline on hover. That double-underline is not how the component should work.

## Fix: defer all underlining to Link

Breadcrumb now follows Link to the letter — it exposes Link's exact `underline` prop (`"always" | "hover" | "none"`, default `"always"`) and forwards it to each item Link. The bespoke `.link` CSS (color + hover/focus underline) is deleted: Link already owns the color (`var(--link-color)`), the wavy underline, and the focus ring. Consumers now pick which underline behavior the trail uses, if any.

## Verified
- Breadcrumb vitest **9/9** incl. pass-through (default `always` adds the `wavyUnderline` class, `none` omits it)
- Computed `text-decoration-line: none` on hover — no stacked underline; all three modes eyeballed
- Controls **100% operable / 0 inert** (`underline` is a live contract-derived select); test-storybook **8/8** (axe + AT snapshots unchanged)
- validate:components + check:contract-props; vitest full **1918/1918**; typecheck, lint, lint:css (baseline flat), build

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Breadcrumbs now support a configurable underline mode: `always`, `hover`, or `none`.
  * Added example stories showing each underline style in action.

* **Bug Fixes**
  * Updated breadcrumb link styling so underline and focus behavior are handled consistently across states.
  * Improved test coverage for the new underline options and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->