### PR TITLE
feat(design-system): promote Grid beta→stable

### DIFF
--- a/nextjs-app/shared/components/Grid/Grid.contract.json
+++ b/nextjs-app/shared/components/Grid/Grid.contract.json
@@ -3,7 +3,7 @@
     "name": "Grid",
     "tier": "atom",
     "group": "layout",
-    "status": "beta",
+    "status": "stable",
     "description": "CSS grid layout primitive with tokenized gaps.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-grid",
     "radixPrimitive": null,
@@ -48,14 +48,22 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories; AT snapshots refreshed compare-clean in all four modes (plain/light/dark/forced-colors); Controls 9/9 operable + 0 inert. Pure two-dimensional layout primitive with no color surface of its own (tokens.colors empty), so light/dark is a structural no-op. The GridProps `[key: string]: any` passthrough is the intentional, documented escape hatch for arbitrary grid CSS props — kept as-is."
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/Footer/Footer.tsx",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "children": {
@@ -141,7 +149,8 @@
         }
     },
     "forbiddenUse": [
-        "Bypass design tokens or skip forced-colors verification at beta."
+        "Use Grid for single-axis flows — Stack (token gaps) or FlexBox (free-form) read clearer and cost less.",
+        "Size cells by styling children with widths; spans and templates belong on the grid, not in the card."
     ],
     "composesWith": [
         "Card",

--- a/nextjs-app/shared/components/Grid/Grid.stories.tsx
+++ b/nextjs-app/shared/components/Grid/Grid.stories.tsx
@@ -35,7 +35,7 @@ const defaultArgs = {
 const meta = {
   title: "Layout/Grid",
   component: Grid,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--custom-template.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--custom-template.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Sidebar Content

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--default.dark.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--default.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Cell A
 - paragraph: Cell B
 - paragraph: Cell C

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--default.forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Cell A
 - paragraph: Cell B
 - paragraph: Cell C

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--default.light.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--default.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Cell A
 - paragraph: Cell B
 - paragraph: Cell C

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--default.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--default.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Cell A
 - paragraph: Cell B
 - paragraph: Cell C

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--equal-tracks.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--equal-tracks.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Cell 1 Cell 2 Cell 3 Cell 4 Cell 5 Cell 6

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--example.dark.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--example.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Services
 - paragraph: Work
 - paragraph: About

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--example.forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Services
 - paragraph: Work
 - paragraph: About

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--example.light.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--example.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Services
 - paragraph: Work
 - paragraph: About

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--example.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--example.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Services
 - paragraph: Work
 - paragraph: About

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--forced-colors.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Cell A
 - paragraph: Cell B
 - paragraph: Cell C

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--forced-colors.forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Cell A
 - paragraph: Cell B
 - paragraph: Cell C

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--forced-colors.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Cell A
 - paragraph: Cell B
 - paragraph: Cell C

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--forced-colors.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Cell A
 - paragraph: Cell B
 - paragraph: Cell C

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--playground.dark.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--playground.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Cell A
 - paragraph: Cell B
 - paragraph: Cell C

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--playground.forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Cell A
 - paragraph: Cell B
 - paragraph: Cell C

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--playground.light.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--playground.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Cell A
 - paragraph: Cell B
 - paragraph: Cell C

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--playground.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--playground.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Cell A
 - paragraph: Cell B
 - paragraph: Cell C

--- a/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--spanned-feature.yaml
+++ b/nextjs-app/shared/components/Grid/__a11y-snapshots__/layout-grid--spanned-feature.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Featured (span 2) Cell Cell Cell Cell

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -6329,7 +6329,7 @@
       "name": "Grid",
       "group": "layout",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "CSS grid layout primitive with tokenized gaps.",
       "dense": "CSS-grid wrapper: numeric columns for equal tracks or template strings; gap/rowGap/colGap strings; Grid.Item adds span/rowSpan; extra grid CSS props pass through via style",
       "keywords": [
@@ -6463,7 +6463,8 @@
       ],
       "prefersOver": [],
       "forbiddenUse": [
-        "Bypass design tokens or skip forced-colors verification at beta."
+        "Use Grid for single-axis flows — Stack (token gaps) or FlexBox (free-form) read clearer and cost less.",
+        "Size cells by styling children with widths; spans and templates belong on the grid, not in the card."
       ],
       "usage": {
         "description": "Grid is the two-dimensional layout primitive: pass `columns` as a number for equal tracks or a template string for custom ones, gaps as CSS strings (prefer space tokens), and wrap children needing to span in `Grid.Item` with `span`/`rowSpan`. Reach for it when both axes matter — card walls, media mosaics, dashboard modules; single-axis flows are Stack/FlexBox territory.",

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -143,6 +143,31 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "layout",
     "import": "import { Container } from "@dt/Container";",
   },
+  "Grid": {
+    "exampleStories": [
+      "EqualTracks",
+      "SpannedFeature",
+      "CustomTemplate",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "layout",
+    "import": "import Grid from "@dt/Grid";",
+  },
   "Icon": {
     "exampleStories": [
       "BrandIcon",


### PR DESCRIPTION
## Astryx roadmap — beta→stable fleet, #3

**Grid** is the two-dimensional layout primitive, consumed in production by the **Footer** pattern.

### Independent re-verify
- **axe** clean across all 7 stories; **AT snapshots** refreshed compare-clean in all four modes (WipBadge line drops now that `showBadge` is stable-gated — 19 files, 19 deletions).
- **Controls** 9/9 operable + 0 inert. Pure layout primitive with no color surface (`tokens.colors` empty), so light/dark is a structural no-op.
- `element="div"` and `variants.align` (`align` ∈ VARIANT_PROP_NAMES) already correct. Reworded the stale beta-scoped `forbiddenUse` into real misuse guidance.
- The `GridProps [key: string]: any` passthrough is the documented intentional escape hatch for arbitrary grid CSS props — kept as-is (an API rebuild would be its own task, like Card).

### Verification
`validate:components` · `check:contract-props` · `check:consumers` · `check:generated` · typecheck · lint · lint:css · vitest **1928/1928** · build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)