### PR TITLE
feat(design-system): List beta to stable (fleet #9)

### DIFF
--- a/nextjs-app/shared/components/List/List.contract.json
+++ b/nextjs-app/shared/components/List/List.contract.json
@@ -3,11 +3,11 @@
     "name": "List",
     "tier": "molecule",
     "group": "structure",
-    "status": "beta",
-    "description": "List — production @dt component (Storybook beta).",
+    "status": "stable",
+    "description": "Typographic list (ul or ol) that renders `items` on the text ladder — size and terminals match the surrounding Text voice, listStyleType styles or removes markers, and spacing owns the inter-item rhythm.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-list",
     "radixPrimitive": null,
-    "element": "div",
+    "element": "ul",
     "variants": {
         "size": {
             "values": [
@@ -27,7 +27,7 @@
                 "serif",
                 "sans"
             ],
-            "default": "serif",
+            "default": "sans",
             "propSourced": true
         }
     },
@@ -47,15 +47,81 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true,
+        "ariaRequirements": [
+            "Renders a real `<ul>`/`<ol>` with one `<li>` per entry, so assistive tech announces list role and item count.",
+            "`listStyleType=\"none\"` maps to a single-space marker (`\" \"`) rather than CSS `none`, which preserves list semantics in Safari/VoiceOver where `list-style:none` silences them."
+        ],
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all stories in all four modes; AT snapshots refreshed compare-clean; Controls operable + 0 inert; no motion in the CSS so reducedMotion is trivially honest. Fixed real defects: `element` was \"div\" but the root render is a `<ul>`/`<ol>`; the placeholder description was replaced with an honest one; `variants.terminals.default` said \"serif\" but the component defaults to \"sans\"; and the docs overclaimed `dl` support (the `as` prop is only ul|ol and children are always `<li>`)."
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/GarageJunction/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/LlmComponentSchema/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/NewThingsCo/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "items": {
@@ -141,7 +207,8 @@
         }
     },
     "forbiddenUse": [
-        "Bypass design tokens or skip forced-colors verification at beta."
+        "Pass pre-wrapped `<li>` elements in items — items are the contents; List renders the li.",
+        "Use it for a single item or for layout — Stack is layout, List is list semantics."
     ],
     "composesWith": [
         "Text",
@@ -156,13 +223,13 @@
         "description list",
         "items"
     ],
