### PR TITLE
feat(design-system): promote ProjectNav alpha→beta with Figma component

### DIFF
--- a/nextjs-app/shared/components/ProjectNav/ProjectNav.contract.json
+++ b/nextjs-app/shared/components/ProjectNav/ProjectNav.contract.json
@@ -3,30 +3,36 @@
     "name": "ProjectNav",
     "tier": "molecule",
     "group": "navigation",
-    "status": "alpha",
-    "description": "Prev/next navigation for case studies.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-project-nav",
+    "status": "beta",
+    "description": "Previous/next navigation between case studies, with a back-to-work action, for the foot of work detail pages.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1028-89",
     "radixPrimitive": null,
-    "element": "div",
+    "element": "nav",
     "variants": {},
     "slots": [],
     "asChild": false,
     "subParts": [],
     "requiredStories": [
-        "Default"
+        "Default",
+        "Example",
+        "ForcedColors"
     ],
     "a11y": {
         "keyboard": [],
-        "ariaRequirements": [],
+        "ariaRequirements": [
+            "Wrapped in a nav landmark labelled via aria-label (projectNavLabel)",
+            "Disabled edge control announced via aria-disabled"
+        ],
         "reducedMotion": true,
-        "reviewed": false,
-        "forcedColorsVerified": false
+        "reviewed": true,
+        "reviewedNote": "2026-07-06 alpha->beta: axe clean via test-storybook a11y test:error across base + light + dark + forced-colors on all stories; 4-mode AT snapshots captured and compare-clean. nav landmark labelled via projectNavLabel; prev/next targets from getProjectNavigation, disabled edges use aria-disabled. Tailwind className styling retained as an intentional per-surface owner call (same as NavLink/Pagination). No own animation.",
+        "forcedColorsVerified": true
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
-    "lightDarkVerified": false,
+    "lightDarkVerified": true,
     "schemaVersion": 2,
     "props": {
         "currentSlug": {
@@ -40,22 +46,21 @@
     },
     "forbiddenUse": [
         "invent parallel primitives inside this folder",
-        "promote to stable without production consumer evidence"
+        "use for site-wide navigation (that is SiteHeader)"
     ],
     "composesWith": [
-        "ProjectGallery",
-        "Container",
-        "Section"
+        "Container"
     ],
     "displayName": "ProjectNav",
     "keywords": [
         "case study",
         "navigation",
         "prev next",
-        "work"
+        "work",
+        "project"
     ],
-    "dense": "Prev/next case-study navigation footer for work detail pages",
+    "dense": "Prev/next case-study navigation with back-to-work action for work detail pages",
     "usage": {
-        "description": "Previous/next navigation between case studies at the foot of work detail pages."
+        "description": "Previous/next navigation between case studies at the foot of work detail pages, plus a back-to-work action. Targets are derived from the project ordering; the control at each sequence edge is disabled."
     }
 }

--- a/nextjs-app/shared/components/ProjectNav/ProjectNav.spec.md
+++ b/nextjs-app/shared/components/ProjectNav/ProjectNav.spec.md
@@ -1,19 +1,19 @@
 # ProjectNav
 
 ## Intent
-Prev/next navigation for case studies.
+Previous/next navigation between case studies, with a back-to-work action, for the foot of work detail pages.
 
 ## Interaction contract
-- Keyboard: inherit from composed @dt/* primitives
-- Pointer: standard link/button targets where interactive
-- Screen readers: use landmarks and labels from child components
+- Keyboard: native link focus/activation on the back, previous and next links
+- Pointer: standard link targets; the control at each sequence edge is a disabled span
+- Screen readers: rendered inside a `nav` landmark labelled via `aria-label` (projectNavLabel); the disabled edge uses `aria-disabled`
 
 ## Do / don't
-- Do: compose from cataloged @dt/* atoms and molecules for new UI in this surface
-- Do: treat this as a page assembly reference when matching production routes
+- Do: pass the current project `currentSlug`; prev/next targets derive from the project ordering
+- Do: keep the Tailwind className styling (intentional per-surface owner call, as with NavLink/Pagination)
 - Don't: invent parallel primitives inside this folder
-- Don't: promote to stable without production consumer evidence
+- Don't: use this for site-wide navigation (that is SiteHeader)
 
 ## Design notes
-- Tokens: inherit from child components
-- Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-project-nav
+- Tokens: Tailwind utility classes mapped to the theme tokens (muted-foreground/foreground/primary)
+- Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1028-89

--- a/nextjs-app/shared/components/ProjectNav/ProjectNav.stories.tsx
+++ b/nextjs-app/shared/components/ProjectNav/ProjectNav.stories.tsx
@@ -1,0 +1,82 @@
+import contract from "./ProjectNav.contract.json";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { within, expect } from "storybook/test";
+import { ProjectNav } from "./ProjectNav";
+
+const meta: Meta<typeof ProjectNav> = {
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts).
+  title: "Site/ProjectNav",
+  component: ProjectNav,
+  tags: ["beta", "!autodocs"],
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-project-nav",
+    },
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+    layout: "fullscreen",
+  },
+  argTypes: {
+    currentSlug: {
+      control: "text",
+      description:
+        "Slug of the project currently being viewed; determines the previous/next targets and which edge is disabled.",
+      table: { category: "Content" },
+    },
+    className: {
+      control: "text",
+      description: "Extra class names merged onto the nav landmark.",
+      table: { category: "Appearance" },
+    },
+  },
+  args: {
+    currentSlug: "project-spine",
+    className: "",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ProjectNav>;
+
+/** Mid-sequence project: both previous and next links are active. */
+export const Default: Story = {
+  tags: ["beta-matrix"],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(
+      canvas.getByRole("navigation", { name: "Project navigation" }),
+    ).toBeInTheDocument();
+    expect(
+      canvas.getByRole("link", { name: /previous project/i }),
+    ).toBeInTheDocument();
+    expect(
+      canvas.getByRole("link", { name: /next project/i }),
+    ).toBeInTheDocument();
+  },
+};
+
+/** First project: the previous control is disabled. */
+export const FirstProject: Story = {
+  args: { currentSlug: "dsharp-design-system" },
+};
+
+/** Last project: the next control is disabled. */
+export const LastProject: Story = {
+  args: { currentSlug: "finnish-transport-agency" },
+};
+
+export const Playground: Story = Default;
+
+export const Example: Story = {
+  tags: ["beta-matrix"],
+  parameters: { controls: { disable: true } },
+  ...Default,
+};
+
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "active" },
+  ...Default,
+};

