### PR TITLE
feat(design-system): CodeBlockWindow beta to stable (fleet #20)

### DIFF
--- a/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.contract.json
+++ b/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.contract.json
@@ -3,8 +3,8 @@
     "name": "CodeBlockWindow",
     "tier": "organism",
     "group": "structure",
-    "status": "beta",
-    "description": "CodeBlockWindow — production @dt component (Storybook beta).",
+    "status": "stable",
+    "description": "Framed code block with a title bar, language label, optional line numbers, and copy button; renders pre-highlighted Shiki output with theme-aware syntax colors.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-code-block-window",
     "radixPrimitive": null,
     "element": "div",
@@ -24,14 +24,67 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-07-06 — beta→stable: AT snapshots bootstrapped across base/light/dark/forced-colors (all beta-matrix stories green, deterministic); shiki dual-theme (--shiki-light/--shiki-dark) syntax colors + forced-colors CanvasText mapping verified.",
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/BlogArticleMdxBody.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ServerArticleContent.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ServerArticleMain.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/dev/code-window/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/index.ts",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "title": {

--- a/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.stories.tsx
+++ b/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta<typeof CodeBlockWindow> = {
     a11y: { test: "error" },
     layout: "padded",
   },
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
 };
 
 export default meta;

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--dark-preview.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--dark-preview.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: theme-dark.tsx
+  - button "Copy code to clipboard": Copy
+  - group "Code block in TSX":
+    - code: "type Props = { label: string; }; export function DemoButton({ label }: Props) { return ( <button type=\"button\" aria-label={label}> {label} </button> ); }"

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--default.dark.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--default.dark.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: components/DemoButton.tsx
+  - button "Copy code to clipboard": Copy
+  - group "Code block in TSX":
+    - code: "type Props = { label: string; }; export function DemoButton({ label }: Props) { return ( <button type=\"button\" aria-label={label}> {label} </button> ); }"

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--default.forced-colors.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: components/DemoButton.tsx
+  - button "Copy code to clipboard": Copy
+  - group "Code block in TSX":
+    - code: "type Props = { label: string; }; export function DemoButton({ label }: Props) { return ( <button type=\"button\" aria-label={label}> {label} </button> ); }"

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--default.light.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--default.light.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: components/DemoButton.tsx
+  - button "Copy code to clipboard": Copy
+  - group "Code block in TSX":
+    - code: "type Props = { label: string; }; export function DemoButton({ label }: Props) { return ( <button type=\"button\" aria-label={label}> {label} </button> ); }"

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--default.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--default.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: components/DemoButton.tsx
+  - button "Copy code to clipboard": Copy
+  - group "Code block in TSX":
+    - code: "type Props = { label: string; }; export function DemoButton({ label }: Props) { return ( <button type=\"button\" aria-label={label}> {label} </button> ); }"

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--example.dark.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--example.dark.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: components/DemoButton.tsx
+  - button "Copy code to clipboard": Copy
+  - group "Code block in TSX":
+    - code: "type Props = { label: string; }; export function DemoButton({ label }: Props) { return ( <button type=\"button\" aria-label={label}> {label} </button> ); }"

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--example.forced-colors.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: components/DemoButton.tsx
+  - button "Copy code to clipboard": Copy
+  - group "Code block in TSX":
+    - code: "type Props = { label: string; }; export function DemoButton({ label }: Props) { return ( <button type=\"button\" aria-label={label}> {label} </button> ); }"

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--example.light.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--example.light.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: components/DemoButton.tsx
+  - button "Copy code to clipboard": Copy
+  - group "Code block in TSX":
+    - code: "type Props = { label: string; }; export function DemoButton({ label }: Props) { return ( <button type=\"button\" aria-label={label}> {label} </button> ); }"

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--example.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--example.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: components/DemoButton.tsx
+  - button "Copy code to clipboard": Copy
+  - group "Code block in TSX":
+    - code: "type Props = { label: string; }; export function DemoButton({ label }: Props) { return ( <button type=\"button\" aria-label={label}> {label} </button> ); }"

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--forced-colors.dark.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: components/DemoButton.tsx
+  - button "Copy code to clipboard": Copy
+  - group "Code block in TSX":
+    - code: "type Props = { label: string; }; export function DemoButton({ label }: Props) { return ( <button type=\"button\" aria-label={label}> {label} </button> ); }"

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--forced-colors.forced-colors.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: components/DemoButton.tsx
+  - button "Copy code to clipboard": Copy
+  - group "Code block in TSX":
+    - code: "type Props = { label: string; }; export function DemoButton({ label }: Props) { return ( <button type=\"button\" aria-label={label}> {label} </button> ); }"

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--forced-colors.light.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: components/DemoButton.tsx
+  - button "Copy code to clipboard": Copy
+  - group "Code block in TSX":
+    - code: "type Props = { label: string; }; export function DemoButton({ label }: Props) { return ( <button type=\"button\" aria-label={label}> {label} </button> ); }"

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--forced-colors.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--forced-colors.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: components/DemoButton.tsx
+  - button "Copy code to clipboard": Copy
+  - group "Code block in TSX":
+    - code: "type Props = { label: string; }; export function DemoButton({ label }: Props) { return ( <button type=\"button\" aria-label={label}> {label} </button> ); }"

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--json-example.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--json-example.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: payload.json
+  - button "Copy code to clipboard": Copy
+  - group "Code block in JSON":
+    - code: "{\"service\":\"digitaltableteur\",\"mode\":\"active\",\"regions\":[\"eu\",\"us\"]}"

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--long-line.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--long-line.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: long-line.ts
+  - button "Copy code to clipboard": Copy
+  - group "Code block in TS":
+    - code: const longLine = 'This is an intentionally long line to verify horizontal scrolling within the code window without wrapping.';

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--no-title.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--no-title.yaml
@@ -1,0 +1,4 @@
+- figure:
+  - button "Copy code to clipboard": Copy
+  - group "Code block in BASH":
+    - code: "curl -X POST https://api.digitaltableteur.com/v1/send \\ + -H \"Authorization: Bearer $TOKEN\" \\ + -H \"Content-Type: application/json\" \\ + -d '{\"name\":\"Petri\",\"message\":\"Hello\"}'"

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--playground.dark.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--playground.dark.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: components/DemoButton.tsx
+  - button "Copy code to clipboard": Copy
+  - group "Code block in TSX":
+    - code: "type Props = { label: string; }; export function DemoButton({ label }: Props) { return ( <button type=\"button\" aria-label={label}> {label} </button> ); }"

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--playground.forced-colors.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: components/DemoButton.tsx
+  - button "Copy code to clipboard": Copy
+  - group "Code block in TSX":
+    - code: "type Props = { label: string; }; export function DemoButton({ label }: Props) { return ( <button type=\"button\" aria-label={label}> {label} </button> ); }"

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--playground.light.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--playground.light.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: components/DemoButton.tsx
+  - button "Copy code to clipboard": Copy
+  - group "Code block in TSX":
+    - code: "type Props = { label: string; }; export function DemoButton({ label }: Props) { return ( <button type=\"button\" aria-label={label}> {label} </button> ); }"