-    "dense": "Typographic list: as ul|ol|dl, items ReactNode[], size on the text ladder, terminals serif|sans, listStyleType incl. none, spacing compact|normal|relaxed; component owns rhythm — no per-item margins",
+    "dense": "Typographic list: as ul|ol, items ReactNode[], size on the text ladder, terminals serif|sans, listStyleType incl. none, spacing compact|normal|relaxed; component owns rhythm — no per-item margins",
     "usage": {
-        "description": "List renders `items` as a typographic list on the text ladder: `as` picks ul/ol/dl semantics, `size` and `terminals` match the surrounding Text voice, `listStyleType` styles or removes markers, `spacing` sets the rhythm between items. It owns inter-item spacing — no margins on items. For custom marker treatments (like ProcessBlock's em dashes) pass `listStyleType=\"none\"` and style via className.",
+        "description": "List renders `items` as a typographic list on the text ladder: `as` picks ul/ol semantics, `size` and `terminals` match the surrounding Text voice, `listStyleType` styles or removes markers, `spacing` sets the rhythm between items. It owns inter-item spacing — no margins on items. For custom marker treatments (like ProcessBlock's em dashes) pass `listStyleType=\"none\"` and style via className.",
         "bestPractices": [
             {
                 "guidance": true,
-                "description": "Pick as by meaning: ol when order matters, ul otherwise, dl for term-description pairs."
+                "description": "Pick as by meaning: ol when order matters, ul otherwise."
             },
             {
                 "guidance": true,
@@ -189,12 +256,12 @@
             {
                 "name": "List element",
                 "required": true,
-                "description": "ul, ol, or dl chosen by as; carries size/terminals typography and spacing rhythm."
+                "description": "ul or ol chosen by as; carries size/terminals typography and spacing rhythm."
             },
             {
                 "name": "Item",
                 "required": true,
-                "description": "Rendered li (or dt/dd content) per entry in items; List owns the wrapper, callers pass contents only."
+                "description": "Rendered `<li>` per entry in items; List owns the wrapper, callers pass the contents only."
             },
             {
                 "name": "Marker",

--- a/nextjs-app/shared/components/List/List.stories.tsx
+++ b/nextjs-app/shared/components/List/List.stories.tsx
@@ -22,7 +22,7 @@ import schema from "./schema.json";
 const meta: Meta<typeof List> = {
   title: "Content/List",
   component: List,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--default.dark.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--default.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: First list item
   - listitem: Second list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--default.forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: First list item
   - listitem: Second list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--default.light.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--default.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: First list item
   - listitem: Second list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--default.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--default.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: First list item
   - listitem: Second list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--different-list-styles.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--different-list-styles.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Disc
 - list:
   - listitem: First list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--different-sizes.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--different-sizes.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: XXS
 - list:
   - listitem: First list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--different-spacing.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--different-spacing.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Compact Spacing
 - list:
   - listitem: First list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--example.dark.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--example.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: First list item
   - listitem: Second list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--example.forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: First list item
   - listitem: Second list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--example.light.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--example.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: First list item
   - listitem: Second list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--example.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--example.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: First list item
   - listitem: Second list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--forced-colors.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: First list item
   - listitem: Second list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--forced-colors.forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: First list item
   - listitem: Second list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--forced-colors.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: First list item
   - listitem: Second list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--forced-colors.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: First list item
   - listitem: Second list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--ordered-list.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--ordered-list.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: First list item
   - listitem: Second list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--playground.dark.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--playground.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: First list item
   - listitem: Second list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--playground.forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: First list item
   - listitem: Second list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--playground.light.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--playground.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: First list item
   - listitem: Second list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--playground.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--playground.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: First list item
   - listitem: Second list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--serif-and-sans.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--serif-and-sans.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Sans (Default)
 - list:
   - listitem: First list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--unordered-list.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--unordered-list.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: First list item
   - listitem: Second list item

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--with-complex-items.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--with-complex-items.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem:
     - strong: Bold text

--- a/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--with-line-heights.yaml
+++ b/nextjs-app/shared/components/List/__a11y-snapshots__/content-list--with-line-heights.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - paragraph: Tight
 - list:
   - listitem: This is a longer list item that demonstrates the effect of different line heights on text readability and visual density.

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -7941,9 +7941,9 @@
       "name": "List",
       "group": "structure",
       "tier": 1,
-      "status": "beta",
-      "description": "List — production @dt component (Storybook beta).",
-      "dense": "Typographic list: as ul|ol|dl, items ReactNode[], size on the text ladder, terminals serif|sans, listStyleType incl. none, spacing compact|normal|relaxed; component owns rhythm — no per-item margins",
+      "status": "stable",
+      "description": "Typographic list (ul or ol) that renders `items` on the text ladder — size and terminals match the surrounding Text voice, listStyleType styles or removes markers, and spacing owns the inter-item rhythm.",
+      "dense": "Typographic list: as ul|ol, items ReactNode[], size on the text ladder, terminals serif|sans, listStyleType incl. none, spacing compact|normal|relaxed; component owns rhythm — no per-item margins",
       "keywords": [
         "list",
         "bullet",
@@ -8074,14 +8074,15 @@
       ],
       "prefersOver": [],
       "forbiddenUse": [
-        "Bypass design tokens or skip forced-colors verification at beta."
+        "Pass pre-wrapped `<li>` elements in items — items are the contents; List renders the li.",
+        "Use it for a single item or for layout — Stack is layout, List is list semantics."
       ],
       "usage": {
-        "description": "List renders `items` as a typographic list on the text ladder: `as` picks ul/ol/dl semantics, `size` and `terminals` match the surrounding Text voice, `listStyleType` styles or removes markers, `spacing` sets the rhythm between items. It owns inter-item spacing — no margins on items. For custom marker treatments (like ProcessBlock's em dashes) pass `listStyleType=\"none\"` and style via className.",
+        "description": "List renders `items` as a typographic list on the text ladder: `as` picks ul/ol semantics, `size` and `terminals` match the surrounding Text voice, `listStyleType` styles or removes markers, `spacing` sets the rhythm between items. It owns inter-item spacing — no margins on items. For custom marker treatments (like ProcessBlock's em dashes) pass `listStyleType=\"none\"` and style via className.",
         "bestPractices": [
           {
             "guidance": true,
-            "description": "Pick as by meaning: ol when order matters, ul otherwise, dl for term-description pairs."
+            "description": "Pick as by meaning: ol when order matters, ul otherwise."
           },
           {
             "guidance": true,
@@ -8108,12 +8109,12 @@
           {
             "name": "List element",
             "required": true,
-            "description": "ul, ol, or dl chosen by as; carries size/terminals typography and spacing rhythm."
+            "description": "ul or ol chosen by as; carries size/terminals typography and spacing rhythm."
           },
           {
             "name": "Item",
             "required": true,
-            "description": "Rendered li (or dt/dd content) per entry in items; List owns the wrapper, callers pass contents only."
+            "description": "Rendered `<li>` per entry in items; List owns the wrapper, callers pass the contents only."
           },
           {
             "name": "Marker",

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -292,6 +292,32 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "navigation",
     "import": "import Link from "@dt/Link";",
   },
+  "List": {
+    "exampleStories": [
+      "UnorderedList",
+      "OrderedList",
+      "DifferentSpacing",
+      "DifferentListStyles",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "structure",
+    "import": "import List from "@dt/List";",
+  },
   "Pagination": {
     "exampleStories": [
       "ManyPages",


### PR DESCRIPTION
Promotes **List** (the typographic list primitive) beta → stable. Fleet #9 of the Phase 5 promotion wave.

## Consumer qualification
`audit:consumers` populated **12 real consumers** — the Work case-study pages, through the ServicesBlock / ProcessBlock patterns.

## Re-verified independently (did not trust flags)
- **axe-clean** across all 12 stories in all four modes (plain / light / dark / forced-colors).
- **AT snapshots refreshed** compare-clean — the only change is the dropped Work-in-progress badge line; removed the themed-file pollution the UPDATE run wrote for the eight example-only stories.
- **Controls** 8/8 operable, 0 inert.
- Eyeballed light + dark; no motion in the CSS, so `reducedMotion` is trivially honest.

## Defects fixed — all were contract inaccuracies (List.tsx was already correct)
- `element` was `"div"` but the root render is a `<ul>`/`<ol>`.
- `description` was the scaffolder placeholder ("List — production @dt component") → honest one-liner.
- `variants.terminals.default` claimed `"serif"` but the component defaults to `"sans"`.
- The docs overclaimed `dl` support — the `as` prop is only `ul|ol` and children are always `<li>`. Corrected dense / usage / anatomy / bestPractices.
- Documented the real ARIA behavior, including the `listStyleType="none"` → single-space-marker Safari/VoiceOver list-semantics workaround.

## Gates (all green locally)
validate:components · check:contract-props · check:consumers · audit:controls --effects (100% / 0 inert) · 4-mode AT compare · typecheck · lint · lint:css · vitest (1988 passed) · build · docs-registry + zod-catalog regenerated and committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
