### PR TITLE
feat(design-system): promote WorkNav alpha→beta with Figma component

### DIFF
--- a/nextjs-app/shared/components/WorkNav/WorkNav.contract.json
+++ b/nextjs-app/shared/components/WorkNav/WorkNav.contract.json
@@ -3,41 +3,56 @@
     "name": "WorkNav",
     "tier": "molecule",
     "group": "navigation",
-    "status": "alpha",
-    "description": "Work section sub-navigation.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-work-nav",
+    "status": "beta",
+    "description": "Work section sub-navigation: a back-to-index action plus previous/next controls for stepping through the portfolio case studies.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1027-2672",
     "radixPrimitive": null,
-    "element": "div",
+    "element": "nav",
+    "props": {
+        "currentPath": {
+            "optional": true,
+            "type": "string"
+        }
+    },
     "variants": {},
     "slots": [],
     "asChild": false,
     "subParts": [],
     "requiredStories": [
-        "Default"
+        "Default",
+        "Example",
+        "ForcedColors"
     ],
     "a11y": {
         "keyboard": [],
-        "ariaRequirements": [],
+        "ariaRequirements": [
+            "Wrapped in a nav landmark labelled via aria-label (workNavLabel)"
+        ],
         "reducedMotion": true,
-        "reviewed": false,
-        "forcedColorsVerified": false
+        "reviewed": true,
+        "reviewedNote": "2026-07-06 alpha->beta: axe clean via test-storybook a11y test:error across base + light + dark + forced-colors on all 6 stories; 4-mode AT snapshots captured and compare-clean (15 yamls). Rendered in a nav landmark labelled via workNavLabel (en/fi/sv). Composes verified beta Button/Icon primitives; no own animation so reduced-motion is N/A.",
+        "forcedColorsVerified": true
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
-    "lightDarkVerified": false,
+    "lightDarkVerified": true,
     "schemaVersion": 2,
-    "composesWith": [],
+    "composesWith": [
+        "Button",
+        "Icon"
+    ],
     "displayName": "WorkNav",
     "keywords": [
         "work",
         "navigation",
         "sub nav",
-        "portfolio"
+        "portfolio",
+        "prev next"
     ],
-    "dense": "Work-section sub-navigation (filters/sections) for portfolio pages",
+    "dense": "Work-section sub-navigation: back-to-index plus prev/next stepping for portfolio case-study pages",
     "usage": {
-        "description": "Sub-navigation for the work section. Portfolio chrome; site-wide nav lives in SiteHeader."
+        "description": "Sub-navigation for the work section. Renders a back-to-work action and previous/next controls that step through the case-study sequence, disabling the edges. Portfolio chrome; site-wide nav lives in SiteHeader."
     }
 }

--- a/nextjs-app/shared/components/WorkNav/WorkNav.spec.md
+++ b/nextjs-app/shared/components/WorkNav/WorkNav.spec.md
@@ -1,19 +1,19 @@
 # WorkNav
 
 ## Intent
-Work section sub-navigation.
+Work section sub-navigation: a back-to-index action plus previous/next controls for stepping through the portfolio case studies.
 
 ## Interaction contract
