### PR TITLE
feat(design-system): ReadingProgress beta to stable (fleet #21)

### DIFF
--- a/nextjs-app/shared/components/ReadingProgress/ReadingProgress.contract.json
+++ b/nextjs-app/shared/components/ReadingProgress/ReadingProgress.contract.json
@@ -3,7 +3,7 @@
     "name": "ReadingProgress",
     "tier": "molecule",
     "group": "feedback",
-    "status": "beta",
+    "status": "stable",
     "description": "Scroll-linked reading progress indicator for long content.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-reading-progress",
     "radixPrimitive": null,
@@ -25,8 +25,10 @@
         ],
         "reducedMotion": true,
         "reviewed": true,
-        "reviewedNote": "2026-05-28 — Beta promotion review: progressbar role with aria-valuenow/min/max + aria-label is set; passive scroll listener avoids jank; transition is decorative (transform-only) and respected by reduced motion. ForcedColors story verifies the bar/percentage remain visible in CanvasText/Highlight. Light/dark verified via matrix CI.",
-        "forcedColorsVerified": true
+        "reviewedNote": "2026-07-06 — beta→stable: progressbar role with aria-valuenow/min/max + aria-label; passive scroll listener avoids jank. Added the missing prefers-reduced-motion guard (the bar-fill + root-fade transitions now actually drop under reduced motion, matching the prior claim). AT snapshots bootstrapped across base/light/dark/forced-colors; percentage uses --secondary-text-color (theme-aware, CanvasText in forced-colors).",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true
     },
     "tokens": {
         "colors": [
@@ -36,7 +38,68 @@
         "spacing": []
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/BlogArticleMdxBody.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ClientArticleShell.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ServerArticleContent.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ServerArticleMain.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ArticleLayout/ArticleLayout.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ArticleLayout/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/index.ts",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "targetRef": {

--- a/nextjs-app/shared/components/ReadingProgress/ReadingProgress.module.css
+++ b/nextjs-app/shared/components/ReadingProgress/ReadingProgress.module.css
@@ -37,3 +37,13 @@
   inset-block-start: 100%;
   inset-inline-end: var(--space-internal-8);
 }
+
+/* The bar fill tracks scroll and the root fades in; both animate for everyone
+ * by default. Drop the tweens under reduced-motion so the fill and the
+ * appearance snap instead of easing. */
+@media (prefers-reduced-motion: reduce) {
+  .root,
+  .bar {
+    transition: none;
+  }
+}

--- a/nextjs-app/shared/components/ReadingProgress/ReadingProgress.stories.tsx
+++ b/nextjs-app/shared/components/ReadingProgress/ReadingProgress.stories.tsx
@@ -6,7 +6,7 @@ import contract from "./ReadingProgress.contract.json";
 const meta = {
   title: "Site/ReadingProgress",
   component: ReadingProgress,
-  tags: ["!autodocs"],
+  tags: ["stable", "!autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--default.dark.yaml
+++ b/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--default.dark.yaml
@@ -1,0 +1,14 @@
+- progressbar "Reading progress"
+- heading "Long article" [level=1]
+- paragraph: Paragraph 1. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 2. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 3. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 4. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 5. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 6. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 7. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 8. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 9. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 10. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 11. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 12. Scroll to see the reading progress bar at the top of the viewport.

--- a/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--default.forced-colors.yaml
@@ -1,0 +1,14 @@
+- progressbar "Reading progress"
+- heading "Long article" [level=1]
+- paragraph: Paragraph 1. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 2. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 3. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 4. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 5. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 6. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 7. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 8. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 9. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 10. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 11. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 12. Scroll to see the reading progress bar at the top of the viewport.

--- a/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--default.light.yaml
+++ b/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--default.light.yaml
@@ -1,0 +1,14 @@
+- progressbar "Reading progress"
+- heading "Long article" [level=1]
+- paragraph: Paragraph 1. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 2. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 3. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 4. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 5. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 6. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 7. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 8. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 9. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 10. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 11. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 12. Scroll to see the reading progress bar at the top of the viewport.

--- a/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--default.yaml
+++ b/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--default.yaml
@@ -1,0 +1,14 @@
+- progressbar "Reading progress"
+- heading "Long article" [level=1]
+- paragraph: Paragraph 1. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 2. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 3. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 4. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 5. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 6. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 7. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 8. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 9. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 10. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 11. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 12. Scroll to see the reading progress bar at the top of the viewport.

--- a/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--example.dark.yaml
+++ b/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--example.dark.yaml
@@ -1,0 +1,14 @@
+- progressbar "Reading progress"
+- heading "Long article" [level=1]
+- paragraph: Paragraph 1. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 2. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 3. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 4. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 5. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 6. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 7. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 8. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 9. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 10. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 11. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 12. Scroll to see the reading progress bar at the top of the viewport.

--- a/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--example.forced-colors.yaml
@@ -1,0 +1,14 @@
+- progressbar "Reading progress"
+- heading "Long article" [level=1]
+- paragraph: Paragraph 1. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 2. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 3. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 4. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 5. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 6. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 7. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 8. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 9. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 10. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 11. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 12. Scroll to see the reading progress bar at the top of the viewport.

--- a/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--example.light.yaml
+++ b/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--example.light.yaml
@@ -1,0 +1,14 @@
+- progressbar "Reading progress"
+- heading "Long article" [level=1]
+- paragraph: Paragraph 1. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 2. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 3. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 4. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 5. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 6. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 7. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 8. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 9. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 10. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 11. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 12. Scroll to see the reading progress bar at the top of the viewport.

--- a/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--example.yaml
+++ b/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--example.yaml
@@ -1,0 +1,14 @@
+- progressbar "Reading progress"
+- heading "Long article" [level=1]
+- paragraph: Paragraph 1. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 2. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 3. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 4. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 5. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 6. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 7. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 8. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 9. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 10. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 11. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 12. Scroll to see the reading progress bar at the top of the viewport.

--- a/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--forced-colors.dark.yaml
@@ -1,0 +1,14 @@
+- progressbar "Reading progress": 100%
+- heading "Long article" [level=1]
+- paragraph: Paragraph 1. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 2. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 3. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 4. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 5. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 6. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 7. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 8. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 9. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 10. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 11. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 12. Scroll to see the reading progress bar at the top of the viewport.

--- a/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--forced-colors.forced-colors.yaml
@@ -1,0 +1,14 @@
+- progressbar "Reading progress": 100%
+- heading "Long article" [level=1]
+- paragraph: Paragraph 1. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 2. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 3. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 4. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 5. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 6. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 7. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 8. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 9. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 10. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 11. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 12. Scroll to see the reading progress bar at the top of the viewport.

--- a/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--forced-colors.light.yaml
@@ -1,0 +1,14 @@
+- progressbar "Reading progress": 100%
+- heading "Long article" [level=1]
+- paragraph: Paragraph 1. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 2. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 3. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 4. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 5. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 6. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 7. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 8. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 9. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 10. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 11. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 12. Scroll to see the reading progress bar at the top of the viewport.

--- a/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--forced-colors.yaml
+++ b/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--forced-colors.yaml
@@ -1,0 +1,14 @@
+- progressbar "Reading progress": 100%
+- heading "Long article" [level=1]
+- paragraph: Paragraph 1. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 2. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 3. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 4. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 5. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 6. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 7. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 8. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 9. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 10. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 11. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 12. Scroll to see the reading progress bar at the top of the viewport.

--- a/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--playground.dark.yaml
+++ b/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--playground.dark.yaml
@@ -1,0 +1,14 @@
+- progressbar "Reading progress"
+- heading "Long article" [level=1]
+- paragraph: Paragraph 1. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 2. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 3. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 4. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 5. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 6. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 7. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 8. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 9. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 10. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 11. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 12. Scroll to see the reading progress bar at the top of the viewport.

--- a/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--playground.forced-colors.yaml
@@ -1,0 +1,14 @@
+- progressbar "Reading progress"
+- heading "Long article" [level=1]
+- paragraph: Paragraph 1. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 2. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 3. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 4. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 5. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 6. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 7. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 8. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 9. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 10. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 11. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 12. Scroll to see the reading progress bar at the top of the viewport.

--- a/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--playground.light.yaml
+++ b/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--playground.light.yaml
@@ -1,0 +1,14 @@
+- progressbar "Reading progress"
+- heading "Long article" [level=1]
+- paragraph: Paragraph 1. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 2. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 3. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 4. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 5. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 6. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 7. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 8. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 9. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 10. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 11. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 12. Scroll to see the reading progress bar at the top of the viewport.

--- a/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--playground.yaml
+++ b/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--playground.yaml
@@ -1,0 +1,14 @@
+- progressbar "Reading progress"
+- heading "Long article" [level=1]
+- paragraph: Paragraph 1. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 2. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 3. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 4. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 5. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 6. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 7. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 8. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 9. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 10. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 11. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 12. Scroll to see the reading progress bar at the top of the viewport.

--- a/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--with-percentage.yaml
+++ b/nextjs-app/shared/components/ReadingProgress/__a11y-snapshots__/site-readingprogress--with-percentage.yaml
@@ -1,0 +1,14 @@
+- progressbar "Reading progress": 100%
+- heading "Long article" [level=1]
+- paragraph: Paragraph 1. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 2. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 3. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 4. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 5. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 6. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 7. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 8. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 9. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 10. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 11. Scroll to see the reading progress bar at the top of the viewport.
+- paragraph: Paragraph 12. Scroll to see the reading progress bar at the top of the viewport.

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -11208,7 +11208,7 @@
       "name": "ReadingProgress",
       "group": "feedback",
       "tier": 2,
-      "status": "beta",
+      "status": "stable",
       "description": "Scroll-linked reading progress indicator for long content.",
       "dense": "Scroll-linked reading progress bar for long articles; decorative for AT (content position is conveyed by scroll)",
       "keywords": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -517,6 +517,27 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "navigation",
     "import": "import { Pagination } from "@dt/Pagination";",
   },
+  "ReadingProgress": {
+    "exampleStories": [],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "feedback",
+    "import": "import { ReadingProgress } from "@dt/ReadingProgress";",
+  },
   "Section": {
     "exampleStories": [
       "SpacingBands",


### PR DESCRIPTION
Promotes **ReadingProgress** beta→stable. Re-verification surfaced two real defects, both fixed.

## Defects fixed
1. **Reduced-motion gap.** `.bar` (transform) and `.root` (opacity) both animated for everyone, yet the a11y `reviewedNote` *claimed* "transition is respected by reduced motion" — the CSS had no guard. Added a `@media (prefers-reduced-motion: reduce)` block dropping both transitions; verified in the compiled CSSOM (default `.bar` = `transform 0.1s`, reduced = `none`). This is the recurring transition/reduced-motion gap seen across prior fleet promotions.
2. **Missing status meta tag.** Stories meta was `tags: ["!autodocs"]` with no status segment (the only component like this in the repo) — no sidebar status dot. Now `["stable", "!autodocs"]`.

## Also
- Bootstrapped AT snapshots across base/light/dark/forced-colors (17 files; none existed before), deterministic on re-run.
- Populated `consumers[]` (12 real article-pipeline paths); set `accessibilityTreeVerified` + `realBrowserForcedColorsVerified`.

## Verification
- `progressbar` role + `aria-valuenow/min/max/label`; percentage text uses `--secondary-text-color` (theme-aware, `CanvasText` in forced-colors); axe passed light+dark+forced.
- unit + `validate:components` + `check:contract-props` + `check:consumers` pass; typecheck, lint, full vitest (1991), build green. docs-registry snapshot updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)