### PR TITLE
feat(design-system): Breadcrumb collapses overflow into an ellipsis Menu

### DIFF
--- a/docs/plans/2026-07-05-breadcrumb-collapse-design.md
+++ b/docs/plans/2026-07-05-breadcrumb-collapse-design.md
@@ -1,0 +1,34 @@
+# Design: Breadcrumb overflow collapse (ellipsis Menu)
+
+**Date:** 2026-07-05
+**Status:** validated design, implemented
+**Trigger:** long trails run out of horizontal room; the current (last) level must always stay visible. Owner-approved decisions: **automatic width-based collapse by default, with a static prop override**, keeping **as many leading items as fit** plus the current item, collapsing the overflow into an ellipsis dropdown that reuses the shared `Menu` primitive.
+
+## API
+
+```tsx
+<Breadcrumb
+  items={items}
+  underline="always | hover | none"   // (Link contract, #862)
+  maxItems={number}                    // static override; 0/unset = auto
+  collapseLabel="Show N hidden levels" // a11y name for the ellipsis trigger
+/>
+```
+
+- **Default (auto):** the trail measures itself against its container and collapses only when it overflows, always showing the current item and as many leading items as fit; the overflowed middle levels move into an ellipsis Menu. Re-measures on resize (`ResizeObserver`), so it re-expands when there is room.
+- **Static override:** `maxItems` (a positive number below the item count) collapses deterministically without measuring — the first `maxItems − 2` leading items and the current stay visible. `0`/unset selects the automatic path (also the no-op value the Controls args-enhancer seeds).
+- **Ellipsis element:** an `<li>` wrapping a "…" button that triggers the `Menu`; collapsed links render as `MenuItem href` (real `role=menuitem` anchors), linkless levels as disabled items. The glyph flips to a chevron while open (CSS on Radix `[data-state="open"]`).
+
+## Measurement
+
+`computeLeadingCount({ itemWidths, ellipsisWidth, listGap, available })` is a pure function (unit-tested): it returns how many leading items to show before the ellipsis, or `null` to show everything. Widths come from an off-screen, `inert` + `aria-hidden` clone of the full trail rendered only when there are more than three items and no `maxItems`, measured in an isomorphic layout effect + `ResizeObserver`. First paint shows the full trail, then it collapses on the client — standard for responsive breadcrumbs.
+
+## A11y & degradation
+
+The `<nav><ol>` structure stays for visible items; the ellipsis trigger carries an accessible name and Radix's `aria-haspopup`/`aria-expanded`; hidden links stay keyboard-reachable in the menu. Never collapses when everything fits or when there are three or fewer items; degrades to `first / … / current` rather than dropping the current level.
+
+## Testing
+
+- `computeLeadingCount` — pure unit tests (overflow, exact-fit, degenerate, unmeasured).
+- Static `maxItems` path — jsdom (deterministic): collapse shape, ellipsis menu opens with the hidden links, custom `collapseLabel`.
+- Auto width path — verified in a real browser (Storybook `Responsive` story in a 340px container + a Playwright probe): collapses only on overflow, re-expands when wide.

--- a/nextjs-app/shared/components/Breadcrumb/Breadcrumb.contract.json
+++ b/nextjs-app/shared/components/Breadcrumb/Breadcrumb.contract.json
@@ -57,6 +57,14 @@
                 "hover",
                 "none"
             ]
+        },
+        "maxItems": {
+            "optional": true,
+            "type": "number"
+        },
+        "collapseLabel": {
+            "optional": true,
+            "type": "string"
         }
     },
     "forbiddenUse": [

--- a/nextjs-app/shared/components/Breadcrumb/Breadcrumb.module.css
+++ b/nextjs-app/shared/components/Breadcrumb/Breadcrumb.module.css
@@ -35,3 +35,56 @@
   font-weight: 600;
   color: var(--primary-text-color);
 }
