### PR TITLE
feat(design-system): promote ValueCard beta->stable

### DIFF
--- a/nextjs-app/shared/components/ValueCard/ValueCard.contract.json
+++ b/nextjs-app/shared/components/ValueCard/ValueCard.contract.json
@@ -3,7 +3,7 @@
     "name": "ValueCard",
     "tier": "molecule",
     "group": "display",
-    "status": "beta",
+    "status": "stable",
     "description": "Card variant for values / principles grids — icon + title + short description, with the same three visual treatments as `LocationCard`.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-value-card",
     "radixPrimitive": null,
@@ -39,7 +39,9 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all stories in all four modes; AT snapshots bootstrapped (had none) compare-clean; Controls 6/6 operable + 0 inert; eyeballed the elevated card surface in light and dark. Fixed a real reduced-motion gap: the elevated hover lift (hover:-translate-y-1) and the color/shadow transitions had no motion-reduce guard, yet reducedMotion claimed true — the global reset only covers the logo marquee. Added motion-reduce:transition-none + motion-reduce:hover:translate-y-0. Also added the missing unit test (axe + variant surface + reduced-motion guard)."
     },
     "tokens": {
         "colors": [
@@ -57,7 +59,43 @@
         ]
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AboutPage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/AboutPageContent/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ValuesSection/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ValuesSection/ValuesSection.tsx",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "icon": {

--- a/nextjs-app/shared/components/ValueCard/ValueCard.stories.tsx
+++ b/nextjs-app/shared/components/ValueCard/ValueCard.stories.tsx
@@ -15,7 +15,7 @@ const defaultArgs = {
 const meta = {
   title: "Site/ValueCard",
   component: ValueCard,
-  tags: ["beta", "!autodocs"],
+  tags: ["stable", "!autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/ValueCard/ValueCard.test.tsx
+++ b/nextjs-app/shared/components/ValueCard/ValueCard.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { ValueCard } from "./ValueCard";
+
+expect.extend(toHaveNoViolations);
+
+const baseProps = {
+  icon: <svg aria-hidden data-testid="icon" />,
+  title: "Clarity first",
+  description: "Interfaces should explain themselves before they decorate.",
+};
+
+describe("ValueCard", () => {
+  it("renders the title and description inside an article region", () => {
+    render(<ValueCard {...baseProps} />);
+    expect(screen.getByRole("article")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Clarity first" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(baseProps.description)).toBeInTheDocument();
+  });
+
+  it("applies the variant surface class", () => {
+    const { container } = render(<ValueCard {...baseProps} variant="elevated" />);
+    expect((container.firstChild as HTMLElement).className).toContain("bg-card");
+  });
+
+  it("keeps the elevated lift flat under reduced motion", () => {
+    const { container } = render(<ValueCard {...baseProps} variant="elevated" />);
+    const className = (container.firstChild as HTMLElement).className;
+    expect(className).toContain("motion-reduce:hover:translate-y-0");
+    expect(className).toContain("motion-reduce:transition-none");
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(<ValueCard {...baseProps} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/ValueCard/ValueCard.tsx
+++ b/nextjs-app/shared/components/ValueCard/ValueCard.tsx
@@ -27,7 +27,9 @@ const variantClasses: Record<NonNullable<ValueCardProps["variant"]>, string> = {
 const hoverClasses: Record<NonNullable<ValueCardProps["variant"]>, string> = {
   default: "hover:bg-muted/50",
   bordered: "hover:border-primary/50 hover:shadow-sm",
-  elevated: "hover:shadow-xl hover:-translate-y-1",
+  // motion-reduce keeps the lift's end position flat so reduced-motion users
+  // get no positional jump (the global reset only covers the logo marquee).
+  elevated: "hover:shadow-xl hover:-translate-y-1 motion-reduce:hover:translate-y-0",
 };
 
 export function ValueCard({
@@ -42,7 +44,7 @@ export function ValueCard({
     <article
       className={cn(
         "group relative overflow-hidden p-6 rounded-lg",
-        "transition-all duration-300 ease-out",
+        "transition-all duration-300 ease-out motion-reduce:transition-none",
         variantClasses[variant],
         hoverClasses[variant],
         className,
@@ -55,7 +57,7 @@ export function ValueCard({
             "flex items-center justify-center",
             "w-12 h-12 rounded-lg mb-4",
             "bg-primary/10 text-primary",
-            "transition-colors duration-300",
+            "transition-colors duration-300 motion-reduce:transition-none",
             "group-hover:bg-primary/20",
             iconClassName,
           )}

--- a/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--default.dark.yaml
+++ b/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--default.dark.yaml
@@ -1,0 +1,3 @@
+- article:
+  - heading "Clarity first" [level=3]
+  - paragraph: Interfaces should explain themselves before they decorate.

--- a/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--default.forced-colors.yaml
@@ -1,0 +1,3 @@
+- article:
+  - heading "Clarity first" [level=3]
+  - paragraph: Interfaces should explain themselves before they decorate.

--- a/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--default.light.yaml
+++ b/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--default.light.yaml
@@ -1,0 +1,3 @@
+- article:
+  - heading "Clarity first" [level=3]
+  - paragraph: Interfaces should explain themselves before they decorate.

--- a/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--default.yaml
+++ b/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--default.yaml
@@ -1,0 +1,3 @@
+- article:
+  - heading "Clarity first" [level=3]
+  - paragraph: Interfaces should explain themselves before they decorate.

--- a/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--example.dark.yaml
+++ b/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--example.dark.yaml
@@ -1,0 +1,6 @@
+- article:
+  - heading "Clarity first" [level=3]
+  - paragraph: Interfaces should explain themselves before they decorate.
+- article:
+  - heading "Accessible by default" [level=3]
+  - paragraph: Keyboard, contrast, and semantics are part of the definition of done.

--- a/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--example.forced-colors.yaml
@@ -1,0 +1,6 @@
+- article:
+  - heading "Clarity first" [level=3]
+  - paragraph: Interfaces should explain themselves before they decorate.
+- article:
+  - heading "Accessible by default" [level=3]
+  - paragraph: Keyboard, contrast, and semantics are part of the definition of done.

--- a/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--example.light.yaml
+++ b/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--example.light.yaml
@@ -1,0 +1,6 @@
+- article:
+  - heading "Clarity first" [level=3]
+  - paragraph: Interfaces should explain themselves before they decorate.
+- article:
+  - heading "Accessible by default" [level=3]
+  - paragraph: Keyboard, contrast, and semantics are part of the definition of done.

--- a/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--example.yaml
+++ b/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--example.yaml
@@ -1,0 +1,6 @@
+- article:
+  - heading "Clarity first" [level=3]
+  - paragraph: Interfaces should explain themselves before they decorate.
+- article:
+  - heading "Accessible by default" [level=3]
+  - paragraph: Keyboard, contrast, and semantics are part of the definition of done.

--- a/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--forced-colors.dark.yaml
@@ -1,0 +1,3 @@
+- article:
+  - heading "Clarity first" [level=3]
+  - paragraph: Interfaces should explain themselves before they decorate.

--- a/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--forced-colors.forced-colors.yaml
@@ -1,0 +1,3 @@
+- article:
+  - heading "Clarity first" [level=3]
+  - paragraph: Interfaces should explain themselves before they decorate.

--- a/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--forced-colors.light.yaml
@@ -1,0 +1,3 @@
+- article:
+  - heading "Clarity first" [level=3]
+  - paragraph: Interfaces should explain themselves before they decorate.

--- a/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--forced-colors.yaml
+++ b/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--forced-colors.yaml
@@ -1,0 +1,3 @@
+- article:
+  - heading "Clarity first" [level=3]
+  - paragraph: Interfaces should explain themselves before they decorate.

--- a/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--playground.dark.yaml
+++ b/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--playground.dark.yaml
@@ -1,0 +1,3 @@
+- article:
+  - heading "Clarity first" [level=3]
+  - paragraph: Interfaces should explain themselves before they decorate.

--- a/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--playground.forced-colors.yaml
@@ -1,0 +1,3 @@
+- article:
+  - heading "Clarity first" [level=3]
+  - paragraph: Interfaces should explain themselves before they decorate.

--- a/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--playground.light.yaml
+++ b/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--playground.light.yaml
@@ -1,0 +1,3 @@
+- article:
+  - heading "Clarity first" [level=3]
+  - paragraph: Interfaces should explain themselves before they decorate.

--- a/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--playground.yaml
+++ b/nextjs-app/shared/components/ValueCard/__a11y-snapshots__/site-valuecard--playground.yaml
@@ -1,0 +1,3 @@
+- article:
+  - heading "Clarity first" [level=3]
+  - paragraph: Interfaces should explain themselves before they decorate.

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -14962,7 +14962,7 @@
       "name": "ValueCard",
       "group": "display",
       "tier": 2,
-      "status": "beta",
+      "status": "stable",
       "description": "Card variant for values / principles grids — icon + title + short description, with the same three visual treatments as `LocationCard`.",
       "dense": "Values/principles card: icon + title + short description; grid unit for about/culture sections",
       "keywords": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -388,5 +388,26 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "display",
     "import": "import Title from "@dt/Title";",
   },
+  "ValueCard": {
+    "exampleStories": [],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "display",
+    "import": "import { ValueCard } from "@dt/ValueCard";",
+  },
 }
 `;


### PR DESCRIPTION
Fifth of the near-ready beta->stable fleet. ValueCard is the values/
principles card, consumed in production by AboutPage + the AboutPageContent
and ValuesSection patterns (7 real consumers).

Depended on the AT-snapshot resolver fix (#872) - ValueCard's stories seed
a defaultArgs.title, so its snapshot dir never resolved and it had zero
snapshots. With the resolver fixed, bootstrapped 16 snapshots (4 stories x
4 modes), compare-clean.

Independent re-verify surfaced two real gaps, both fixed:
- reduced-motion: the elevated hover lift (hover:-translate-y-1) plus the
  color/shadow transitions had no motion-reduce guard, yet reducedMotion
  claimed true (the global reset only covers the logo marquee). Added
  motion-reduce:transition-none + motion-reduce:hover:translate-y-0.
- missing unit test: authored ValueCard.test.tsx (axe + article region +
  variant surface + the reduced-motion guard).

Also: axe-clean all 4 modes; Controls 6/6 operable + 0 inert; eyeballed the
card surface light + dark (border/icon-chip/title/description hold contrast,
primary adapts).

Gates: validate:components, check:contract-props, check:consumers,
check:generated, typecheck, lint, lint:css, vitest 1932/1932, build - green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)