### PR TITLE
feat(design-system): promote ProjectCard alpha→beta with Figma component

### DIFF
--- a/nextjs-app/shared/components/ProjectCard/ProjectCard.contract.json
+++ b/nextjs-app/shared/components/ProjectCard/ProjectCard.contract.json
@@ -3,30 +3,55 @@
     "name": "ProjectCard",
     "tier": "molecule",
     "group": "content",
-    "status": "alpha",
-    "description": "Portfolio project card for work grid.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-project-card",
+    "status": "beta",
+    "description": "Basic portfolio project card for the work grid: a clickable thumbnail with title, optional category eyebrow and up to three tags.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1031-109",
     "radixPrimitive": null,
-    "element": "div",
-    "variants": {},
+    "element": "a",
+    "variants": {
+        "aspectRatio": {
+            "values": [
+                "video",
+                "square",
+                "portrait",
+                "landscape"
+            ],
+            "default": "video",
+            "propSourced": true
+        },
+        "titlePosition": {
+            "values": [
+                "overlay",
+                "below"
+            ],
+            "default": "overlay",
+            "propSourced": true
+        }
+    },
     "slots": [],
     "asChild": false,
     "subParts": [],
     "requiredStories": [
-        "Default"
+        "Default",
+        "Example",
+        "ForcedColors"
     ],
     "a11y": {
         "keyboard": [],
-        "ariaRequirements": [],
+        "ariaRequirements": [
+            "Whole card is a single link to the project detail page; the thumbnail carries the project title as alt text"
+        ],
+        "motion": true,
         "reducedMotion": true,
-        "reviewed": false,
-        "forcedColorsVerified": false
+        "reviewed": true,
+        "reviewedNote": "2026-07-06 alpha->beta: axe clean via test-storybook a11y test:error across base + light + dark + forced-colors on all stories, both overlay and below title positions; 4-mode AT snapshots captured and compare-clean. Card is one Link with the title as image alt. Hover scale/translate/opacity transitions are decorative and now gated behind motion-reduce: utilities (the global reset only covers focus rings). Tailwind className styling retained as an intentional per-surface owner call.",
+        "forcedColorsVerified": true
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
-    "lightDarkVerified": false,
+    "lightDarkVerified": true,
     "schemaVersion": 2,
     "props": {
         "title": {

--- a/nextjs-app/shared/components/ProjectCard/ProjectCard.spec.md
+++ b/nextjs-app/shared/components/ProjectCard/ProjectCard.spec.md
@@ -1,19 +1,20 @@
 # ProjectCard
 
 ## Intent
-Portfolio project card for work grid.
+Basic portfolio project card for the work grid: a clickable thumbnail with title, optional category eyebrow and up to three tags.
 
 ## Interaction contract
-- Keyboard: inherit from composed @dt/* primitives
-- Pointer: standard link/button targets where interactive
-- Screen readers: use landmarks and labels from child components
+- Keyboard: the whole card is a single focusable link to the project detail page
+- Pointer: click anywhere on the card to open the project; hover scales the thumbnail
+- Screen readers: one link; the thumbnail carries the project title as alt text
+- Reduced motion: hover scale/translate/opacity transitions are gated behind `motion-reduce:` utilities
 
 ## Do / don't
-- Do: compose from cataloged @dt/* atoms and molecules for new UI in this surface
-- Do: treat this as a page assembly reference when matching production routes
+- Do: pass `title`, `slug` and `thumbnail`; add `category`/`tags` for richer cards
+- Do: choose `titlePosition` (overlay | below) and `aspectRatio` per surface
 - Don't: invent parallel primitives inside this folder
-- Don't: promote to stable without production consumer evidence
+- Don't: reach for this when EnhancedProjectCard's richer surface is needed — pick one per surface
 
 ## Design notes
-- Tokens: inherit from child components
-- Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-project-card
+- Tokens: Tailwind utility classes mapped to theme tokens; thumbnail radius uses rounded-lg
+- Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1031-109

--- a/nextjs-app/shared/components/ProjectCard/ProjectCard.stories.tsx
+++ b/nextjs-app/shared/components/ProjectCard/ProjectCard.stories.tsx
@@ -1,0 +1,133 @@
+import contract from "./ProjectCard.contract.json";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { within, expect } from "storybook/test";
+import { ProjectCard } from "./ProjectCard";
+import thumbnail from "../../assets/images/dt-studio.jpg";
+
+const tagPresets = {
+  Few: ["Figma", "React"],
+  Many: ["Figma", "React", "Design tokens", "Storybook"],
+  None: [],
+};
+
+const meta: Meta<typeof ProjectCard> = {
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts).
+  title: "Site/ProjectCard",
+  component: ProjectCard,
+  tags: ["beta", "!autodocs"],
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-project-card",
+    },
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+    layout: "centered",
+  },
+  argTypes: {
+    title: {
+      control: "text",
+      description: "Project title, rendered as the card heading and image alt text.",
+      table: { category: "Content" },
+    },
+    slug: {
+      control: "text",
+      description: "URL slug; the whole card links to /work/{slug}.",
+      table: { category: "Content" },
+    },
+    thumbnail: {
+      control: "text",
+      description: "Thumbnail image source.",
+      table: { category: "Content" },
+    },
+    category: {
+      control: "text",
+      description: "Optional category eyebrow shown above the title.",
+      table: { category: "Content" },
+    },
+    tags: {
+      options: Object.keys(tagPresets),
+      mapping: tagPresets,
+      control: { type: "select" },
+      description: "Up to three tags are rendered.",
+      table: { category: "Content" },
+    },
+    aspectRatio: {
+      options: ["video", "square", "portrait", "landscape"],
+      control: { type: "select" },
+      description: "Aspect ratio of the thumbnail frame.",
+      table: { category: "Appearance", defaultValue: { summary: "video" } },
+    },
+    titlePosition: {
+      options: ["overlay", "below"],
+      control: { type: "inline-radio" },
+      description: "Whether the title sits over the image or beneath it.",
+      table: { category: "Appearance", defaultValue: { summary: "overlay" } },
+    },
+    className: {
+      control: "text",
+      description: "Extra class names merged onto the card link.",
+      table: { category: "Appearance" },
+    },
+  },
+  args: {
+    title: "Helsinki Design System",
+    slug: "helsinki-design-system",
+    thumbnail,
+    category: "Design systems",
+    tags: tagPresets.Few as unknown as string[],
+    aspectRatio: "video",
+    titlePosition: "overlay",
+    className: "",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ProjectCard>;
+
+/** Overlay title over the thumbnail, with category and tags. */
+export const Default: Story = {
+  tags: ["beta-matrix"],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByRole("link")).toHaveAttribute(
+      "href",
+      "/work/helsinki-design-system",
+    );
+    expect(
+      canvas.getByRole("heading", { name: "Helsinki Design System" }),
+    ).toBeInTheDocument();
+  },
+};
+
+/** Title and metadata rendered below the thumbnail. */
+export const TitleBelow: Story = {
+  args: { titlePosition: "below" },
+};
+
+/** Square thumbnail frame. */
+export const SquareRatio: Story = {
+  args: { aspectRatio: "square" },
+};
+
+export const Playground: Story = Default;
+
+export const Example: Story = {
+  tags: ["beta-matrix"],
+  parameters: { controls: { disable: true } },
+  ...Default,
+};
+
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "active" },
+  ...Default,
+};

