### PR TITLE
feat(design-system): promote ProjectGallery alpha→beta with Figma component

### DIFF
--- a/nextjs-app/shared/components/ProjectGallery/ProjectGallery.contract.json
+++ b/nextjs-app/shared/components/ProjectGallery/ProjectGallery.contract.json
@@ -3,30 +3,67 @@
     "name": "ProjectGallery",
     "tier": "organism",
     "group": "media",
-    "status": "alpha",
-    "description": "Case study image gallery.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-project-gallery",
+    "status": "beta",
+    "description": "Responsive case-study image gallery: a labelled grid of figures where each thumbnail opens a shared lightbox.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1032-110",
     "radixPrimitive": null,
     "element": "div",
-    "variants": {},
+    "variants": {
+        "columns": {
+            "values": [
+                "2",
+                "3",
+                "4"
+            ],
+            "default": "3",
+            "propSourced": true
+        },
+        "gap": {
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "default": "md",
+            "propSourced": true
+        },
+        "aspectRatio": {
+            "values": [
+                "square",
+                "video",
+                "mixed"
+            ],
+            "default": "mixed",
+            "propSourced": true
+        }
+    },
     "slots": [],
     "asChild": false,
     "subParts": [],
     "requiredStories": [
-        "Default"
+        "Default",
+        "Example",
+        "ForcedColors"
     ],
     "a11y": {
-        "keyboard": [],
-        "ariaRequirements": [],
+        "keyboard": [
+            "Enter/Space on a thumbnail opens the lightbox"
+        ],
+        "ariaRequirements": [
+            "Grid is role=list labelled \"Project gallery\"; each image is a listitem figure",
+            "Each thumbnail button names itself \"View {alt} in fullscreen\" when the lightbox is enabled"
+        ],
+        "motion": true,
         "reducedMotion": true,
-        "reviewed": false,
-        "forcedColorsVerified": false
+        "reviewed": true,
+        "reviewedNote": "2026-07-06 alpha->beta: axe clean via test-storybook a11y test:error across base + light + dark + forced-colors on all stories (3/4 columns, mixed/square, lightbox on/off); 4-mode AT snapshots captured and compare-clean. Grid is role=list; thumbnails are keyboard-activatable buttons naming the fullscreen action. GSAP scroll-stagger is already gated behind a prefers-reduced-motion check in the component. Tailwind className styling retained as an intentional per-surface owner call.",
+        "forcedColorsVerified": true
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
-    "lightDarkVerified": false,
+    "lightDarkVerified": true,
     "schemaVersion": 2,
     "props": {
         "images": {

--- a/nextjs-app/shared/components/ProjectGallery/ProjectGallery.spec.md
+++ b/nextjs-app/shared/components/ProjectGallery/ProjectGallery.spec.md
@@ -1,19 +1,20 @@
 # ProjectGallery
 
 ## Intent
-Case study image gallery.
+Responsive case-study image gallery: a labelled grid of figures where each thumbnail opens a shared lightbox.
 
 ## Interaction contract
-- Keyboard: inherit from composed @dt/* primitives
-- Pointer: standard link/button targets where interactive
-- Screen readers: use landmarks and labels from child components
+- Keyboard: each thumbnail is a button; Enter/Space opens the lightbox
+- Pointer: click a thumbnail to open it fullscreen (when the lightbox is enabled)
+- Screen readers: grid is `role="list"` labelled "Project gallery"; each image is a listitem figure with a fullscreen-action button name
+- Reduced motion: the GSAP scroll-stagger is skipped when prefers-reduced-motion is set
 
 ## Do / don't
-- Do: compose from cataloged @dt/* atoms and molecules for new UI in this surface
-- Do: treat this as a page assembly reference when matching production routes
+- Do: pass `images` with width/height; tune `columns`, `gap` and `aspectRatio` per surface
+- Do: set `enableLightbox={false}` for static, non-interactive figure grids
 - Don't: invent parallel primitives inside this folder
-- Don't: promote to stable without production consumer evidence
+- Don't: use this for decorative marquees — it is for case-study imagery
 
 ## Design notes
-- Tokens: inherit from child components
-- Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-project-gallery
+- Tokens: Tailwind grid utilities mapped to theme spacing; thumbnails use rounded-lg
+- Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1032-110

--- a/nextjs-app/shared/components/ProjectGallery/ProjectGallery.stories.tsx
+++ b/nextjs-app/shared/components/ProjectGallery/ProjectGallery.stories.tsx
@@ -1,0 +1,130 @@
+import contract from "./ProjectGallery.contract.json";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { within, expect } from "storybook/test";
+import { ProjectGallery, type GalleryImage } from "./ProjectGallery";
+import img1 from "../../assets/images/future1.webp";
+import img2 from "../../assets/images/future2.webp";
+import img3 from "../../assets/images/future3.webp";
+import img4 from "../../assets/images/future4.webp";
+import img6 from "../../assets/images/future6.webp";
+import img7 from "../../assets/images/dt-studio.jpg";
+
+const make = (src: string, alt: string, caption?: string): GalleryImage => ({
+  src,
+  alt,
+  width: 1200,
+  height: 900,
+  caption,
+});
+
+const sixImages: GalleryImage[] = [
+  make(img1, "Concept frame one", "Early exploration"),
+  make(img2, "Concept frame two"),
+  make(img3, "Concept frame three", "Colour study"),
+  make(img4, "Concept frame four"),
+  make(img6, "Concept frame five"),
+  make(img7, "Studio shot", "Final render"),
+];
+
+const threeImages = sixImages.slice(0, 3);
+
+const meta: Meta<typeof ProjectGallery> = {
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts).
+  title: "Site/ProjectGallery",
+  component: ProjectGallery,
+  tags: ["beta", "!autodocs"],
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-project-gallery",
+    },
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+    layout: "padded",
+  },
+  argTypes: {
+    images: {
+      options: ["Three", "Six"],
+      mapping: { Three: threeImages, Six: sixImages },
+      control: { type: "select" },
+      description: "Images to display; each opens in the lightbox when enabled.",
+      table: { category: "Content" },
+    },
+    columns: {
+      options: [2, 3, 4],
+      control: { type: "inline-radio" },
+      description: "Column count at the widest breakpoint.",
+      table: { category: "Appearance", defaultValue: { summary: "3" } },
+    },
+    gap: {
+      options: ["sm", "md", "lg"],
+      control: { type: "inline-radio" },
+      description: "Gap between gallery items.",
+      table: { category: "Appearance", defaultValue: { summary: "md" } },
+    },
+    aspectRatio: {
+      options: ["square", "video", "mixed"],
+      control: { type: "select" },
+      description: "Thumbnail aspect ratio; mixed preserves each image's ratio.",
+      table: { category: "Appearance", defaultValue: { summary: "mixed" } },
+    },
+    enableLightbox: {
+      control: "boolean",
+      description: "Open a fullscreen lightbox when an image is activated.",
+      table: { category: "Behavior", defaultValue: { summary: "true" } },
+    },
+    className: {
+      control: "text",
+      description: "Extra class names merged onto the grid.",
+      table: { category: "Appearance" },
+    },
+  },
+  args: {
+    images: sixImages,
+    columns: 3,
+    gap: "md",
+    aspectRatio: "mixed",
+    enableLightbox: true,
+    className: "",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ProjectGallery>;
+
+/** Three-column mixed-ratio gallery with clickable, lightbox-enabled thumbnails. */
+export const Default: Story = {
+  tags: ["beta-matrix"],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(
+      canvas.getByRole("list", { name: "Project gallery" }),
+    ).toBeInTheDocument();
+    expect(canvas.getAllByRole("listitem").length).toBeGreaterThan(0);
+  },
+};
+
+/** Four columns with a tight gap and square thumbnails. */
+export const FourColumnsSquare: Story = {
+  args: { columns: 4, gap: "sm", aspectRatio: "square", images: sixImages },
+};
+
+/** Lightbox disabled: thumbnails are static, non-interactive figures. */
+export const StaticNoLightbox: Story = {
+  args: { enableLightbox: false, images: threeImages },
+};
+
+export const Playground: Story = Default;
+
+export const Example: Story = {
+  tags: ["beta-matrix"],
+  parameters: { controls: { disable: true } },
+  ...Default,
+};
+
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "active" },
+  ...Default,
+};

