### PR TITLE
fix(design-system): stop the Docs-badge vs sidebar-dot status conflict

### DIFF
--- a/nextjs-app/shared/patterns/SiteFooter/SiteFooter.stories.tsx
+++ b/nextjs-app/shared/patterns/SiteFooter/SiteFooter.stories.tsx
@@ -5,7 +5,7 @@ import { SiteFooter } from "./SiteFooter";
 const meta: Meta<typeof SiteFooter> = {
   title: "Patterns/SiteFooter",
   component: SiteFooter,
-  tags: ["beta", "!autodocs"],
+  tags: ["stable", "!autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/patterns/SiteHeader/SiteHeader.stories.tsx
+++ b/nextjs-app/shared/patterns/SiteHeader/SiteHeader.stories.tsx
@@ -5,7 +5,7 @@ import { SiteHeader } from "./SiteHeader";
 const meta: Meta<typeof SiteHeader> = {
   title: "Patterns/SiteHeader",
   component: SiteHeader,
-  tags: ["beta", "!autodocs"],
+  tags: ["stable", "!autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/scripts/design-system/validate-components.ts
+++ b/scripts/design-system/validate-components.ts
@@ -823,6 +823,37 @@ export function validateComponentsDir(root: string): ValidationResult {
             }
         }
 
+        // Status source-of-truth consistency: the Docs-page StatusPill
+        // (.storybook/blocks/DocHeader) reads `contract.status`, while the
+        // sidebar lifecycle dot (.storybook/manager.ts renderLabel) reads the
+        // story meta `tags` status. These are two independent copies of the
+        // same fact; when they drift the docs badge and the sidebar dot show
+        // different lifecycles for the same component (e.g. Docs "Beta" but an
+        // alpha dot). Enforce that the meta status tag, when present, equals
+        // contract.status so a promotion must update both.
+        {
+            const storiesPath = join(dir, `${name}.stories.tsx`)
+            if (existsSync(storiesPath)) {
+                const storiesText = readFileSync(storiesPath, 'utf-8')
+                const metaCut = storiesText.indexOf('export default meta')
+                const metaRegion = metaCut > 0 ? storiesText.slice(0, metaCut) : storiesText
+                const tagsMatch = metaRegion.match(/tags:\s*\[([^\]]*)\]/)
+                if (tagsMatch) {
+                    const metaTags = tagsMatch[1]
+                        .split(',')
+                        .map(entry => entry.trim().replace(/["'!]/g, ''))
+                    const metaStatus = (['stable', 'beta', 'alpha', 'deprecated'] as const).find(
+                        candidate => metaTags.includes(candidate),
+                    )
+                    if (metaStatus && metaStatus !== manifest.status) {
+                        errors.push(
+                            `${name}.stories.tsx: meta tags status "${metaStatus}" disagrees with ${name}.contract.json status "${manifest.status}". The sidebar lifecycle dot reads the meta tag and the Docs StatusPill reads contract.status, so they would show different lifecycles for the same component. Update the meta tags status to "${manifest.status}".`,
+                        )
+                    }
+                }
+            }
+        }
+
         const strictLifecycle = manifest.status === 'beta' || manifest.status === 'stable'
 
         // AST checks via ts-morph


### PR DESCRIPTION
Fixes the conflict between a component's **Docs-page status badge** and its **left-menu status dot**.

## Root cause
Status has two independent sources of truth, read by two surfaces:
- **Docs badge** (`StatusPill`, `.storybook/blocks/DocHeader.tsx`) → reads `contract.status`
- **Sidebar dot** (`renderLabel`, `.storybook/manager.ts`) → reads the story meta `tags` status

Nothing kept them in sync or validated they agreed, so they could drift.

Two things were happening:
1. **Committed drift (real):** `SiteHeader` and `SiteFooter` had `contract.status: stable` but meta `tags: ["beta", …]` → docs showed **Stable**, sidebar showed a **beta** dot.
2. **Transient "most stories" drift:** flipping meta `tags` alpha→beta while the dev server runs hot-reloads the **preview** (docs badge updates) but **not** the manager sidebar index, so the dots lag until a restart. A fresh build is consistent — verified only the 2 above are genuinely drifted in committed code.

## Fix
- **New `validate:components` gate:** when a story meta carries a status tag, it must equal `contract.status`. Runs for every component; a promotion must now update both. Caught exactly the 2 real drifts, zero false positives across 157 components.
- **Corrected** `SiteHeader` / `SiteFooter` meta tags `beta` → `stable`.

## Verification
- Gate fails on the 2 drifts pre-fix, passes post-fix
- Live manager: SiteHeader/SiteFooter sidebar dots now render `stable`, matching the docs badge
- AT snapshots unchanged (the WIP badge reads `contract.status`, not the meta tag) — SiteHeader/SiteFooter compare 4/4 each
- typecheck · lint · lint:css · check:generated · validator unit tests — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
