### PR TITLE
feat(design-system): Modal beta to stable (fleet #18)

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -66,6 +66,7 @@ const STORYBOOK_WATCH_IGNORED = [
   "**/docs/**",
   "**/tests/**",
   "**/__visual__/**",
+  "**/__a11y-snapshots__/**",
   "**/playwright-report/**",
 ];
 

--- a/nextjs-app/shared/components/Modal/Modal.contract.json
+++ b/nextjs-app/shared/components/Modal/Modal.contract.json
@@ -3,7 +3,7 @@
     "name": "Modal",
     "tier": "molecule",
     "group": "overlay",
-    "status": "beta",
+    "status": "stable",
     "description": "Modal dialog for confirmations, forms, and focused tasks.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=384-13",
     "radixPrimitive": null,
@@ -45,15 +45,43 @@
         ],
         "reducedMotion": true,
         "reviewed": true,
-        "reviewedNote": "2026-06-05 — portal-aware AT snapshots, severity polish, forced-colors story; focus trap + Escape reviewed in plays.",
-        "forcedColorsVerified": true
+        "reviewedNote": "2026-07-06 — beta→stable: portal-aware AT snapshots regenerated across base/light/dark/forced-colors (all 9 beta-matrix stories green), severity color axis verified per value via getComputedStyle, footer default fixed; focus trap + Escape reviewed in plays.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/EmailSignatureContent.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/CVDownloadSection/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/index.ts",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "severity": {

--- a/nextjs-app/shared/components/Modal/Modal.stories.tsx
+++ b/nextjs-app/shared/components/Modal/Modal.stories.tsx
@@ -12,7 +12,7 @@ import schema from "./schema.json";
 const meta = {
   title: "Feedback/Modal",
   component: Modal,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",
@@ -383,10 +383,10 @@ export const Playground: Story = {
   parameters: { a11y: { disable: true, test: "off" } },
   tags: ["beta-matrix"],
   render: PlaygroundRender,
-  // severity seeded so the header icon exists (iconSize drives it); showFooter
-  // seeded true because the component treats undefined as true but the panel's
-  // boolean seed would otherwise read false and hide the whole footer region.
-  args: { ...Default.args, isOpen: true, severity: "info", showFooter: true },
+  // severity seeded so the header icon exists (iconSize drives it). showFooter
+  // defaults true on the component, so the autogen boolean seed reads true and
+  // the footer region renders without an explicit arg here.
+  args: { ...Default.args, isOpen: true, severity: "info" },
 };
 
 export const Example = {

--- a/nextjs-app/shared/components/Modal/Modal.tsx
+++ b/nextjs-app/shared/components/Modal/Modal.tsx
@@ -83,7 +83,7 @@ const Modal: React.FC<ModalProps> = ({
   closeIconName = "x",
   closeButtonLabel = "Close dialog",
   className,
-  showFooter,
+  showFooter = true,
   panelRef,
   animation = "none",
 }) => {

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--animated-entrance.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--animated-entrance.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "scale"
 - button "slide"
 - button "fade"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--close-via-icon.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--close-via-icon.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Open modal"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--confirmation.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--confirmation.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Delete project…"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--default.dark.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--default.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Confirm changes":
   - heading "Confirm changes" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--default.forced-colors.yaml
@@ -1,6 +1,6 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Confirm changes":
   - heading "Confirm changes" [level=2]
   - button "Close dialog"
   - text: Your edits will be applied immediately.
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--default.light.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--default.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Confirm changes":
   - heading "Confirm changes" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--default.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--default.yaml
@@ -1,6 +1,6 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Confirm changes":
   - heading "Confirm changes" [level=2]
   - button "Close dialog"
   - text: Your edits will be applied immediately.
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--error-dialog.dark.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--error-dialog.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - alertdialog "Something went wrong":
   - heading "Something went wrong" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--error-dialog.forced-colors.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--error-dialog.forced-colors.yaml
@@ -1,5 +1,5 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - alertdialog "Something went wrong":
   - heading "Something went wrong" [level=2]
   - paragraph: We could not save your changes. Check your connection and try again.
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--error-dialog.light.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--error-dialog.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - alertdialog "Something went wrong":
   - heading "Something went wrong" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--error-dialog.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--error-dialog.yaml
@@ -1,5 +1,5 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - alertdialog "Something went wrong":
   - heading "Something went wrong" [level=2]
   - paragraph: We could not save your changes. Check your connection and try again.
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--example.dark.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--example.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Confirm changes":
   - heading "Confirm changes" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--example.forced-colors.yaml
@@ -1,6 +1,6 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Confirm changes":
   - heading "Confirm changes" [level=2]
   - button "Close dialog"
   - text: Your edits will be applied immediately.
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--example.light.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--example.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Confirm changes":
   - heading "Confirm changes" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--example.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--example.yaml
@@ -1,6 +1,6 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Confirm changes":
   - heading "Confirm changes" [level=2]
   - button "Close dialog"
   - text: Your edits will be applied immediately.
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--forced-colors.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - alertdialog "Something went wrong":
   - heading "Something went wrong" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--forced-colors.forced-colors.yaml
@@ -1,5 +1,5 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - alertdialog "Something went wrong":
   - heading "Something went wrong" [level=2]
   - paragraph: We could not save your changes. Check your connection and try again.
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--forced-colors.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - alertdialog "Something went wrong":
   - heading "Something went wrong" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--forced-colors.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--forced-colors.yaml
@@ -1,5 +1,5 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - alertdialog "Something went wrong":
   - heading "Something went wrong" [level=2]
   - paragraph: We could not save your changes. Check your connection and try again.
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--form-in-modal.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--form-in-modal.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Rename workspace…"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--info-dialog.dark.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--info-dialog.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Heads up":
   - heading "Heads up" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--info-dialog.forced-colors.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--info-dialog.forced-colors.yaml
@@ -1,5 +1,5 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Heads up":
   - heading "Heads up" [level=2]
   - text: This workspace is read-only during maintenance.
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--info-dialog.light.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--info-dialog.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Heads up":
   - heading "Heads up" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--info-dialog.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--info-dialog.yaml
@@ -1,5 +1,5 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Heads up":
   - heading "Heads up" [level=2]
   - text: This workspace is read-only during maintenance.
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--loading.dark.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--loading.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Saving changes":
   - heading "Saving changes" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--loading.forced-colors.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--loading.forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Saving changes":
   - heading "Saving changes" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--loading.light.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--loading.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Saving changes":
   - heading "Saving changes" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--loading.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--loading.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Saving changes":
   - heading "Saving changes" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--playground.dark.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--playground.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Confirm changes":
   - heading "Confirm changes" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--playground.forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Confirm changes":
   - heading "Confirm changes" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--playground.light.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--playground.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Confirm changes":
   - heading "Confirm changes" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--playground.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--playground.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Confirm changes":
   - heading "Confirm changes" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--scrollable.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--scrollable.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "View terms"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--success-dialog.dark.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--success-dialog.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Changes saved":
   - heading "Changes saved" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--success-dialog.forced-colors.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--success-dialog.forced-colors.yaml
@@ -1,5 +1,5 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Changes saved":
   - heading "Changes saved" [level=2]
   - text: Your edits are live.
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--success-dialog.light.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--success-dialog.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Changes saved":
   - heading "Changes saved" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--success-dialog.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--success-dialog.yaml
@@ -1,5 +1,5 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - dialog "Changes saved":
   - heading "Changes saved" [level=2]
   - text: Your edits are live.
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--warning-dialog.dark.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--warning-dialog.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - alertdialog "Unsaved changes":
   - heading "Unsaved changes" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--warning-dialog.forced-colors.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--warning-dialog.forced-colors.yaml
@@ -1,5 +1,5 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - alertdialog "Unsaved changes":
   - heading "Unsaved changes" [level=2]
   - text: Leaving now discards your edits.
+  - button "OK"

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--warning-dialog.light.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--warning-dialog.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - alertdialog "Unsaved changes":
   - heading "Unsaved changes" [level=2]

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--warning-dialog.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--warning-dialog.yaml
@@ -1,5 +1,5 @@
-- status: Work in progress (beta)
 - button "Open modal"
 - alertdialog "Unsaved changes":
   - heading "Unsaved changes" [level=2]
   - text: Leaving now discards your edits.
+  - button "OK"

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -8833,7 +8833,7 @@
       "name": "Modal",
       "group": "overlay",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "Modal dialog for confirmations, forms, and focused tasks.",
       "dense": "Portal dialog w/ focus trap + inert bg; severity info|success|warning|error (error/warning => alertdialog); title/description ARIA-wired; menu/footer/icon slots; animation scale|slide|fade",
       "keywords": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -395,6 +395,32 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "structure",
     "import": "import List from "@dt/List";",
   },
+  "Modal": {
+    "exampleStories": [
+      "Confirmation",
+      "FormInModal",
+      "Scrollable",
+      "AnimatedEntrance",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "overlay",
+    "import": "import Modal from "@dt/Modal";",
+  },
   "NavLink": {
     "exampleStories": [
       "PrimaryNav",


### PR DESCRIPTION
Promotes **Modal** beta→stable. Per the fleet convention, re-verification was full (not a flag flip) and surfaced two real defects, both fixed at the root.

## Defects found & fixed

**1. `showFooter` had no default → footer hidden in every story**
The contract-derived Controls autogen seeds booleans to `summary === "true"`, so a boolean prop lacking an explicit `= true` default gets seeded **false**. `showFooter` had no default, so every Modal story rendered footerless. This split the AT snapshots: base snaps (#849) captured the footerless render while light/dark snaps (#825) predated the seeding and still showed the OK footer. Fix: give `showFooter` its documented default (`= true`). Behaviour is identical (`showFooter !== false` already treated undefined as shown); only the docgen default + Controls seed change.

**2. AT snapshot self-poison via Vite reload**
Writing `__a11y-snapshots__/*.yaml` into the Vite-watched tree triggered a dev-server HMR reload that de-registered `globalThis.__getContext`, producing flaky `TypeError: __getContext is not a function` on later stories — worst for portal components like Modal, whose capture scans every `[role=dialog]` on the page. Fix: add `**/__a11y-snapshots__/**` to `STORYBOOK_WATCH_IGNORED`. Dev-server-only; makes local AT regeneration deterministic for **all** components.

## Verification (all local, farm-parity)
- AT snapshots regenerated across **base/light/dark/forced-colors** — 9/9 beta-matrix + 14/14 base stories green, deterministic on re-run. 41 snapshots updated (beta status-line dropped; OK footer restored).
- **Per-severity color axis** checked via `getComputedStyle` (the DOM-diff blind spot): error=red, success=green, warning=amber border + contrast-safe icon, info=teal; roles error/warning=`alertdialog`, success/info=`dialog`.
- `audit:controls` 100% operable, 0 inert.
- `validate:components`, `check:contract-props`, `check:consumers` pass; `consumers[]` populated (5 real consumers); a11y tree + real-browser forced-colors attestations set.
- typecheck, lint, full vitest (1991), build — all green. `docs-registry` snapshot updated: Modal now appears in the stable MCP registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Modal component is now marked stable and its examples/docs reflect that status.
  * Modal previews now show the footer by default when no setting is provided.
* **Bug Fixes**
  * Accessibility snapshots were refreshed to match the current modal UI, including updated dialog actions and forced-colors behavior.
  * Storybook no longer reloads when accessibility snapshot files change, reducing preview interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->