--- a/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--playground.yaml
+++ b/nextjs-app/shared/components/CodeBlockWindow/__a11y-snapshots__/content-codeblockwindow--playground.yaml
@@ -1,0 +1,5 @@
+- figure:
+  - text: components/DemoButton.tsx
+  - button "Copy code to clipboard": Copy
+  - group "Code block in TSX":
+    - code: "type Props = { label: string; }; export function DemoButton({ label }: Props) { return ( <button type=\"button\" aria-label={label}> {label} </button> ); }"

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -3533,8 +3533,8 @@
       "name": "CodeBlockWindow",
       "group": "structure",
       "tier": 1,
-      "status": "beta",
-      "description": "CodeBlockWindow — production @dt component (Storybook beta).",
+      "status": "stable",
+      "description": "Framed code block with a title bar, language label, optional line numbers, and copy button; renders pre-highlighted Shiki output with theme-aware syntax colors.",
       "dense": "Framed code: header w/ title (filename) + language label, caption below, context default|article (prose width, 35vh scroll); children expect highlighted pre/code (Shiki), not raw strings",
       "keywords": [
         "code window",

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -140,6 +140,31 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "structure",
     "import": "import Card from "@dt/Card";",
   },
+  "CodeBlockWindow": {
+    "exampleStories": [
+      "NoTitle",
+      "JsonExample",
+      "LongLine",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "structure",
+    "import": "import CodeBlockWindow from "@dt/CodeBlockWindow";",
+  },
   "Container": {
     "exampleStories": [
       "SizeLadder",


### PR DESCRIPTION
Promotes **CodeBlockWindow** beta→stable. The component was already well-built (shiki dual-theme syntax colors, forced-colors handling); the promotion bootstraps the missing AT coverage.

## Changes
- **Bootstrapped AT snapshots** for every required story across base/light/dark/forced-colors (20 files; none existed before). Deterministic on re-run.
- **Populated `consumers[]`** (10 real blog-pipeline + dev-page paths); set `accessibilityTreeVerified` + `realBrowserForcedColorsVerified`.
- Replaced placeholder "(Storybook beta)" contract description with an honest one-liner.

## Verification
- Syntax-color axis confirmed in **both themes** via screenshot + computed style: light = dark shiki tokens on white; dark = bright shiki tokens on `#242424`. The `--shiki-light`/`--shiki-dark` dual-theme switch works; forced colors map to `CanvasText` (with the Storybook `sb-forced-colors` mirror so axe tests the right colors). axe passed in light+dark+forced.
- unit 3/3; `validate:components`, `check:contract-props`, `check:consumers` pass; typecheck, lint, full vitest (1991), build all green. docs-registry snapshot updated (CodeBlockWindow enters the stable MCP registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)