### PR TITLE
fix(design-system): flip Avatar story meta tag beta→stable

### DIFF
--- a/nextjs-app/shared/components/Avatar/Avatar.stories.tsx
+++ b/nextjs-app/shared/components/Avatar/Avatar.stories.tsx
@@ -11,7 +11,7 @@ import schema from "./schema.json";
 export default {
   title: "Content/Avatar",
   component: Avatar,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",


### PR DESCRIPTION
Follow-up to #857 (Avatar beta→stable) and #867 (Container beta→stable, which surfaced this).

Avatar's Storybook meta tag stayed `["beta", "autodocs"]` after promotion. The sidebar lifecycle dot reads meta `STATUS_TAGS` via `.storybook/manager.ts` `renderLabel`, so Avatar rendered a **hollow beta dot despite being stable** — every other stable component (Button/Badge/Card/Icon/Text/Title/Link/Label/Container) uses `["stable", "autodocs"]`. The docs-page StatusPill was already correct (it reads `contractStatus` from the contract, not the meta tag).

**Fix:** meta `tags` `["beta"]` → `["stable"]`. Per-story `["beta-matrix"]` tags kept (they drive themed snapshot capture; stable components keep them).

**Snapshot-neutral:** the WipBadge is gated on `contractStatus === "stable"`, so the AT snapshots don't change (verified — empty snapshot diff).

**Verified:** `validate:components` ✓ · vitest Avatar **80/80** · scoped `test-storybook "Avatar/Avatar.stories"` **8/8** (axe + AT compare) · AT snapshots unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)