### PR TITLE
feat(design-system): promote ServiceCard beta->stable

### DIFF
--- a/nextjs-app/shared/components/ServiceCard/ServiceCard.contract.json
+++ b/nextjs-app/shared/components/ServiceCard/ServiceCard.contract.json
@@ -3,7 +3,7 @@
     "name": "ServiceCard",
     "tier": "molecule",
     "group": "marketing",
-    "status": "beta",
+    "status": "stable",
     "description": "Service tile with icon, title, description, and optional link.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-service-card",
     "radixPrimitive": null,
@@ -34,14 +34,37 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean all four modes; AT snapshots bootstrapped (had none — snapshot dir only resolved after the #872 resolver fix) compare-clean; Controls 8/8 operable + 0 inert; eyeballed the card surface light + dark. Fixed the same reduced-motion gap as ValueCard: the hover scale/lift transforms (icon group-hover:scale-105/-translate-y-0.5, card hover:-translate-y-2/scale-[1.02]) ran on transition-all with no motion-reduce guard while reducedMotion claimed true — added motion-reduce:transition-none to both transition sites. Also added the missing unit test (axe + link/div render + variant surface + reduced-motion guard)."
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ServicesSection/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ServicesSection/ServicesSection.tsx",
+            "since": "2026-06-04"
+        }
+    ],
     "slots": [
         "icon"
     ],
