### PR TITLE
feat(design-system): Stack beta to stable (fleet #10)

### DIFF
--- a/nextjs-app/shared/components/Stack/Stack.contract.json
+++ b/nextjs-app/shared/components/Stack/Stack.contract.json
@@ -3,7 +3,7 @@
     "name": "Stack",
     "tier": "atom",
     "group": "layout",
-    "status": "beta",
+    "status": "stable",
     "description": "Flex stack primitive for vertical and horizontal rhythm.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-stack",
     "radixPrimitive": null,
@@ -11,12 +11,12 @@
     "variants": {
         "align": {
             "values": [
-                "center",
                 "stretch",
-                "end",
-                "start"
+                "start",
+                "center",
+                "end"
             ],
-            "default": "center",
+            "default": "stretch",
             "propSourced": true
         }
     },
@@ -31,18 +31,68 @@
     ],
     "a11y": {
         "keyboard": [],
-        "ariaRequirements": [],
+        "ariaRequirements": [
+            "Stack is a presentational flex container with no role of its own; it inherits the semantics of its `as` element (default `div`). Use `as=\"ul\"`/`\"ol\"` with `li` children when the group is semantically a list so assistive tech announces list role and item count."
+        ],
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all stories in all four modes (plain/light/dark/forced); AT snapshots refreshed compare-clean (only change is the dropped Work-in-progress badge line); Controls operable + 0 inert; no motion in the CSS so reducedMotion is trivially honest. Fixed real defect: `align` claimed `@default \"center\"` in the JSDoc and `variants.align.default`/order in the contract, but the component defaults to `stretch` (matching sibling FlexBox); corrected the JSDoc, union order (stretch first), and contract so the derived default is honest and sync-stable — zero render change since the runtime default was already `stretch`."
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/dev/tailwind-test/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/layout.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/HomeHero/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/navigation/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/SiteFooter/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "children": {
@@ -73,10 +123,10 @@
             "optional": true,
             "type": "union",
             "values": [
-                "center",
                 "stretch",
-                "end",
-                "start"
+                "start",
+                "center",
+                "end"
             ]
         },
         "justify": {
@@ -284,7 +334,9 @@
         }
     },
     "forbiddenUse": [
-        "Bypass design tokens or skip forced-colors verification at beta."
+        "Nest Stacks purely to sum gaps — pick the right gap token on one Stack instead.",
+        "Add margins to Stack children — the gap owns the spacing and margins fight it.",
+        "Use it when items need individual offsets or a non-token gap (that's FlexBox) or when both axes matter (that's Grid)."
     ],
     "composesWith": [
         "Card",

--- a/nextjs-app/shared/components/Stack/Stack.spec.md
+++ b/nextjs-app/shared/components/Stack/Stack.spec.md
@@ -9,8 +9,8 @@ Documents how **Stack** is used in production layouts and Storybook examples.
 - Screen readers: Verify labels, roles, and live regions in stories.
 
 ## Do / don't
-- Do: Match the **Example** story composition on Stack pages.
-- Don't: Bypass design tokens or skip forced-colors verification at beta.
+- Do: Match the **Example** story composition on Stack pages; pick one `gap` token per Stack.
+- Don't: Nest Stacks to sum gaps, or add margins to Stack children — the `gap` owns the spacing.
 
 ## Design notes
 - Tokens: Uses semantic colors/spacing from `variables.css`.

--- a/nextjs-app/shared/components/Stack/Stack.stories.tsx
+++ b/nextjs-app/shared/components/Stack/Stack.stories.tsx
@@ -21,7 +21,7 @@ const defaultArgs = {
 const meta = {
   title: "Layout/Stack",
   component: Stack,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/Stack/Stack.tsx
+++ b/nextjs-app/shared/components/Stack/Stack.tsx
@@ -8,8 +8,8 @@ export interface StackProps {
   direction?: "vertical" | "horizontal";
   /** Gap token between items. @default "md" */
   gap?: "none" | "xs" | "sm" | "md" | "lg" | "xl";
-  /** Cross-axis alignment. @default "center" */
-  align?: "start" | "center" | "end" | "stretch";
+  /** Cross-axis alignment. @default "stretch" */
+  align?: "stretch" | "start" | "center" | "end";
   /** Main-axis distribution. */
   justify?: "start" | "center" | "end" | "between" | "around";
   /** Allow wrapping on horizontal stacks. */

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--default.dark.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--default.dark.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: First item
 - paragraph: Second item

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--default.forced-colors.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: First item
 - paragraph: Second item

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--default.light.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--default.light.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: First item
 - paragraph: Second item

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--default.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--default.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: First item
 - paragraph: Second item

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--example.dark.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--example.dark.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: Hero copy block
 - paragraph: Supporting line with consistent spacing

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--example.forced-colors.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: Hero copy block
 - paragraph: Supporting line with consistent spacing

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--example.light.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--example.light.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: Hero copy block
 - paragraph: Supporting line with consistent spacing

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--example.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--example.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: Hero copy block
 - paragraph: Supporting line with consistent spacing

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--forced-colors.dark.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: First item
 - paragraph: Second item

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--forced-colors.forced-colors.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: First item
 - paragraph: Second item

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--forced-colors.light.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: First item
 - paragraph: Second item

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--forced-colors.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--forced-colors.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: First item
 - paragraph: Second item

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--gap-scale.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--gap-scale.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: gap xs steps gap md steps gap xl steps

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--horizontal-cluster.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--horizontal-cluster.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Save"
 - button "Cancel"
 - text: Last saved 2 min ago

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--playground.dark.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--playground.dark.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: First item
 - paragraph: Second item

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--playground.forced-colors.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: First item
 - paragraph: Second item

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--playground.light.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--playground.light.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: First item
 - paragraph: Second item

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--playground.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--playground.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: First item
 - paragraph: Second item

--- a/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--semantic-list.yaml
+++ b/nextjs-app/shared/components/Stack/__a11y-snapshots__/layout-stack--semantic-list.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - list:
   - listitem: Design tokens
   - listitem: Components

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -12797,7 +12797,7 @@
       "name": "Stack",
       "group": "layout",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "Flex stack primitive for vertical and horizontal rhythm.",
       "dense": "Token-gapped flex: direction vertical|horizontal, gap none|xs 4|sm 8|md 16 (default)|lg 24|xl 32px, align/justify shorthands, wrap; polymorphic as (ul/ol for semantic lists)",
       "keywords": [
@@ -12827,7 +12827,7 @@
         },
         {
           "name": "align",
-          "type": "center | stretch | end | start",
+          "type": "stretch | start | center | end",
           "required": false
         },
         {
@@ -12870,10 +12870,10 @@
           "optional": true,
           "type": "union",
           "values": [
-            "center",
             "stretch",
-            "end",
-            "start"
+            "start",
+            "center",
+            "end"
           ]
         },
         "justify": {
@@ -13087,7 +13087,9 @@
       ],
       "prefersOver": [],
       "forbiddenUse": [
-        "Bypass design tokens or skip forced-colors verification at beta."
+        "Nest Stacks purely to sum gaps — pick the right gap token on one Stack instead.",
+        "Add margins to Stack children — the gap owns the spacing and margins fight it.",
+        "Use it when items need individual offsets or a non-token gap (that's FlexBox) or when both axes matter (that's Grid)."
       ],
       "usage": {
         "description": "Stack is the default way to space siblings: a flex column (or row) whose `gap` comes from a fixed token scale, so vertical rhythm stays on the grid without margin fiddling. Use `as=\"ul\"` with `li` children when the stack is semantically a list. If items need individual offsets or non-token gaps, that's FlexBox; if both axes matter, Grid.",

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -431,6 +431,31 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "navigation",
     "import": "import { SiteHeader } from "@dt/SiteHeader";",
   },
+  "Stack": {
+    "exampleStories": [
+      "GapScale",
+      "HorizontalCluster",
+      "SemanticList",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "layout",
+    "import": "import { Stack } from "@dt/Stack";",
+  },
   "Text": {
     "exampleStories": [
       "AllTags",


### PR DESCRIPTION
## What

Promote the layout **Stack** primitive from beta to stable — **fleet #10**.

Picked via a fresh `audit:consumers` transitive scan of every beta component: Stack has **9 real production consumers** (`app/layout.tsx`, `HomePage`, `HomeHero`, `SiteFooter`, and the patterns barrel), the highest-adoption layout primitive left after the FlexBox/Grid/Container/Section fleet went stable.

## Defect found (promotions are never flag-flips)

`Stack.tsx` runtime was correct, but the **documented default lied**:

- JSDoc said `align` `@default "center"`, and the contract's `variants.align.default` + value order also said `"center"` — but the component actually defaults to `stretch` (matching sibling FlexBox).
- Because the union's first member drives the `propSourced` default derivation (`build-component-agent-blocks.ts`), the union had `"start"` first while the runtime defaulted to `"stretch"` — **three different values** for one default.

**Fix:** corrected the JSDoc, reordered the union `stretch`-first, and set the contract default to `"stretch"` so the derived default is honest and `sync:contract-props`-stable. **Zero render change** — the runtime default was already `stretch`, so the 9 consumers are unaffected (proven by the snapshot diff below).

## Verification (independent, not flag-trusting)

- **AT snapshots** refreshed across all four modes (plain/light/dark/forced-colors): the *only* change is the dropped `- status: Work in progress (beta)` badge line — **19 files, −1 line each, zero additions**. Confirms the align edit is DOM-identical.
- All **7 stories pass the Storybook test-runner** with the error-level axe gate.
- Controls operable; no motion in the CSS so `reducedMotion` is trivially honest.

Also: replaced scaffolder-placeholder `forbiddenUse`/spec don'ts with real Stack guidance, set `a11y.accessibilityTreeVerified` + `realBrowserForcedColorsVerified`, populated `consumers[]` via `audit:consumers`, flipped the story meta tag, regenerated `docs-registry.json` + the get-shape snapshot.

## Local gate (all green)

typecheck ✓ · lint ✓ (0 errors) · full test suite **1988/1988** ✓ · build ✓ · `check:contract-props` ✓ · `check:consumers` ✓ · `validate:components` ✓ · pre-commit: contrast ✓, stylelint baseline ✓, rhythmguard 0 new findings ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
