### PR TITLE
feat(design-system): promote Section beta→stable

### DIFF
--- a/nextjs-app/shared/components/Section/Section.contract.json
+++ b/nextjs-app/shared/components/Section/Section.contract.json
@@ -3,12 +3,36 @@
     "name": "Section",
     "tier": "atom",
     "group": "layout",
-    "status": "beta",
+    "status": "stable",
     "description": "Semantic section wrapper with spacing and background tokens.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-section",
     "radixPrimitive": null,
-    "element": "div",
-    "variants": {},
+    "element": "section",
+    "variants": {
+        "spacing": {
+            "values": [
+                "none",
+                "sm",
+                "md",
+                "lg",
+                "xl",
+                "hero",
+                "follow"
+            ],
+            "default": "md",
+            "propSourced": true
+        },
+        "background": {
+            "values": [
+                "default",
+                "muted",
+                "accent",
+                "inverse"
+            ],
+            "default": "default",
+            "propSourced": true
+        }
+    },
     "slots": [],
     "asChild": false,
     "subParts": [],
@@ -24,14 +48,77 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories in all four modes (plain/light/dark/forced-colors); AT snapshots refreshed compare-clean; Controls 100% operable + 0 inert. Unlike a pure wrapper, Section owns a real surface (background=inverse flips bg-foreground/text-background) — eyeballed the Backgrounds story in light and dark: default/muted/inverse track the theme and inverse contrast holds both ways. Fixed two contract defects: element was \"div\" (renders <section>) and variants was empty (spacing + background are the styling axes)."
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/BlogArticleMdxBody.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ServerArticleContent.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ServerArticleMain.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AboutPage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "children": {
@@ -75,7 +162,8 @@
         }
     },
     "forbiddenUse": [
-        "Bypass design tokens or skip forced-colors verification at beta."
+        "Nest Sections — bands are siblings; nesting compounds paddings and backgrounds.",
+        "Use Section inside a component or card; it is page architecture, not component padding."
     ],
     "composesWith": [
         "Container",

--- a/nextjs-app/shared/components/Section/Section.stories.tsx
+++ b/nextjs-app/shared/components/Section/Section.stories.tsx
@@ -16,7 +16,7 @@ const defaultArgs = {
 const meta = {
   title: "Layout/Section",
   component: Section,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--backgrounds.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--backgrounds.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: background default background muted background inverse

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--default.dark.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--default.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - paragraph: Semantic section with tokenized vertical spacing.

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--default.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - paragraph: Semantic section with tokenized vertical spacing.

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--default.light.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--default.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - paragraph: Semantic section with tokenized vertical spacing.

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--default.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--default.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - paragraph: Semantic section with tokenized vertical spacing.

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--example.dark.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--example.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - paragraph: Used across marketing patterns for vertical rhythm.

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--example.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - paragraph: Used across marketing patterns for vertical rhythm.

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--example.light.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--example.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - paragraph: Used across marketing patterns for vertical rhythm.

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--example.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--example.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - paragraph: Used across marketing patterns for vertical rhythm.

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--forced-colors.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - paragraph: Semantic section with tokenized vertical spacing.

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--forced-colors.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - paragraph: Semantic section with tokenized vertical spacing.

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--forced-colors.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - paragraph: Semantic section with tokenized vertical spacing.

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--forced-colors.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - paragraph: Semantic section with tokenized vertical spacing.

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--hero-follow-pair.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--hero-follow-pair.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Hero band (spacing hero) First content band (spacing follow)

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--playground.dark.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--playground.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - paragraph: Semantic section with tokenized vertical spacing.

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--playground.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - paragraph: Semantic section with tokenized vertical spacing.

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--playground.light.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--playground.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - paragraph: Semantic section with tokenized vertical spacing.

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--playground.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--playground.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - paragraph: Semantic section with tokenized vertical spacing.

--- a/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--spacing-bands.yaml
+++ b/nextjs-app/shared/components/Section/__a11y-snapshots__/layout-section--spacing-bands.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: spacing sm spacing md spacing lg

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -11243,7 +11243,7 @@
       "name": "Section",
       "group": "layout",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "Semantic section wrapper with spacing and background tokens.",
       "dense": "Page band: spacing none|sm|md (default)|lg|xl + hero/follow pair (hero = roomy top tight bottom, follow = no top), background default|muted|accent|inverse; id/donnyTarget anchors",
       "keywords": [
@@ -11335,7 +11335,8 @@
       ],
       "prefersOver": [],
       "forbiddenUse": [
-        "Bypass design tokens or skip forced-colors verification at beta."
+        "Nest Sections — bands are siblings; nesting compounds paddings and backgrounds.",
+        "Use Section inside a component or card; it is page architecture, not component padding."
       ],
       "usage": {
         "description": "Section is the page-level band: it owns vertical rhythm (`spacing`, responsive paddings) and surface (`background`), while Container inside it owns the horizontal clamp. `hero` and `follow` are a pair — the hero band keeps a generous top and tight bottom, and the section right after uses `follow` to avoid a double gap. `inverse` flips to the dark surface with matching text tokens. Give sections an `id` when they are anchor or skip targets.",

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -220,6 +220,31 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "navigation",
     "import": "import Link from "@dt/Link";",
   },
+  "Section": {
+    "exampleStories": [
+      "SpacingBands",
+      "HeroFollowPair",
+      "Backgrounds",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "layout",
+    "import": "import { Section } from "@dt/Section";",
+  },
   "SiteFooter": {
     "exampleStories": [],
     "fields": [


### PR DESCRIPTION
## Astryx roadmap — beta→stable fleet, #2

Pairs with Container (#867). **Section** is the page-level band primitive with **12 genuine production consumers** (blog article pipeline, AboutPage, BlogPage, HomePage, Work/DSharpDesignSystem) via `audit:consumers`.

### Two real defects the re-verify surfaced
- **`element` was `"div"`** but the component renders `<section>` — corrected to `"section"`.
- **`variants` was `{}`** despite two clear styling axes — declared `spacing` (7 values, default `md`) and `background` (4 values, default `default`), both `propSourced`.

### Real color surface (not a no-op)
Unlike a pure wrapper, Section owns a surface — `background="inverse"` flips `bg-foreground`/`text-background` — so light/dark/forced-colors matters here:
- **axe** clean across all 7 stories in all four modes; **AT snapshots** refreshed compare-clean (the WipBadge line drops now that `showBadge` is stable-gated — 19 files, 19 deletions).
- **Controls** 100% operable + 0 inert.
- **Eyeballed** the Backgrounds story in light and dark: default/muted/inverse track the theme and inverse contrast holds both ways.
- Reworded the stale beta-scoped `forbiddenUse` into real misuse guidance.
- Verified the custom `tablet:`/`desktop:` screens and all `bg-*`/`text-*` tokens resolve (no silent-missing-class).

### Verification
`validate:components` · `check:contract-props` · `check:consumers` · `check:generated` · typecheck · lint · lint:css · vitest **1928/1928** · build — all green. docs-registry per-stable-shape snapshot + registry regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Promoted the Section component to stable.
  * Improved Section options with clearer spacing and background choices.
  * Updated the component to use a semantic section element.

* **Bug Fixes**
  * Refined accessibility details and verification notes.
  * Removed outdated beta status from accessibility snapshots.

* **Chores**
  * Updated Storybook metadata to match the stable release status.
  * Added downstream usage references and refreshed usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->