### PR TITLE
fix(design-system): bolder stroke for the Breadcrumb home icon

### DIFF
--- a/nextjs-app/shared/components/Breadcrumb/Breadcrumb.tsx
+++ b/nextjs-app/shared/components/Breadcrumb/Breadcrumb.tsx
@@ -145,7 +145,9 @@ const Breadcrumb: React.FC<BreadcrumbProps> = ({
     // First item optionally renders as a house icon; its label is the icon's
     // accessible name. Icons carry no wavy underline.
     if (homeIcon && idx === 0) {
-      const icon = <Icon name="house" ariaLabel={item.label} size="sm" />;
+      const icon = (
+        <Icon name="house" ariaLabel={item.label} size="sm" weight="bold" />
+      );
       return isLink ? (
         <Link
           href={item.href as string}


### PR DESCRIPTION
The house icon now renders in Phosphor's **bold** weight (the same outline stroke, just heavier), so it matches the visual weight of the medium (500) trail links instead of looking thin beside them.

Verified: Breadcrumb vitest 19/19, test-storybook 11/11 (axe + AT snapshots unchanged — weight only changes the svg path, tree stays `img "Home"`), vitest full 1928/1928, typecheck, lint, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)