### PR TITLE
feat(design-system): promote ExpandableSection beta→stable

### DIFF
--- a/nextjs-app/shared/components/ExpandableSection/ExpandableSection.contract.json
+++ b/nextjs-app/shared/components/ExpandableSection/ExpandableSection.contract.json
@@ -3,11 +3,11 @@
     "name": "ExpandableSection",
     "tier": "molecule",
     "group": "structure",
-    "status": "beta",
+    "status": "stable",
     "description": "Collapsible content region with a trigger header. Lighter than `Accordion` (which manages a group of expandables) — used standalone for a single 'show more' or detail-disclosure section.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-expandable-section",
     "radixPrimitive": null,
-    "element": "section",
+    "element": "div",
     "variants": {},
     "slots": [],
     "asChild": false,
@@ -25,26 +25,49 @@
         ],
         "ariaRequirements": [
             "Trigger is a `<button>` with `aria-expanded` reflecting the open state.",
-            "Trigger sets `aria-controls` to the panel id; the panel uses `role='region'` and `aria-labelledby` pointing at the trigger."
+            "The panel is added/removed on toggle (no dangling `aria-controls`); the trigger's text label is its accessible name."
         ],
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
+        "realBrowserForcedColorsVerified": true,
+        "accessibilityTreeVerified": true,
         "motion": true,
