### PR TITLE
feat(design-system): Toast beta to stable (fleet #16)

### DIFF
--- a/nextjs-app/shared/components/Toast/Toast.contract.json
+++ b/nextjs-app/shared/components/Toast/Toast.contract.json
@@ -3,7 +3,7 @@
     "name": "Toast",
     "tier": "molecule",
     "group": "feedback",
-    "status": "beta",
+    "status": "stable",
     "description": "Transient status message with tone, position, and auto-dismiss.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=393-35",
     "radixPrimitive": null,
@@ -61,15 +61,48 @@
         ],
         "reducedMotion": true,
         "reviewed": true,
-        "reviewedNote": "2026-05-26 — production behavior verified in Storybook; argTypes and required stories aligned with validate:components. 2026-07-03 (batch 4) — Toaster (Tailwind duplicate host) deleted; providers/ToastProvider is the single imperative host and now forwards tone/position.",
-        "forcedColorsVerified": true
+        "reviewedNote": "2026-07-05 — beta→stable (fleet #16): renders a real <div role=status|alert> with aria-live/aria-atomic; role/politeness derive from tone (error/warning=assertive, else polite). Slide-in animation is guarded by @media (prefers-reduced-motion:reduce){ transition:none }, so reducedMotion is honest. tone is optional at runtime (untinted, polite when omitted); the enum default 'info' is the nominal semantic default. Re-verified: axe + plays green in light/dark/forced-colors, 100% controls operable / 0 inert (duration EFFECT_EXEMPT — timing prop), AT snapshots refreshed 4 modes. 2026-05-26 origin: production behavior verified; required stories aligned with validate:components. 2026-07-03 (batch 4): Toaster (Tailwind duplicate host) deleted; providers/ToastProvider is the single imperative host forwarding tone/position.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/BlogArticleShare.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ServerArticleContent.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ServerArticleMain.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/EmailSignatureContent.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/page.tsx",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "open": {

--- a/nextjs-app/shared/components/Toast/Toast.stories.tsx
+++ b/nextjs-app/shared/components/Toast/Toast.stories.tsx
@@ -10,7 +10,7 @@ import schema from "./schema.json";
 const meta: Meta<typeof Toast> = {
   title: "Feedback/Toast",
   component: Toast,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--default.dark.yaml
+++ b/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--default.dark.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - button "Show Toast"
 - status: Toast notification!

--- a/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--default.forced-colors.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - button "Show Toast"
 - status: Toast notification!

--- a/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--default.light.yaml
+++ b/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--default.light.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - button "Show Toast"
 - status: Toast notification!

--- a/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--default.yaml
+++ b/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--default.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - button "Show Toast"
 - status: Toast notification!

--- a/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--example.dark.yaml
+++ b/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--example.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status: Saved successfully.

--- a/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--example.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status: Saved successfully.

--- a/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--example.light.yaml
+++ b/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--example.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status: Saved successfully.

--- a/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--example.yaml
+++ b/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--example.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status: Saved successfully.

--- a/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--forced-colors.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status

--- a/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--forced-colors.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status

--- a/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--forced-colors.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status

--- a/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--forced-colors.yaml
+++ b/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status

--- a/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--playground.dark.yaml
+++ b/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--playground.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status: Saved successfully.

--- a/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--playground.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status: Saved successfully.

--- a/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--playground.light.yaml
+++ b/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--playground.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status: Saved successfully.

--- a/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--playground.yaml
+++ b/nextjs-app/shared/components/Toast/__a11y-snapshots__/feedback-toast--playground.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status: Saved successfully.

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -12209,7 +12209,8 @@
       ],
       "prefersOver": [],
       "forbiddenUse": [
-        "Bypass design tokens or skip forced-colors verification at beta."
+        "Hide it with display:none or visibility:hidden — it must stay in the tab order; the component already handles visual hiding.",
+        "Render it anywhere but first in the layout — it must be the first focusable element to be reachable."
       ],
       "usage": {
         "description": "SkipLink lets keyboard and switch users bypass repeated chrome: visually hidden until focused, it surfaces as a high-contrast pill and jumps to the main content anchor (default `#main-content`). Render it as the first focusable element inside the layout so it is the very first Tab stop on every page, and keep the target id stable on the main wrapper.",
@@ -14504,7 +14505,7 @@
       "name": "Toast",
       "group": "feedback",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "Transient status message with tone, position, and auto-dismiss.",
       "dense": "transient auto-dismiss status (default 3000ms); tone success|error|warning|info, 6 positions, sm/md/lg; fire imperatively via useToast().showToast(message, {tone, duration, position})",
       "keywords": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -633,6 +633,32 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "display",
     "import": "import Title from "@dt/Title";",
   },
+  "Toast": {
+    "exampleStories": [
+      "Tones",
+      "Placement",
+      "ProviderDriven",
+      "Example",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "feedback",
+    "import": "import Toast from "@dt/Toast";",
+  },
   "ValueCard": {
     "exampleStories": [],
     "fields": [


### PR DESCRIPTION
Promotes **Toast** (Feedback molecule) from beta to stable — fleet #16, stable count 24 → 25.

## Clean promotion, no defects
- Renders a real `<div role=status|alert>` with `aria-live`/`aria-atomic`; role/politeness derive from tone (error/warning → assertive, else polite). `element` `"div"` correct.
- The slide-in animation is **already** guarded by `@media (prefers-reduced-motion: reduce) { transition: none }`, so `reducedMotion:true` needed no change.

## Why it qualifies
- **6 real consumers** via `audit:consumers`: the blog article pipeline (BlogArticleShare, page, ServerArticleContent, ServerArticleMain) + the email-signature tool.

## Independent re-verification (not a flag flip)
- Screened stories first (7/7 green — no pre-existing failures)
- axe + plays green on all 7 stories in **light / dark / forced-colors**
- **100% controls operable, 0 inert** (`duration` is EFFECT_EXEMPT — a timing prop that can't be DOM-diffed)
- AT snapshots refreshed for the 4 beta-matrix stories in all 4 modes; **compare-clean 7/7 each mode**

## Note on `tone`
`tone` is optional at runtime (untinted + polite when omitted); the enum `default: "info"` documents the nominal semantic default. Left the component behavior unchanged — forcing an `info` default would alter production toast visuals (the blog copy-link confirmations render untinted today).

## Local gate (CI is quota-dead; verified locally)
typecheck ✓ · lint ✓ · full vitest 1990/1990 ✓ · build ✓ · validate:components ✓ · check:contract-props ✓ · check:consumers ✓ · lint:css ✓ · rhythmguard 0 new drift ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Toast is now marked as stable in the UI and related metadata.
  * Updated toast examples and accessibility snapshots to show the latest notification text.

* **Bug Fixes**
  * Removed outdated “work in progress” wording from toast snapshots and replaced it with current status messages.
  * Improved consistency across light, dark, forced-colors, and playground views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->