### PR TITLE
fix(design-system): render AuthorBio tagline markdown

### DIFF
--- a/nextjs-app/shared/components/AuthorBio/AuthorBio.contract.json
+++ b/nextjs-app/shared/components/AuthorBio/AuthorBio.contract.json
@@ -29,7 +29,7 @@
             "region role via aria-label",
             "heading level 3 for author name"
         ],
-        "reviewedNote": "2026-07-06 — beta→stable: AT snapshots bootstrapped across base/light/dark/forced-colors (all beta-matrix stories green, deterministic); axe color-contrast passed in light+dark+forced for the bordered color surface; stale compliance story removed."
+        "reviewedNote": "2026-07-06 — beta→stable: AT snapshots bootstrapped across base/light/dark/forced-colors (all beta-matrix stories green, deterministic); axe color-contrast passed in light+dark+forced for the bordered color surface; stale compliance story removed. Follow-up: lead/tagline now renders through ReactMarkdown (internal whitespace collapsed to keep one paragraph) so inline links resolve instead of showing raw markdown; markdown links get an underline affordance (card is not-prose) for WCAG 1.4.1."
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/AuthorBio/AuthorBio.module.css
+++ b/nextjs-app/shared/components/AuthorBio/AuthorBio.module.css
@@ -55,3 +55,14 @@
 .bioContent p {
   margin: 0 0 1rem;
 }
+
+/* The card carries `not-prose`, so markdown links inherit no typography link
+ * styling and would be indistinguishable from body text (WCAG 1.4.1). Give
+ * them an underline affordance while keeping the text color for contrast. */
+
+.tagline a,
+.bioContent a {
+  text-decoration: underline;
+  color: inherit;
+  text-underline-offset: 0.15em;
+}