--- a/nextjs-app/shared/components/ProjectCard/ProjectCard.test.tsx
+++ b/nextjs-app/shared/components/ProjectCard/ProjectCard.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { ProjectCard } from "./ProjectCard";
+
+expect.extend(toHaveNoViolations);
+
+const baseProps = {
+  title: "Helsinki Design System",
+  slug: "helsinki-design-system",
+  thumbnail: "/images/portfolio/hds.jpg",
+};
+
+describe("ProjectCard", () => {
+  it("links to the project detail page", () => {
+    render(<ProjectCard {...baseProps} />);
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "/work/helsinki-design-system",
+    );
+  });
+
+  it("renders the title as a heading and the thumbnail alt text", () => {
+    render(<ProjectCard {...baseProps} />);
+    expect(
+      screen.getByRole("heading", { name: "Helsinki Design System" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "Helsinki Design System" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders category and up to three tags", () => {
+    render(
+      <ProjectCard
+        {...baseProps}
+        category="Design systems"
+        tags={["Figma", "React", "Tokens", "Ignored"]}
+      />,
+    );
+    expect(screen.getByText("Design systems")).toBeInTheDocument();
+    expect(screen.getByText("Figma")).toBeInTheDocument();
+    expect(screen.getByText("Tokens")).toBeInTheDocument();
+    expect(screen.queryByText("Ignored")).not.toBeInTheDocument();
+  });
+
+  it("supports the below title position", () => {
+    render(<ProjectCard {...baseProps} titlePosition="below" />);
+    expect(
+      screen.getByRole("heading", { name: "Helsinki Design System" }),
+    ).toBeInTheDocument();
+  });
+
+  it("has no axe violations (overlay)", async () => {
+    const { container } = render(
+      <ProjectCard {...baseProps} category="Design systems" tags={["Figma"]} />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("has no axe violations (below)", async () => {
+    const { container } = render(
+      <ProjectCard {...baseProps} titlePosition="below" category="Design systems" />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/ProjectCard/ProjectCard.tsx
+++ b/nextjs-app/shared/components/ProjectCard/ProjectCard.tsx
@@ -30,6 +30,13 @@ const aspectRatioClasses: Record<NonNullable<ProjectCardProps["aspectRatio"]>, s
   landscape: "aspect-[4/3]",
 };
 
+/**
+ * Basic portfolio project card for the work grid: a clickable thumbnail with
+ * the project title, optional category eyebrow and up to three tags. The title
+ * can sit over the image (`overlay`) or beneath it (`below`), and the thumbnail
+ * frame follows the chosen `aspectRatio`. EnhancedProjectCard is the richer
+ * variant — pick one per surface.
+ */
 export function ProjectCard({
   title,
   slug,
@@ -64,7 +71,8 @@ export function ProjectCard({
           className={cn(
             "object-cover",
             "transition-transform duration-500 ease-out",
-            "group-hover:scale-105"
+            "group-hover:scale-105",
+            "motion-reduce:transition-none motion-reduce:group-hover:scale-100"
           )}
           sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
         />
@@ -76,7 +84,8 @@ export function ProjectCard({
               "absolute inset-0",
               "bg-gradient-to-t from-black/80 via-black/20 to-transparent",
               "opacity-60 group-hover:opacity-90",
-              "transition-opacity duration-300"
+              "transition-opacity duration-300",
+              "motion-reduce:transition-none"
             )}
           />
         )}
@@ -88,7 +97,8 @@ export function ProjectCard({
               "absolute inset-x-0 bottom-0 p-6",
               "translate-y-2 group-hover:translate-y-0",
               "opacity-90 group-hover:opacity-100",
-              "transition-all duration-300"
+              "transition-all duration-300",
+              "motion-reduce:transition-none motion-reduce:translate-y-0"
             )}
           >
             {category && (

--- a/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--default.dark.yaml
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--default.dark.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- link "Helsinki Design System Design systems Helsinki Design System Figma React":
+  - /url: /work/helsinki-design-system
+  - img "Helsinki Design System"
+  - text: Design systems
+  - heading "Helsinki Design System" [level=3]
+  - text: Figma React

--- a/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--default.forced-colors.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- link "Helsinki Design System Design systems Helsinki Design System Figma React":
+  - /url: /work/helsinki-design-system
+  - img "Helsinki Design System"
+  - text: Design systems
+  - heading "Helsinki Design System" [level=3]
+  - text: Figma React

--- a/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--default.light.yaml
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--default.light.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- link "Helsinki Design System Design systems Helsinki Design System Figma React":
+  - /url: /work/helsinki-design-system
+  - img "Helsinki Design System"
+  - text: Design systems
+  - heading "Helsinki Design System" [level=3]
+  - text: Figma React

--- a/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--default.yaml
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--default.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- link "Helsinki Design System Design systems Helsinki Design System Figma React":
+  - /url: /work/helsinki-design-system
+  - img "Helsinki Design System"
+  - text: Design systems
+  - heading "Helsinki Design System" [level=3]
+  - text: Figma React

--- a/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--example.dark.yaml
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--example.dark.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- link "Helsinki Design System Design systems Helsinki Design System Figma React":
+  - /url: /work/helsinki-design-system
+  - img "Helsinki Design System"
+  - text: Design systems
+  - heading "Helsinki Design System" [level=3]
+  - text: Figma React

--- a/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--example.forced-colors.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- link "Helsinki Design System Design systems Helsinki Design System Figma React":
+  - /url: /work/helsinki-design-system
+  - img "Helsinki Design System"
+  - text: Design systems
+  - heading "Helsinki Design System" [level=3]
+  - text: Figma React

--- a/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--example.light.yaml
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--example.light.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- link "Helsinki Design System Design systems Helsinki Design System Figma React":
+  - /url: /work/helsinki-design-system
+  - img "Helsinki Design System"
+  - text: Design systems
+  - heading "Helsinki Design System" [level=3]
+  - text: Figma React

--- a/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--example.yaml
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--example.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- link "Helsinki Design System Design systems Helsinki Design System Figma React":
+  - /url: /work/helsinki-design-system
+  - img "Helsinki Design System"
+  - text: Design systems
+  - heading "Helsinki Design System" [level=3]
+  - text: Figma React

--- a/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--forced-colors.dark.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- link "Helsinki Design System Design systems Helsinki Design System Figma React":
+  - /url: /work/helsinki-design-system
+  - img "Helsinki Design System"
+  - text: Design systems
+  - heading "Helsinki Design System" [level=3]
+  - text: Figma React

--- a/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--forced-colors.forced-colors.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- link "Helsinki Design System Design systems Helsinki Design System Figma React":
+  - /url: /work/helsinki-design-system
+  - img "Helsinki Design System"
+  - text: Design systems
+  - heading "Helsinki Design System" [level=3]
+  - text: Figma React

--- a/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--forced-colors.light.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- link "Helsinki Design System Design systems Helsinki Design System Figma React":
+  - /url: /work/helsinki-design-system
+  - img "Helsinki Design System"
+  - text: Design systems
+  - heading "Helsinki Design System" [level=3]
+  - text: Figma React

--- a/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--forced-colors.yaml
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--forced-colors.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- link "Helsinki Design System Design systems Helsinki Design System Figma React":
+  - /url: /work/helsinki-design-system
+  - img "Helsinki Design System"
+  - text: Design systems
+  - heading "Helsinki Design System" [level=3]
+  - text: Figma React

--- a/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--playground.yaml
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--playground.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- link "Helsinki Design System Design systems Helsinki Design System Figma React":
+  - /url: /work/helsinki-design-system
+  - img "Helsinki Design System"
+  - text: Design systems
+  - heading "Helsinki Design System" [level=3]
+  - text: Figma React

--- a/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--square-ratio.yaml
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--square-ratio.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- link "Helsinki Design System Design systems Helsinki Design System Figma React":
+  - /url: /work/helsinki-design-system
+  - img "Helsinki Design System"
+  - text: Design systems
+  - heading "Helsinki Design System" [level=3]
+  - text: Figma React

--- a/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--title-below.yaml
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--title-below.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- link "Helsinki Design System Design systems Helsinki Design System Figma React":
+  - /url: /work/helsinki-design-system
+  - img "Helsinki Design System"
+  - text: Design systems
+  - heading "Helsinki Design System" [level=3]
+  - text: Figma React

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -10575,8 +10575,8 @@
       "name": "ProjectCard",
       "group": "content",
       "tier": 2,
-      "status": "alpha",
-      "description": "Portfolio project card for work grid.",
+      "status": "beta",
+      "description": "Basic portfolio project card for the work grid: a clickable thumbnail with title, optional category eyebrow and up to three tags.",
       "dense": "Basic portfolio project card for the work grid (image, title, tags)",
       "keywords": [
         "portfolio",


### PR DESCRIPTION
Promotes **ProjectCard** alpha→beta (fleet #4 of the remaining alpha site composites) with a real Figma component.

## Figma
Built the ProjectCard organism in `DT-Site-stuff` (node `1031-109`, Organisms page): a rounded thumbnail with a gradient overlay, category eyebrow, title and tag chips — replacing the placeholder `dt-project-card` node-id.

## Component
- New `Site/ProjectCard` story: Default / TitleBelow / SquareRatio / Example / ForcedColors / Playground + a play test, with full controls (tags via mapped presets, aspectRatio/titlePosition selects).
- New test file: link target, heading + alt text, category/tag cap (3), below title position, axe (overlay + below).
- Contract to beta with the real node-id; `element` div→a; `aspectRatio` and `titlePosition` declared as `propSourced` variant axes; JSDoc on the export.
- **Reduced-motion fix**: gated the hover scale/translate/opacity transitions behind `motion-reduce:` utilities (the global reset only covers focus rings) and declared `motion` honestly in the contract.
- Tailwind className styling kept as an intentional per-surface owner call.

## Verification (local)
- axe clean across base + light + dark + forced-colors (overlay + below positions)
- 4-mode AT snapshots captured + compare-clean (zero pollution)
- `audit:controls --only ProjectCard --effects`: 100% operable, 0 inert
- `validate:components`, `check:contract-props`, `check:consumers` green
- typecheck, lint, `npm test`, `npm run build` — all exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
