### PR TITLE
feat(design-system): promote EmptyState alpha→beta with Figma component

### DIFF
--- a/nextjs-app/shared/components/EmptyState/EmptyState.contract.json
+++ b/nextjs-app/shared/components/EmptyState/EmptyState.contract.json
@@ -3,9 +3,9 @@
     "name": "EmptyState",
     "tier": "molecule",
     "group": "display",
-    "status": "alpha",
+    "status": "beta",
     "description": "Placeholder block for empty lists, zero search results, and first-run screens.",
-    "figma": null,
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1014-192",
     "radixPrimitive": null,
     "element": "div",
     "variants": {
@@ -15,12 +15,11 @@
                 "md",
                 "lg"
             ],
-            "default": "md"
+            "default": "md",
+            "propSourced": true
         }
     },
-    "slots": [
-        "children"
-    ],
+    "slots": [],
     "asChild": false,
     "subParts": [],
     "requiredStories": [

--- a/nextjs-app/shared/components/EmptyState/EmptyState.stories.tsx
+++ b/nextjs-app/shared/components/EmptyState/EmptyState.stories.tsx
@@ -7,7 +7,7 @@ import contract from "./EmptyState.contract.json";
 const meta = {
   title: "Content/EmptyState",
   component: EmptyState,
-  tags: ["alpha", "autodocs"],
+  tags: ["beta", "autodocs"],
   parameters: {
     layout: "padded",
     a11y: { test: "error" },
@@ -69,7 +69,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  tags: ["example"],
+  tags: ["beta-matrix", "example"],
   parameters: {
     docs: {
       description: { story: "Search empty state: icon, headline, and a way forward in the description." },
@@ -77,7 +77,7 @@ export const Default: Story = {
   },
 };
 
-export const Playground: Story = {};
+export const Playground: Story = { tags: ["beta-matrix"] };
 
 export const WithAction: Story = {
   tags: ["example"],
@@ -149,6 +149,7 @@ export const ClearedFilters: Story = {
 };
 
 export const Example: Story = {
+  tags: ["beta-matrix"],
   parameters: { controls: { disable: true } },
   render: () => (
     <EmptyState
@@ -160,6 +161,7 @@ export const Example: Story = {
 };
 
 export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
   parameters: { a11y: { disable: true, test: "off" } },
 };

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--cleared-filters.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--cleared-filters.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- heading "No matches" [level=3]
+- paragraph: Nothing matches the current filters.
+- button "Clear filters"

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--default.dark.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--default.dark.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "No results found" [level=2]
+- paragraph: Try a different search term, or clear the filters to see everything.

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--default.forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "No results found" [level=2]
+- paragraph: Try a different search term, or clear the filters to see everything.

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--default.light.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--default.light.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "No results found" [level=2]
+- paragraph: Try a different search term, or clear the filters to see everything.

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--default.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--default.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "No results found" [level=2]
+- paragraph: Try a different search term, or clear the filters to see everything.

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--example.dark.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--example.dark.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "No results found" [level=2]
+- paragraph: Try a different search term.

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--example.forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "No results found" [level=2]
+- paragraph: Try a different search term.

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--example.light.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--example.light.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "No results found" [level=2]
+- paragraph: Try a different search term.

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--example.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--example.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "No results found" [level=2]
+- paragraph: Try a different search term.

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--forced-colors.dark.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "No results found" [level=2]
+- paragraph: Try a different search term, or clear the filters to see everything.

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--forced-colors.forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "No results found" [level=2]
+- paragraph: Try a different search term, or clear the filters to see everything.

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--forced-colors.light.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "No results found" [level=2]
+- paragraph: Try a different search term, or clear the filters to see everything.

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--forced-colors.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "No results found" [level=2]
+- paragraph: Try a different search term, or clear the filters to see everything.

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--playground.dark.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--playground.dark.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "No results found" [level=2]
+- paragraph: Try a different search term, or clear the filters to see everything.

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--playground.forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "No results found" [level=2]
+- paragraph: Try a different search term, or clear the filters to see everything.

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--playground.light.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--playground.light.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "No results found" [level=2]
+- paragraph: Try a different search term, or clear the filters to see everything.

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--playground.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--playground.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "No results found" [level=2]
+- paragraph: Try a different search term, or clear the filters to see everything.

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--sizes.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--sizes.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- heading "Nothing here" [level=3]
+- heading "Nothing here" [level=3]
+- paragraph: Items you add will appear in this list.

--- a/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--with-action.yaml
+++ b/nextjs-app/shared/components/EmptyState/__a11y-snapshots__/content-emptystate--with-action.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- heading "No projects yet" [level=2]
+- paragraph: Projects you create will show up here.
+- button "New project"
+- button "Import"

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -5109,7 +5109,7 @@
       "name": "EmptyState",
       "group": "display",
       "tier": 2,
-      "status": "alpha",
+      "status": "beta",
       "description": "Placeholder block for empty lists, zero search results, and first-run screens.",
       "dense": "centered icon + heading + description + action slot for empty lists/search/first-run; sm/md/lg step padding and type together",
       "keywords": [
@@ -5268,7 +5268,7 @@
         {
           "story": "Default",
           "description": "Search empty state: icon, headline, and a way forward in the description.",
-          "source": "export const Default: Story = {\n  tags: [\"example\"],\n  parameters: {\n    docs: {\n      description: { story: \"Search empty state: icon, headline, and a way forward in the description.\" },\n    },\n  },\n};"
+          "source": "export const Default: Story = {\n  tags: [\"beta-matrix\", \"example\"],\n  parameters: {\n    docs: {\n      description: { story: \"Search empty state: icon, headline, and a way forward in the description.\" },\n    },\n  },\n};"
         },
         {
           "story": "WithAction",


### PR DESCRIPTION
Promotes **EmptyState** alpha→beta with a real Figma DS component.

## Figma
Built the `EmptyState` COMPONENT_SET in DT-Site-stuff → Molecules (node `1014-192`): three `Size` variants (sm/md/lg) composing a muted icon, a `Title` instance, a muted `Text` instance, and a primary `Button` instance — padding/gap/icon/text step together per size. Wired the node-id into `contract.figma`.

## Promotion + real defect fixed
- Flipped status alpha→beta; tagged the four lifecycle stories `beta-matrix`.
- **Real contract defect:** `slots` listed `["children"]` (default composition, not a named slot) → corrected to `[]`.
- Added `propSourced: true` to the class-map `size` axis.

## Verification
- axe clean 7/7, controls 100% / 0 inert, AT snapshots 4-mode (19 files) compare-deterministic
- dark + forced-colors eyeballed in Storybook
- validate:components · check:contract-props · check:contract-drift · check:consumers · full vitest (1991) · typecheck · lint · lint:css · build · check:generated — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)