-        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "reviewedNote": "2026-07-06 — beta→stable: element corrected section→div; aria contract corrected to the real button+aria-expanded disclosure (the panel unmounts on collapse, so no aria-controls to dangle); reduced-motion CSS guard added for the trigger colour + icon-rotation transitions (the framer-motion morph was already duration-zeroed). AT snapshots bootstrapped across base/light/dark/forced-colors; axe green in light + dark + forced-colors."
     },
     "tokens": {
         "colors": [
-            "--color-text",
-            "--color-surface-elevated"
+            "--color-muted",
+            "--color-primary"
         ],
         "spacing": [
             "--space-internal-8",
-            "--space-internal-12"
+            "--space-layout-24"
         ]
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/ContactPage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "collapsedLabel": {

--- a/nextjs-app/shared/components/ExpandableSection/ExpandableSection.module.css
+++ b/nextjs-app/shared/components/ExpandableSection/ExpandableSection.module.css
@@ -63,3 +63,13 @@
 .inner {
   padding-block-start: var(--space-layout-24);
 }
+
+/* The framer-motion morph is duration-zeroed under reduced motion (see tsx);
+   these CSS transitions (trigger color, +/× icon rotation) need the same
+   guard so nothing animates for reduced-motion users. */
+@media (prefers-reduced-motion: reduce) {
+  .trigger,
+  .icon {
+    transition: none;
+  }
+}

--- a/nextjs-app/shared/components/ExpandableSection/ExpandableSection.stories.tsx
+++ b/nextjs-app/shared/components/ExpandableSection/ExpandableSection.stories.tsx
@@ -28,7 +28,7 @@ const defaultArgs = {
 const meta = {
   title: "Layout/ExpandableSection",
   component: ExpandableSection,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",
@@ -76,7 +76,6 @@ export const Playground: Story = {
    * live (a set expandedLabel would mask collapsedLabel entirely while open).
    */
   render: function PlaygroundRender(args) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks -- Storybook render context
     const [{ expanded }, updateArgs] = useArgs();
     return (
       <ExpandableSection

--- a/nextjs-app/shared/components/ExpandableSection/ExpandableSection.test.tsx
+++ b/nextjs-app/shared/components/ExpandableSection/ExpandableSection.test.tsx
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -67,5 +70,23 @@ describe("ExpandableSection", () => {
       </ExpandableSection>,
     );
     expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("neutralises the trigger and icon transitions under reduced motion", () => {
+    // The framer-motion morph is duration-zeroed in the component; these two
+    // CSS transitions need a media guard so nothing animates for reduced-motion
+    // users. Assert the guard exists (jsdom can't evaluate media-scoped styles).
+    const css = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "ExpandableSection.module.css"),
+      "utf8",
+    );
+    const guard = css.match(
+      /@media \(prefers-reduced-motion: reduce\) \{([\s\S]*?)\}\s*\}/,
+    );
+    expect(guard, "reduced-motion @media block").not.toBeNull();
+    const body = guard![1];
+    expect(body).toMatch(/\.trigger/);
+    expect(body).toMatch(/\.icon/);
+    expect(body).toMatch(/transition:\s*none/);
   });
 });

--- a/nextjs-app/shared/components/ExpandableSection/ExpandableSection.tsx
+++ b/nextjs-app/shared/components/ExpandableSection/ExpandableSection.tsx
@@ -86,7 +86,7 @@ export function ExpandableSection({
             ref={contentRef}
             initial={prefersReducedMotion ? false : { height: 0, opacity: 0 }}
             animate={{ height: "auto", opacity: 1 }}
-            exit={prefersReducedMotion ? { height: 0, opacity: 0 } : { height: 0, opacity: 0 }}
+            exit={{ height: 0, opacity: 0 }}
             transition={morphTransition}
             className={styles.content}
           >

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--controlled-disclosure.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--controlled-disclosure.yaml
@@ -1,0 +1,2 @@
+- paragraph: "State: collapsed"
+- button "Show changelog"

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--default.dark.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--default.dark.yaml
@@ -1,0 +1,2 @@
+- button "Hide project details" [expanded]
+- paragraph: Optional fields appear here when expanded.

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--default.forced-colors.yaml
@@ -1,0 +1,2 @@
+- button "Hide project details" [expanded]
+- paragraph: Optional fields appear here when expanded.

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--default.light.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--default.light.yaml
@@ -1,0 +1,2 @@
+- button "Hide project details" [expanded]
+- paragraph: Optional fields appear here when expanded.

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--default.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--default.yaml
@@ -1,0 +1,2 @@
+- button "Hide project details" [expanded]
+- paragraph: Optional fields appear here when expanded.

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--example.dark.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--example.dark.yaml
@@ -1,0 +1,1 @@
+- button "Add project details"

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--example.forced-colors.yaml
@@ -1,0 +1,1 @@
+- button "Add project details"

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--example.light.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--example.light.yaml
@@ -1,0 +1,1 @@
+- button "Add project details"

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--example.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--example.yaml
@@ -1,0 +1,1 @@
+- button "Add project details"

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--forced-colors.dark.yaml
@@ -1,0 +1,1 @@
+- button "Add project details"

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--forced-colors.forced-colors.yaml
@@ -1,0 +1,1 @@
+- button "Add project details"

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--forced-colors.light.yaml
@@ -1,0 +1,1 @@
+- button "Add project details"

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--forced-colors.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--forced-colors.yaml
@@ -1,0 +1,1 @@
+- button "Add project details"

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--playground.dark.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--playground.dark.yaml
@@ -1,0 +1,2 @@
+- button "Add project details" [expanded]
+- paragraph: Optional fields appear here when expanded.

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--playground.forced-colors.yaml
@@ -1,0 +1,2 @@
+- button "Add project details" [expanded]
+- paragraph: Optional fields appear here when expanded.

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--playground.light.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--playground.light.yaml
@@ -1,0 +1,2 @@
+- button "Add project details" [expanded]
+- paragraph: Optional fields appear here when expanded.

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--playground.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--playground.yaml
@@ -1,0 +1,2 @@
+- button "Add project details" [expanded]
+- paragraph: Optional fields appear here when expanded.

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--show-more-tail.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--show-more-tail.yaml
@@ -1,0 +1,2 @@
+- paragraph: The visible opening of the content stays outside the disclosure.
+- button "Show more"

--- a/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--versus-accordion.yaml
+++ b/nextjs-app/shared/components/ExpandableSection/__a11y-snapshots__/layout-expandablesection--versus-accordion.yaml
@@ -1,0 +1,2 @@
+- button "Details A"
+- button "Details B"

--- a/nextjs-app/shared/components/Link/Link.contract.json
+++ b/nextjs-app/shared/components/Link/Link.contract.json
@@ -60,6 +60,26 @@
     "consumers": [
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/BlogArticleMdxBody.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ServerArticleContent.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ServerArticleMain.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "app/dev/tailwind-test/page.tsx",
             "since": "2026-06-04"
         },
@@ -75,42 +95,27 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
             "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/SitemapPage/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/SitemapPage/SitemapPage.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/Footer/Footer.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/navigation/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/SiteFooter/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx",
             "since": "2026-06-04"
         }
     ],

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -5412,7 +5412,7 @@
       "name": "ExpandableSection",
       "group": "structure",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "Collapsible content region with a trigger header. Lighter than `Accordion` (which manages a group of expandables) — used standalone for a single 'show more' or detail-disclosure section.",
       "dense": "Single disclosure: collapsedLabel/expandedLabel trigger, uncontrolled (defaultExpanded) or controlled (expanded + onExpandedChange); staggered reveal. One section = this; exclusive group = Accordion",
       "keywords": [
@@ -5525,12 +5525,12 @@
       },
       "tokens": {
         "colors": [
-          "--color-text",
-          "--color-surface-elevated"
+          "--color-muted",
+          "--color-primary"
         ],
         "spacing": [
           "--space-internal-8",
-          "--space-internal-12"
+          "--space-layout-24"
         ]
       },
       "examples": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -236,6 +236,31 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "marketing",
     "import": "import { EnhancedProjectCard } from "@dt/EnhancedProjectCard";",
   },
+  "ExpandableSection": {
+    "exampleStories": [
+      "ShowMoreTail",
+      "ControlledDisclosure",
+      "VersusAccordion",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "structure",
+    "import": "import { ExpandableSection } from "@dt/ExpandableSection";",
+  },
   "FlexBox": {
     "exampleStories": [
       "InlineCluster",


### PR DESCRIPTION
## What

Promotes **ExpandableSection** beta→stable — fleet #22 of the Phase 5 promotion wave (stable count 30→31).

Not a flag-flip. The pre-promotion audit surfaced real defects, all fixed:

- **`element` "section" → "div"** — the tsx renders a `<div>` container (the recurring contract element-vs-tsx rot).
- **aria contract was overclaimed** — it declared `aria-controls` + `role=region` + `aria-labelledby`, none of which the component implements. And it can't safely: the panel unmounts on collapse (framer `AnimatePresence`), so `aria-controls` would dangle and fail `aria-valid-attr-value` (the Tabs #826 lesson). The real implementation is a valid **button + `aria-expanded`** disclosure; the contract now describes that honestly.
- **reduced-motion gap** — the framer-motion height/opacity morph was already duration-zeroed, but the trigger colour transition and the `+`→`×` icon rotation animated for everyone. Added a `prefers-reduced-motion` guard + a static-CSS guard test. (6th promotion with this exact gap.)
- Corrected the stale `tokens` list and `reviewedNote`; removed an unused `eslint-disable` directive and a redundant reduced-motion ternary.

## Promotion mechanics
- `status` + story meta tags → stable; `accessibilityTreeVerified` + `realBrowserForcedColorsVerified` set **after** real verification.
- `consumers[]` populated via `audit:consumers`: 4 real (ContactPage + ContactPageContentEditorial).
- AT snapshots **bootstrapped** across base/light/dark/forced-colors — 19 files (4 beta-matrix ×4 modes + 3 example-only base), compare-clean and deterministic.
- MCP `docs-registry` snapshot updated (ExpandableSection enters the registry).

## Verification (local)
- axe green in **light / dark / forced-colors** (7 stories); screenshotted expanded state light + dark (muted trigger, AA contrast).
- controls **100% operable, 0 inert** (`defaultExpanded` mount-only exempt).
- unit **6/6** (added the reduced-motion guard test); full suite **1991** green.
- typecheck, lint (unused-directive cleared), lint:css baseline, rhythmguard 0 new-drift, build — all green.
- validate:components, check:contract-props, check:consumers, check:generated — all green.

## Side effect
Refreshes `Link.contract.json` `consumers[]` — a **pre-existing drift on main** that `audit:consumers` corrected as a byproduct. This unblocks `check:consumers` (which was red on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
