### PR TITLE
feat(design-system): Figma components for StatusDot + Kbd, promote alpha→beta

### DIFF
--- a/nextjs-app/shared/components/Kbd/Kbd.contract.json
+++ b/nextjs-app/shared/components/Kbd/Kbd.contract.json
@@ -3,9 +3,9 @@
     "name": "Kbd",
     "tier": "atom",
     "group": "display",
-    "status": "alpha",
+    "status": "beta",
     "description": "Inline keyboard-key indicator rendered as a semantic kbd keycap.",
-    "figma": null,
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1005-1638",
     "radixPrimitive": null,
     "element": "kbd",
     "variants": {
@@ -15,7 +15,8 @@
                 "md",
                 "lg"
             ],
-            "default": "md"
+            "default": "md",
+            "propSourced": true
         }
     },
     "slots": [],
@@ -34,7 +35,7 @@
         ],
         "reducedMotion": true,
         "reviewed": true,
-        "reviewedNote": "2026-07-03 — static inline element; axe asserted in unit test and story gate.",
+        "reviewedNote": "2026-07-06 — alpha→beta: created the Figma component (size variant keycap set, border/bg/text bound to DT/Color, radius from radius/sm) at node 1005-1638, the only remaining beta blocker. Static inline element; axe asserted in unit test and story gate; forced-colors border verified.",
         "forcedColorsVerified": true
     },
     "tokens": {

--- a/nextjs-app/shared/components/Kbd/Kbd.stories.tsx
+++ b/nextjs-app/shared/components/Kbd/Kbd.stories.tsx
@@ -6,7 +6,7 @@ import contract from "./Kbd.contract.json";
 const meta = {
   title: "Content/Kbd",
   component: Kbd,
-  tags: ["alpha", "autodocs"],
+  tags: ["beta", "autodocs"],
   parameters: {
     layout: "centered",
     a11y: { test: "error" },
@@ -31,7 +31,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  tags: ["example"],
+  tags: ["beta-matrix", "example"],
   parameters: {
     docs: {
       description: { story: "A single keycap; the element is a semantic <kbd>." },
@@ -40,10 +40,10 @@ export const Default: Story = {
   args: { children: "Esc" },
 };
 
-export const Playground: Story = {};
+export const Playground: Story = { tags: ["beta-matrix"] };
 
 export const Example: Story = {
-  tags: ["example"],
+  tags: ["beta-matrix", "example"],
   parameters: {
     controls: { disable: true },
     docs: {
@@ -90,6 +90,7 @@ export const KeyNames: Story = {
 };
 
 export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
   parameters: { a11y: { disable: true, test: "off" } },
   args: { children: "Enter" },

--- a/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--default.dark.yaml
+++ b/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--default.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Esc

--- a/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--default.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Esc

--- a/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--default.light.yaml
+++ b/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--default.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Esc

--- a/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--default.yaml
+++ b/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--default.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Esc

--- a/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--example.dark.yaml
+++ b/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--example.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: ⌘ + K

--- a/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--example.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: ⌘ + K

--- a/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--example.light.yaml
+++ b/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--example.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: ⌘ + K

--- a/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--example.yaml
+++ b/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--example.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: ⌘ + K

--- a/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--forced-colors.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Enter

--- a/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--forced-colors.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Enter

--- a/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--forced-colors.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Enter

--- a/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--forced-colors.yaml
+++ b/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Enter

--- a/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--key-names.yaml
+++ b/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--key-names.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Esc Enter Space Tab

--- a/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--playground.dark.yaml
+++ b/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--playground.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: ⌘

--- a/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--playground.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: ⌘

--- a/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--playground.light.yaml
+++ b/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--playground.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: ⌘

--- a/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--playground.yaml
+++ b/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--playground.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: ⌘

--- a/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--sizes.yaml
+++ b/nextjs-app/shared/components/Kbd/__a11y-snapshots__/content-kbd--sizes.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Shift Shift Shift

--- a/nextjs-app/shared/components/StatusDot/StatusDot.contract.json
+++ b/nextjs-app/shared/components/StatusDot/StatusDot.contract.json
@@ -3,9 +3,9 @@
     "name": "StatusDot",
     "tier": "atom",
     "group": "feedback",
-    "status": "alpha",
+    "status": "beta",
     "description": "Tiny semantic status indicator: colored dot with visible or sr-only label.",
-    "figma": null,
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1004-1677",
     "radixPrimitive": null,
     "element": "span",
     "variants": {
@@ -17,7 +17,8 @@
                 "error",
                 "info"
             ],
-            "default": "neutral"
+            "default": "neutral",
+            "propSourced": true
         },
         "size": {
             "values": [
@@ -25,7 +26,8 @@
                 "md",
                 "lg"
             ],
-            "default": "md"
+            "default": "md",
+            "propSourced": true
         }
     },
     "slots": [],
@@ -45,7 +47,7 @@
         ],
         "reducedMotion": true,
         "reviewed": true,
-        "reviewedNote": "2026-07-03 — pulse animation disabled under prefers-reduced-motion; axe asserted in unit test.",
+        "reviewedNote": "2026-07-06 — alpha→beta: created the Figma component (tone×size variant set, dot fill bound to DT/Color tone tokens) at node 1004-1677, the only remaining beta blocker. Pulse animation disabled under prefers-reduced-motion (CSS guard verified); axe asserted in unit test; forced-colors + light/dark re-verified.",
         "forcedColorsVerified": true
     },
     "tokens": {

--- a/nextjs-app/shared/components/StatusDot/StatusDot.stories.tsx
+++ b/nextjs-app/shared/components/StatusDot/StatusDot.stories.tsx
@@ -6,7 +6,7 @@ import contract from "./StatusDot.contract.json";
 const meta = {
   title: "Feedback/StatusDot",
   component: StatusDot,
-  tags: ["alpha", "autodocs"],
+  tags: ["beta", "autodocs"],
   parameters: {
     layout: "centered",
     a11y: { test: "error" },
@@ -24,7 +24,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  tags: ["example"],
+  tags: ["beta-matrix", "example"],
   parameters: {
     docs: {
       description: { story: "Dot + visible label; the dot itself is decorative (aria-hidden)." },
@@ -35,6 +35,7 @@ export const Default: Story = {
 // children is seeded empty here so the sr-only label path is live in the
 // panel (children would otherwise mask label entirely).
 export const Playground: Story = {
+  tags: ["beta-matrix"],
   args: { children: "", label: "Operational" },
 };
 
@@ -86,11 +87,13 @@ export const SrOnlyLabel: Story = {
 };
 
 export const Example: Story = {
+  tags: ["beta-matrix"],
   parameters: { controls: { disable: true } },
   render: () => <StatusDot tone="success">Operational</StatusDot>,
 };
 
 export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
   parameters: { a11y: { disable: true, test: "off" } },
 };

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--default.dark.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--default.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--default.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--default.light.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--default.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--default.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--default.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--example.dark.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--example.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--example.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--example.light.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--example.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--example.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--example.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--forced-colors.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--forced-colors.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--forced-colors.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--forced-colors.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--live.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--live.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Live

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--playground.dark.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--playground.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--playground.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--playground.light.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--playground.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--playground.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--playground.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--sr-only-label.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--sr-only-label.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Connection lost

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--tones.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--tones.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- text: Idle Operational Degraded Down Maintenance

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -7297,7 +7297,7 @@
       "name": "Kbd",
       "group": "display",
       "tier": 2,
-      "status": "alpha",
+      "status": "beta",
       "description": "Inline keyboard-key indicator rendered as a semantic kbd keycap.",
       "dense": "semantic <kbd> keycap; sm/md/lg mono sizes; compose combos as sibling Kbds with literal separators",
       "keywords": [
@@ -7381,12 +7381,12 @@
         {
           "story": "Default",
           "description": "A single keycap; the element is a semantic <kbd>.",
-          "source": "export const Default: Story = {\n  tags: [\"example\"],\n  parameters: {\n    docs: {\n      description: { story: \"A single keycap; the element is a semantic <kbd>.\" },\n    },\n  },\n  args: { children: \"Esc\" },\n};"
+          "source": "export const Default: Story = {\n  tags: [\"beta-matrix\", \"example\"],\n  parameters: {\n    docs: {\n      description: { story: \"A single keycap; the element is a semantic <kbd>.\" },\n    },\n  },\n  args: { children: \"Esc\" },\n};"
         },
         {
           "story": "Example",
           "description": "Shortcut combinations read naturally inline: compose several Kbds with + between them.",
-          "source": "export const Example: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: {\n      description: {\n        story: \"Shortcut combinations read naturally inline: compose several Kbds with + between them.\",\n      },\n    },\n  },\n  render: () => (\n    <span>\n      <Kbd>⌘</Kbd> + <Kbd>K</Kbd>\n    </span>\n  ),\n};"
+          "source": "export const Example: Story = {\n  tags: [\"beta-matrix\", \"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: {\n      description: {\n        story: \"Shortcut combinations read naturally inline: compose several Kbds with + between them.\",\n      },\n    },\n  },\n  render: () => (\n    <span>\n      <Kbd>⌘</Kbd> + <Kbd>K</Kbd>\n    </span>\n  ),\n};"
         },
         {
           "story": "Sizes",
@@ -13092,7 +13092,7 @@
       "name": "StatusDot",
       "group": "feedback",
       "tier": 2,
-      "status": "alpha",
+      "status": "beta",
       "description": "Tiny semantic status indicator: colored dot with visible or sr-only label.",
       "dense": "colored semantic dot + label (visible children or sr-only label); tone x sm/md/lg, optional pulse for live states",
       "keywords": [
@@ -13238,7 +13238,7 @@
         {
           "story": "Default",
           "description": "Dot + visible label; the dot itself is decorative (aria-hidden).",
-          "source": "export const Default: Story = {\n  tags: [\"example\"],\n  parameters: {\n    docs: {\n      description: { story: \"Dot + visible label; the dot itself is decorative (aria-hidden).\" },\n    },\n  },\n};\n\n// children is seeded empty here so the sr-only label path is live in the\n// panel (children would otherwise mask label entirely)."
+          "source": "export const Default: Story = {\n  tags: [\"beta-matrix\", \"example\"],\n  parameters: {\n    docs: {\n      description: { story: \"Dot + visible label; the dot itself is decorative (aria-hidden).\" },\n    },\n  },\n};\n\n// children is seeded empty here so the sr-only label path is live in the\n// panel (children would otherwise mask label entirely)."
         },
         {
           "story": "Tones",


### PR DESCRIPTION
## What

Unblocks and promotes two atoms — **StatusDot** and **Kbd** — from alpha→beta by **creating their Figma components** (the validator hard-requires a real `figma` node-id at beta, which was the *only* thing missing for both).

## Figma components created

Built in `DT-Site-stuff` under the **Atoms** section, bound to the DT design tokens (not hardcoded):

- **StatusDot** → node `1004-1677`: `tone`(5)×`size`(3) variant set; dot fill bound to DT/Color tone tokens (`muted`/`success`/`warning`/`error`/`info`), label to `color/text`.
- **Kbd** → node `1005-1638`: `size`(3) keycap set; border/background/text bound to DT/Color (`color/border`, `color/surface`, `color/text`), radius from `radius/sm`, 2px bottom border for keycap depth.

## Promotion

- Wired the figma node-ids, flipped `status` + story meta tags to beta, tagged `beta-matrix`.
- The validator's CVA-axis gate flagged that these use CSS-module class maps (`styles[tone]`/`styles[size]`) rather than a root CVA. Marked each axis `propSourced: true` — matching Divider's convention for self-applied class-map variants (the honest representation; no code change).

## Verification (local)

- `validate:components` + `check:contract-props` green.
- controls **100% operable / 0 inert** on both (`--effects`).
- AT snapshots **bootstrapped** across base/light/dark/forced-colors (StatusDot 19, Kbd 18), compare-clean and deterministic.
- unit **9/9**, full suite **1991**, typecheck / lint / lint:css / rhythmguard (0 new) / build all green.

Note: no component source changed — StatusDot/Kbd already had the reduced-motion guard, forced-colors handling, tests, and stories from the #815 gap-fill; the Figma component was the sole blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
