### PR TITLE
feat(design-system): promote ButtonGroup alpha→beta with Figma component

### DIFF
--- a/nextjs-app/shared/components/ButtonGroup/ButtonGroup.contract.json
+++ b/nextjs-app/shared/components/ButtonGroup/ButtonGroup.contract.json
@@ -3,15 +3,13 @@
     "name": "ButtonGroup",
     "tier": "molecule",
     "group": "actions",
-    "status": "alpha",
+    "status": "beta",
     "description": "Groups related Buttons into one attached (segmented) or spaced row.",
-    "figma": null,
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1012-176",
     "radixPrimitive": null,
     "element": "div",
     "variants": {},
-    "slots": [
-        "children"
-    ],
+    "slots": [],
     "asChild": false,
     "subParts": [],
     "requiredStories": [

--- a/nextjs-app/shared/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/nextjs-app/shared/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -26,7 +26,7 @@ const segments = (count: number) =>
 const meta = {
   title: "Actions/ButtonGroup",
   component: ButtonGroup,
-  tags: ["alpha", "autodocs"],
+  tags: ["beta", "autodocs"],
   parameters: {
     layout: "centered",
     a11y: { test: "error" },
@@ -54,7 +54,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  tags: ["example"],
+  tags: ["beta-matrix", "example"],
   parameters: {
     docs: {
       description: { story: "Attached segments share seams; use one variant and size across the group." },
@@ -62,7 +62,7 @@ export const Default: Story = {
   },
 };
 
-export const Playground: Story = {};
+export const Playground: Story = { tags: ["beta-matrix"] };
 
 export const Spaced: Story = {
   tags: ["example"],
@@ -139,6 +139,7 @@ export const Pager: Story = {
 };
 
 export const Example: Story = {
+  tags: ["beta-matrix"],
   parameters: { controls: { disable: true } },
   render: () => (
     <ButtonGroup ariaLabel="View">
@@ -149,6 +150,7 @@ export const Example: Story = {
 };
 
 export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
   parameters: { a11y: { disable: true, test: "off" } },
   render: () => (

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--default.dark.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--default.dark.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- group "Text alignment":
+  - button "Day"
+  - button "Week"
+  - button "Month"

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--default.forced-colors.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- group "Text alignment":
+  - button "Day"
+  - button "Week"
+  - button "Month"

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--default.light.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--default.light.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- group "Text alignment":
+  - button "Day"
+  - button "Week"
+  - button "Month"

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--default.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--default.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- group "Text alignment":
+  - button "Day"
+  - button "Week"
+  - button "Month"

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--example.dark.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--example.dark.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- group "View":
+  - button "List"
+  - button "Grid"

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--example.forced-colors.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- group "View":
+  - button "List"
+  - button "Grid"

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--example.light.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--example.light.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- group "View":
+  - button "List"
+  - button "Grid"

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--example.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--example.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- group "View":
+  - button "List"
+  - button "Grid"

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--forced-colors.dark.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- group "View":
+  - button "List"
+  - button "Grid"

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--forced-colors.forced-colors.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- group "View":
+  - button "List"
+  - button "Grid"

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--forced-colors.light.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- group "View":
+  - button "List"
+  - button "Grid"

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--forced-colors.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--forced-colors.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- group "View":
+  - button "List"
+  - button "Grid"

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--pager.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--pager.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (beta)
+- group "Pagination":
+  - button "Previous page":
+    - img
+  - button "Next page":
+    - img

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--playground.dark.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--playground.dark.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- group "Text alignment":
+  - button "Day"
+  - button "Week"
+  - button "Month"

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--playground.forced-colors.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- group "Text alignment":
+  - button "Day"
+  - button "Week"
+  - button "Month"

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--playground.light.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--playground.light.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- group "Text alignment":
+  - button "Day"
+  - button "Week"
+  - button "Month"

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--playground.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--playground.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- group "Text alignment":
+  - button "Day"
+  - button "Week"
+  - button "Month"

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--spaced.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--spaced.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- group "Form actions":
+  - button "Save"
+  - button "Cancel"

--- a/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--with-icon-buttons.yaml
+++ b/nextjs-app/shared/components/ButtonGroup/__a11y-snapshots__/actions-buttongroup--with-icon-buttons.yaml
@@ -1,0 +1,8 @@
+- status: Work in progress (beta)
+- group "Text formatting":
+  - button "Bold":
+    - img
+  - button "Italic":
+    - img
+  - button "Underline":
+    - img

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -2238,7 +2238,7 @@
       "name": "ButtonGroup",
       "group": "actions",
       "tier": 2,
-      "status": "alpha",
+      "status": "beta",
       "description": "Groups related Buttons into one attached (segmented) or spaced row.",
       "dense": "role=group row of Buttons/IconButtons; attached mode fuses seams (segmented look), attached=false spaces on the token gap",
       "keywords": [
@@ -2340,7 +2340,7 @@
         {
           "story": "Default",
           "description": "Attached segments share seams; use one variant and size across the group.",
-          "source": "export const Default: Story = {\n  tags: [\"example\"],\n  parameters: {\n    docs: {\n      description: { story: \"Attached segments share seams; use one variant and size across the group.\" },\n    },\n  },\n};"
+          "source": "export const Default: Story = {\n  tags: [\"beta-matrix\", \"example\"],\n  parameters: {\n    docs: {\n      description: { story: \"Attached segments share seams; use one variant and size across the group.\" },\n    },\n  },\n};"
         },
         {
           "story": "Spaced",


### PR DESCRIPTION
Promotes **ButtonGroup** alpha→beta with a real Figma DS component.

## Figma
Built the `ButtonGroup` COMPONENT_SET in DT-Site-stuff → Molecules (node `1012-176`): `Attached=True/False` variants of secondary `Button` instances. Attached collapses inner segment radii into shared seams (segmented control); spaced keeps group semantics on the token gap. Wired the node-id into `contract.figma`.

## Promotion + real defect fixed
- Flipped status alpha→beta; tagged the four lifecycle stories `beta-matrix`.
- **Real contract defect:** `slots` listed `["children"]` (children is the default composition, not a named slot) → corrected to `[]`. No variant axes, so no `propSourced`.

## Verification
- axe clean 7/7, controls 100% / 0 inert, AT snapshots 4-mode (19 files) compare-deterministic
- dark + forced-colors segment seams eyeballed in Storybook
- validate:components · check:contract-props · check:contract-drift · check:consumers · full vitest (1991) · typecheck · lint · lint:css · build · check:generated — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)