### PR TITLE
feat(design-system): Pagination beta to stable (fleet #8)

### DIFF
--- a/nextjs-app/shared/components/Pagination/Pagination.contract.json
+++ b/nextjs-app/shared/components/Pagination/Pagination.contract.json
@@ -3,7 +3,7 @@
     "name": "Pagination",
     "tier": "molecule",
     "group": "navigation",
-    "status": "beta",
+    "status": "stable",
     "description": "Pagination controls for paged lists (article archive, search results). Renders a `<nav>` landmark with previous/next buttons and a numbered list; supports ellipsis truncation for long page ranges.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-pagination",
     "radixPrimitive": null,
@@ -24,14 +24,17 @@
             "Enter / Space — activates the focused control."
         ],
         "ariaRequirements": [
-            "Renders a `<nav>` element with `aria-label='Pagination'` (overridable).",
+            "Renders a `<nav>` landmark labelled from i18n (`blogPageNavigation` → 'Page navigation' / 'Sivunavigointi' / 'Sidnavigering').",
             "Current page sets `aria-current='page'`.",
-            "Previous/next buttons that are unavailable use `aria-disabled='true'` instead of being removed, so the visual structure does not jump."
+            "Previous/next are `<button disabled>` on the edges (still in the DOM) so the visual structure does not jump.",
+            "Chevrons and the ellipsis are `aria-hidden`; each page button carries its own `Page N` accessible name."
         ],
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all stories in all four modes; AT snapshots refreshed compare-clean; Controls operable + 0 inert; eyeballed the pager in light and dark. Fixed two real defects: (1) the `<nav>` landmark reused the `blogPage` i18n key, so its accessible name resolved to 'Page' / 'Sivu' instead of a navigation label — added a dedicated `blogPageNavigation` key (en/fi/sv) and dropped the redundant explicit `role='navigation'`; (2) the color transitions had no `prefers-reduced-motion` guard yet reducedMotion claimed true — added `motion-reduce:transition-none`."
     },
     "tokens": {
         "colors": [
@@ -49,7 +52,33 @@
         ]
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/BlogIndexContent/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/index.ts",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "currentPage": {
@@ -74,7 +103,7 @@
         }
     },
     "forbiddenUse": [
-        "Remove Previous/Next on edges — use `aria-disabled` so the visual stays stable.",
+        "Remove Previous/Next on edges — keep them as disabled buttons so the visual stays stable.",
         "Render more than ~10 page numbers inline — switch to a 'Page X of Y' label with prev/next only."
     ],
     "composesWith": [

--- a/nextjs-app/shared/components/Pagination/Pagination.stories.tsx
+++ b/nextjs-app/shared/components/Pagination/Pagination.stories.tsx
@@ -33,7 +33,7 @@ const defaultArgs = {
 const meta = {
   title: "Navigation/Pagination",
   component: Pagination,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/Pagination/Pagination.tsx
+++ b/nextjs-app/shared/components/Pagination/Pagination.tsx
@@ -93,8 +93,7 @@ export function Pagination({
 
   return (
     <nav
-      role="navigation"
-      aria-label={t("blogPage", "Page navigation")}
+      aria-label={t("blogPageNavigation", "Page navigation")}
       className={cn("flex items-center justify-center gap-1", className)}
     >
       {/* Previous button */}
@@ -107,7 +106,7 @@ export function Pagination({
           "inline-flex items-center justify-center",
           "w-10 h-10 rounded-lg",
           "font-body text-sm",
-          "transition-colors duration-200",
+          "transition-colors duration-200 motion-reduce:transition-none",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
           canGoPrev
             ? "text-foreground hover:bg-accent hover:text-accent-foreground"
@@ -145,7 +144,7 @@ export function Pagination({
                 "inline-flex items-center justify-center",
                 "w-10 h-10 rounded-lg",
                 "font-body text-sm",
-                "transition-colors duration-200",
+                "transition-colors duration-200 motion-reduce:transition-none",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                 isActive
                   ? "bg-foreground text-background"
@@ -168,7 +167,7 @@ export function Pagination({
           "inline-flex items-center justify-center",
           "w-10 h-10 rounded-lg",
           "font-body text-sm",
-          "transition-colors duration-200",
+          "transition-colors duration-200 motion-reduce:transition-none",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
           canGoNext
             ? "text-foreground hover:bg-accent hover:text-accent-foreground"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--default.dark.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--default.dark.yaml
@@ -1,5 +1,4 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 2": "2"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--default.forced-colors.yaml
@@ -1,5 +1,4 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 2": "2"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--default.light.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--default.light.yaml
@@ -1,5 +1,4 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 2": "2"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--default.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--default.yaml
@@ -1,5 +1,4 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 2": "2"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--example.dark.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--example.dark.yaml
@@ -1,5 +1,4 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 2": "2"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--example.forced-colors.yaml
@@ -1,5 +1,4 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 2": "2"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--example.light.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--example.light.yaml
@@ -1,5 +1,4 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 2": "2"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--example.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--example.yaml
@@ -1,5 +1,4 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 2": "2"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--forced-colors.dark.yaml
@@ -1,5 +1,4 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 2": "2"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--forced-colors.forced-colors.yaml
@@ -1,5 +1,4 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 2": "2"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--forced-colors.light.yaml
@@ -1,5 +1,4 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 2": "2"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--forced-colors.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--forced-colors.yaml
@@ -1,5 +1,4 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 2": "2"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--interactive.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--interactive.yaml
@@ -1,5 +1,4 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 2": "2"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--many-pages.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--many-pages.yaml
@@ -1,5 +1,4 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 24": "24"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--playground.dark.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--playground.dark.yaml
@@ -1,5 +1,4 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 2": "2"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--playground.forced-colors.yaml
@@ -1,5 +1,4 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 2": "2"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--playground.light.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--playground.light.yaml
@@ -1,5 +1,4 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 2": "2"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--playground.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--playground.yaml
@@ -1,5 +1,4 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 2": "2"

--- a/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--sibling-count.yaml
+++ b/nextjs-app/shared/components/Pagination/__a11y-snapshots__/navigation-pagination--sibling-count.yaml
@@ -1,11 +1,10 @@
-- status: Work in progress (beta)
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 10": "10"
   - button "Page 20": "20"
   - button "Next"
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 9": "9"
@@ -13,7 +12,7 @@
   - button "Page 11": "11"
   - button "Page 20": "20"
   - button "Next"
-- navigation "Page":
+- navigation "Page navigation":
   - button "Previous"
   - button "Page 1": "1"
   - button "Page 8": "8"

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -9720,7 +9720,7 @@
       "name": "Pagination",
       "group": "navigation",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "Pagination controls for paged lists (article archive, search results). Renders a `<nav>` landmark with previous/next buttons and a numbered list; supports ellipsis truncation for long page ranges.",
       "dense": "Numbered pager: prev/next chevrons + sibling window w/ ellipsis; controlled (1-indexed currentPage + onPageChange); aria-current=page on active; labels en/fi/sv; null when totalPages<=1",
       "keywords": [
@@ -9781,7 +9781,7 @@
       ],
       "prefersOver": [],
       "forbiddenUse": [
-        "Remove Previous/Next on edges — use `aria-disabled` so the visual stays stable.",
+        "Remove Previous/Next on edges — keep them as disabled buttons so the visual stays stable.",
         "Render more than ~10 page numbers inline — switch to a 'Page X of Y' label with prev/next only."
       ],
       "usage": {

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -292,6 +292,31 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "navigation",
     "import": "import Link from "@dt/Link";",
   },
+  "Pagination": {
+    "exampleStories": [
+      "ManyPages",
+      "SiblingCount",
+      "Interactive",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "navigation",
+    "import": "import { Pagination } from "@dt/Pagination";",
+  },
   "Section": {
     "exampleStories": [
       "SpacingBands",

--- a/nextjs-app/shared/locales/en/translation.json
+++ b/nextjs-app/shared/locales/en/translation.json
@@ -1259,6 +1259,7 @@
   "blogPrevPage": "Previous",
   "blogNextPage": "Next",
   "blogPage": "Page",
+  "blogPageNavigation": "Page navigation",
   "scrollToContent": "Scroll",
   "articleTOCTitle": "Table of Contents",
   "articleShareTitle": "Share this article",

--- a/nextjs-app/shared/locales/fi/translation.json
+++ b/nextjs-app/shared/locales/fi/translation.json
@@ -1259,6 +1259,7 @@
   "blogPrevPage": "Edellinen",
   "blogNextPage": "Seuraava",
   "blogPage": "Sivu",
+  "blogPageNavigation": "Sivunavigointi",
   "scrollToContent": "Vieritä",
   "articleTOCTitle": "Sisällysluettelo",
   "articleShareTitle": "Jaa tämä artikkeli",

--- a/nextjs-app/shared/locales/sv/translation.json
+++ b/nextjs-app/shared/locales/sv/translation.json
@@ -1269,6 +1269,7 @@
   "blogPrevPage": "Föregående",
   "blogNextPage": "Nästa",
   "blogPage": "Sida",
+  "blogPageNavigation": "Sidnavigering",
   "scrollToContent": "Rulla",
   "articleTOCTitle": "Innehållsförteckning",
   "articleShareTitle": "Dela denna artikel",


### PR DESCRIPTION
Promotes **Pagination** (the content pager) beta → stable. Fleet #8 of the Phase 5 promotion wave.

## Consumer qualification
`audit:consumers` populated **5 real consumers** — BlogPage and the BlogIndexContent pattern.

## Re-verified independently (did not trust flags)
- **axe-clean** across all 7 stories in all four modes (plain / light / dark / forced-colors).
- **AT snapshots refreshed** compare-clean; removed the themed-file pollution the UPDATE run wrote for the three example-only stories (ManyPages / SiblingCount / Interactive stay plain-only).
- **Controls** 4/4 operable, 0 inert.
- Eyeballed light + dark — the active page inverts correctly in both.

## Real defects fixed
- **Mislabeled landmark:** the `<nav>` reused the `blogPage` i18n key, so its accessible name resolved to **"Page" / "Sivu" / "Sida"** instead of a navigation label — the AT snapshot literally read `navigation "Page"`. Added a dedicated `blogPageNavigation` key (en/fi/sv → "Page navigation" / "Sivunavigointi" / "Sidnavigering") and dropped the now-redundant explicit `role="navigation"`.
- **Reduced-motion:** color transitions had no `prefers-reduced-motion` guard despite `reducedMotion: true` — added `motion-reduce:transition-none`.
- Corrected two stale contract claims (`aria-label` "overridable"; `aria-disabled` vs the native `disabled` the component actually uses).

## Gates (all green locally)
validate:components · check:contract-props · check:consumers · audit:controls --effects (100% / 0 inert) · 4-mode AT compare · typecheck · lint · lint:css · vitest (1988 passed) · build · docs-registry + zod-catalog regenerated and committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