@@ -91,7 +114,8 @@
         }
     },
     "forbiddenUse": [
-        "Bypass design tokens or skip forced-colors verification at beta."
+        "Use for a value or principle without a link/CTA — that is ValueCard.",
+        "Place outside a ServicesGrid; the tile is sized and gapped by that grid."
     ],
     "displayName": "ServiceCard",
     "keywords": [

--- a/nextjs-app/shared/components/ServiceCard/ServiceCard.stories.tsx
+++ b/nextjs-app/shared/components/ServiceCard/ServiceCard.stories.tsx
@@ -17,7 +17,7 @@ const defaultArgs = {
 const meta = {
   title: "Site/ServiceCard",
   component: ServiceCard,
-  tags: ["beta", "!autodocs"],
+  tags: ["stable", "!autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/ServiceCard/ServiceCard.test.tsx
+++ b/nextjs-app/shared/components/ServiceCard/ServiceCard.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { ServiceCard } from "./ServiceCard";
+
+expect.extend(toHaveNoViolations);
+
+const baseProps = {
+  icon: <svg aria-hidden data-testid="icon" />,
+  title: "Design systems",
+  description: "Tokens, components, and governance that scale with your product.",
+};
+
+describe("ServiceCard", () => {
+  it("renders the title and description", () => {
+    render(<ServiceCard {...baseProps} />);
+    expect(
+      screen.getByRole("heading", { name: "Design systems" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(baseProps.description)).toBeInTheDocument();
+  });
+
+  it("renders a link when href is provided", () => {
+    render(<ServiceCard {...baseProps} href="/services/design-systems" />);
+    const link = screen.getByRole("link", { name: /Design systems/ });
+    expect(link).toHaveAttribute("href", "/services/design-systems");
+  });
+
+  it("applies the variant surface class", () => {
+    const { container } = render(
+      <ServiceCard {...baseProps} variant="elevated" />,
+    );
+    expect((container.firstChild as HTMLElement).className).toContain("bg-card");
+  });
+
+  it("guards the hover animation under reduced motion", () => {
+    const { container } = render(
+      <ServiceCard {...baseProps} variant="elevated" />,
+    );
+    expect((container.firstChild as HTMLElement).className).toContain(
+      "motion-reduce:transition-none",
+    );
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(
+      <ServiceCard {...baseProps} href="/services/design-systems" />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/ServiceCard/ServiceCard.tsx
+++ b/nextjs-app/shared/components/ServiceCard/ServiceCard.tsx
@@ -55,7 +55,7 @@ export function ServiceCard({
       {icon && (
         <div
           className={cn(
-            "flex-shrink-0 text-primary transition-all duration-500 ease-out",
+            "flex-shrink-0 text-primary transition-all duration-500 ease-out motion-reduce:transition-none",
             iconPosition === "top" ? "mb-6" : "mr-6",
             "[&>svg]:size-10 lg:[&>svg]:size-12 [&>svg]:stroke-[1.25]",
             // Premium hover: subtle scale + lift + enhanced color vibrancy
@@ -78,7 +78,10 @@ export function ServiceCard({
   );
 
   const baseClasses = cn(
-    "group flex h-full rounded-lg p-8 lg:p-10 transition-all duration-500",
+    // motion-reduce guard: reducedMotion is claimed in the contract but the
+    // global reset only covers the logo marquee; kill the animated hover
+    // transitions (scale/lift) for reduced-motion users.
+    "group flex h-full rounded-lg p-8 lg:p-10 transition-all duration-500 motion-reduce:transition-none",
     iconPosition === "top" ? "flex-col" : "flex-row items-start",
     variantClasses[variant],
     hoverVariantClasses[variant],

--- a/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--default.dark.yaml
+++ b/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--default.dark.yaml
@@ -1,0 +1,2 @@
+- heading "Design systems" [level=3]
+- paragraph: Tokens, components, and governance that scale with your product.

--- a/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--default.forced-colors.yaml
@@ -1,0 +1,2 @@
+- heading "Design systems" [level=3]
+- paragraph: Tokens, components, and governance that scale with your product.

--- a/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--default.light.yaml
+++ b/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--default.light.yaml
@@ -1,0 +1,2 @@
+- heading "Design systems" [level=3]
+- paragraph: Tokens, components, and governance that scale with your product.

--- a/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--default.yaml
+++ b/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--default.yaml
@@ -1,0 +1,2 @@
+- heading "Design systems" [level=3]
+- paragraph: Tokens, components, and governance that scale with your product.

--- a/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--example.dark.yaml
+++ b/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--example.dark.yaml
@@ -1,0 +1,2 @@
+- heading "Design systems" [level=3]
+- paragraph: Tokens, components, and governance that scale with your product.

--- a/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--example.forced-colors.yaml
@@ -1,0 +1,2 @@
+- heading "Design systems" [level=3]
+- paragraph: Tokens, components, and governance that scale with your product.

--- a/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--example.light.yaml
+++ b/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--example.light.yaml
@@ -1,0 +1,2 @@
+- heading "Design systems" [level=3]
+- paragraph: Tokens, components, and governance that scale with your product.

--- a/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--example.yaml
+++ b/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--example.yaml
@@ -1,0 +1,2 @@
+- heading "Design systems" [level=3]
+- paragraph: Tokens, components, and governance that scale with your product.

--- a/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--forced-colors.dark.yaml
@@ -1,0 +1,2 @@
+- heading "Design systems" [level=3]
+- paragraph: Tokens, components, and governance that scale with your product.

--- a/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--forced-colors.forced-colors.yaml
@@ -1,0 +1,2 @@
+- heading "Design systems" [level=3]
+- paragraph: Tokens, components, and governance that scale with your product.

--- a/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--forced-colors.light.yaml
@@ -1,0 +1,2 @@
+- heading "Design systems" [level=3]
+- paragraph: Tokens, components, and governance that scale with your product.

--- a/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--forced-colors.yaml
+++ b/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--forced-colors.yaml
@@ -1,0 +1,2 @@
+- heading "Design systems" [level=3]
+- paragraph: Tokens, components, and governance that scale with your product.

--- a/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--playground.dark.yaml
+++ b/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--playground.dark.yaml
@@ -1,0 +1,2 @@
+- heading "Design systems" [level=3]
+- paragraph: Tokens, components, and governance that scale with your product.

--- a/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--playground.forced-colors.yaml
@@ -1,0 +1,2 @@
+- heading "Design systems" [level=3]
+- paragraph: Tokens, components, and governance that scale with your product.

--- a/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--playground.light.yaml
+++ b/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--playground.light.yaml
@@ -1,0 +1,2 @@
+- heading "Design systems" [level=3]
+- paragraph: Tokens, components, and governance that scale with your product.

--- a/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--playground.yaml
+++ b/nextjs-app/shared/components/ServiceCard/__a11y-snapshots__/site-servicecard--playground.yaml
@@ -1,0 +1,2 @@
+- heading "Design systems" [level=3]
+- paragraph: Tokens, components, and governance that scale with your product.

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -11675,7 +11675,7 @@
       "name": "ServiceCard",
       "group": "marketing",
       "tier": 2,
-      "status": "beta",
+      "status": "stable",
       "description": "Service tile with icon, title, description, and optional link.",
       "dense": "Service tile: icon, title, description, optional link; services-grid unit",
       "keywords": [
@@ -11764,7 +11764,8 @@
       "composesWith": [],
       "prefersOver": [],
       "forbiddenUse": [
-        "Bypass design tokens or skip forced-colors verification at beta."
+        "Use for a value or principle without a link/CTA — that is ValueCard.",
+        "Place outside a ServicesGrid; the tile is sized and gapped by that grid."
       ],
       "usage": {
         "description": "Tile for one service offering — icon, title, short description, optional link. Renders inside ServicesGrid."

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -295,6 +295,27 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "layout",
     "import": "import { Section } from "@dt/Section";",
   },
+  "ServiceCard": {
+    "exampleStories": [],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "marketing",
+    "import": "import { ServiceCard } from "@dt/ServiceCard";",
+  },
   "SiteFooter": {
     "exampleStories": [],
     "fields": [


### PR DESCRIPTION
Sixth of the near-ready beta->stable fleet; sibling of ValueCard. ServiceCard
is the service tile, consumed in production by HomePage + the ServicesSection
pattern (4 real consumers).

Same story as ValueCard: its stories seed defaultArgs.title, so the snapshot
dir only resolved after the #872 resolver fix - bootstrapped 16 snapshots
(4 stories x 4 modes), compare-clean.

Independent re-verify surfaced the same two gaps, both fixed:
- reduced-motion: the hover scale/lift transforms (icon group-hover:scale-105 /
  -translate-y-0.5, card hover:-translate-y-2 / scale-[1.02]) ran on
  transition-all with no motion-reduce guard while reducedMotion claimed true
  (the global reset only covers the logo marquee). Added
  motion-reduce:transition-none to both transition sites.
- missing unit test: authored ServiceCard.test.tsx (axe + heading + link render
  + variant surface + reduced-motion guard).

Also: axe-clean all 4 modes; Controls 8/8 operable + 0 inert; eyeballed the
card surface light + dark (border/icon/title/description hold contrast, primary
adapts).

Gates: validate:components, check:contract-props, check:consumers,
check:generated, typecheck, lint, lint:css, vitest 1937/1937, build - green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)