--- a/nextjs-app/shared/components/ProjectGallery/ProjectGallery.test.tsx
+++ b/nextjs-app/shared/components/ProjectGallery/ProjectGallery.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { ProjectGallery, type GalleryImage } from "./ProjectGallery";
+
+expect.extend(toHaveNoViolations);
+
+const images: GalleryImage[] = [
+  { src: "/images/a.jpg", alt: "Screen one", width: 800, height: 600, caption: "One" },
+  { src: "/images/b.jpg", alt: "Screen two", width: 800, height: 600 },
+  { src: "/images/c.jpg", alt: "Screen three", width: 800, height: 600 },
+];
+
+describe("ProjectGallery", () => {
+  it("renders a labelled list with one item per image", () => {
+    render(<ProjectGallery images={images} />);
+    const list = screen.getByRole("list", { name: "Project gallery" });
+    expect(list).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  it("exposes a fullscreen affordance per image when the lightbox is enabled", () => {
+    render(<ProjectGallery images={images} />);
+    expect(
+      screen.getByRole("button", { name: "View Screen one in fullscreen" }),
+    ).toBeEnabled();
+  });
+
+  it("renders captions when present", () => {
+    render(<ProjectGallery images={images} />);
+    expect(screen.getByText("One")).toBeInTheDocument();
+  });
+
+  it("disables the triggers when the lightbox is off", () => {
+    render(<ProjectGallery images={images} enableLightbox={false} />);
+    screen.getAllByRole("button").forEach((btn) => expect(btn).toBeDisabled());
+  });
+
+  it("renders nothing without images", () => {
+    const { container } = render(<ProjectGallery images={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(<ProjectGallery images={images} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/ProjectGallery/ProjectGallery.tsx
+++ b/nextjs-app/shared/components/ProjectGallery/ProjectGallery.tsx
@@ -53,6 +53,12 @@ const aspectClasses: Record<"square" | "video", string> = {
   video: "aspect-video",
 };
 
+/**
+ * Responsive image grid for a project case study. Renders each image as a
+ * figure in a labelled `role="list"` grid; when `enableLightbox` is set (the
+ * default) each thumbnail is a button that opens the shared Lightbox. Items
+ * stagger in on scroll via GSAP, gated behind a reduced-motion check.
+ */
 export function ProjectGallery({
   images,
   columns = 3,

--- a/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--default.dark.yaml
+++ b/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--default.dark.yaml
@@ -1,0 +1,23 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem "Early exploration":
+    - button "View Concept frame one in fullscreen":
+      - img "Concept frame one"
+    - text: Early exploration
+  - listitem:
+    - button "View Concept frame two in fullscreen":
+      - img "Concept frame two"
+  - listitem "Colour study":
+    - button "View Concept frame three in fullscreen":
+      - img "Concept frame three"
+    - text: Colour study
+  - listitem:
+    - button "View Concept frame four in fullscreen":
+      - img "Concept frame four"
+  - listitem:
+    - button "View Concept frame five in fullscreen":
+      - img "Concept frame five"
+  - listitem "Final render":
+    - button "View Studio shot in fullscreen":
+      - img "Studio shot"
+    - text: Final render

--- a/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--default.forced-colors.yaml
@@ -1,0 +1,23 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem "Early exploration":
+    - button "View Concept frame one in fullscreen":
+      - img "Concept frame one"
+    - text: Early exploration
+  - listitem:
+    - button "View Concept frame two in fullscreen":
+      - img "Concept frame two"
+  - listitem "Colour study":
+    - button "View Concept frame three in fullscreen":
+      - img "Concept frame three"
+    - text: Colour study
+  - listitem:
+    - button "View Concept frame four in fullscreen":
+      - img "Concept frame four"
+  - listitem:
+    - button "View Concept frame five in fullscreen":
+      - img "Concept frame five"
+  - listitem "Final render":
+    - button "View Studio shot in fullscreen":
+      - img "Studio shot"
+    - text: Final render

--- a/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--default.light.yaml
+++ b/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--default.light.yaml
@@ -1,0 +1,23 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem "Early exploration":
+    - button "View Concept frame one in fullscreen":
+      - img "Concept frame one"
+    - text: Early exploration
+  - listitem:
+    - button "View Concept frame two in fullscreen":
+      - img "Concept frame two"
+  - listitem "Colour study":
+    - button "View Concept frame three in fullscreen":
+      - img "Concept frame three"
+    - text: Colour study
+  - listitem:
+    - button "View Concept frame four in fullscreen":
+      - img "Concept frame four"
+  - listitem:
+    - button "View Concept frame five in fullscreen":
+      - img "Concept frame five"
+  - listitem "Final render":
+    - button "View Studio shot in fullscreen":
+      - img "Studio shot"
+    - text: Final render

--- a/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--default.yaml
+++ b/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--default.yaml
@@ -1,0 +1,23 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem "Early exploration":
+    - button "View Concept frame one in fullscreen":
+      - img "Concept frame one"
+    - text: Early exploration
+  - listitem:
+    - button "View Concept frame two in fullscreen":
+      - img "Concept frame two"
+  - listitem "Colour study":
+    - button "View Concept frame three in fullscreen":
+      - img "Concept frame three"
+    - text: Colour study
+  - listitem:
+    - button "View Concept frame four in fullscreen":
+      - img "Concept frame four"
+  - listitem:
+    - button "View Concept frame five in fullscreen":
+      - img "Concept frame five"
+  - listitem "Final render":
+    - button "View Studio shot in fullscreen":
+      - img "Studio shot"
+    - text: Final render

--- a/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--example.dark.yaml
+++ b/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--example.dark.yaml
@@ -1,0 +1,23 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem "Early exploration":
+    - button "View Concept frame one in fullscreen":
+      - img "Concept frame one"
+    - text: Early exploration
+  - listitem:
+    - button "View Concept frame two in fullscreen":
+      - img "Concept frame two"
+  - listitem "Colour study":
+    - button "View Concept frame three in fullscreen":
+      - img "Concept frame three"
+    - text: Colour study
+  - listitem:
+    - button "View Concept frame four in fullscreen":
+      - img "Concept frame four"
+  - listitem:
+    - button "View Concept frame five in fullscreen":
+      - img "Concept frame five"
+  - listitem "Final render":
+    - button "View Studio shot in fullscreen":
+      - img "Studio shot"
+    - text: Final render

--- a/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--example.forced-colors.yaml
@@ -1,0 +1,23 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem "Early exploration":
+    - button "View Concept frame one in fullscreen":
+      - img "Concept frame one"
+    - text: Early exploration
+  - listitem:
+    - button "View Concept frame two in fullscreen":
+      - img "Concept frame two"
+  - listitem "Colour study":
+    - button "View Concept frame three in fullscreen":
+      - img "Concept frame three"
+    - text: Colour study
+  - listitem:
+    - button "View Concept frame four in fullscreen":
+      - img "Concept frame four"
+  - listitem:
+    - button "View Concept frame five in fullscreen":
+      - img "Concept frame five"
+  - listitem "Final render":
+    - button "View Studio shot in fullscreen":
+      - img "Studio shot"
+    - text: Final render

--- a/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--example.light.yaml
+++ b/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--example.light.yaml
@@ -1,0 +1,23 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem "Early exploration":
+    - button "View Concept frame one in fullscreen":
+      - img "Concept frame one"
+    - text: Early exploration
+  - listitem:
+    - button "View Concept frame two in fullscreen":
+      - img "Concept frame two"
+  - listitem "Colour study":
+    - button "View Concept frame three in fullscreen":
+      - img "Concept frame three"
+    - text: Colour study
+  - listitem:
+    - button "View Concept frame four in fullscreen":
+      - img "Concept frame four"
+  - listitem:
+    - button "View Concept frame five in fullscreen":
+      - img "Concept frame five"
+  - listitem "Final render":
+    - button "View Studio shot in fullscreen":
+      - img "Studio shot"
+    - text: Final render

--- a/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--example.yaml
+++ b/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--example.yaml
@@ -1,0 +1,23 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem "Early exploration":
+    - button "View Concept frame one in fullscreen":
+      - img "Concept frame one"
+    - text: Early exploration
+  - listitem:
+    - button "View Concept frame two in fullscreen":
+      - img "Concept frame two"
+  - listitem "Colour study":
+    - button "View Concept frame three in fullscreen":
+      - img "Concept frame three"
+    - text: Colour study
+  - listitem:
+    - button "View Concept frame four in fullscreen":
+      - img "Concept frame four"
+  - listitem:
+    - button "View Concept frame five in fullscreen":
+      - img "Concept frame five"
+  - listitem "Final render":
+    - button "View Studio shot in fullscreen":
+      - img "Studio shot"
+    - text: Final render

--- a/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--forced-colors.dark.yaml
@@ -1,0 +1,23 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem "Early exploration":
+    - button "View Concept frame one in fullscreen":
+      - img "Concept frame one"
+    - text: Early exploration
+  - listitem:
+    - button "View Concept frame two in fullscreen":
+      - img "Concept frame two"
+  - listitem "Colour study":
+    - button "View Concept frame three in fullscreen":
+      - img "Concept frame three"
+    - text: Colour study
+  - listitem:
+    - button "View Concept frame four in fullscreen":
+      - img "Concept frame four"
+  - listitem:
+    - button "View Concept frame five in fullscreen":
+      - img "Concept frame five"
+  - listitem "Final render":
+    - button "View Studio shot in fullscreen":
+      - img "Studio shot"
+    - text: Final render

--- a/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--forced-colors.forced-colors.yaml
@@ -1,0 +1,23 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem "Early exploration":
+    - button "View Concept frame one in fullscreen":
+      - img "Concept frame one"
+    - text: Early exploration
+  - listitem:
+    - button "View Concept frame two in fullscreen":
+      - img "Concept frame two"
+  - listitem "Colour study":
+    - button "View Concept frame three in fullscreen":
+      - img "Concept frame three"
+    - text: Colour study
+  - listitem:
+    - button "View Concept frame four in fullscreen":
+      - img "Concept frame four"
+  - listitem:
+    - button "View Concept frame five in fullscreen":
+      - img "Concept frame five"
+  - listitem "Final render":
+    - button "View Studio shot in fullscreen":
+      - img "Studio shot"
+    - text: Final render

--- a/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--forced-colors.light.yaml
@@ -1,0 +1,23 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem "Early exploration":
+    - button "View Concept frame one in fullscreen":
+      - img "Concept frame one"
+    - text: Early exploration
+  - listitem:
+    - button "View Concept frame two in fullscreen":
+      - img "Concept frame two"
+  - listitem "Colour study":
+    - button "View Concept frame three in fullscreen":
+      - img "Concept frame three"
+    - text: Colour study
+  - listitem:
+    - button "View Concept frame four in fullscreen":
+      - img "Concept frame four"
+  - listitem:
+    - button "View Concept frame five in fullscreen":
+      - img "Concept frame five"
+  - listitem "Final render":
+    - button "View Studio shot in fullscreen":
+      - img "Studio shot"
+    - text: Final render

--- a/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--forced-colors.yaml
+++ b/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--forced-colors.yaml
@@ -1,0 +1,23 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem "Early exploration":
+    - button "View Concept frame one in fullscreen":
+      - img "Concept frame one"
+    - text: Early exploration
+  - listitem:
+    - button "View Concept frame two in fullscreen":
+      - img "Concept frame two"
+  - listitem "Colour study":
+    - button "View Concept frame three in fullscreen":
+      - img "Concept frame three"
+    - text: Colour study
+  - listitem:
+    - button "View Concept frame four in fullscreen":
+      - img "Concept frame four"
+  - listitem:
+    - button "View Concept frame five in fullscreen":
+      - img "Concept frame five"
+  - listitem "Final render":
+    - button "View Studio shot in fullscreen":
+      - img "Studio shot"
+    - text: Final render

--- a/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--four-columns-square.yaml
+++ b/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--four-columns-square.yaml
@@ -1,0 +1,23 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem "Early exploration":
+    - button "View Concept frame one in fullscreen":
+      - img "Concept frame one"
+    - text: Early exploration
+  - listitem:
+    - button "View Concept frame two in fullscreen":
+      - img "Concept frame two"
+  - listitem "Colour study":
+    - button "View Concept frame three in fullscreen":
+      - img "Concept frame three"
+    - text: Colour study
+  - listitem:
+    - button "View Concept frame four in fullscreen":
+      - img "Concept frame four"
+  - listitem:
+    - button "View Concept frame five in fullscreen":
+      - img "Concept frame five"
+  - listitem "Final render":
+    - button "View Studio shot in fullscreen":
+      - img "Studio shot"
+    - text: Final render

--- a/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--playground.yaml
+++ b/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--playground.yaml
@@ -1,0 +1,23 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem "Early exploration":
+    - button "View Concept frame one in fullscreen":
+      - img "Concept frame one"
+    - text: Early exploration
+  - listitem:
+    - button "View Concept frame two in fullscreen":
+      - img "Concept frame two"
+  - listitem "Colour study":
+    - button "View Concept frame three in fullscreen":
+      - img "Concept frame three"
+    - text: Colour study
+  - listitem:
+    - button "View Concept frame four in fullscreen":
+      - img "Concept frame four"
+  - listitem:
+    - button "View Concept frame five in fullscreen":
+      - img "Concept frame five"
+  - listitem "Final render":
+    - button "View Studio shot in fullscreen":
+      - img "Studio shot"
+    - text: Final render

--- a/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--static-no-lightbox.yaml
+++ b/nextjs-app/shared/components/ProjectGallery/__a11y-snapshots__/site-projectgallery--static-no-lightbox.yaml
@@ -1,0 +1,13 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem "Early exploration":
+    - button "Concept frame one" [disabled]:
+      - img "Concept frame one"
+    - text: Early exploration
+  - listitem:
+    - button "Concept frame two" [disabled]:
+      - img "Concept frame two"
+  - listitem "Colour study":
+    - button "Concept frame three" [disabled]:
+      - img "Concept frame three"
+    - text: Colour study

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -10680,8 +10680,8 @@
       "name": "ProjectGallery",
       "group": "media",
       "tier": 2,
-      "status": "alpha",
-      "description": "Case study image gallery.",
+      "status": "beta",
+      "description": "Responsive case-study image gallery: a labelled grid of figures where each thumbnail opens a shared lightbox.",
       "dense": "Case-study image gallery arranging project shots within article layouts",
       "keywords": [
         "case study",


### PR DESCRIPTION
Promotes **ProjectGallery** alpha→beta (fleet #5 of the remaining alpha site composites) with a real Figma component.

## Figma
Built the ProjectGallery organism in `DT-Site-stuff` (node `1032-110`, Organisms page): a wrapped three-column grid of rounded thumbnails — replacing the placeholder `dt-project-gallery` node-id.

## Component
- New `Site/ProjectGallery` story: Default / FourColumnsSquare / StaticNoLightbox / Example / ForcedColors / Playground + a play test; full controls (images via mapped presets, columns/gap/aspectRatio, enableLightbox).
- New test file: labelled `role=list`, one item per image, per-image fullscreen affordance, captions, disabled triggers when the lightbox is off, empty guard, axe.
- Contract to beta with the real node-id; columns/gap/aspectRatio as `propSourced` variant axes; `motion` declared honestly (the GSAP scroll-stagger already guards `prefers-reduced-motion`); JSDoc on the export.
- Tailwind className styling kept as an intentional per-surface owner call.

## Verification (local)
- axe clean across base + light + dark + forced-colors (3/4 columns, mixed/square, lightbox on/off)
- 4-mode AT snapshots captured + compare-clean (zero pollution)
- `audit:controls --only ProjectGallery --effects`: 100% operable, 0 inert
- `validate:components`, `check:contract-props`, `check:consumers` green
- typecheck, lint, `npm test` (2015 passed), `npm run build` — all exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
