### PR TITLE
feat(design-system): NavLink beta to stable (fleet #13)

### DIFF
--- a/nextjs-app/shared/components/NavLink/NavLink.contract.json
+++ b/nextjs-app/shared/components/NavLink/NavLink.contract.json
@@ -3,7 +3,7 @@
     "name": "NavLink",
     "tier": "atom",
     "group": "navigation",
-    "status": "beta",
+    "status": "stable",
     "description": "Navigation anchor primitive used inside `SiteHeader`, `Footer`, and in-page navs. Renders an underlying `next/link` and applies the `aria-current='page'` token when the active route matches.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-nav-link",
     "radixPrimitive": null,
@@ -30,7 +30,9 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true,
+        "reviewedNote": "2026-07-05 — beta→stable (fleet #13): renders a real next/link <a>, aria-current='page' on the active route. Fixed a reduced-motion gap — the transition-colors fade now carries motion-reduce:transition-none so a11y.reducedMotion is literally honest (matches Pagination / ValueCard); unit-tested. Styling is a deliberate className contract (active/inactiveClassName), so exact + activeClassName are EFFECT_EXEMPT in audit:controls with unit tests covering the active/inactive class swap. Re-verified: axe + plays green in light/dark/forced-colors, 100% controls operable / 0 inert, AT snapshots captured 4 modes. 2026-05-28 origin: Bucket-1 beta port, keyboard/ARIA reviewed, ForcedColors story + Storybook axe gate."
     },
     "tokens": {
         "colors": [
@@ -44,7 +46,43 @@
         ]
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/dev/tailwind-test/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/layout.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/navigation/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/SiteHeader/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "href": {

--- a/nextjs-app/shared/components/NavLink/NavLink.stories.tsx
+++ b/nextjs-app/shared/components/NavLink/NavLink.stories.tsx
@@ -12,7 +12,7 @@ const defaultArgs = {
 const meta = {
   title: "Navigation/NavLink",
   component: NavLink,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/NavLink/NavLink.test.tsx
+++ b/nextjs-app/shared/components/NavLink/NavLink.test.tsx
@@ -77,6 +77,16 @@ describe("NavLink", () => {
     expect(link.className).not.toContain("is-idle");
   });
 
+  it("guards its color transition under prefers-reduced-motion", () => {
+    usePathnameMock.mockReturnValue("/work");
+    render(<NavLink href="/work">Work</NavLink>);
+    // reducedMotion:true must be literally honest — the transition-colors
+    // fade is neutralised via motion-reduce (matches Pagination / ValueCard).
+    expect(screen.getByRole("link", { name: "Work" }).className).toContain(
+      "motion-reduce:transition-none",
+    );
+  });
+
   it("has no axe violations inside a labelled nav", async () => {
     usePathnameMock.mockReturnValue("/work");
     const { container } = render(

--- a/nextjs-app/shared/components/NavLink/NavLink.tsx
+++ b/nextjs-app/shared/components/NavLink/NavLink.tsx
@@ -44,7 +44,9 @@ export function NavLink({
       className={cn(
         // rounded-sm matches the LanguageSwitcher buttons so the global
         // :focus-visible outline renders with the same corner rounding.
-        "font-body text-text-m transition-colors rounded-sm",
+        // motion-reduce guard keeps a11y.reducedMotion honest (matches the
+        // Pagination / ValueCard color-transition treatment).
+        "font-body text-text-m transition-colors motion-reduce:transition-none rounded-sm",
         className,
         isActive ? activeClassName : inactiveClassName
       )}

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--custom-styling.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--custom-styling.yaml
@@ -1,0 +1,5 @@
+- navigation "Footer":
+  - link "Privacy":
+    - /url: /privacy
+  - link "Terms":
+    - /url: /terms

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--default.dark.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--default.dark.yaml
@@ -1,0 +1,2 @@
+- link "Work":
+  - /url: /work

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--default.forced-colors.yaml
@@ -1,0 +1,2 @@
+- link "Work":
+  - /url: /work

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--default.light.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--default.light.yaml
@@ -1,0 +1,2 @@
+- link "Work":
+  - /url: /work

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--default.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--default.yaml
@@ -1,0 +1,2 @@
+- link "Work":
+  - /url: /work

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--exact-matching.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--exact-matching.yaml
@@ -1,0 +1,5 @@
+- navigation "Docs":
+  - link "Home (exact)":
+    - /url: /
+  - link "Work (prefix)":
+    - /url: /work

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--example.dark.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--example.dark.yaml
@@ -1,0 +1,9 @@
+- navigation "Primary":
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Contact":
+    - /url: /contact

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--example.forced-colors.yaml
@@ -1,0 +1,9 @@
+- navigation "Primary":
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Contact":
+    - /url: /contact

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--example.light.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--example.light.yaml
@@ -1,0 +1,9 @@
+- navigation "Primary":
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Contact":
+    - /url: /contact

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--example.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--example.yaml
@@ -1,0 +1,9 @@
+- navigation "Primary":
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Contact":
+    - /url: /contact

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--forced-colors.dark.yaml
@@ -1,0 +1,2 @@
+- link "Work":
+  - /url: /work

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--forced-colors.forced-colors.yaml
@@ -1,0 +1,2 @@
+- link "Work":
+  - /url: /work

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--forced-colors.light.yaml
@@ -1,0 +1,2 @@
+- link "Work":
+  - /url: /work

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--forced-colors.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--forced-colors.yaml
@@ -1,0 +1,2 @@
+- link "Work":
+  - /url: /work

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--playground.dark.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--playground.dark.yaml
@@ -1,0 +1,2 @@
+- link "Work":
+  - /url: /work

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--playground.forced-colors.yaml
@@ -1,0 +1,2 @@
+- link "Work":
+  - /url: /work

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--playground.light.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--playground.light.yaml
@@ -1,0 +1,2 @@
+- link "Work":
+  - /url: /work

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--playground.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--playground.yaml
@@ -1,0 +1,2 @@
+- link "Work":
+  - /url: /work

--- a/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--primary-nav.yaml
+++ b/nextjs-app/shared/components/NavLink/__a11y-snapshots__/navigation-navlink--primary-nav.yaml
@@ -1,0 +1,9 @@
+- navigation "Primary":
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Contact":
+    - /url: /contact

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -9308,7 +9308,7 @@
       "name": "NavLink",
       "group": "navigation",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "Navigation anchor primitive used inside `SiteHeader`, `Footer`, and in-page navs. Renders an underlying `next/link` and applies the `aria-current='page'` token when the active route matches.",
       "dense": "Next.js nav link deriving active state from usePathname (prefix match, exact opt-in); sets aria-current=page; styled via className/activeClassName/inactiveClassName (Tailwind-token defaults by design)",
       "keywords": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -370,6 +370,31 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "structure",
     "import": "import List from "@dt/List";",
   },
+  "NavLink": {
+    "exampleStories": [
+      "PrimaryNav",
+      "ExactMatching",
+      "CustomStyling",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "navigation",
+    "import": "import { NavLink } from "@dt/NavLink";",
+  },
   "Pagination": {
     "exampleStories": [
       "ManyPages",


### PR DESCRIPTION
Promotes **NavLink** (Navigation atom) from beta to stable — fleet #13, stable count 21 → 22.

## Real defect fixed
Reduced-motion gap: the `transition-colors` fade had no `motion-reduce` guard while `a11y.reducedMotion` was already `true`. Added `motion-reduce:transition-none` (matches the Pagination #882 / ValueCard #873 treatment) plus a unit test asserting the class, so the flag is literally honest.

## Why it qualifies
- **7 real consumers** via `audit:consumers`: SiteHeader, MobileDrawer, app/layout, patterns barrels.

## className-contract note (owner call, recorded)
NavLink is deliberately styled through the `activeClassName` / `inactiveClassName` Tailwind-`cn` contract. So `exact` + `activeClassName` are **EFFECT_EXEMPT** in `audit:controls` (a single canvas state can't exercise both active and inactive), with unit tests covering the active/inactive class swap by route state.

## Independent re-verification (not a flag flip)
- axe + plays green on all 7 stories in **light / dark / forced-colors**
- **100% controls operable, 0 inert**
- AT snapshots bootstrapped for the 4 beta-matrix stories in all 4 modes; **compare-clean 7/7 each mode**
- element `"a"` (next/link) confirmed; no variants (className contract)

## Local gate (CI is quota-dead; verified locally)
typecheck ✓ · lint ✓ · full vitest 1989/1989 ✓ · build ✓ · validate:components ✓ · check:contract-props ✓ · check:consumers ✓ · lint:css ✓ · rhythmguard 0 new drift ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
