### PR TITLE
feat(design-system): LanguageSwitcher beta to stable (fleet #14)

### DIFF
--- a/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.contract.json
+++ b/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.contract.json
@@ -3,7 +3,7 @@
     "name": "LanguageSwitcher",
     "tier": "molecule",
     "group": "navigation",
-    "status": "beta",
+    "status": "stable",
     "description": "Compact language selector: a current-language trigger that fans out the other locales as a button group.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-language-switcher",
     "radixPrimitive": null,
@@ -33,15 +33,53 @@
         ],
         "reducedMotion": true,
         "reviewed": true,
-        "reviewedNote": "Verified 2026-06-02: role=group + aria-label; trigger exposes aria-expanded/aria-controls/aria-current; options are native buttons with aria-label. Escape and outside-click close; reduced motion swaps the fan for a fade. KeyboardToggle play function drives open-via-trigger / close-via-Escape and passes axe; Default/Example/Playground pass axe with test:error; light + dark verified in Storybook.",
-        "forcedColorsVerified": true
+        "reviewedNote": "2026-07-05 — beta→stable (fleet #14): the fan animation is reduced-motion-guarded via framer useReducedMotion (spring→plain fade); the button color transition now also carries motion-reduce:transition-none (unit-tested), so a11y.reducedMotion is fully honest. State-conditional className props (openTriggerClassName, floatedButtonClassName) are EFFECT_EXEMPT in audit:controls (only apply while the tray is open) with the KeyboardToggle play + unit tests exercising both states. Re-verified: axe + KeyboardToggle play green in light/dark/forced-colors, 100% controls operable / 0 inert, AT snapshots captured 4 modes — KeyboardToggle drives open→Escape and settles closed (so its snapshot is the closed group), while the FanOpen example snapshots the open fan (all locales + expanded trigger). 2026-06-02 origin: role=group + aria-label; trigger exposes aria-expanded/aria-controls/aria-current; options are native buttons with aria-label; Escape + outside-click close.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/dev/tailwind-test/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/layout.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/navigation/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/SiteHeader/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "languages": {

--- a/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.stories.tsx
+++ b/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.stories.tsx
@@ -29,7 +29,7 @@ function LanguageSwitcherDemo(props: { initialLang?: string }) {
 const meta = {
   title: "Navigation/LanguageSwitcher",
   component: LanguageSwitcher,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.test.tsx
+++ b/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.test.tsx
@@ -80,4 +80,14 @@ describe("LanguageSwitcher", () => {
     expect(onLanguageChange).toHaveBeenCalledWith("fi");
     expect(screen.queryByRole("button", { name: /^swedish$/i })).not.toBeInTheDocument();
   });
+
+  it("guards the button color transition under prefers-reduced-motion", () => {
+    // The fan animation is reduced-motion-guarded via framer useReducedMotion;
+    // the button color fade carries motion-reduce:transition-none so
+    // a11y.reducedMotion is literally honest (matches NavLink / Pagination).
+    renderSwitcher("en");
+    expect(
+      screen.getByRole("button", { name: /english/i }).className,
+    ).toContain("motion-reduce:transition-none");
+  });
 });

--- a/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.tsx
@@ -13,7 +13,7 @@ export type LanguageSwitcherOption = {
 };
 
 const defaultButtonClassName =
-  "shrink-0 whitespace-nowrap px-2.5 py-1.5 text-sm font-heading font-semibold uppercase tracking-widest transition-colors cursor-pointer rounded-sm border border-transparent bg-transparent text-muted-foreground hover:text-foreground hover:bg-foreground/5 hover:border-border";
+  "shrink-0 whitespace-nowrap px-2.5 py-1.5 text-sm font-heading font-semibold uppercase tracking-widest transition-colors motion-reduce:transition-none cursor-pointer rounded-sm border border-transparent bg-transparent text-muted-foreground hover:text-foreground hover:bg-foreground/5 hover:border-border";
 
 const defaultActiveButtonClassName =
   "font-bold text-foreground hover:text-foreground";

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--accessible-names.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--accessible-names.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--controlled-wiring.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--controlled-wiring.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--default.dark.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--default.dark.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--default.forced-colors.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--default.light.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--default.light.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--default.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--default.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--example.dark.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--example.dark.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--example.forced-colors.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--example.light.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--example.light.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--example.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--example.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--fan-open.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--fan-open.yaml
@@ -1,0 +1,5 @@
+- group "Language":
+  - button "Swedish": SV
+  - button "Finnish": FI
+  - button "Hide language options" [expanded]: EN
+  - text: Hide language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--forced-colors.dark.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--forced-colors.forced-colors.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--forced-colors.light.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--forced-colors.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--forced-colors.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--keyboard-toggle.dark.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--keyboard-toggle.dark.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--keyboard-toggle.forced-colors.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--keyboard-toggle.forced-colors.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--keyboard-toggle.light.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--keyboard-toggle.light.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--keyboard-toggle.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--keyboard-toggle.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--playground.dark.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--playground.dark.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--playground.forced-colors.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--playground.light.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--playground.light.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--playground.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--playground.yaml
@@ -1,0 +1,3 @@
+- group "Language":
+  - button "English. Show language options": EN
+  - text: Show language options

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -7581,7 +7581,7 @@
       "name": "LanguageSwitcher",
       "group": "navigation",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "Compact language selector: a current-language trigger that fans out the other locales as a button group.",
       "dense": "Locale toggle: current-language button fans out a tray of other locales (spring motion, reduced-motion fade; closed tray inert); Escape/outside click close; controlled currentLang + onLanguageChange",
       "keywords": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -319,6 +319,31 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "form",
     "import": "import Label from "@dt/Label";",
   },
+  "LanguageSwitcher": {
+    "exampleStories": [
+      "FanOpen",
+      "AccessibleNames",
+      "ControlledWiring",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "navigation",
+    "import": "import LanguageSwitcher from "@dt/LanguageSwitcher";",
+  },
   "Link": {
     "exampleStories": [
       "Sizes",


### PR DESCRIPTION
Promotes **LanguageSwitcher** (Navigation molecule) from beta to stable — fleet #14, stable count 22 → 23.

## Reduced-motion
The fan tray's primary motion is already reduced-motion-guarded via framer `useReducedMotion` (spring → plain fade). Closed the residual gap: the button color transition now carries `motion-reduce:transition-none` (unit-tested), so `a11y.reducedMotion` is fully honest (matches NavLink / Pagination / ValueCard).

## Why it qualifies
- **7 real consumers** via `audit:consumers`: SiteHeader, MobileDrawer, app/layout, patterns barrels.

## className-contract note (owner call, recorded)
State-conditional className props (`openTriggerClassName`, `floatedButtonClassName`) apply only while the tray is open, so they are **EFFECT_EXEMPT** in `audit:controls`; the KeyboardToggle play + unit tests exercise both open and closed states.

## Independent re-verification (not a flag flip)
- axe + KeyboardToggle play green on all 8 stories in **light / dark / forced-colors**
- **100% controls operable, 0 inert**
- AT snapshots bootstrapped for the 5 beta-matrix stories in all 4 modes; **compare-clean 8/8 each mode**. KeyboardToggle drives open→Escape and settles closed (closed-group snapshot); the FanOpen example snapshots the open fan (all locales + expanded trigger).
- element `"div"` (`role="group"`) confirmed.

## Local gate (CI is quota-dead; verified locally)
typecheck ✓ · lint ✓ · full vitest 1990/1990 ✓ · build ✓ · validate:components ✓ · check:contract-props ✓ · check:consumers ✓ · lint:css ✓ · rhythmguard 0 new drift ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
