### PR TITLE
feat(design-system): SkipLink beta to stable (fleet #15)

### DIFF
--- a/nextjs-app/shared/components/SkipLink/SkipLink.contract.json
+++ b/nextjs-app/shared/components/SkipLink/SkipLink.contract.json
@@ -3,11 +3,11 @@
     "name": "SkipLink",
     "tier": "atom",
     "group": "navigation",
-    "status": "beta",
+    "status": "stable",
     "description": "Skip-to-main link shown on keyboard focus.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-skip-link",
     "radixPrimitive": null,
-    "element": "div",
+    "element": "a",
     "variants": {},
     "asChild": false,
     "subParts": [],
@@ -18,19 +18,48 @@
         "ForcedColors"
     ],
     "a11y": {
-        "keyboard": [],
-        "ariaRequirements": [],
+        "keyboard": [
+            "Tab — first focusable element on the page; reveals the link.",
+            "Enter — jumps focus to the main content target."
+        ],
+        "ariaRequirements": [
+            "Renders a real `<a href=\"#main-content\">` so the browser moves focus to the target region natively; no ARIA needed.",
+            "Visually hidden off-screen until focused, then revealed as a high-contrast pill — never `display:none` (which would drop it from the tab order)."
+        ],
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true,
+        "reviewedNote": "2026-07-05 — beta→stable (fleet #15): renders a real <a> (contract element corrected div→a). The reveal slide (transition: inset-block-start) is already guarded by a prefers-reduced-motion:reduce { transition:none } block, so reducedMotion is honest. --color-primary/--color-white token pairing holds contrast across all 4 themes. Re-verified: axe + plays green in light/dark/forced-colors, 100% controls operable / 0 inert, AT snapshots captured 4 modes. 2026-05-28 origin: Breadth beta port, keyboard/ARIA reviewed, ForcedColors story + Storybook axe gate."
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/dev/tailwind-test/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/layout.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/navigation/index.ts",
+            "since": "2026-06-04"
+        }
+    ],
     "slots": [],
     "schemaVersion": 2,
     "props": {
@@ -48,7 +77,8 @@
         }
     },
     "forbiddenUse": [
-        "Bypass design tokens or skip forced-colors verification at beta."
+        "Hide it with display:none or visibility:hidden — it must stay in the tab order; the component already handles visual hiding.",
+        "Render it anywhere but first in the layout — it must be the first focusable element to be reachable."
     ],
     "composesWith": [
         "NavLink"

--- a/nextjs-app/shared/components/SkipLink/SkipLink.stories.tsx
+++ b/nextjs-app/shared/components/SkipLink/SkipLink.stories.tsx
@@ -11,7 +11,7 @@ const defaultArgs = {
 const meta = {
   title: "Navigation/SkipLink",
   component: SkipLink,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--custom-target.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--custom-target.yaml
@@ -1,0 +1,2 @@
+- link "Skip to search results":
+  - /url: "#results"

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--default.dark.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--default.dark.yaml
@@ -1,0 +1,2 @@
+- link "Skip to main content":
+  - /url: "#main-content"

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--default.forced-colors.yaml
@@ -1,0 +1,2 @@
+- link "Skip to main content":
+  - /url: "#main-content"

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--default.light.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--default.light.yaml
@@ -1,0 +1,2 @@
+- link "Skip to main content":
+  - /url: "#main-content"

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--default.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--default.yaml
@@ -1,0 +1,2 @@
+- link "Skip to main content":
+  - /url: "#main-content"

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--example.dark.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--example.dark.yaml
@@ -1,0 +1,2 @@
+- link "Skip to main content":
+  - /url: "#main-content"

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--example.forced-colors.yaml
@@ -1,0 +1,2 @@
+- link "Skip to main content":
+  - /url: "#main-content"

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--example.light.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--example.light.yaml
@@ -1,0 +1,2 @@
+- link "Skip to main content":
+  - /url: "#main-content"

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--example.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--example.yaml
@@ -1,0 +1,2 @@
+- link "Skip to main content":
+  - /url: "#main-content"

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--focus-reveal.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--focus-reveal.yaml
@@ -1,0 +1,2 @@
+- link "Skip to main content":
+  - /url: "#main-content"

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--forced-colors.dark.yaml
@@ -1,0 +1,2 @@
+- link "Skip to main content":
+  - /url: "#main-content"

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--forced-colors.forced-colors.yaml
@@ -1,0 +1,2 @@
+- link "Skip to main content":
+  - /url: "#main-content"

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--forced-colors.light.yaml
@@ -1,0 +1,2 @@
+- link "Skip to main content":
+  - /url: "#main-content"

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--forced-colors.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--forced-colors.yaml
@@ -1,0 +1,2 @@
+- link "Skip to main content":
+  - /url: "#main-content"

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--in-layout.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--in-layout.yaml
@@ -1,0 +1,10 @@
+- link "Skip to main content":
+  - /url: "#demo-main"
+- navigation "Primary":
+  - link "Home":
+    - /url: "#one"
+  - link "Work":
+    - /url: "#two"
+  - link "Contact":
+    - /url: "#three"
+- main: Main content starts here.

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--playground.dark.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--playground.dark.yaml
@@ -1,0 +1,2 @@
+- link "Skip to main content":
+  - /url: "#main-content"

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--playground.forced-colors.yaml
@@ -1,0 +1,2 @@
+- link "Skip to main content":
+  - /url: "#main-content"

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--playground.light.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--playground.light.yaml
@@ -1,0 +1,2 @@
+- link "Skip to main content":
+  - /url: "#main-content"

--- a/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--playground.yaml
+++ b/nextjs-app/shared/components/SkipLink/__a11y-snapshots__/navigation-skiplink--playground.yaml
@@ -1,0 +1,2 @@
+- link "Skip to main content":
+  - /url: "#main-content"

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -12161,7 +12161,7 @@
       "name": "SkipLink",
       "group": "navigation",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "Skip-to-main link shown on keyboard focus.",
       "dense": "Visually hidden anchor that surfaces as a high-contrast pill on keyboard focus; jumps to #main-content (href overridable); belongs as the first focusable element of the page",
       "keywords": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -533,6 +533,31 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "navigation",
     "import": "import { SiteHeader } from "@dt/SiteHeader";",
   },
+  "SkipLink": {
+    "exampleStories": [
+      "FocusReveal",
+      "InLayout",
+      "CustomTarget",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "navigation",
+    "import": "import { SkipLink } from "@dt/SkipLink";",
+  },
   "Stack": {
     "exampleStories": [
       "GapScale",


### PR DESCRIPTION
Promotes **SkipLink** (Navigation atom) from beta to stable — fleet #15, stable count 23 → 24.

## Real defect fixed
Contract `element` was `"div"` but the component renders a real `<a>` → corrected to `"a"` (same element-vs-tsx rot caught on Section and Divider; the validator doesn't cross-check `element`).

## Reduced-motion (already honest)
The reveal slide (`transition: inset-block-start`) already sits under a `@media (prefers-reduced-motion: reduce) { transition: none }` block, so `reducedMotion:true` needed no change. `--color-primary`/`--color-white` pairing holds contrast across all four themes.

## Why it qualifies
- **4 real consumers** — `app/layout.tsx` is the site's actual skip link, plus patterns barrels.

## Independent re-verification (not a flag flip)
- axe + plays green on all 7 stories in **light / dark / forced-colors**
- **100% controls operable, 0 inert**
- AT snapshots bootstrapped for the 4 beta-matrix stories in all 4 modes; **compare-clean 7/7 each mode**

## Contract quality
Populated the previously-empty `keyboard` / `ariaRequirements` arrays with the real Tab/Enter + native-anchor-focus contract, and replaced the stale beta-referencing `forbiddenUse` with real constraints (never `display:none`; render first in the layout).

## Local gate (CI is quota-dead; verified locally)
typecheck ✓ · lint ✓ · full vitest 1990/1990 ✓ · build ✓ · validate:components ✓ · check:contract-props ✓ · check:consumers ✓ · lint:css ✓ · rhythmguard 0 new drift ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
