### PR TITLE
fix(design-system): AT-snapshot resolver picks the meta title, not the first title:

### DIFF
--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -241,7 +241,7 @@ function loadStoryPrefixMap(): Map<string, string> {
     path.join(ROOT_DIR, "nextjs-app/shared/components"),
     path.join(ROOT_DIR, "nextjs-app/shared/patterns"),
   ];
-  const titleRe = /title:\s*["']([^"']+)["']/;
+  const titleRe = /title:\s*["']([^"']+)["']/g;
 
   for (const base of roots) {
     if (!fs.existsSync(base)) continue;
@@ -251,9 +251,15 @@ function loadStoryPrefixMap(): Map<string, string> {
       const storyPath = path.join(dir, `${name}.stories.tsx`);
       if (!fs.existsSync(contractPath) || !fs.existsSync(storyPath)) continue;
       const text = fs.readFileSync(storyPath, "utf8");
-      const m = text.match(titleRe);
-      if (!m) continue;
-      storyPrefixToDir.set(sanitizeStorybookTitle(m[1]), dir);
+      // The meta title is the story-path one ("Category/Name"). A component whose
+      // stories seed a `title:` ARG (e.g. ValueCard's defaultArgs.title "Clarity
+      // first") would otherwise hijack the first match and the snapshot dir would
+      // never resolve. Pick the first title: value shaped like a story path.
+      const metaTitle = [...text.matchAll(titleRe)]
+        .map((mt) => mt[1])
+        .find((t) => t.includes("/"));
+      if (!metaTitle) continue;
+      storyPrefixToDir.set(sanitizeStorybookTitle(metaTitle), dir);
     }
   }
   return storyPrefixToDir;

--- a/scripts/design-system/capture-story-a11y-snapshots.mjs
+++ b/scripts/design-system/capture-story-a11y-snapshots.mjs
@@ -29,7 +29,7 @@ function loadStoryPrefixMap() {
     join(ROOT, "nextjs-app/shared/components"),
     join(ROOT, "nextjs-app/shared/patterns"),
   ];
-  const titleRe = /title:\s*["']([^"']+)["']/;
+  const titleRe = /title:\s*["']([^"']+)["']/g;
 
   for (const base of roots) {
     if (!existsSync(base)) continue;
@@ -39,12 +39,18 @@ function loadStoryPrefixMap() {
       const storyPath = join(dir, `${name}.stories.tsx`);
       if (!existsSync(contractPath) || !existsSync(storyPath)) continue;
       const text = readFileSync(storyPath, "utf8");
-      const m = text.match(titleRe);
-      if (!m) continue;
+      // The meta title is the story-path one ("Category/Name"). A component whose
+      // stories seed a `title:` ARG (e.g. ValueCard's defaultArgs.title "Clarity
+      // first") would otherwise hijack the first match and the snapshot dir would
+      // never resolve. Pick the first title: value shaped like a story path.
+      const metaTitle = [...text.matchAll(titleRe)]
+        .map((mt) => mt[1])
+        .find((t) => t.includes("/"));
+      if (!metaTitle) continue;
       // Match Storybook's own @storybook/csf `sanitize`: lowercase, collapse
       // every non-alphanumeric run to a single "-", trim. No camelCase splitting,
       // so `Forms/TextArea` → `forms-textarea` (the real story-id prefix).
-      const prefix = m[1]
+      const prefix = metaTitle
         .toLowerCase()
         .replace(/[ ’–—―′¿'`~!@#$%^&*()_|+\-=?;:'",.<>{}[\]\\/]/g, "-")
         .replace(/-+/g, "-")


### PR DESCRIPTION
The story-id to component-dir resolver (test-runner.ts loadStoryPrefixMap +
capture-story-a11y-snapshots.mjs) matched the FIRST title: string in a stories
file. For any component whose stories seed a title: ARG before the meta (e.g.
ValueCard's defaultArgs.title "Clarity first"), that arg hijacked the match, so
the resolver keyed the dir under the wrong prefix (clarity-first) and
componentSnapshotDir() returned null for the real story id (site-valuecard--*).
The AT-snapshot capture was then SILENTLY skipped: these components could never
get snapshots written, which reads as permanent backfill debt.

12 components/patterns were affected: ValueCard, ServiceCard, ArticleCard,
EnhancedProjectCard, NavMenuList, SentrySummaryCard, CTASection, ContactHero,
HighlightSection, ServicesSection, WorkMagneticField, WorkPreviewSection.

Fix: match ALL title: occurrences and pick the first shaped like a story path
(Category/Name, i.e. contains a slash) - that is always the meta title; seeded
arg titles are plain strings without a slash. Same fix in both loaders.

Verified: affected components now resolve (site-valuecard, site-servicecard,
site-articlecard); normal components unchanged (layout-container, layout-grid);
Container compares 7/7 with no regression; test-runner UPDATE now writes
snapshots to a previously-unresolvable component's dir (ServiceCard, throwaway,
discarded); typecheck + lint + vitest 1928/1928 clean. Backfilling the 12
components' snapshots is separate per-component work.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)