### PR TITLE
fix(design-system): restore CodeSnippet line-number gutter in Storybook docs

### DIFF
--- a/nextjs-app/shared/components/CodeSnippet/CodeSnippet.tsx
+++ b/nextjs-app/shared/components/CodeSnippet/CodeSnippet.tsx
@@ -204,7 +204,11 @@ export const CodeSnippet: React.FC<CodeSnippetProps> = ({
   // Single and Multi variants
   return (
     <figure
-      className={`${styles.wrapper} ${styles[variant]}`}
+      // `sb-unstyled` opts the whole snippet out of Storybook's docs-container
+      // typography reset. Without it, `.css-1xxktr1 :where(pre:not(...)):not(.prismjs)`
+      // (specificity 0,2,0) zeroes the `.pre` padding (0,1,0) in docs pages, so the
+      // line-number gutter collapses flush to the left edge. Inert outside Storybook.
+      className={`${styles.wrapper} ${styles[variant]} sb-unstyled`}
       data-variant={variant}
     >
       <div className={styles.toolbar} aria-hidden={!allowCopy}>


### PR DESCRIPTION
## The bug
On docs pages (e.g. the List **LLM Schema** block), the CodeSnippet line numbers render **flush against the left edge** — the gutter padding is gone.

## Root cause (verified in the running docs page, not guessed)
The multi/single CodeSnippet draws its line-number gutter with `.pre { padding: var(--space-layout-16) }` — a CSS-module class (specificity **0,1,0**). Inside a Storybook docs page, the docs container applies:

`.css-1xxktr1 :where(pre:not(.sb-anchor,.sb-unstyled,.sb-unstyled pre)):not(.prismjs) { padding: 0 }`

`:where()` contributes 0, but `.css-1xxktr1` + `:not(.prismjs)` sum to specificity **0,2,0**, which beats the module class and zeroes the padding. Confirmed live: the `<pre>` computed `padding-left: 0px` and the first line number sat `0.0px` from the pre's left edge.

## Fix
Add Storybook's intended **`sb-unstyled`** opt-out class to the snippet wrapper. It's explicitly in the docs selector's `:not()` list, so the docs container stops resetting the snippet's `<pre>` and the component's own padding applies again. After the fix the pre computes `padding-left: 24px` and the gutter is restored.

- Inert outside Storybook (no matching CSS in the app).
- The **inline** variant is deliberately left untouched — inline code *should* inherit docs prose styling.

## Verification
- Live docs re-inspection: padding `0px → 24px`, line-number gutter restored.
- CodeSnippet stories green (11/11), AT snapshots unchanged (the class isn't in the aria tree).
- Local gate: typecheck ✓ · lint ✓ · full vitest 1991/1991 ✓ · build ✓ · validate:components ✓ · lint:css ✓ · rhythmguard 0 new drift ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