--- a/nextjs-app/shared/components/AuthorBio/AuthorBio.tsx
+++ b/nextjs-app/shared/components/AuthorBio/AuthorBio.tsx
@@ -43,6 +43,11 @@ export const AuthorBio: React.FC<AuthorBioProps> = ({ slug, className, heading }
   const bioContent = author.bio ?? "";
   const [lead = "", ...rest] = bioContent.split(/\n{2,}/);
   const leadText = lead.trim();
+  // The lead can still hold markdown-significant blank lines that the \n{2,}
+  // split misses (whitespace-only lines). Collapse internal whitespace so the
+  // tagline renders as a single inline paragraph — matching the pre-markdown
+  // Text rendering while still resolving inline links.
+  const leadInline = leadText.replace(/\s+/g, " ");
   const remainder = rest.join("\n\n").trim();
 
   return (
@@ -63,9 +68,19 @@ export const AuthorBio: React.FC<AuthorBioProps> = ({ slug, className, heading }
         </div>
       </div>
       {leadText && (
-        <Text className={styles.tagline}>
-          {leadText}
-        </Text>
+        // The lead is markdown like the rest of the bio, so render it through
+        // ReactMarkdown too — otherwise inline syntax (e.g. Founder
+        // [@](https://digitaltableteur.com)) shows up as raw text. Mapping the
+        // paragraph back to Text keeps the tagline typography and divider.
+        <ReactMarkdown
+          components={{
+            p: ({ children }) => (
+              <Text className={styles.tagline}>{children}</Text>
+            ),
+          }}
+        >
+          {leadInline}
+        </ReactMarkdown>
       )}
       {remainder && (
         <div className={styles.bioContent}>

--- a/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--custom-heading.yaml
+++ b/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--custom-heading.yaml
@@ -1,7 +1,11 @@
 - region "About Petri Lahdelma":
   - img "Petri Lahdelma"
   - heading "Meet the author" [level=3]
-  - paragraph: TLDr; Creating GenAI UX, design, products & experiences. Founder [@](https://digitaltableteur.com)digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
+  - paragraph:
+    - text: TLDr; Creating GenAI UX, design, products & experiences. Founder
+    - link "@":
+      - /url: https://digitaltableteur.com
+    - text: digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
   - paragraph: With +15 yrs XP years, I specialize in platform agnostic solutions and have a track record in building and scaling Design Systems, DesignOps, AI Solutions and User-Centric Design.
   - paragraph: My expertise spans UX/UI, Branding, Visual Communication, Typography, DS component design & development and crafting solutions for diverse sectors including software, consultancies, publications, and government agencies. I excel in Figma and related UX/UI tooling, driving cross-functional collaboration with an accessibility and inclusive design mindset.
   - paragraph: Currently, I lead Design Systems and AI-integration initiatives for both B2B and B2C markets, focusing on strategic governance and adoption.

--- a/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--default.dark.yaml
+++ b/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--default.dark.yaml
@@ -1,7 +1,11 @@
 - region "About Petri Lahdelma":
   - img "Petri Lahdelma"
   - heading "Petri Lahdelma" [level=3]
-  - paragraph: TLDr; Creating GenAI UX, design, products & experiences. Founder [@](https://digitaltableteur.com)digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
+  - paragraph:
+    - text: TLDr; Creating GenAI UX, design, products & experiences. Founder
+    - link "@":
+      - /url: https://digitaltableteur.com
+    - text: digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
   - paragraph: With +15 yrs XP years, I specialize in platform agnostic solutions and have a track record in building and scaling Design Systems, DesignOps, AI Solutions and User-Centric Design.
   - paragraph: My expertise spans UX/UI, Branding, Visual Communication, Typography, DS component design & development and crafting solutions for diverse sectors including software, consultancies, publications, and government agencies. I excel in Figma and related UX/UI tooling, driving cross-functional collaboration with an accessibility and inclusive design mindset.
   - paragraph: Currently, I lead Design Systems and AI-integration initiatives for both B2B and B2C markets, focusing on strategic governance and adoption.

--- a/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--default.forced-colors.yaml
@@ -1,7 +1,11 @@
 - region "About Petri Lahdelma":
   - img "Petri Lahdelma"
   - heading "Petri Lahdelma" [level=3]
-  - paragraph: TLDr; Creating GenAI UX, design, products & experiences. Founder [@](https://digitaltableteur.com)digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
+  - paragraph:
+    - text: TLDr; Creating GenAI UX, design, products & experiences. Founder
+    - link "@":
+      - /url: https://digitaltableteur.com
+    - text: digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
   - paragraph: With +15 yrs XP years, I specialize in platform agnostic solutions and have a track record in building and scaling Design Systems, DesignOps, AI Solutions and User-Centric Design.
   - paragraph: My expertise spans UX/UI, Branding, Visual Communication, Typography, DS component design & development and crafting solutions for diverse sectors including software, consultancies, publications, and government agencies. I excel in Figma and related UX/UI tooling, driving cross-functional collaboration with an accessibility and inclusive design mindset.
   - paragraph: Currently, I lead Design Systems and AI-integration initiatives for both B2B and B2C markets, focusing on strategic governance and adoption.

--- a/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--default.light.yaml
+++ b/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--default.light.yaml
@@ -1,7 +1,11 @@
 - region "About Petri Lahdelma":
   - img "Petri Lahdelma"
   - heading "Petri Lahdelma" [level=3]
-  - paragraph: TLDr; Creating GenAI UX, design, products & experiences. Founder [@](https://digitaltableteur.com)digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
+  - paragraph:
+    - text: TLDr; Creating GenAI UX, design, products & experiences. Founder
+    - link "@":
+      - /url: https://digitaltableteur.com
+    - text: digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
   - paragraph: With +15 yrs XP years, I specialize in platform agnostic solutions and have a track record in building and scaling Design Systems, DesignOps, AI Solutions and User-Centric Design.
   - paragraph: My expertise spans UX/UI, Branding, Visual Communication, Typography, DS component design & development and crafting solutions for diverse sectors including software, consultancies, publications, and government agencies. I excel in Figma and related UX/UI tooling, driving cross-functional collaboration with an accessibility and inclusive design mindset.
   - paragraph: Currently, I lead Design Systems and AI-integration initiatives for both B2B and B2C markets, focusing on strategic governance and adoption.

--- a/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--default.yaml
+++ b/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--default.yaml
@@ -1,7 +1,11 @@
 - region "About Petri Lahdelma":
   - img "Petri Lahdelma"
   - heading "Petri Lahdelma" [level=3]
-  - paragraph: TLDr; Creating GenAI UX, design, products & experiences. Founder [@](https://digitaltableteur.com)digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
+  - paragraph:
+    - text: TLDr; Creating GenAI UX, design, products & experiences. Founder
+    - link "@":
+      - /url: https://digitaltableteur.com
+    - text: digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
   - paragraph: With +15 yrs XP years, I specialize in platform agnostic solutions and have a track record in building and scaling Design Systems, DesignOps, AI Solutions and User-Centric Design.
   - paragraph: My expertise spans UX/UI, Branding, Visual Communication, Typography, DS component design & development and crafting solutions for diverse sectors including software, consultancies, publications, and government agencies. I excel in Figma and related UX/UI tooling, driving cross-functional collaboration with an accessibility and inclusive design mindset.
   - paragraph: Currently, I lead Design Systems and AI-integration initiatives for both B2B and B2C markets, focusing on strategic governance and adoption.

--- a/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--example.dark.yaml
+++ b/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--example.dark.yaml
@@ -1,7 +1,11 @@
 - region "About Petri Lahdelma":
   - img "Petri Lahdelma"
   - heading "Petri Lahdelma" [level=3]
-  - paragraph: TLDr; Creating GenAI UX, design, products & experiences. Founder [@](https://digitaltableteur.com)digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
+  - paragraph:
+    - text: TLDr; Creating GenAI UX, design, products & experiences. Founder
+    - link "@":
+      - /url: https://digitaltableteur.com
+    - text: digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
   - paragraph: With +15 yrs XP years, I specialize in platform agnostic solutions and have a track record in building and scaling Design Systems, DesignOps, AI Solutions and User-Centric Design.
   - paragraph: My expertise spans UX/UI, Branding, Visual Communication, Typography, DS component design & development and crafting solutions for diverse sectors including software, consultancies, publications, and government agencies. I excel in Figma and related UX/UI tooling, driving cross-functional collaboration with an accessibility and inclusive design mindset.
   - paragraph: Currently, I lead Design Systems and AI-integration initiatives for both B2B and B2C markets, focusing on strategic governance and adoption.

--- a/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--example.forced-colors.yaml
@@ -1,7 +1,11 @@
 - region "About Petri Lahdelma":
   - img "Petri Lahdelma"
   - heading "Petri Lahdelma" [level=3]
-  - paragraph: TLDr; Creating GenAI UX, design, products & experiences. Founder [@](https://digitaltableteur.com)digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
+  - paragraph:
+    - text: TLDr; Creating GenAI UX, design, products & experiences. Founder
+    - link "@":
+      - /url: https://digitaltableteur.com
+    - text: digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
   - paragraph: With +15 yrs XP years, I specialize in platform agnostic solutions and have a track record in building and scaling Design Systems, DesignOps, AI Solutions and User-Centric Design.
   - paragraph: My expertise spans UX/UI, Branding, Visual Communication, Typography, DS component design & development and crafting solutions for diverse sectors including software, consultancies, publications, and government agencies. I excel in Figma and related UX/UI tooling, driving cross-functional collaboration with an accessibility and inclusive design mindset.
   - paragraph: Currently, I lead Design Systems and AI-integration initiatives for both B2B and B2C markets, focusing on strategic governance and adoption.

--- a/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--example.light.yaml
+++ b/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--example.light.yaml
@@ -1,7 +1,11 @@
 - region "About Petri Lahdelma":
   - img "Petri Lahdelma"
   - heading "Petri Lahdelma" [level=3]
-  - paragraph: TLDr; Creating GenAI UX, design, products & experiences. Founder [@](https://digitaltableteur.com)digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
+  - paragraph:
+    - text: TLDr; Creating GenAI UX, design, products & experiences. Founder
+    - link "@":
+      - /url: https://digitaltableteur.com
+    - text: digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
   - paragraph: With +15 yrs XP years, I specialize in platform agnostic solutions and have a track record in building and scaling Design Systems, DesignOps, AI Solutions and User-Centric Design.
   - paragraph: My expertise spans UX/UI, Branding, Visual Communication, Typography, DS component design & development and crafting solutions for diverse sectors including software, consultancies, publications, and government agencies. I excel in Figma and related UX/UI tooling, driving cross-functional collaboration with an accessibility and inclusive design mindset.
   - paragraph: Currently, I lead Design Systems and AI-integration initiatives for both B2B and B2C markets, focusing on strategic governance and adoption.

--- a/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--example.yaml
+++ b/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--example.yaml
@@ -1,7 +1,11 @@
 - region "About Petri Lahdelma":
   - img "Petri Lahdelma"
   - heading "Petri Lahdelma" [level=3]
-  - paragraph: TLDr; Creating GenAI UX, design, products & experiences. Founder [@](https://digitaltableteur.com)digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
+  - paragraph:
+    - text: TLDr; Creating GenAI UX, design, products & experiences. Founder
+    - link "@":
+      - /url: https://digitaltableteur.com
+    - text: digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
   - paragraph: With +15 yrs XP years, I specialize in platform agnostic solutions and have a track record in building and scaling Design Systems, DesignOps, AI Solutions and User-Centric Design.
   - paragraph: My expertise spans UX/UI, Branding, Visual Communication, Typography, DS component design & development and crafting solutions for diverse sectors including software, consultancies, publications, and government agencies. I excel in Figma and related UX/UI tooling, driving cross-functional collaboration with an accessibility and inclusive design mindset.
   - paragraph: Currently, I lead Design Systems and AI-integration initiatives for both B2B and B2C markets, focusing on strategic governance and adoption.

--- a/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--forced-colors.dark.yaml
@@ -1,7 +1,11 @@
 - region "About Petri Lahdelma":
   - img "Petri Lahdelma"
   - heading "Petri Lahdelma" [level=3]
-  - paragraph: TLDr; Creating GenAI UX, design, products & experiences. Founder [@](https://digitaltableteur.com)digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
+  - paragraph:
+    - text: TLDr; Creating GenAI UX, design, products & experiences. Founder
+    - link "@":
+      - /url: https://digitaltableteur.com
+    - text: digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
   - paragraph: With +15 yrs XP years, I specialize in platform agnostic solutions and have a track record in building and scaling Design Systems, DesignOps, AI Solutions and User-Centric Design.
   - paragraph: My expertise spans UX/UI, Branding, Visual Communication, Typography, DS component design & development and crafting solutions for diverse sectors including software, consultancies, publications, and government agencies. I excel in Figma and related UX/UI tooling, driving cross-functional collaboration with an accessibility and inclusive design mindset.
   - paragraph: Currently, I lead Design Systems and AI-integration initiatives for both B2B and B2C markets, focusing on strategic governance and adoption.

--- a/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--forced-colors.forced-colors.yaml
@@ -1,7 +1,11 @@
 - region "About Petri Lahdelma":
   - img "Petri Lahdelma"
   - heading "Petri Lahdelma" [level=3]
-  - paragraph: TLDr; Creating GenAI UX, design, products & experiences. Founder [@](https://digitaltableteur.com)digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
+  - paragraph:
+    - text: TLDr; Creating GenAI UX, design, products & experiences. Founder
+    - link "@":
+      - /url: https://digitaltableteur.com
+    - text: digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
   - paragraph: With +15 yrs XP years, I specialize in platform agnostic solutions and have a track record in building and scaling Design Systems, DesignOps, AI Solutions and User-Centric Design.
   - paragraph: My expertise spans UX/UI, Branding, Visual Communication, Typography, DS component design & development and crafting solutions for diverse sectors including software, consultancies, publications, and government agencies. I excel in Figma and related UX/UI tooling, driving cross-functional collaboration with an accessibility and inclusive design mindset.
   - paragraph: Currently, I lead Design Systems and AI-integration initiatives for both B2B and B2C markets, focusing on strategic governance and adoption.

--- a/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--forced-colors.light.yaml
@@ -1,7 +1,11 @@
 - region "About Petri Lahdelma":
   - img "Petri Lahdelma"
   - heading "Petri Lahdelma" [level=3]
-  - paragraph: TLDr; Creating GenAI UX, design, products & experiences. Founder [@](https://digitaltableteur.com)digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
+  - paragraph:
+    - text: TLDr; Creating GenAI UX, design, products & experiences. Founder
+    - link "@":
+      - /url: https://digitaltableteur.com
+    - text: digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
   - paragraph: With +15 yrs XP years, I specialize in platform agnostic solutions and have a track record in building and scaling Design Systems, DesignOps, AI Solutions and User-Centric Design.
   - paragraph: My expertise spans UX/UI, Branding, Visual Communication, Typography, DS component design & development and crafting solutions for diverse sectors including software, consultancies, publications, and government agencies. I excel in Figma and related UX/UI tooling, driving cross-functional collaboration with an accessibility and inclusive design mindset.
   - paragraph: Currently, I lead Design Systems and AI-integration initiatives for both B2B and B2C markets, focusing on strategic governance and adoption.

--- a/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--forced-colors.yaml
+++ b/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--forced-colors.yaml
@@ -1,7 +1,11 @@
 - region "About Petri Lahdelma":
   - img "Petri Lahdelma"
   - heading "Petri Lahdelma" [level=3]
-  - paragraph: TLDr; Creating GenAI UX, design, products & experiences. Founder [@](https://digitaltableteur.com)digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
+  - paragraph:
+    - text: TLDr; Creating GenAI UX, design, products & experiences. Founder
+    - link "@":
+      - /url: https://digitaltableteur.com
+    - text: digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
   - paragraph: With +15 yrs XP years, I specialize in platform agnostic solutions and have a track record in building and scaling Design Systems, DesignOps, AI Solutions and User-Centric Design.
   - paragraph: My expertise spans UX/UI, Branding, Visual Communication, Typography, DS component design & development and crafting solutions for diverse sectors including software, consultancies, publications, and government agencies. I excel in Figma and related UX/UI tooling, driving cross-functional collaboration with an accessibility and inclusive design mindset.
   - paragraph: Currently, I lead Design Systems and AI-integration initiatives for both B2B and B2C markets, focusing on strategic governance and adoption.

--- a/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--playground.yaml
+++ b/nextjs-app/shared/components/AuthorBio/__a11y-snapshots__/site-authorbio--playground.yaml
@@ -1,7 +1,11 @@
 - region "About Petri Lahdelma":
   - img "Petri Lahdelma"
   - heading "Petri Lahdelma" [level=3]
-  - paragraph: TLDr; Creating GenAI UX, design, products & experiences. Founder [@](https://digitaltableteur.com)digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
+  - paragraph:
+    - text: TLDr; Creating GenAI UX, design, products & experiences. Founder
+    - link "@":
+      - /url: https://digitaltableteur.com
+    - text: digitaltableteur. Expert | Design Systems | UX Strategy & Design Ops | AI-Assisted Workflows | React, TypeScript & Next.JS Enthusiast | Entrepreneur
   - paragraph: With +15 yrs XP years, I specialize in platform agnostic solutions and have a track record in building and scaling Design Systems, DesignOps, AI Solutions and User-Centric Design.
   - paragraph: My expertise spans UX/UI, Branding, Visual Communication, Typography, DS component design & development and crafting solutions for diverse sectors including software, consultancies, publications, and government agencies. I excel in Figma and related UX/UI tooling, driving cross-functional collaboration with an accessibility and inclusive design mindset.
   - paragraph: Currently, I lead Design Systems and AI-integration initiatives for both B2B and B2C markets, focusing on strategic governance and adoption.


### PR DESCRIPTION
Fixes the spawned follow-up from the AuthorBio stable promotion (#896).

## Problem
The AuthorBio bio is split into a lead "tagline" (first paragraph) and a remainder. The remainder rendered through `ReactMarkdown`, but the lead was plain `<Text>` — so author-data markdown in the first paragraph (e.g. `Founder [@](https://digitaltableteur.com)digitaltableteur`) showed as literal `[@](https://digitaltableteur.com)` syntax on the live blog author bio and the Storybook story.

## Fix
Design call: **render it, don't strip it** — the bio is authored markdown and the link is intended.

- Render the lead through ReactMarkdown too, mapping the paragraph back to `<Text className={tagline}>` so the tagline typography + divider are preserved.
- **Collapse the lead's internal whitespace first.** The lead can hold a markdown-significant blank line (a whitespace-only line the `\n{2,}` split misses) that ReactMarkdown would otherwise render as *two* paragraphs → two stacked dividers. Collapsing keeps it one inline paragraph, matching the pre-markdown Text render.
- The card is `not-prose`, so markdown links inherit no link styling and would be indistinguishable from body text (WCAG 1.4.1). Added an underline affordance for links in the tagline + bio content.

## Result
The tagline now reads "…Founder **@**digitaltableteur…" with `@` a real underlined link to `https://digitaltableteur.com`, in a single tagline block (layout unchanged).

## Verification
- Re-bootstrapped AT snapshots (base/light/dark/forced-colors): the tagline paragraph now carries a proper `link "@" → /url` node instead of raw markdown; no snapshot retains raw markdown. Deterministic on re-run.
- axe passed in light+dark+forced with the underlined link. unit 31/31; `validate:components`, typecheck, lint, stylelint baseline, rhythmguard (0 new drift), full vitest (1986), build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