-- Keyboard: inherit from composed @dt/* primitives
-- Pointer: standard link/button targets where interactive
-- Screen readers: use landmarks and labels from child components
+- Keyboard: inherit from composed @dt/Button primitives (native button focus/activation)
+- Pointer: standard button targets; disabled at the sequence edges
+- Screen readers: rendered inside a `nav` landmark labelled via `aria-label` (workNavLabel)
 
 ## Do / don't
 - Do: compose from cataloged @dt/* atoms and molecules for new UI in this surface
-- Do: treat this as a page assembly reference when matching production routes
+- Do: pass `currentPath` in stories/tests to drive the prev/next disabled state
 - Don't: invent parallel primitives inside this folder
-- Don't: promote to stable without production consumer evidence
+- Don't: use this for site-wide navigation (that is SiteHeader)
 
 ## Design notes
-- Tokens: inherit from child components
-- Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-work-nav
+- Tokens: inherit from child components (Button, Icon)
+- Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1027-2672

--- a/nextjs-app/shared/components/WorkNav/WorkNav.stories.tsx
+++ b/nextjs-app/shared/components/WorkNav/WorkNav.stories.tsx
@@ -1,0 +1,76 @@
+import contract from "./WorkNav.contract.json";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { within, expect } from "storybook/test";
+import WorkNav from "@dt/WorkNav";
+
+const meta: Meta<typeof WorkNav> = {
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts).
+  // `currentPath` is a plain text control seeded from a real work route so the
+  // prev/next disabled state is operable from the panel.
+  title: "Site/WorkNav",
+  component: WorkNav,
+  tags: ["beta", "!autodocs"],
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-work-nav",
+    },
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+    layout: "padded",
+  },
+  argTypes: {
+    currentPath: {
+      control: "text",
+      description:
+        "Active route used to compute the prev/next disabled state. Defaults to the router pathname; seeded here to a real work route.",
+      table: { category: "Behavior", defaultValue: { summary: "usePathname()" } },
+    },
+  },
+  args: {
+    currentPath: "/work/new-things-co",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof WorkNav>;
+
+/** Mid-sequence page: both Prev and Next are enabled. */
+export const Default: Story = {
+  tags: ["beta-matrix"],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const nav = canvas.getByRole("navigation", {
+      name: "Work project navigation",
+    });
+    expect(nav).toBeInTheDocument();
+    // Mid sequence: neither edge button is disabled.
+    expect(canvas.getByRole("button", { name: /prev/i })).toBeEnabled();
+    expect(canvas.getByRole("button", { name: /next/i })).toBeEnabled();
+  },
+};
+
+/** First work page: Prev is disabled. */
+export const FirstPage: Story = {
+  args: { currentPath: "/work/helsinki-design-system" },
+};
+
+/** Last work page: Next is disabled. */
+export const LastPage: Story = {
+  args: { currentPath: "/work/garage-junction" },
+};
+
+export const Playground: Story = Default;
+
+export const Example: Story = {
+  tags: ["beta-matrix"],
+  parameters: { controls: { disable: true } },
+  ...Default,
+};
+
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "active" },
+  ...Default,
+};

--- a/nextjs-app/shared/components/WorkNav/WorkNav.test.tsx
+++ b/nextjs-app/shared/components/WorkNav/WorkNav.test.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { vi } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
 import WorkNav from "@dt/WorkNav";
