### PR TITLE
fix(design-system): Breadcrumb emphasis + home-icon vertical centering

### DIFF
--- a/nextjs-app/shared/components/Breadcrumb/Breadcrumb.module.css
+++ b/nextjs-app/shared/components/Breadcrumb/Breadcrumb.module.css
@@ -34,12 +34,26 @@
   color: var(--color-border);
 }
 
-/* Link owns all color + underline behavior (color, wavy underline, focus ring)
-   via the underline prop; Breadcrumb must not re-decorate it. */
+/* Link owns underline behavior (wavy underline, focus ring) via the underline
+   prop; Breadcrumb must not re-decorate it. It DOES set the trail emphasis:
+   clickable levels are primary + medium weight, the current level is muted +
+   regular. .item .link outranks Link's own single-class .link. */
+
+.item .link {
+  font-weight: 500;
+  color: var(--color-primary);
+}
 
 .current {
-  font-weight: 600;
-  color: var(--primary-text-color);
+  font-weight: 400;
+  color: var(--color-muted);
+}
+
+/* Home icon: centered on the line box rather than baseline-aligned, so it sits
+   optically level with the adjacent text (an icon has no text baseline). */
+
+.homeLink {
+  align-self: center;
 }
 
 /* Ellipsis trigger: an unstyled button that reads like the trail text and

--- a/nextjs-app/shared/components/Breadcrumb/Breadcrumb.tsx
+++ b/nextjs-app/shared/components/Breadcrumb/Breadcrumb.tsx
@@ -147,15 +147,25 @@ const Breadcrumb: React.FC<BreadcrumbProps> = ({
     if (homeIcon && idx === 0) {
       const icon = <Icon name="house" ariaLabel={item.label} size="sm" />;
       return isLink ? (
-        <Link href={item.href as string} size="sm" underline="none">
+        <Link
+          href={item.href as string}
+          size="sm"
+          underline="none"
+          className={`${styles.link} ${styles.homeLink}`}
+        >
           {icon}
         </Link>
       ) : (
-        <span className={styles.current}>{icon}</span>
+        <span className={`${styles.current} ${styles.homeLink}`}>{icon}</span>
       );
     }
     return isLink ? (
-      <Link href={item.href as string} size="sm" underline={underline}>
+      <Link
+        href={item.href as string}
+        size="sm"
+        underline={underline}
+        className={styles.link}
+      >
         {item.label}
       </Link>
     ) : (


### PR DESCRIPTION
Design-feedback polish on Breadcrumb.

- **Clickable levels** now read as the primary affordance: `--color-primary` + medium (500) weight.
- **Current level** is de-emphasized: `--color-muted` + regular (400) weight (was bold + primary ink).
- **Home icon** is centered on the line box (`align-self: center`) instead of baseline-aligned, so it sits optically level with the trail text (an icon has no text baseline). Measured within ~0.3px of the text center, exactly on the separator center.

Applied through the shared `renderItemContent` helper so the visible trail and the width measurer stay in sync (bolder links change width; the measurer matches).

### Verified
- Breadcrumb vitest **19/19**; Controls **100% / 0 inert**
- test-storybook **11/11** — axe contrast passes with the muted current + primary links; AT snapshots unchanged (styling only)
- validate:components, vitest full green, typecheck, lint, lint:css (baseline flat), rhythm (0 new), build
- Emphasis + centered house icon eyeballed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved breadcrumb styling so the current page is shown with a clearer, more muted emphasis.
  * Updated breadcrumb link appearance to keep clickable items consistently styled, including the home item with an icon.
  * Fixed visual conflicts where breadcrumb link styles could override the intended per-item emphasis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->