+
+/* Ellipsis trigger: an unstyled button that reads like the trail text and
+   opens the shared Menu holding the collapsed levels. */
+
+.ellipsis {
+  display: inline-flex;
+  padding: 0;
+  align-items: center;
+  border: none;
+  background: none;
+  font: inherit;
+  line-height: 1;
+  color: var(--link-color);
+  cursor: pointer;
+}
+
+.ellipsis:focus-visible {
+  border-radius: var(--radius-md);
+  outline: 2px solid var(--focus-ring-color, var(--color-primary));
+  outline-offset: 2px;
+}
+
+.ellipsisDots {
+  font-size: 1.1em;
+  letter-spacing: 0.05em;
+}
+
+/* The glyph flips to a chevron while the menu is open (Radix data-state). */
+
+.ellipsisCaret {
+  display: none;
+}
+
+.ellipsis[data-state="open"] .ellipsisDots {
+  display: none;
+}
+
+.ellipsis[data-state="open"] .ellipsisCaret {
+  display: inline-flex;
+}
+
+/* Off-screen clone used only to measure natural item widths for the
+   automatic (width-based) collapse; inert + aria-hidden keeps it out of the
+   a11y tree and the tab order. */
+
+.measurer {
+  position: absolute;
+  white-space: nowrap;
+  pointer-events: none;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+  visibility: hidden;
+}

--- a/nextjs-app/shared/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/nextjs-app/shared/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -92,6 +92,13 @@ export const ForcedColors: Story = {
   parameters: { a11y: { disable: true, test: "off" } },
   tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
+  args: {
+    items: [
+      { label: "Home", href: "/" },
+      { label: "Blog", href: "/blog" },
+      { label: "Article" },
+    ],
+  },
 };
 
 /** Underline follows the Link contract: always, hover, or none. */
@@ -120,6 +127,52 @@ export const UnderlineModes: Story = {
       </div>
     );
   },
+};
+
+const longTrail = [
+  { label: "Home", href: "/" },
+  { label: "Components", href: "/components" },
+  { label: "Overlays", href: "/components/overlays" },
+  { label: "Menu", href: "/components/overlays/menu" },
+  { label: "Dropdown", href: "/components/overlays/menu/dropdown" },
+  { label: "Button" },
+];
+
+/** Static collapse: maxItems caps the trail without measuring. */
+export const Collapsed: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story:
+          "Pass maxItems to collapse a long trail deterministically (no measuring): the first maxItems − 2 leading items and the current item stay visible, and the middle levels move into an ellipsis menu (the shared Menu primitive). The current page is always shown. The ellipsis glyph flips to a chevron while the menu is open.",
+      },
+    },
+  },
+  args: {
+    items: longTrail,
+    maxItems: 4,
+  },
+};
+
+/** Automatic collapse: the trail measures itself and collapses only when it overflows its container. */
+export const Responsive: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story:
+          "With no maxItems, the trail measures itself against its container and collapses only when it cannot fit, keeping as many leading items as possible plus the current page, and re-expands on resize. Shown in a narrow 340px container so the overflow collapses; widen it and the hidden levels return.",
+      },
+    },
+  },
+  render: (args) => (
+    <div style={{ maxWidth: 340, border: "1px dashed var(--color-border)", padding: "0.75rem", resize: "horizontal", overflow: "auto" }}>
+      <Breadcrumb {...args} items={longTrail} />
+    </div>
+  ),
 };
 
 /** A four-level trail: every level except the current one is a link. */

--- a/nextjs-app/shared/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/nextjs-app/shared/components/Breadcrumb/Breadcrumb.test.tsx
@@ -1,6 +1,17 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeAll } from "vitest";
 import { render, screen } from "@testing-library/react";