+
+expect.extend(toHaveNoViolations);
 
 const { mockPush, mockUsePathname } = vi.hoisted(() => ({
   mockPush: vi.fn(),
@@ -20,6 +23,7 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string) => {
       const translations: Record<string, string> = {
+        workNavLabel: "Work project navigation",
         workNavBackToWork: "Work",
         workNavPrev: "Prev",
         workNavNext: "Next",
@@ -141,5 +145,29 @@ describe("WorkNav", () => {
     // When currentIndex is -1 (not found), prev should be disabled, next should be enabled
     expect(prevButton).toBeDisabled();
     expect(nextButton).not.toBeDisabled();
+  });
+
+  it("exposes a labelled navigation landmark", () => {
+    renderWorkNav();
+
+    expect(
+      screen.getByRole("navigation", { name: "Work project navigation" }),
+    ).toBeInTheDocument();
+  });
+
+  it("prefers the currentPath prop over the router pathname", () => {
+    // Router is on the last page, but the prop points at the first page.
+    mockUsePathname.mockReturnValue("/work/garage-junction");
+    render(<WorkNav currentPath="/work/helsinki-design-system" />);
+
+    expect(screen.getByText("Prev").closest("button")).toBeDisabled();
+    expect(screen.getByText("Next").closest("button")).not.toBeDisabled();
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(
+      <WorkNav currentPath="/work/new-things-co" />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
   });
 });

--- a/nextjs-app/shared/components/WorkNav/WorkNav.tsx
+++ b/nextjs-app/shared/components/WorkNav/WorkNav.tsx
@@ -8,58 +8,68 @@ import { useTranslation } from "react-i18next";
 import Icon from "@dt/Icon";
 
 const workPages = [
-  {
-    path: "/work/helsinki-design-system",
-    labelKey: "workNavHelsinkiDesignSystem",
-  },
-  { path: "/work/new-things-co", labelKey: "workNavNewThingsCo" },
-  { path: "/work/illustrations", labelKey: "workNavIllustrations" },
-  { path: "/work/garage-junction", labelKey: "workNavGarageJunction" },
+  { path: "/work/helsinki-design-system" },
+  { path: "/work/new-things-co" },
+  { path: "/work/illustrations" },
+  { path: "/work/garage-junction" },
 ];
 
-const WorkNav: React.FC = () => {
+export interface WorkNavProps {
+  /**
+   * Active route used to compute the prev/next disabled state. Defaults to the
+   * current pathname from the router; stories and tests override it to show a
+   * given position in the work sequence.
+   */
+  currentPath?: string;
+}
+
+/**
+ * Work section sub-navigation: a back-to-index action plus previous/next
+ * controls that step through the portfolio case-study sequence, disabling the
+ * button at each edge. Rendered inside a labelled `nav` landmark.
+ */
+const WorkNav: React.FC<WorkNavProps> = ({ currentPath: currentPathProp }) => {
   const { t } = useTranslation();
-  const currentPath = usePathname() ?? "/";
+  const pathname = usePathname() ?? "/";
+  const currentPath = currentPathProp ?? pathname;
   const currentIndex = workPages.findIndex((p) => p.path === currentPath);
   const router = useRouter();
   return (
-    <>
-      <div className={styles.workNavBar}>
+    <nav className={styles.workNavBar} aria-label={t("workNavLabel")}>
+      <Button
+        variant="tertiary"
+        size="md"
+        icon={<Icon name="briefcase" ariaLabel={t("workNavBackToWork")} />}
+        onClick={() => router.push("/work")}
+      >
+        {t("workNavBackToWork")}
+      </Button>
+      <div className={styles.rightNavGroup}>
         <Button
           variant="tertiary"
           size="md"
-          icon={<Icon name="briefcase" ariaLabel={t("workNavBackToWork")} />}
-          onClick={() => router.push("/work")}
+          icon={<Icon name="arrow-left" ariaLabel={t("workNavPrev")} />}
+          disabled={currentIndex <= 0}
+          onClick={() => {
+            if (currentIndex > 0) router.push(workPages[currentIndex - 1].path);
+          }}
         >
-          {t("workNavBackToWork")}
+          {t("workNavPrev")}
         </Button>
-        <div className={styles.rightNavGroup}>
-          <Button
-            variant="tertiary"
-            size="md"
-            icon={<Icon name="arrow-left" ariaLabel={t("workNavPrev")} />}
-            disabled={currentIndex <= 0}
-            onClick={() => {
-              if (currentIndex > 0) router.push(workPages[currentIndex - 1].path);
-            }}
-          >
-            {t("workNavPrev")}
-          </Button>
-          <Button
-            variant="tertiary"
-            size="md"
-            endIcon={<Icon name="arrow-right" ariaLabel={t("workNavNext")} />}
-            disabled={currentIndex === workPages.length - 1}
-            onClick={() => {
-              if (currentIndex < workPages.length - 1)
-                router.push(workPages[currentIndex + 1].path);
-            }}
-          >
-            {t("workNavNext")}
-          </Button>
-        </div>
+        <Button
+          variant="tertiary"
+          size="md"
+          endIcon={<Icon name="arrow-right" ariaLabel={t("workNavNext")} />}
+          disabled={currentIndex === workPages.length - 1}
+          onClick={() => {
+            if (currentIndex < workPages.length - 1)
+              router.push(workPages[currentIndex + 1].path);
+          }}
+        >
+          {t("workNavNext")}
+        </Button>
       </div>
-    </>
+    </nav>
   );
 };
 

--- a/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--default.dark.yaml
+++ b/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--default.dark.yaml
@@ -1,0 +1,11 @@
+- status: Work in progress (beta)
+- navigation "Work project navigation":
+  - button "Work Work":
+    - img "Work"
+    - text: Work
+  - button "Prev Prev":
+    - img "Prev"
+    - text: Prev
+  - button "Next Next":
+    - text: Next
+    - img "Next"

--- a/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--default.forced-colors.yaml
@@ -1,0 +1,11 @@
+- status: Work in progress (beta)
+- navigation "Work project navigation":
+  - button "Work Work":
+    - img "Work"
+    - text: Work
+  - button "Prev Prev":
+    - img "Prev"
+    - text: Prev
+  - button "Next Next":
+    - text: Next
+    - img "Next"

--- a/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--default.light.yaml
+++ b/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--default.light.yaml
@@ -1,0 +1,11 @@
+- status: Work in progress (beta)
+- navigation "Work project navigation":
+  - button "Work Work":
+    - img "Work"
+    - text: Work
+  - button "Prev Prev":
+    - img "Prev"
+    - text: Prev
+  - button "Next Next":
+    - text: Next
+    - img "Next"

--- a/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--default.yaml
+++ b/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--default.yaml
@@ -1,0 +1,11 @@
+- status: Work in progress (beta)
+- navigation "Work project navigation":
+  - button "Work Work":
+    - img "Work"
+    - text: Work
+  - button "Prev Prev":
+    - img "Prev"
+    - text: Prev
+  - button "Next Next":
+    - text: Next
+    - img "Next"

--- a/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--example.dark.yaml
+++ b/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--example.dark.yaml
@@ -1,0 +1,11 @@
+- status: Work in progress (beta)
+- navigation "Work project navigation":
+  - button "Work Work":
+    - img "Work"
+    - text: Work
+  - button "Prev Prev":
+    - img "Prev"
+    - text: Prev
+  - button "Next Next":
+    - text: Next
+    - img "Next"

--- a/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--example.forced-colors.yaml
@@ -1,0 +1,11 @@
+- status: Work in progress (beta)
+- navigation "Work project navigation":
+  - button "Work Work":
+    - img "Work"
+    - text: Work
+  - button "Prev Prev":
+    - img "Prev"
+    - text: Prev
+  - button "Next Next":
+    - text: Next
+    - img "Next"

--- a/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--example.light.yaml
+++ b/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--example.light.yaml
@@ -1,0 +1,11 @@
+- status: Work in progress (beta)
+- navigation "Work project navigation":
+  - button "Work Work":
+    - img "Work"
+    - text: Work
+  - button "Prev Prev":
+    - img "Prev"
+    - text: Prev
+  - button "Next Next":
+    - text: Next
+    - img "Next"

--- a/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--example.yaml
+++ b/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--example.yaml
@@ -1,0 +1,11 @@
+- status: Work in progress (beta)
+- navigation "Work project navigation":
+  - button "Work Work":
+    - img "Work"
+    - text: Work
+  - button "Prev Prev":
+    - img "Prev"
+    - text: Prev
+  - button "Next Next":
+    - text: Next
+    - img "Next"

--- a/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--first-page.yaml
+++ b/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--first-page.yaml
@@ -1,0 +1,11 @@
+- status: Work in progress (beta)
+- navigation "Work project navigation":
+  - button "Work Work":
+    - img "Work"
+    - text: Work
+  - button "Prev Prev" [disabled]:
+    - img "Prev"
+    - text: Prev
+  - button "Next Next":
+    - text: Next
+    - img "Next"

--- a/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--forced-colors.dark.yaml
@@ -1,0 +1,11 @@
+- status: Work in progress (beta)
+- navigation "Work project navigation":
+  - button "Work Work":
+    - img "Work"
+    - text: Work
+  - button "Prev Prev":
+    - img "Prev"
+    - text: Prev
+  - button "Next Next":
+    - text: Next
+    - img "Next"

--- a/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--forced-colors.forced-colors.yaml
@@ -1,0 +1,11 @@
+- status: Work in progress (beta)
+- navigation "Work project navigation":
+  - button "Work Work":
+    - img "Work"
+    - text: Work
+  - button "Prev Prev":
+    - img "Prev"
+    - text: Prev
+  - button "Next Next":
+    - text: Next
+    - img "Next"

--- a/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--forced-colors.light.yaml
@@ -1,0 +1,11 @@
+- status: Work in progress (beta)
+- navigation "Work project navigation":
+  - button "Work Work":
+    - img "Work"
+    - text: Work
+  - button "Prev Prev":
+    - img "Prev"
+    - text: Prev
+  - button "Next Next":
+    - text: Next
+    - img "Next"

--- a/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--forced-colors.yaml
+++ b/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--forced-colors.yaml
@@ -1,0 +1,11 @@
+- status: Work in progress (beta)
+- navigation "Work project navigation":
+  - button "Work Work":
+    - img "Work"
+    - text: Work
+  - button "Prev Prev":
+    - img "Prev"
+    - text: Prev
+  - button "Next Next":
+    - text: Next
+    - img "Next"

--- a/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--last-page.yaml
+++ b/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--last-page.yaml
@@ -1,0 +1,11 @@
+- status: Work in progress (beta)
+- navigation "Work project navigation":
+  - button "Work Work":
+    - img "Work"
+    - text: Work
+  - button "Prev Prev":
+    - img "Prev"
+    - text: Prev
+  - button "Next Next" [disabled]:
+    - text: Next
+    - img "Next"

--- a/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--playground.yaml
+++ b/nextjs-app/shared/components/WorkNav/__a11y-snapshots__/site-worknav--playground.yaml
@@ -1,0 +1,11 @@
+- status: Work in progress (beta)
+- navigation "Work project navigation":
+  - button "Work Work":
+    - img "Work"
+    - text: Work
+  - button "Prev Prev":
+    - img "Prev"
+    - text: Prev
+  - button "Next Next":
+    - text: Next
+    - img "Next"

--- a/nextjs-app/shared/components/WorkNav/worknav.module.css
+++ b/nextjs-app/shared/components/WorkNav/worknav.module.css
@@ -12,10 +12,3 @@
   display: flex;
   gap: 1rem;
 }
-
-.hrLine {
-  width: 100%;
-  border: none;
-  border-top: 1px solid var(--color-primary);
-  margin-bottom: 2rem;
-}

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -15253,23 +15253,38 @@
       "name": "WorkNav",
       "group": "navigation",
       "tier": 2,
-      "status": "alpha",
-      "description": "Work section sub-navigation.",
-      "dense": "Work-section sub-navigation (filters/sections) for portfolio pages",
+      "status": "beta",
+      "description": "Work section sub-navigation: a back-to-index action plus previous/next controls for stepping through the portfolio case studies.",
+      "dense": "Work-section sub-navigation: back-to-index plus prev/next stepping for portfolio case-study pages",
       "keywords": [
         "work",
         "navigation",
         "sub nav",
-        "portfolio"
+        "portfolio",
+        "prev next"
       ],
       "importLine": "import WorkNav from \"@dt/WorkNav\";",
-      "keyProps": [],
-      "props": {},
-      "composesWith": [],
+      "keyProps": [
+        {
+          "name": "currentPath",
+          "type": "string",
+          "required": false
+        }
+      ],
+      "props": {
+        "currentPath": {
+          "optional": true,
+          "type": "string"
+        }
+      },
+      "composesWith": [
+        "Button",
+        "Icon"
+      ],
       "prefersOver": [],
       "forbiddenUse": [],
       "usage": {
-        "description": "Sub-navigation for the work section. Portfolio chrome; site-wide nav lives in SiteHeader."
+        "description": "Sub-navigation for the work section. Renders a back-to-work action and previous/next controls that step through the case-study sequence, disabling the edges. Portfolio chrome; site-wide nav lives in SiteHeader."
       },
       "tokens": {
         "colors": [],

--- a/nextjs-app/shared/locales/en/translation.json
+++ b/nextjs-app/shared/locales/en/translation.json
@@ -859,6 +859,7 @@
   "templateArticleMetaDescription": "Template description for future articles.",
   "shareHeading": "Share",
   "siteUnderDevelopment": "Site Under Development! 🚧 Stay tuned!",
+  "workNavLabel": "Work project navigation",
   "workNavBackToWork": "Work",
   "workNavPrev": "Prev",
   "workNavNext": "Next",

--- a/nextjs-app/shared/locales/fi/translation.json
+++ b/nextjs-app/shared/locales/fi/translation.json
@@ -859,6 +859,7 @@
   "templateArticleMetaDescription": "Mallikuvaus tuleville artikkeleille.",
   "shareHeading": "Jaa",
   "siteUnderDevelopment": "Sivusto kehitteillä! 🚧 Pysy kuulolla!",
+  "workNavLabel": "Työprojektien navigointi",
   "workNavBackToWork": "Töihin",
   "workNavPrev": "Edellinen",
   "workNavNext": "Seuraava",

--- a/nextjs-app/shared/locales/sv/translation.json
+++ b/nextjs-app/shared/locales/sv/translation.json
@@ -869,6 +869,7 @@
   "templateArticleMetaDescription": "Mallbeskrivning för framtida artiklar.",
   "shareHeading": "Dela",
   "siteUnderDevelopment": "Sidan under utveckling! 🚧 Håll utkik!",
+  "workNavLabel": "Navigering för arbetsprojekt",
   "workNavBackToWork": "Arbete",
   "workNavPrev": "Föregående",
   "workNavNext": "Nästa",


### PR DESCRIPTION
Promotes **WorkNav** alpha→beta as the first of the remaining alpha site composites, with a real Figma component.

## Figma
Built the WorkNav organism in `DT-Site-stuff` (node `1027-2672`, Organisms page), composed from Tertiary/MD `Button` instances with real Phosphor icons (briefcase, arrow-left, arrow-right) — replacing the placeholder `dt-work-nav` node-id.

## Component
- New `Site/WorkNav` Storybook story: Default / FirstPage / LastPage / Example / ForcedColors / Playground, with a play test asserting the nav landmark and mid-sequence button states.
- Added an optional `currentPath` prop (defaults to `usePathname()`) so stories/tests/Controls drive the prev/next disabled state deterministically. All 17 consumers render `<WorkNav />` unchanged.
- Wrapped the bar in a labelled `nav` landmark (`workNavLabel`, en/fi/sv) — an a11y upgrade over the bare `<div>`.
- Removed dead `labelKey` data (never rendered; two of its keys didn't even exist in the locales) and the unused `.hrLine` CSS.

## Verification (local)
- axe clean via test-storybook `a11y.test: error` across base + light + dark + forced-colors on all 6 stories
- 4-mode AT snapshots captured + compare-clean (15 yamls, zero pollution)
- `audit:controls --only WorkNav --effects`: 100% operable, 0 inert
- `validate:components`, `check:contract-props`, `check:consumers` green
- typecheck, lint, `npm test` (1994 passed), `npm run build` — all exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an updated Work navigation experience with clearer prev/next controls and a dedicated navigation landmark.
  * Introduced support for setting the current work page explicitly, improving edge-state behavior for first/last items.
  * Added accessibility coverage and visual snapshots for default, example, forced-colors, and edge-case states.

* **Bug Fixes**
  * Improved keyboard and screen-reader behavior for the Work navigation.
  * Added localized navigation labels in English, Finnish, and Swedish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->