### PR TITLE
fix(design-system): restore the Docs-page masthead on List (+ CodeSnippet, ImagePlaceholder)

### DIFF
--- a/nextjs-app/shared/components/CodeSnippet/CodeSnippet.stories.tsx
+++ b/nextjs-app/shared/components/CodeSnippet/CodeSnippet.stories.tsx
@@ -2,15 +2,6 @@ import contract from "./CodeSnippet.contract.json";
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { userEvent, within } from "storybook/test";
-import {
-  Controls,
-  Description,
-  Heading,
-  Primary,
-  Stories,
-  Subtitle,
-  Title,
-} from "@storybook/addon-docs/blocks";
 import CodeSnippet from "@dt/CodeSnippet";
 import Text from "@dt/Text";
 import schema from "./schema.json";
@@ -72,27 +63,6 @@ const meta: Meta<typeof CodeSnippet> = {
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },
-    docs: {
-      page: () => (
-        <>
-          <Primary />
-          <Title />
-          <Subtitle />
-          <Description />
-          <Controls />
-          <Stories />
-          <Heading>LLM Schema</Heading>
-          <CodeSnippet
-            code={JSON.stringify(schema, null, 2)}
-            language="json"
-            variant="multi"
-            maxLines={20}
-            showLineNumbers={true}
-            allowCopy={true}
-          />
-        </>
-      ),
-    },
   },
   args: {
     code: sampleTs,

--- a/nextjs-app/shared/components/ImagePlaceholder/ImagePlaceholder.stories.tsx
+++ b/nextjs-app/shared/components/ImagePlaceholder/ImagePlaceholder.stories.tsx
@@ -1,17 +1,7 @@
 import contract from "./ImagePlaceholder.contract.json";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import React from "react";
-import {
-  Controls,
-  Description,
-  Heading,
-  Primary,
-  Stories,
-  Subtitle,
-  Title,
-} from "@storybook/addon-docs/blocks";
 import ImagePlaceholder, { ImagePlaceholderPresets } from "./ImagePlaceholder";
-import CodeSnippet from "@dt/CodeSnippet";
 import schema from "./schema.json";
 
 const meta: Meta<typeof ImagePlaceholder> = {
@@ -27,27 +17,6 @@ const meta: Meta<typeof ImagePlaceholder> = {
     a11y: { test: "error" },
     layout: "centered",
     llm: { schema },
-    docs: {
-      page: () => (
-        <>
-          <Primary />
-          <Title />
-          <Subtitle />
-          <Description />
-          <Controls />
-          <Stories />
-          <Heading>LLM Schema</Heading>
-          <CodeSnippet
-            code={JSON.stringify(schema, null, 2)}
-            language="json"
-            variant="multi"
-            maxLines={20}
-            showLineNumbers={true}
-            allowCopy={true}
-          />
-        </>
-      ),
-    },
   },
   // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts).
 };

--- a/nextjs-app/shared/components/List/List.stories.tsx
+++ b/nextjs-app/shared/components/List/List.stories.tsx
@@ -2,20 +2,10 @@ import contract from "./List.contract.json";
 import React from "react";
 import type { Meta, StoryFn } from "@storybook/react-vite";
 import { expect, within } from "storybook/test";
-import {
-  Controls,
-  Description,
-  Heading,
-  Primary,
-  Stories,
-  Subtitle,
-  Title,
-} from "@storybook/addon-docs/blocks";
 import List from "@dt/List";
 import Icon from "@dt/Icon";
 import ComplianceCard from "@dt/ComplianceCard";
 import { useTranslation } from "react-i18next";
-import CodeSnippet from "@dt/CodeSnippet";
 import schema from "./schema.json";
 
 
@@ -31,27 +21,6 @@ const meta: Meta<typeof List> = {
     contractStatus: contract.status,
     a11y: { test: "error" },
     llm: { schema },
-    docs: {
-      page: () => (
-        <>
-          <Primary />
-          <Title />
-          <Subtitle />
-          <Description />
-          <Controls />
-          <Stories />
-          <Heading>LLM Schema</Heading>
-          <CodeSnippet
-            code={JSON.stringify(schema, null, 2)}
-            language="json"
-            variant="multi"
-            maxLines={20}
-            showLineNumbers={true}
-            allowCopy={true}
-          />
-        </>
-      ),
-    },
   },
   argTypes: {
     items: {

--- a/scripts/design-system/validate-components.ts
+++ b/scripts/design-system/validate-components.ts
@@ -851,6 +851,20 @@ export function validateComponentsDir(root: string): ValidationResult {
                         )
                     }
                 }
+
+                // Docs-frame consistency: the global autodocs page is the DT
+                // frame (.storybook/preview.tsx -> DtDocsPage), which renders
+                // the DocHeader masthead (group, name + StatusPill, description,
+                // Figma link) plus the contract-driven Usage/Anatomy/Props/etc.
+                // A contract-backed component that overrides `parameters.docs.page`
+                // in its meta shadows that frame with a bespoke page, dropping the
+                // masthead and every authored contract doc section. Forbid it so
+                // every contract component keeps the same docs shell.
+                if (/docs:\s*\{[\s\S]*?\bpage:/.test(metaRegion)) {
+                    errors.push(
+                        `${name}.stories.tsx: meta overrides parameters.docs.page, which shadows the DtDocsPage autodocs frame and drops the DocHeader masthead + contract doc sections for a contract-backed component. Remove the docs.page override so ${name} uses the shared frame (see .storybook/preview.tsx / DtDocsPage).`,
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
fix(design-system): restore the Docs-page masthead on List (+ CodeSnippet, ImagePlaceholder)

List's Docs page was missing the entire top part: no group, no name +
StatusPill, no contract description, no "View in Figma" link, and none of its
authored Usage/Anatomy/Best-practices sections.

Root cause: the global autodocs page is the DT frame (preview.tsx -> DtDocsPage),
which renders the DocHeader masthead plus the contract-driven sections. List's
meta overrode parameters.docs.page with a bespoke classic-blocks page
(<Primary/><Title/><Subtitle/><Description/>...), which shadows that frame for a
contract-backed component. CodeSnippet had the identical override (also autodocs,
also missing its masthead); ImagePlaceholder had the same override as dead code
(it is !autodocs, so no docs page rendered it at all).

- Removed the docs.page override from List and CodeSnippet so they use the shared
  DtDocsPage frame — masthead and all contract doc sections now render (verified
  in Storybook). Removed the now-dead override from ImagePlaceholder.
- Kept the standard `llm: { schema }` param and schema.json (used across many
  components), dropped the now-unused @storybook/addon-docs/blocks imports.
- Added a validate:components gate: a contract-backed component may not override
  parameters.docs.page (it shadows the frame and drops the masthead). Catches any
  reintroduction; zero false positives across the catalog.

Story rendering is unchanged (only the docs page), so AT snapshots are
unaffected. typecheck, lint, full vitest (1991), build, check:generated green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized component story pages to use the shared documentation layout.
  * Removed custom per-component documentation sections that duplicated schema details.

* **Bug Fixes**
  * Prevented story pages from overriding the common docs experience, improving consistency across components.

* **Chores**
  * Added validation to catch unsupported custom documentation overrides in the future.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->