### PR TITLE
feat(design-system): Divider beta to stable (fleet #12)

### DIFF
--- a/nextjs-app/shared/components/Divider/Divider.contract.json
+++ b/nextjs-app/shared/components/Divider/Divider.contract.json
@@ -3,11 +3,11 @@
     "name": "Divider",
     "tier": "atom",
     "group": "structure",
-    "status": "beta",
+    "status": "stable",
     "description": "Visual separator between sections (horizontal or vertical).",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=368-6",
     "radixPrimitive": null,
-    "element": "div",
+    "element": "hr",
     "variants": {
         "orientation": {
             "values": [
@@ -33,7 +33,9 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true,
+        "reviewedNote": "2026-07-05 — beta→stable (fleet #12): renders a real <hr> (contract element corrected div→hr). decorative default role=none; decorative={false} announces role=separator + aria-orientation. No motion; single hairline on --color-border. Re-verified independently: axe + plays green in light/dark/forced-colors, 100% controls operable / 0 inert, AT snapshots refreshed 4 modes. 2026-05-28 origin: promoted from alpha with Example + ForcedColors stories and the Storybook axe gate."
     },
     "tokens": {
         "colors": [
@@ -43,7 +45,38 @@
         "spacing": []
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/dev/tailwind-test/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/layout.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/navigation/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/SiteFooter/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "orientation": {
@@ -64,7 +97,8 @@
         }
     },
     "forbiddenUse": [
-        "Bypass design tokens or skip forced-colors verification at beta."
+        "Use a divider as spacing — reach for gap or Spacer when you only need distance.",
+        "Put a divider between every list row — List's own rhythm and borders handle that."
     ],
     "composesWith": [
         "Stack",

--- a/nextjs-app/shared/components/Divider/Divider.stories.tsx
+++ b/nextjs-app/shared/components/Divider/Divider.stories.tsx
@@ -5,7 +5,7 @@ import contract from "./Divider.contract.json";
 const meta = {
   title: "Layout/Divider",
   component: Divider,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--decorative-rhythm.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--decorative-rhythm.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: Intro block of content.
 - paragraph: The next thought, visually set apart.

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--default.dark.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--default.dark.yaml
@@ -1,1 +1,0 @@
-- status: Work in progress (beta)

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--default.forced-colors.yaml
@@ -1,1 +1,0 @@
-- status: Work in progress (beta)

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--default.light.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--default.light.yaml
@@ -1,1 +1,0 @@
-- status: Work in progress (beta)

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--default.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--default.yaml
@@ -1,1 +1,0 @@
-- status: Work in progress (beta)

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--example.dark.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--example.dark.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: Section one
 - paragraph: Section two

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--example.forced-colors.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: Section one
 - paragraph: Section two

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--example.light.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--example.light.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: Section one
 - paragraph: Section two

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--example.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--example.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - paragraph: Section one
 - paragraph: Section two

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--forced-colors.dark.yaml
@@ -1,1 +1,0 @@
-- status: Work in progress (beta)

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--forced-colors.forced-colors.yaml
@@ -1,1 +1,0 @@
-- status: Work in progress (beta)

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--forced-colors.light.yaml
@@ -1,1 +1,0 @@
-- status: Work in progress (beta)

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--forced-colors.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--forced-colors.yaml
@@ -1,1 +1,0 @@
-- status: Work in progress (beta)

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--meaningful-separator.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--meaningful-separator.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - menu "Actions":
   - menuitem "Rename"
   - menuitem "Duplicate"

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--playground.dark.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--playground.dark.yaml
@@ -1,1 +1,0 @@
-- status: Work in progress (beta)

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--playground.forced-colors.yaml
@@ -1,1 +1,0 @@
-- status: Work in progress (beta)

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--playground.light.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--playground.light.yaml
@@ -1,1 +1,0 @@
-- status: Work in progress (beta)

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--playground.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--playground.yaml
@@ -1,1 +1,0 @@
-- status: Work in progress (beta)

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--vertical-in-row.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--vertical-in-row.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Docs API Support

--- a/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--vertical.yaml
+++ b/nextjs-app/shared/components/Divider/__a11y-snapshots__/layout-divider--vertical.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Left Right

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -4821,7 +4821,7 @@
       "name": "Divider",
       "group": "structure",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "Visual separator between sections (horizontal or vertical).",
       "dense": "hr separator on border tokens: orientation horizontal|vertical; decorative=true (default) removes it from the AT tree (role=none), decorative=false announces role=separator + aria-orientation",
       "keywords": [
@@ -4873,7 +4873,8 @@
       ],
       "prefersOver": [],
       "forbiddenUse": [
-        "Bypass design tokens or skip forced-colors verification at beta."
+        "Use a divider as spacing — reach for gap or Spacer when you only need distance.",
+        "Put a divider between every list row — List's own rhythm and borders handle that."
       ],
       "usage": {
         "description": "Divider draws a rule on the production border tokens. By default it is decorative — `role=\"none\"`, invisible to assistive tech — which is right when it only supports visual rhythm. Set `decorative={false}` when the rule conveys real structure (menu groups, toolbar clusters) so AT users get the same grouping. Vertical dividers need a height from their flex row.",

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -144,6 +144,31 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "layout",
     "import": "import { Container } from "@dt/Container";",
   },
+  "Divider": {
+    "exampleStories": [
+      "DecorativeRhythm",
+      "MeaningfulSeparator",
+      "VerticalInRow",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "structure",
+    "import": "import { Divider } from "@dt/Divider";",
+  },
   "EnhancedProjectCard": {
     "exampleStories": [],
     "fields": [


### PR DESCRIPTION
Promotes **Divider** (Layout/structure atom) from beta to stable — fleet #12, stable count 20 → 21.

## Real defect fixed
Contract `element` was `"div"` but the component renders a real `<hr>` → corrected to `"hr"`. This is the same element-vs-tsx rot the Section promotion caught; the validator does not cross-check `element` against the tsx, so it must be audited every promotion.

## Why it qualifies
- **6 real consumers** via `audit:consumers`: SiteFooter, app/layout, patterns barrels.

## Independent re-verification (not a flag flip)
- axe + plays green on all 8 stories in **light / dark / forced-colors**
- **100% controls operable, 0 inert**
- AT snapshots refreshed for the 4 beta-matrix stories in all 4 modes; **compare-clean 8/8 each mode**. Purely-decorative stories (`role="none"`) snapshot as an empty AT tree *by design*; `MeaningfulSeparator` (`decorative={false}`) correctly captures the `separator` role — so the empty files are the correct contract, not flakes (proven by the compare pass).
- No motion; single hairline on `--color-border`, so `reducedMotion` is honest.

## Changes
- `Divider.contract.json`: status stable; element div→hr; `accessibilityTreeVerified` + `realBrowserForcedColorsVerified`; reviewedNote; consumers[]; reworded stale beta-referencing forbiddenUse
- `Divider.stories.tsx`: meta tags `["beta"]` → `["stable"]`
- refreshed `__a11y-snapshots__` (badge line dropped) + `docs-registry.json` + per-stable-shape snap

## Local gate (CI is quota-dead; verified locally)
typecheck ✓ · lint ✓ · full vitest 1988/1988 ✓ · build ✓ · validate:components ✓ · check:contract-props ✓ · check:consumers ✓ · lint:css ✓ · rhythmguard 0 new drift ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)