--- a/nextjs-app/shared/components/ProjectNav/ProjectNav.test.tsx
+++ b/nextjs-app/shared/components/ProjectNav/ProjectNav.test.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { ProjectNav } from "./ProjectNav";
+
+expect.extend(toHaveNoViolations);
+
+// t(key, fallback) → return the fallback so labels are readable.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+describe("ProjectNav", () => {
+  it("renders a labelled navigation landmark with a back-to-work link", () => {
+    render(<ProjectNav currentSlug="project-spine" />);
+
+    expect(
+      screen.getByRole("navigation", { name: "Project navigation" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /back to work/i }),
+    ).toHaveAttribute("href", "/work");
+  });
+
+  it("renders previous and next project links for a mid-sequence project", () => {
+    render(<ProjectNav currentSlug="project-spine" />);
+
+    const prev = screen.getByRole("link", { name: /previous project/i });
+    const next = screen.getByRole("link", { name: /next project/i });
+    expect(prev).toHaveAttribute("href", expect.stringContaining("/work/"));
+    expect(next).toHaveAttribute("href", expect.stringContaining("/work/"));
+  });
+
+  it("disables the previous control on the first project", () => {
+    render(<ProjectNav currentSlug="dsharp-design-system" />);
+
+    expect(
+      screen.queryByRole("link", { name: /previous project/i }),
+    ).not.toBeInTheDocument();
+    // The disabled placeholder is announced as aria-disabled.
+    expect(
+      document.querySelector('[aria-disabled="true"]'),
+    ).toBeInTheDocument();
+  });
+
+  it("disables the next control on the last project", () => {
+    render(<ProjectNav currentSlug="finnish-transport-agency" />);
+
+    expect(
+      screen.queryByRole("link", { name: /next project/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("applies a custom className to the nav", () => {
+    render(<ProjectNav currentSlug="project-spine" className="custom-nav" />);
+
+    expect(screen.getByRole("navigation")).toHaveClass("custom-nav");
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(<ProjectNav currentSlug="project-spine" />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/ProjectNav/ProjectNav.tsx
+++ b/nextjs-app/shared/components/ProjectNav/ProjectNav.tsx
@@ -14,6 +14,12 @@ export interface ProjectNavProps {
   className?: string;
 }
 
+/**
+ * Previous/next navigation between case studies for the foot of work detail
+ * pages, with a back-to-work action. Targets come from the project ordering
+ * via `getProjectNavigation`; the control at each sequence edge is disabled.
+ * Rendered inside a labelled `nav` landmark.
+ */
 export function ProjectNav({ currentSlug, className }: ProjectNavProps) {
   const { t } = useTranslation();
   const { previous, next } = getProjectNavigation(currentSlug);

--- a/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--default.dark.yaml
+++ b/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--default.dark.yaml
@@ -1,0 +1,14 @@
+- status: Work in progress (beta)
+- navigation "Project navigation":
+  - link "Back to work":
+    - /url: /work
+    - img
+    - text: Back to work
+  - 'link "Previous project: DSharp Design System"':
+    - /url: /work/dsharp-design-system
+    - img
+    - text: Prev
+  - 'link "Next project: KnobSmith Audio"':
+    - /url: /work/knobsmith-audio
+    - text: Next
+    - img

--- a/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--default.forced-colors.yaml
@@ -1,0 +1,14 @@
+- status: Work in progress (beta)
+- navigation "Project navigation":
+  - link "Back to work":
+    - /url: /work
+    - img
+    - text: Back to work
+  - 'link "Previous project: DSharp Design System"':
+    - /url: /work/dsharp-design-system
+    - img
+    - text: Prev
+  - 'link "Next project: KnobSmith Audio"':
+    - /url: /work/knobsmith-audio
+    - text: Next
+    - img

--- a/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--default.light.yaml
+++ b/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--default.light.yaml
@@ -1,0 +1,14 @@
+- status: Work in progress (beta)
+- navigation "Project navigation":
+  - link "Back to work":
+    - /url: /work
+    - img
+    - text: Back to work
+  - 'link "Previous project: DSharp Design System"':
+    - /url: /work/dsharp-design-system
+    - img
+    - text: Prev
+  - 'link "Next project: KnobSmith Audio"':
+    - /url: /work/knobsmith-audio
+    - text: Next
+    - img

--- a/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--default.yaml
+++ b/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--default.yaml
@@ -1,0 +1,14 @@
+- status: Work in progress (beta)
+- navigation "Project navigation":
+  - link "Back to work":
+    - /url: /work
+    - img
+    - text: Back to work
+  - 'link "Previous project: DSharp Design System"':
+    - /url: /work/dsharp-design-system
+    - img
+    - text: Prev
+  - 'link "Next project: KnobSmith Audio"':
+    - /url: /work/knobsmith-audio
+    - text: Next
+    - img

--- a/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--example.dark.yaml
+++ b/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--example.dark.yaml
@@ -1,0 +1,14 @@
+- status: Work in progress (beta)
+- navigation "Project navigation":
+  - link "Back to work":
+    - /url: /work
+    - img
+    - text: Back to work
+  - 'link "Previous project: DSharp Design System"':
+    - /url: /work/dsharp-design-system
+    - img
+    - text: Prev
+  - 'link "Next project: KnobSmith Audio"':
+    - /url: /work/knobsmith-audio
+    - text: Next
+    - img

--- a/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--example.forced-colors.yaml
@@ -1,0 +1,14 @@
+- status: Work in progress (beta)
+- navigation "Project navigation":
+  - link "Back to work":
+    - /url: /work
+    - img
+    - text: Back to work
+  - 'link "Previous project: DSharp Design System"':
+    - /url: /work/dsharp-design-system
+    - img
+    - text: Prev
+  - 'link "Next project: KnobSmith Audio"':
+    - /url: /work/knobsmith-audio
+    - text: Next
+    - img

--- a/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--example.light.yaml
+++ b/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--example.light.yaml
@@ -1,0 +1,14 @@
+- status: Work in progress (beta)
+- navigation "Project navigation":
+  - link "Back to work":
+    - /url: /work
+    - img
+    - text: Back to work
+  - 'link "Previous project: DSharp Design System"':
+    - /url: /work/dsharp-design-system
+    - img
+    - text: Prev
+  - 'link "Next project: KnobSmith Audio"':
+    - /url: /work/knobsmith-audio
+    - text: Next
+    - img

--- a/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--example.yaml
+++ b/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--example.yaml
@@ -1,0 +1,14 @@
+- status: Work in progress (beta)
+- navigation "Project navigation":
+  - link "Back to work":
+    - /url: /work
+    - img
+    - text: Back to work
+  - 'link "Previous project: DSharp Design System"':
+    - /url: /work/dsharp-design-system
+    - img
+    - text: Prev
+  - 'link "Next project: KnobSmith Audio"':
+    - /url: /work/knobsmith-audio
+    - text: Next
+    - img

--- a/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--first-project.yaml
+++ b/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--first-project.yaml
@@ -1,0 +1,12 @@
+- status: Work in progress (beta)
+- navigation "Project navigation":
+  - link "Back to work":
+    - /url: /work
+    - img
+    - text: Back to work
+  - img
+  - text: Prev
+  - 'link "Next project: Project Spine"':
+    - /url: /work/project-spine
+    - text: Next
+    - img

--- a/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--forced-colors.dark.yaml
@@ -1,0 +1,14 @@
+- status: Work in progress (beta)
+- navigation "Project navigation":
+  - link "Back to work":
+    - /url: /work
+    - img
+    - text: Back to work
+  - 'link "Previous project: DSharp Design System"':
+    - /url: /work/dsharp-design-system
+    - img
+    - text: Prev
+  - 'link "Next project: KnobSmith Audio"':
+    - /url: /work/knobsmith-audio
+    - text: Next
+    - img

--- a/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--forced-colors.forced-colors.yaml
@@ -1,0 +1,14 @@
+- status: Work in progress (beta)
+- navigation "Project navigation":
+  - link "Back to work":
+    - /url: /work
+    - img
+    - text: Back to work
+  - 'link "Previous project: DSharp Design System"':
+    - /url: /work/dsharp-design-system
+    - img
+    - text: Prev
+  - 'link "Next project: KnobSmith Audio"':
+    - /url: /work/knobsmith-audio
+    - text: Next
+    - img

--- a/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--forced-colors.light.yaml
@@ -1,0 +1,14 @@
+- status: Work in progress (beta)
+- navigation "Project navigation":
+  - link "Back to work":
+    - /url: /work
+    - img
+    - text: Back to work
+  - 'link "Previous project: DSharp Design System"':
+    - /url: /work/dsharp-design-system
+    - img
+    - text: Prev
+  - 'link "Next project: KnobSmith Audio"':
+    - /url: /work/knobsmith-audio
+    - text: Next
+    - img

--- a/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--forced-colors.yaml
+++ b/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--forced-colors.yaml
@@ -1,0 +1,14 @@
+- status: Work in progress (beta)
+- navigation "Project navigation":
+  - link "Back to work":
+    - /url: /work
+    - img
+    - text: Back to work
+  - 'link "Previous project: DSharp Design System"':
+    - /url: /work/dsharp-design-system
+    - img
+    - text: Prev
+  - 'link "Next project: KnobSmith Audio"':
+    - /url: /work/knobsmith-audio
+    - text: Next
+    - img

--- a/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--last-project.yaml
+++ b/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--last-project.yaml
@@ -1,0 +1,12 @@
+- status: Work in progress (beta)
+- navigation "Project navigation":
+  - link "Back to work":
+    - /url: /work
+    - img
+    - text: Back to work
+  - 'link "Previous project: Illustrations"':
+    - /url: /work/illustrations
+    - img
+    - text: Prev
+  - text: Next
+  - img

--- a/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--playground.yaml
+++ b/nextjs-app/shared/components/ProjectNav/__a11y-snapshots__/site-projectnav--playground.yaml
@@ -1,0 +1,14 @@
+- status: Work in progress (beta)
+- navigation "Project navigation":
+  - link "Back to work":
+    - /url: /work
+    - img
+    - text: Back to work
+  - 'link "Previous project: DSharp Design System"':
+    - /url: /work/dsharp-design-system
+    - img
+    - text: Prev
+  - 'link "Next project: KnobSmith Audio"':
+    - /url: /work/knobsmith-audio
+    - text: Next
+    - img

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -10766,14 +10766,15 @@
       "name": "ProjectNav",
       "group": "navigation",
       "tier": 2,
-      "status": "alpha",
-      "description": "Prev/next navigation for case studies.",
-      "dense": "Prev/next case-study navigation footer for work detail pages",
+      "status": "beta",
+      "description": "Previous/next navigation between case studies, with a back-to-work action, for the foot of work detail pages.",
+      "dense": "Prev/next case-study navigation with back-to-work action for work detail pages",
       "keywords": [
         "case study",
         "navigation",
         "prev next",
-        "work"
+        "work",
+        "project"
       ],
       "importLine": "import { ProjectNav } from \"@dt/ProjectNav\";",
       "keyProps": [
@@ -10799,17 +10800,15 @@
         }
       },
       "composesWith": [
-        "ProjectGallery",
-        "Container",
-        "Section"
+        "Container"
       ],
       "prefersOver": [],
       "forbiddenUse": [
         "invent parallel primitives inside this folder",
-        "promote to stable without production consumer evidence"
+        "use for site-wide navigation (that is SiteHeader)"
       ],
       "usage": {
-        "description": "Previous/next navigation between case studies at the foot of work detail pages."
+        "description": "Previous/next navigation between case studies at the foot of work detail pages, plus a back-to-work action. Targets are derived from the project ordering; the control at each sequence edge is disabled."
       },
       "tokens": {
         "colors": [],


### PR DESCRIPTION
Promotes **ProjectNav** alpha→beta (fleet #2 of the remaining alpha site composites) with a real Figma component.

## Figma
Built the ProjectNav organism in `DT-Site-stuff` (node `1028-89`, Organisms page), composed from Tertiary/MD `Button` instances with Phosphor icons (briefcase, arrow-left, arrow-right) — replacing the placeholder `dt-project-nav` node-id.

## Component
- New `Site/ProjectNav` story: Default / FirstProject / LastProject / Example / ForcedColors / Playground + a play test.
- New test file: nav landmark, prev/next targets, disabled edges (first/last project), custom className, axe.
- Contract to beta with the real node-id; JSDoc on the export; `className` seeded so both controls are operable.
- Tailwind className styling kept as an intentional per-surface owner call (same as NavLink/Pagination). Already had a labelled `nav` landmark + displayName.

## Verification (local)
- axe clean across base + light + dark + forced-colors on all stories
- 4-mode AT snapshots captured + compare-clean (zero pollution)
- `audit:controls --only ProjectNav --effects`: 100% operable, 0 inert
- `validate:components`, `check:contract-props`, `check:consumers` green
- typecheck, lint, `npm test` (2000 passed), `npm run build` — all exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