-import Breadcrumb, { type BreadcrumbItem } from "./Breadcrumb";
+import userEvent from "@testing-library/user-event";
+import Breadcrumb, {
+  computeLeadingCount,
+  type BreadcrumbItem,
+} from "./Breadcrumb";
+
+// The ellipsis dropdown is the Radix-backed Menu (pointer-capture + scrollIntoView).
+beforeAll(() => {
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  Element.prototype.scrollIntoView = vi.fn();
+});
 
 describe("Breadcrumb", () => {
   it("renders nothing when items array is empty", () => {
@@ -93,5 +104,126 @@ describe("Breadcrumb", () => {
       screen.queryByRole("link", { name: "Current Page" }),
     ).not.toBeInTheDocument();
     expect(screen.getByText("Current Page")).toBeInTheDocument();
+  });
+});
+
+describe("computeLeadingCount", () => {
+  it("never collapses three or fewer items", () => {
+    expect(
+      computeLeadingCount({
+        itemWidths: [100, 100, 100],
+        ellipsisWidth: 40,
+        listGap: 0,
+        available: 10,
+      }),
+    ).toBeNull();
+  });
+
+  it("shows every item when the full trail fits", () => {
+    expect(
+      computeLeadingCount({
+        itemWidths: [50, 50, 50, 50],
+        ellipsisWidth: 40,
+        listGap: 0,
+        available: 1000,
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps as many leading items as fit before the ellipsis", () => {
+    // full = 500 > 340; leading=2 → 200 + 40 + 100 = 340 ≤ 340.
+    expect(
+      computeLeadingCount({
+        itemWidths: [100, 100, 100, 100, 100],
+        ellipsisWidth: 40,
+        listGap: 0,
+        available: 340,
+      }),
+    ).toBe(2);
+  });
+
+  it("still shows first / … / current when nothing else fits", () => {
+    expect(
+      computeLeadingCount({
+        itemWidths: [100, 100, 100, 100, 100],
+        ellipsisWidth: 40,
+        listGap: 0,
+        available: 200,
+      }),
+    ).toBe(1);
+  });
+
+  it("treats an unmeasured trail (zero widths) as show-all", () => {
+    expect(
+      computeLeadingCount({
+        itemWidths: [0, 0, 0, 0, 0],
+        ellipsisWidth: 0,
+        listGap: 0,
+        available: 0,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("Breadcrumb collapse (static maxItems)", () => {
+  const longTrail: BreadcrumbItem[] = [
+    { label: "Home", href: "/" },
+    { label: "Components", href: "/components" },
+    { label: "Overlays", href: "/components/overlays" },
+    { label: "Menu", href: "/components/overlays/menu" },
+    { label: "Button" },
+  ];
+
+  it("does not collapse when items fit within maxItems", () => {
+    render(<Breadcrumb items={longTrail} maxItems={10} />);
+    expect(
+      screen.queryByRole("button", { name: /hidden breadcrumb/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Overlays" })).toBeInTheDocument();
+  });
+
+  it("collapses the middle into an ellipsis trigger, keeping first and current", () => {
+    render(<Breadcrumb items={longTrail} maxItems={4} />);
+    // First (maxItems-2=2) leading links stay visible.
+    expect(screen.getByRole("link", { name: "Home" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Components" }),
+    ).toBeInTheDocument();
+    // The middle links are collapsed (not directly in the trail).
+    expect(
+      screen.queryByRole("link", { name: "Overlays" }),
+    ).not.toBeInTheDocument();
+    // Current is always shown as text.
+    expect(screen.getByText("Button")).toBeInTheDocument();
+    // Ellipsis trigger is present with an accessible name.
+    expect(
+      screen.getByRole("button", { name: /hidden breadcrumb/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("reveals the hidden levels as links when the ellipsis menu opens", async () => {
+    render(<Breadcrumb items={longTrail} maxItems={4} />);
+    await userEvent.click(
+      screen.getByRole("button", { name: /hidden breadcrumb/i }),
+    );
+    expect(
+      await screen.findByRole("menuitem", { name: "Overlays" }),
+    ).toHaveAttribute("href", "/components/overlays");
+    expect(
+      screen.getByRole("menuitem", { name: "Menu" }),
+    ).toHaveAttribute("href", "/components/overlays/menu");
+  });
+
+  it("uses a custom collapseLabel when provided", () => {
+    render(
+      <Breadcrumb
+        items={longTrail}
+        maxItems={4}
+        collapseLabel="More levels"
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "More levels" }),
+    ).toBeInTheDocument();
   });
 });

--- a/nextjs-app/shared/components/Breadcrumb/Breadcrumb.tsx
+++ b/nextjs-app/shared/components/Breadcrumb/Breadcrumb.tsx
@@ -2,6 +2,8 @@
 
 import React from "react";
 import Link from "@dt/Link";
+import Icon from "@dt/Icon";
+import { Menu, MenuContent, MenuItem, MenuTrigger } from "@dt/Menu";
 import styles from "./Breadcrumb.module.css";
 
 export type BreadcrumbItem = {
@@ -20,36 +22,235 @@ export type BreadcrumbProps = {
    * reveals it on hover and keyboard focus, "none" omits it. @default "always"
    */
   underline?: "always" | "hover" | "none";
+  /**
+   * Static collapse cap. When set to a positive number smaller than the item
+   * count, the middle items collapse into an ellipsis menu WITHOUT measuring:
+   * the first `maxItems - 2` leading items and the current item stay visible.
+   * Leave unset (or 0) for automatic width-based collapse (the default).
+   */
+  maxItems?: number;
+  /** Accessible name for the ellipsis menu trigger. @default "Show N hidden breadcrumbs" */
+  collapseLabel?: string;
 };
 
-/** Breadcrumb navigation trail with current page indication. */
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? React.useLayoutEffect : React.useEffect;
+
+/**
+ * How many leading items to show before the ellipsis when the trail overflows,
+ * or null to show every item. The current (last) item is always shown; hidden
+ * items are those between the returned count and the current item. Pure so the
+ * fit math is unit-testable without a DOM.
+ */
+export function computeLeadingCount(params: {
+  /** Per-item natural widths from the measurer; leading widths include their separator, the last is the current label. */
+  itemWidths: number[];
+  /** Width of the ellipsis item (button + separator). */
+  ellipsisWidth: number;
+  /** Gap between list items. */
+  listGap: number;
+  /** Available container width. */
+  available: number;
+}): number | null {
+  const { itemWidths, ellipsisWidth, listGap, available } = params;
+  const n = itemWidths.length;
+  if (n <= 3) return null;
+  // Unmeasured (SSR / jsdom without layout) — never collapse.
+  if (available <= 0 || itemWidths.some((w) => w <= 0)) return null;
+
+  const fullWidth =
+    itemWidths.reduce((sum, w) => sum + w, 0) + listGap * (n - 1);
+  if (fullWidth <= available) return null;
+
+  const currentWidth = itemWidths[n - 1];
+  for (let leading = n - 2; leading >= 1; leading -= 1) {
+    let width = ellipsisWidth + currentWidth + listGap * (leading + 1);
+    for (let i = 0; i < leading; i += 1) width += itemWidths[i];
+    if (width <= available) return leading;
+  }
+  // Even one leading item overflows — still show first / … / current.
+  return 1;
+}
+
+function staticLeadingCount(count: number, maxItems: number): number | null {
+  if (count <= maxItems || count <= 3) return null;
+  return Math.min(Math.max(1, maxItems - 2), count - 2);
+}
+
+/** Breadcrumb navigation trail with current page indication and overflow collapse. */
 const Breadcrumb: React.FC<BreadcrumbProps> = ({
   items,
   "aria-label": ariaLabel = "Breadcrumb",
   underline = "always",
+  maxItems,
+  collapseLabel,
 }) => {
+  const isStatic = typeof maxItems === "number" && maxItems > 0;
+  const navRef = React.useRef<HTMLElement | null>(null);
+  const measureRef = React.useRef<HTMLOListElement | null>(null);
+  const [autoLeading, setAutoLeading] = React.useState<number | null>(null);
+
+  const staticLeading = React.useMemo(
+    () => (isStatic ? staticLeadingCount(items.length, maxItems as number) : null),
+    [isStatic, items.length, maxItems],
+  );
+
+  const measure = React.useCallback(() => {
+    const nav = navRef.current;
+    const measurer = measureRef.current;
+    if (!nav || !measurer) return;
+    const available = nav.clientWidth;
+    const itemWidths = Array.from(
+      measurer.querySelectorAll<HTMLElement>("[data-measure-item]"),
+    ).map((el) => el.offsetWidth);
+    const ellipsisEl = measurer.querySelector<HTMLElement>(
+      "[data-measure-ellipsis]",
+    );
+    const ellipsisWidth = ellipsisEl ? ellipsisEl.offsetWidth : 0;
+    const listGap =
+      parseFloat(getComputedStyle(measurer).columnGap || "0") || 0;
+    setAutoLeading(
+      computeLeadingCount({ itemWidths, ellipsisWidth, listGap, available }),
+    );
+  }, []);
+
+  useIsomorphicLayoutEffect(() => {
+    if (isStatic) return;
+    measure();
+    const nav = navRef.current;
+    if (!nav || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => measure());
+    observer.observe(nav);
+    return () => observer.disconnect();
+  }, [isStatic, measure, items]);
+
   if (!items?.length) return null;
   const lastIndex = items.length - 1;
+  const leadingCount = isStatic ? staticLeading : autoLeading;
+  const isCollapsed = leadingCount != null;
+
+  const renderLink = (item: BreadcrumbItem) => (
+    <Link href={item.href as string} size="sm" underline={underline}>
+      {item.label}
+    </Link>
+  );
+
+  const renderEllipsis = (hidden: BreadcrumbItem[]) => (
+    <Menu>
+      <MenuTrigger asChild>
+        <button
+          type="button"
+          className={styles.ellipsis}
+          aria-label={
+            collapseLabel ||
+            `Show ${hidden.length} hidden breadcrumb${
+              hidden.length === 1 ? "" : "s"
+            }`
+          }
+        >
+          <span className={styles.ellipsisDots} aria-hidden="true">
+            …
+          </span>
+          <span className={styles.ellipsisCaret} aria-hidden="true">
+            <Icon name="caret-down" rotate={180} ariaLabel="" size="sm" />
+          </span>
+        </button>
+      </MenuTrigger>
+      <MenuContent align="start">
+        {hidden.map((item, idx) => (
+          <MenuItem
+            key={`${item.label}-${idx}`}
+            href={item.href}
+            disabled={!item.href}
+          >
+            {item.label}
+          </MenuItem>
+        ))}
+      </MenuContent>
+    </Menu>
+  );
+
+  const collapsed = isCollapsed
+    ? {
+        leading: items.slice(0, leadingCount as number),
+        hidden: items.slice(leadingCount as number, lastIndex),
+        current: items[lastIndex],
+      }
+    : null;
 
   return (
-    <nav className={styles.breadcrumb} aria-label={ariaLabel}>
+    <nav className={styles.breadcrumb} aria-label={ariaLabel} ref={navRef}>
       <ol className={styles.list}>
-        {items.map((item, idx) => {
-          const isLast = idx === lastIndex;
-          return (
-            <li key={`${item.label}-${idx}`} className={styles.item}>
-              {item.href && !isLast ? (
-                <Link href={item.href} size="sm" underline={underline}>
-                  {item.label}
-                </Link>
-              ) : (
-                <span className={styles.current}>{item.label}</span>
-              )}
-              {!isLast && <span className={styles.separator}>/</span>}
+        {collapsed ? (
+          <>
+            {collapsed.leading.map((item, idx) => (
+              <li key={`${item.label}-${idx}`} className={styles.item}>
+                {item.href ? (
+                  renderLink(item)
+                ) : (
+                  <span className={styles.current}>{item.label}</span>
+                )}
+                <span className={styles.separator}>/</span>
+              </li>
+            ))}
+            <li className={styles.item}>
+              {renderEllipsis(collapsed.hidden)}
+              <span className={styles.separator}>/</span>
             </li>
-          );
-        })}
+            <li className={styles.item}>
+              <span className={styles.current}>{collapsed.current.label}</span>
+            </li>
+          </>
+        ) : (
+          items.map((item, idx) => {
+            const isLast = idx === lastIndex;
+            return (
+              <li key={`${item.label}-${idx}`} className={styles.item}>
+                {item.href && !isLast ? (
+                  renderLink(item)
+                ) : (
+                  <span className={styles.current}>{item.label}</span>
+                )}
+                {!isLast && <span className={styles.separator}>/</span>}
+              </li>
+            );
+          })
+        )}
       </ol>
+
+      {!isStatic && items.length > 3 && (
+        <ol
+          ref={measureRef}
+          className={`${styles.list} ${styles.measurer}`}
+          aria-hidden="true"
+          inert
+          data-measurer
+        >
+          {items.map((item, idx) => {
+            const isLast = idx === lastIndex;
+            return (
+              <li
+                key={`m-${item.label}-${idx}`}
+                className={styles.item}
+                data-measure-item
+              >
+                {item.href && !isLast ? (
+                  renderLink(item)
+                ) : (
+                  <span className={styles.current}>{item.label}</span>
+                )}
+                {!isLast && <span className={styles.separator}>/</span>}
+              </li>
+            );
+          })}
+          <li className={styles.item} data-measure-ellipsis>
+            <span className={styles.ellipsis}>
+              <span className={styles.ellipsisDots}>…</span>
+            </span>
+            <span className={styles.separator}>/</span>
+          </li>
+        </ol>
+      )}
     </nav>
   );
 };

--- a/nextjs-app/shared/components/Breadcrumb/__a11y-snapshots__/navigation-breadcrumb--collapsed.yaml
+++ b/nextjs-app/shared/components/Breadcrumb/__a11y-snapshots__/navigation-breadcrumb--collapsed.yaml
@@ -6,7 +6,10 @@
         - /url: /
       - text: /
     - listitem:
-      - link "Blog":
-        - /url: /blog
+      - link "Components":
+        - /url: /components
       - text: /
-    - listitem: Article
+    - listitem:
+      - button "Show 3 hidden breadcrumbs"
+      - text: /
+    - listitem: Button

--- a/nextjs-app/shared/components/Breadcrumb/__a11y-snapshots__/navigation-breadcrumb--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Breadcrumb/__a11y-snapshots__/navigation-breadcrumb--forced-colors.forced-colors.yaml
@@ -1,1 +1,12 @@
 - status: Work in progress (beta)
+- navigation "Breadcrumb":
+  - list:
+    - listitem:
+      - link "Home":
+        - /url: /
+      - text: /
+    - listitem:
+      - link "Blog":
+        - /url: /blog
+      - text: /
+    - listitem: Article

--- a/nextjs-app/shared/components/Breadcrumb/__a11y-snapshots__/navigation-breadcrumb--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Breadcrumb/__a11y-snapshots__/navigation-breadcrumb--forced-colors.light.yaml
@@ -1,1 +1,12 @@
 - status: Work in progress (beta)
+- navigation "Breadcrumb":
+  - list:
+    - listitem:
+      - link "Home":
+        - /url: /
+      - text: /
+    - listitem:
+      - link "Blog":
+        - /url: /blog
+      - text: /
+    - listitem: Article

--- a/nextjs-app/shared/components/Breadcrumb/__a11y-snapshots__/navigation-breadcrumb--forced-colors.yaml
+++ b/nextjs-app/shared/components/Breadcrumb/__a11y-snapshots__/navigation-breadcrumb--forced-colors.yaml
@@ -1,1 +1,12 @@
 - status: Work in progress (beta)
+- navigation "Breadcrumb":
+  - list:
+    - listitem:
+      - link "Home":
+        - /url: /
+      - text: /
+    - listitem:
+      - link "Blog":
+        - /url: /blog
+      - text: /
+    - listitem: Article

--- a/nextjs-app/shared/components/Breadcrumb/__a11y-snapshots__/navigation-breadcrumb--playground.dark.yaml
+++ b/nextjs-app/shared/components/Breadcrumb/__a11y-snapshots__/navigation-breadcrumb--playground.dark.yaml
@@ -1,1 +1,12 @@
 - status: Work in progress (beta)
+- navigation "Breadcrumb":
+  - list:
+    - listitem:
+      - link "Home":
+        - /url: /
+      - text: /
+    - listitem:
+      - link "Blog":
+        - /url: /blog
+      - text: /
+    - listitem: Article

--- a/nextjs-app/shared/components/Breadcrumb/__a11y-snapshots__/navigation-breadcrumb--playground.light.yaml
+++ b/nextjs-app/shared/components/Breadcrumb/__a11y-snapshots__/navigation-breadcrumb--playground.light.yaml
@@ -1,1 +1,12 @@
 - status: Work in progress (beta)
+- navigation "Breadcrumb":
+  - list:
+    - listitem:
+      - link "Home":
+        - /url: /
+      - text: /
+    - listitem:
+      - link "Blog":
+        - /url: /blog
+      - text: /
+    - listitem: Article

--- a/nextjs-app/shared/components/Breadcrumb/__a11y-snapshots__/navigation-breadcrumb--responsive.yaml
+++ b/nextjs-app/shared/components/Breadcrumb/__a11y-snapshots__/navigation-breadcrumb--responsive.yaml
@@ -1,0 +1,19 @@
+- status: Work in progress (beta)
+- navigation "Breadcrumb":
+  - list:
+    - listitem:
+      - link "Home":
+        - /url: /
+      - text: /
+    - listitem:
+      - link "Components":
+        - /url: /components
+      - text: /
+    - listitem:
+      - link "Overlays":
+        - /url: /components/overlays
+      - text: /
+    - listitem:
+      - button "Show 2 hidden breadcrumbs"
+      - text: /
+    - listitem: Button

--- a/nextjs-app/shared/components/Breadcrumb/__a11y-snapshots__/navigation-breadcrumb--underline-modes.yaml
+++ b/nextjs-app/shared/components/Breadcrumb/__a11y-snapshots__/navigation-breadcrumb--underline-modes.yaml
@@ -1,0 +1,34 @@
+- status: Work in progress (beta)
+- navigation "Always":
+  - list:
+    - listitem:
+      - link "Home":
+        - /url: /
+      - text: /
+    - listitem:
+      - link "Blog":
+        - /url: /blog
+      - text: /
+    - listitem: Article
+- navigation "Hover":
+  - list:
+    - listitem:
+      - link "Home":
+        - /url: /
+      - text: /
+    - listitem:
+      - link "Blog":
+        - /url: /blog
+      - text: /
+    - listitem: Article
+- navigation "None":
+  - list:
+    - listitem:
+      - link "Home":
+        - /url: /
+      - text: /
+    - listitem:
+      - link "Blog":
+        - /url: /blog
+      - text: /
+    - listitem: Article

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -1825,6 +1825,16 @@
           "name": "aria-label",
           "type": "string",
           "required": false
+        },
+        {
+          "name": "maxItems",
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "collapseLabel",
+          "type": "string",
+          "required": false
         }
       ],
       "props": {
@@ -1844,6 +1854,14 @@
             "hover",
             "none"
           ]
+        },
+        "maxItems": {
+          "optional": true,
+          "type": "number"
+        },
+        "collapseLabel": {
+          "optional": true,
+          "type": "string"
         }
       },
       "composesWith": [
@@ -1919,7 +1937,17 @@
         {
           "story": "UnderlineModes",
           "description": "The underline prop is forwarded straight to each Link, so the trail behaves exactly like a Link: `always` keeps the wavy underline on, `hover` reveals it on hover and keyboard focus, and `none` omits it. There is no separate breadcrumb underline — Link owns it entirely.",
-          "source": "export const UnderlineModes: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: {\n      description: {\n        story:\n          \"The underline prop is forwarded straight to each Link, so the trail behaves exactly like a Link: `always` keeps the wavy underline on, `hover` reveals it on hover and keyboard focus, and `none` omits it. There is no separate breadcrumb underline — Link owns it entirely.\",\n      },\n    },\n  },\n  render: () => {\n    const items = [\n      { label: \"Home\", href: \"/\" },\n      { label: \"Blog\", href: \"/blog\" },\n      { label: \"Article\" },\n    ];\n    return (\n      <div style={{ display: \"flex\", flexDirection: \"column\", gap: \"1rem\" }}>\n        <Breadcrumb items={items} underline=\"always\" aria-label=\"Always\" />\n        <Breadcrumb items={items} underline=\"hover\" aria-label=\"Hover\" />\n        <Breadcrumb items={items} underline=\"none\" aria-label=\"None\" />\n      </div>\n    );\n  },\n};\n\n/** A four-level trail: every level except the current one is a link. */"
+          "source": "export const UnderlineModes: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: {\n      description: {\n        story:\n          \"The underline prop is forwarded straight to each Link, so the trail behaves exactly like a Link: `always` keeps the wavy underline on, `hover` reveals it on hover and keyboard focus, and `none` omits it. There is no separate breadcrumb underline — Link owns it entirely.\",\n      },\n    },\n  },\n  render: () => {\n    const items = [\n      { label: \"Home\", href: \"/\" },\n      { label: \"Blog\", href: \"/blog\" },\n      { label: \"Article\" },\n    ];\n    return (\n      <div style={{ display: \"flex\", flexDirection: \"column\", gap: \"1rem\" }}>\n        <Breadcrumb items={items} underline=\"always\" aria-label=\"Always\" />\n        <Breadcrumb items={items} underline=\"hover\" aria-label=\"Hover\" />\n        <Breadcrumb items={items} underline=\"none\" aria-label=\"None\" />\n      </div>\n    );\n  },\n};\n\nconst longTrail = [\n  { label: \"Home\", href: \"/\" },\n  { label: \"Components\", href: \"/components\" },\n  { label: \"Overlays\", href: \"/components/overlays\" },\n  { label: \"Menu\", href: \"/components/overlays/menu\" },\n  { label: \"Dropdown\", href: \"/components/overlays/menu/dropdown\" },\n  { label: \"Button\" },\n];\n\n/** Static collapse: maxItems caps the trail without measuring. */"
+        },
+        {
+          "story": "Collapsed",
+          "description": "Pass maxItems to collapse a long trail deterministically (no measuring): the first maxItems − 2 leading items and the current item stay visible, and the middle levels move into an ellipsis menu (the shared Menu primitive). The current page is always shown. The ellipsis glyph flips to a chevron while the menu is open.",
+          "source": "export const Collapsed: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: {\n      description: {\n        story:\n          \"Pass maxItems to collapse a long trail deterministically (no measuring): the first maxItems − 2 leading items and the current item stay visible, and the middle levels move into an ellipsis menu (the shared Menu primitive). The current page is always shown. The ellipsis glyph flips to a chevron while the menu is open.\",\n      },\n    },\n  },\n  args: {\n    items: longTrail,\n    maxItems: 4,\n  },\n};\n\n/** Automatic collapse: the trail measures itself and collapses only when it overflows its container. */"
+        },
+        {
+          "story": "Responsive",
+          "description": "With no maxItems, the trail measures itself against its container and collapses only when it cannot fit, keeping as many leading items as possible plus the current page, and re-expands on resize. Shown in a narrow 340px container so the overflow collapses; widen it and the hidden levels return.",
+          "source": "export const Responsive: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: {\n      description: {\n        story:\n          \"With no maxItems, the trail measures itself against its container and collapses only when it cannot fit, keeping as many leading items as possible plus the current page, and re-expands on resize. Shown in a narrow 340px container so the overflow collapses; widen it and the hidden levels return.\",\n      },\n    },\n  },\n  render: (args) => (\n    <div style={{ maxWidth: 340, border: \"1px dashed var(--color-border)\", padding: \"0.75rem\", resize: \"horizontal\", overflow: \"auto\" }}>\n      <Breadcrumb {...args} items={longTrail} />\n    </div>\n  ),\n};\n\n/** A four-level trail: every level except the current one is a link. */"
         },
         {
           "story": "DeepTrail",

--- a/scripts/design-system/audit-controls.mjs
+++ b/scripts/design-system/audit-controls.mjs
@@ -33,6 +33,10 @@ const EFFECTS = process.argv.includes('--effects')
 // story's default state — every entry carries its justification and how the
 // effect was verified instead.
 const EFFECT_EXEMPT = {
+    Breadcrumb: {
+        maxItems: 'static collapse cap — only changes layout when items.length exceeds it, and the Playground trail is short; verified by the static-collapse unit tests and the Collapsed story',
+        collapseLabel: 'labels the ellipsis trigger, which only exists once the trail collapses; verified by the custom-collapseLabel unit test and the Collapsed story',
+    },
     Avatar: {
         clickable: 'behavior-only: wires onClick navigation, no DOM signature; verified by click->URL navigation probe',
         destinationUrl: 'behavior-only: consumed by the clickable click handler; verified by click->URL navigation probe',


### PR DESCRIPTION
## Breadcrumb overflow collapse (ellipsis Menu)

Long trails now collapse so the **current (last) level is always visible**, matching the mocks: `Home / Components / … / Button`, and the `…` opens a dropdown of the hidden levels.

### Two modes (owner-approved)
- **Automatic (default):** the trail measures itself against its container and collapses **only when it overflows**, keeping as many leading items as fit plus the current item, and **re-expands on resize**.
- **Static override:** `maxItems={n}` collapses by count without measuring (deterministic, SSR-clean).

The overflowed levels move into an ellipsis dropdown that **reuses the `Menu` primitive** (#859); the glyph flips to a chevron while open.

### API
`maxItems?: number` (0/unset = auto) · `collapseLabel?: string` (a11y name for the ellipsis trigger). Fit math is a pure, unit-tested `computeLeadingCount`; widths come from an `inert` + `aria-hidden` off-screen clone measured via an isomorphic layout effect + `ResizeObserver`.

### Verified
- vitest **18/18** (pure fit math + static collapse + menu opens with the hidden links)
- Controls **100% operable / 0 inert** (`maxItems`/`collapseLabel` effect-exempt — conditional-only)
- test-storybook **10/10** (axe + AT snapshots **compare-clean in all 4 modes**)
- Closed and open states eyeballed against the mocks
- validate:components + check:contract-props; vitest full **1927/1927**; typecheck, lint, lint:css (baseline flat), docs-smoke, build

Also refreshed two pre-existing stale-empty themed snapshots (ForcedColors + Playground were captured before those stories had items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
