### PR TITLE
feat(design-system): promote AvatarGroup alpha→beta with Figma component

### DIFF
--- a/nextjs-app/shared/components/AvatarGroup/AvatarGroup.contract.json
+++ b/nextjs-app/shared/components/AvatarGroup/AvatarGroup.contract.json
@@ -3,9 +3,9 @@
     "name": "AvatarGroup",
     "tier": "molecule",
     "group": "display",
-    "status": "alpha",
+    "status": "beta",
     "description": "Overlapping stack of Avatars with a +N overflow bubble.",
-    "figma": null,
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1010-147",
     "radixPrimitive": null,
     "element": "div",
     "variants": {
@@ -15,12 +15,11 @@
                 "md",
                 "lg"
             ],
-            "default": "md"
+            "default": "md",
+            "propSourced": true
         }
     },
-    "slots": [
-        "children"
-    ],
+    "slots": [],
     "asChild": false,
     "subParts": [],
     "requiredStories": [

--- a/nextjs-app/shared/components/AvatarGroup/AvatarGroup.stories.tsx
+++ b/nextjs-app/shared/components/AvatarGroup/AvatarGroup.stories.tsx
@@ -14,7 +14,7 @@ const avatars = (count: number, size: "2rem" | "2.5rem" | "3rem" = "2.5rem") =>
 const meta = {
   title: "Content/AvatarGroup",
   component: AvatarGroup,
-  tags: ["alpha", "autodocs"],
+  tags: ["beta", "autodocs"],
   parameters: {
     layout: "centered",
     a11y: { test: "error" },
@@ -51,7 +51,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  tags: ["example"],
+  tags: ["beta-matrix", "example"],
   parameters: {
     docs: {
       description: { story: "Six members, max 4: the stack shows four and collapses the rest into +2." },
@@ -59,7 +59,7 @@ export const Default: Story = {
   },
 };
 
-export const Playground: Story = {};
+export const Playground: Story = { tags: ["beta-matrix"] };
 
 export const NoOverflow: Story = {
   tags: ["example"],
@@ -114,6 +114,7 @@ export const WithLabel: Story = {
 };
 
 export const Example: Story = {
+  tags: ["beta-matrix"],
   parameters: { controls: { disable: true } },
   render: () => (
     <AvatarGroup ariaLabel="Project members" max={4}>
@@ -123,6 +124,7 @@ export const Example: Story = {
 };
 
 export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
   parameters: { a11y: { disable: true, test: "off" } },
   render: () => <AvatarGroup ariaLabel="Project members">{avatars(5)}</AvatarGroup>,

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--default.dark.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--default.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- group "Project members": AV BL CM DA 2 more

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--default.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- group "Project members": AV BL CM DA 2 more

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--default.light.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--default.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- group "Project members": AV BL CM DA 2 more

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--default.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--default.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- group "Project members": AV BL CM DA 2 more

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--example.dark.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--example.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- group "Project members": AV BL CM DA 2 more

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--example.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- group "Project members": AV BL CM DA 2 more

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--example.light.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--example.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- group "Project members": AV BL CM DA 2 more

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--example.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--example.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- group "Project members": AV BL CM DA 2 more

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--forced-colors.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- group "Project members": AV BL CM DA 1 more

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--forced-colors.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- group "Project members": AV BL CM DA 1 more

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--forced-colors.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- group "Project members": AV BL CM DA 1 more

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--forced-colors.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- group "Project members": AV BL CM DA 1 more

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--no-overflow.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--no-overflow.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- group "Reviewers": AV BL CM

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--playground.dark.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--playground.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- group "Project members": AV BL CM DA 2 more

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--playground.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- group "Project members": AV BL CM DA 2 more

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--playground.light.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--playground.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- group "Project members": AV BL CM DA 2 more

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--playground.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--playground.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- group "Project members": AV BL CM DA 2 more

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--sizes.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--sizes.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- group "Team": AV BL CM 2 more
+- group "Team": AV BL CM 2 more
+- group "Team": AV BL CM 2 more

--- a/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--with-label.yaml
+++ b/nextjs-app/shared/components/AvatarGroup/__a11y-snapshots__/content-avatargroup--with-label.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- group "Contributors": AV BL CM 3 more
+- text: 6 contributors

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -1009,7 +1009,7 @@
       "name": "AvatarGroup",
       "group": "display",
       "tier": 2,
-      "status": "alpha",
+      "status": "beta",
       "description": "Overlapping stack of Avatars with a +N overflow bubble.",
       "dense": "role=group overlapping Avatar stack; max collapses the rest into a +N bubble with sr-only 'N more'; sm/md/lg bubble sizes",
       "keywords": [
@@ -1138,7 +1138,7 @@
         {
           "story": "Default",
           "description": "Six members, max 4: the stack shows four and collapses the rest into +2.",
-          "source": "export const Default: Story = {\n  tags: [\"example\"],\n  parameters: {\n    docs: {\n      description: { story: \"Six members, max 4: the stack shows four and collapses the rest into +2.\" },\n    },\n  },\n};"
+          "source": "export const Default: Story = {\n  tags: [\"beta-matrix\", \"example\"],\n  parameters: {\n    docs: {\n      description: { story: \"Six members, max 4: the stack shows four and collapses the rest into +2.\" },\n    },\n  },\n};"
         },
         {
           "story": "NoOverflow",


### PR DESCRIPTION
Promotes **AvatarGroup** alpha→beta, unblocking it with a real Figma DS component.

## Figma
Built the `AvatarGroup` COMPONENT_SET in DT-Site-stuff → Molecules (node `1010-147`): three `Size` variants (sm/md/lg) of overlapped `Avatar` instances ringed with `color/surface`, plus a token-bound `+N` overflow bubble (`color/neutral/bg` + `color/neutral/text`, `CanvasText` border under forced-colors). Wired the node-id into `contract.figma`.

## Promotion + real defect fixed
- Flipped status alpha→beta; tagged the four lifecycle stories `beta-matrix`.
- **Real contract defect surfaced by the beta gate:** `slots` listed `["children"]`, but the strict-lifecycle validator treats `children` as the default composition, not a named slot → corrected to `[]`.
- Added `propSourced: true` to the class-map `size` axis (`styles[size]`, no root CVA — Divider/StatusDot convention).

## Verification (independent, not flag-trust)
- axe clean 7/7 stories (real-browser test-storybook)
- controls 100% operable / 0 inert (`audit:controls --effects`)
- AT snapshots bootstrapped 4-mode (plain/light/dark/forced-colors, 19 files), compare-mode deterministic
- light / dark / forced-colors eyeballed in Storybook
- validate:components · check:contract-props · check:contract-drift · check:consumers · full vitest (1991) · typecheck · lint · lint:css · build · check:generated — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Avatar Group is now marked as beta, with updated preview and accessibility coverage across light, dark, forced-colors, and playground variants.
  * Improved content examples to better show grouped avatars and overflow behavior.

* **Bug Fixes**
  * Refreshed accessibility snapshots to match the latest rendered output, including updated group labels and member counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->