### PR TITLE
feat(design-system): promote WorkGrid alpha→beta with Figma component

### DIFF
--- a/nextjs-app/shared/components/WorkGrid/WorkGrid.contract.json
+++ b/nextjs-app/shared/components/WorkGrid/WorkGrid.contract.json
@@ -3,30 +3,57 @@
     "name": "WorkGrid",
     "tier": "organism",
     "group": "content",
-    "status": "alpha",
-    "description": "Portfolio work index grid.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-work-grid",
+    "status": "beta",
+    "description": "Responsive portfolio work-index grid: one EnhancedProjectCard per project, with a friendly empty state.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1033-110",
     "radixPrimitive": null,
     "element": "div",
-    "variants": {},
+    "variants": {
+        "columns": {
+            "values": [
+                "2",
+                "3",
+                "4"
+            ],
+            "default": "3",
+            "propSourced": true
+        },
+        "aspectRatio": {
+            "values": [
+                "square",
+                "video",
+                "portrait",
+                "landscape"
+            ],
+            "default": "video",
+            "propSourced": true
+        }
+    },
     "slots": [],
     "asChild": false,
     "subParts": [],
     "requiredStories": [
-        "Default"
+        "Default",
+        "Example",
+        "ForcedColors"
     ],
     "a11y": {
         "keyboard": [],
-        "ariaRequirements": [],
+        "ariaRequirements": [
+            "Grid is role=list labelled via workGalleryLabel; each project is a listitem",
+            "Empty state is a labelled heading + description, not an empty grid"
+        ],
+        "motion": true,
         "reducedMotion": true,
-        "reviewed": false,
-        "forcedColorsVerified": false
+        "reviewed": true,
+        "reviewedNote": "2026-07-06 alpha->beta: axe clean via test-storybook a11y test:error across base + light + dark + forced-colors on all stories (2/3 columns, populated + empty state); 4-mode AT snapshots captured and compare-clean. Grid is role=list; the GSAP scroll-stagger is gated by the AnimationProvider motion preference and seeded off in stories for determinism. Composes the stable EnhancedProjectCard. Tailwind className styling retained as an intentional per-surface owner call.",
+        "forcedColorsVerified": true
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
-    "lightDarkVerified": false,
+    "lightDarkVerified": true,
     "schemaVersion": 2,
     "props": {
         "projects": {
@@ -65,9 +92,7 @@
         "promote to stable without production consumer evidence"
     ],
     "composesWith": [
-        "Container",
-        "Section",
-        "WorkHero",
+        "EnhancedProjectCard",
         "CategoryFilter"
     ],
     "displayName": "WorkGrid",

--- a/nextjs-app/shared/components/WorkGrid/WorkGrid.spec.md
+++ b/nextjs-app/shared/components/WorkGrid/WorkGrid.spec.md
@@ -1,19 +1,20 @@
 # WorkGrid
 
 ## Intent
-Portfolio work index grid.
+Responsive portfolio work-index grid: one EnhancedProjectCard per project, with a friendly empty state.
 
 ## Interaction contract
-- Keyboard: inherit from composed @dt/* primitives
-- Pointer: standard link/button targets where interactive
-- Screen readers: use landmarks and labels from child components
+- Keyboard: focus flows through each card link in order
+- Pointer: each card is an EnhancedProjectCard linking to its project
+- Screen readers: grid is `role="list"` labelled via workGalleryLabel; each project is a listitem; the empty state is a labelled heading + description
+- Reduced motion: the GSAP scroll-stagger is skipped when the AnimationProvider reports a reduced motion preference
 
 ## Do / don't
-- Do: compose from cataloged @dt/* atoms and molecules for new UI in this surface
-- Do: treat this as a page assembly reference when matching production routes
+- Do: pass a `projects` array; tune `columns`, `aspectRatio`, `showCategory`
+- Do: rely on the built-in empty state when a filter yields no results
 - Don't: invent parallel primitives inside this folder
-- Don't: promote to stable without production consumer evidence
+- Don't: hand-roll the card — WorkGrid owns the EnhancedProjectCard composition
 
 ## Design notes
-- Tokens: inherit from child components
-- Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-work-grid
+- Tokens: Tailwind grid utilities mapped to theme spacing
+- Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1033-110

--- a/nextjs-app/shared/components/WorkGrid/WorkGrid.stories.tsx
+++ b/nextjs-app/shared/components/WorkGrid/WorkGrid.stories.tsx
@@ -1,0 +1,116 @@
+import contract from "./WorkGrid.contract.json";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { within, expect } from "storybook/test";
+import { WorkGrid } from "./WorkGrid";
+import { projects } from "../../data/projects";
+
+const six = projects.slice(0, 6);
+const three = projects.slice(0, 3);
+
+const meta: Meta<typeof WorkGrid> = {
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts).
+  title: "Site/WorkGrid",
+  component: WorkGrid,
+  tags: ["beta", "!autodocs"],
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-work-grid",
+    },
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+    layout: "fullscreen",
+  },
+  argTypes: {
+    projects: {
+      options: ["Three", "Six"],
+      mapping: { Three: three, Six: six },
+      control: { type: "select" },
+      description: "Projects to render, one EnhancedProjectCard per item.",
+      table: { category: "Content" },
+    },
+    columns: {
+      options: [2, 3, 4],
+      control: { type: "inline-radio" },
+      description: "Column count at the widest breakpoint.",
+      table: { category: "Appearance", defaultValue: { summary: "3" } },
+    },
+    aspectRatio: {
+      options: ["square", "video", "portrait", "landscape"],
+      control: { type: "select" },
+      description: "Aspect ratio applied to each card thumbnail.",
+      table: { category: "Appearance", defaultValue: { summary: "video" } },
+    },
+    showCategory: {
+      control: "boolean",
+      description: "Show the formatted category label on each card.",
+      table: { category: "Appearance", defaultValue: { summary: "true" } },
+    },
+    animateItems: {
+      control: "boolean",
+      description:
+        "Stagger the cards in on scroll (GSAP). Disabled here so the grid renders settled.",
+      table: { category: "Behavior", defaultValue: { summary: "true" } },
+    },
+    className: {
+      control: "text",
+      description: "Extra class names merged onto the grid.",
+      table: { category: "Appearance" },
+    },
+  },
+  args: {
+    projects: six,
+    columns: 3,
+    aspectRatio: "video",
+    showCategory: true,
+    animateItems: false,
+    className: "",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: 32 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof WorkGrid>;
+
+/** Three-column work grid of project cards. */
+export const Default: Story = {
+  tags: ["beta-matrix"],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(
+      canvas.getByRole("list", { name: /project gallery/i }),
+    ).toBeInTheDocument();
+    expect(canvas.getAllByRole("listitem").length).toBeGreaterThan(0);
+  },
+};
+
+/** Two columns for a denser, larger-card layout. */
+export const TwoColumns: Story = {
+  args: { columns: 2, projects: three },
+};
+
+/** Empty state: a friendly message instead of a blank grid. */
+export const EmptyState: Story = {
+  args: { projects: [] },
+};
+
+export const Playground: Story = Default;
+
+export const Example: Story = {
+  tags: ["beta-matrix"],
+  parameters: { controls: { disable: true } },
+  ...Default,
+};
+
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "active" },
+  ...Default,
+};

--- a/nextjs-app/shared/components/WorkGrid/WorkGrid.test.tsx
+++ b/nextjs-app/shared/components/WorkGrid/WorkGrid.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { WorkGrid } from "./WorkGrid";
+import { projects } from "../../data/projects";
+
+expect.extend(toHaveNoViolations);
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+const sample = projects.slice(0, 3);
+
+describe("WorkGrid", () => {
+  it("renders a labelled list with one item per project", () => {
+    render(<WorkGrid projects={sample} animateItems={false} />);
+    const list = screen.getByRole("list", { name: "Project gallery" });
+    expect(list).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  it("renders each project title as a heading", () => {
+    render(<WorkGrid projects={sample} animateItems={false} />);
+    expect(
+      screen.getByRole("heading", { name: sample[0].title }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a helpful empty state when there are no projects", () => {
+    render(<WorkGrid projects={[]} />);
+    expect(
+      screen.getByRole("heading", { name: "No projects found" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(
+      <WorkGrid projects={sample} animateItems={false} />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("has no axe violations in the empty state", async () => {
+    const { container } = render(<WorkGrid projects={[]} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/WorkGrid/WorkGrid.tsx
+++ b/nextjs-app/shared/components/WorkGrid/WorkGrid.tsx
@@ -31,6 +31,12 @@ const columnClasses = {
   4: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
 } as const;
 
+/**
+ * Responsive grid of portfolio projects, one EnhancedProjectCard per item, in
+ * a labelled `role="list"`. Items stagger in on scroll via GSAP (gated by the
+ * AnimationProvider's motion preference), and an empty project set renders a
+ * friendly empty state instead of a blank grid.
+ */
 export function WorkGrid({
   projects,
   columns = 3,

--- a/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--default.dark.yaml
+++ b/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--default.dark.yaml
@@ -1,0 +1,44 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem:
+    - 'link "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems DSharp Design System Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement. Design Systems AI Architecture Data Science"':
+      - /url: /work/dsharp-design-system
+      - text: "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems"
+      - heading "DSharp Design System" [level=3]
+      - paragraph: "Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement."
+      - text: Design Systems AI Architecture Data Science
+  - listitem:
+    - 'link "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems Helsinki Design System Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components. Design System UX Design Accessibility"':
+      - /url: /work/helsinki-design-system
+      - text: "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems"
+      - heading "Helsinki Design System" [level=3]
+      - paragraph: Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.
+      - text: Design System UX Design Accessibility
+  - listitem:
+    - 'link "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding New Things Co Brand identity and digital presence for a digital transformation consultancy based in Helsinki. Branding Web Design Identity"':
+      - /url: /work/new-things-co
+      - text: "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding"
+      - heading "New Things Co" [level=3]
+      - paragraph: Brand identity and digital presence for a digital transformation consultancy based in Helsinki.
+      - text: Branding Web Design Identity
+  - listitem:
+    - 'link "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design Garage Junction Web and social assets for a creative underground music outing. Web Design Animation Branding"':
+      - /url: /work/garage-junction
+      - text: "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design"
+      - heading "Garage Junction" [level=3]
+      - paragraph: Web and social assets for a creative underground music outing.
+      - text: Web Design Animation Branding
+  - listitem:
+    - 'link "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration Illustrations Collection of editorial illustrations, character designs, and visual storytelling for various clients. Illustration Character Design Editorial"':
+      - /url: /work/illustrations
+      - text: "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration"
+      - heading "Illustrations" [level=3]
+      - paragraph: Collection of editorial illustrations, character designs, and visual storytelling for various clients.
+      - text: Illustration Character Design Editorial
+  - listitem:
+    - 'link "Category: Design Systems. Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems SAP Build Apps Design System Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide. Design Systems Enterprise Low-Code Platform"':
+      - /url: /work/sap-build-apps
+      - text: "Category: Design Systems. Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems"
+      - heading "SAP Build Apps Design System" [level=3]
+      - paragraph: Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.
+      - text: Design Systems Enterprise Low-Code Platform

--- a/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--default.forced-colors.yaml
@@ -1,0 +1,44 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem:
+    - 'link "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems DSharp Design System Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement. Design Systems AI Architecture Data Science"':
+      - /url: /work/dsharp-design-system
+      - text: "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems"
+      - heading "DSharp Design System" [level=3]
+      - paragraph: "Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement."
+      - text: Design Systems AI Architecture Data Science
+  - listitem:
+    - 'link "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems Helsinki Design System Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components. Design System UX Design Accessibility"':
+      - /url: /work/helsinki-design-system
+      - text: "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems"
+      - heading "Helsinki Design System" [level=3]
+      - paragraph: Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.
+      - text: Design System UX Design Accessibility
+  - listitem:
+    - 'link "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding New Things Co Brand identity and digital presence for a digital transformation consultancy based in Helsinki. Branding Web Design Identity"':
+      - /url: /work/new-things-co
+      - text: "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding"
+      - heading "New Things Co" [level=3]
+      - paragraph: Brand identity and digital presence for a digital transformation consultancy based in Helsinki.
+      - text: Branding Web Design Identity
+  - listitem:
+    - 'link "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design Garage Junction Web and social assets for a creative underground music outing. Web Design Animation Branding"':
+      - /url: /work/garage-junction
+      - text: "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design"
+      - heading "Garage Junction" [level=3]
+      - paragraph: Web and social assets for a creative underground music outing.
+      - text: Web Design Animation Branding
+  - listitem:
+    - 'link "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration Illustrations Collection of editorial illustrations, character designs, and visual storytelling for various clients. Illustration Character Design Editorial"':
+      - /url: /work/illustrations
+      - text: "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration"
+      - heading "Illustrations" [level=3]
+      - paragraph: Collection of editorial illustrations, character designs, and visual storytelling for various clients.
+      - text: Illustration Character Design Editorial
+  - listitem:
+    - 'link "Category: Design Systems. Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems SAP Build Apps Design System Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide. Design Systems Enterprise Low-Code Platform"':
+      - /url: /work/sap-build-apps
+      - text: "Category: Design Systems. Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems"
+      - heading "SAP Build Apps Design System" [level=3]
+      - paragraph: Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.
+      - text: Design Systems Enterprise Low-Code Platform

--- a/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--default.light.yaml
+++ b/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--default.light.yaml
@@ -1,0 +1,44 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem:
+    - 'link "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems DSharp Design System Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement. Design Systems AI Architecture Data Science"':
+      - /url: /work/dsharp-design-system
+      - text: "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems"
+      - heading "DSharp Design System" [level=3]
+      - paragraph: "Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement."
+      - text: Design Systems AI Architecture Data Science
+  - listitem:
+    - 'link "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems Helsinki Design System Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components. Design System UX Design Accessibility"':
+      - /url: /work/helsinki-design-system
+      - text: "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems"
+      - heading "Helsinki Design System" [level=3]
+      - paragraph: Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.
+      - text: Design System UX Design Accessibility
+  - listitem:
+    - 'link "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding New Things Co Brand identity and digital presence for a digital transformation consultancy based in Helsinki. Branding Web Design Identity"':
+      - /url: /work/new-things-co
+      - text: "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding"
+      - heading "New Things Co" [level=3]
+      - paragraph: Brand identity and digital presence for a digital transformation consultancy based in Helsinki.
+      - text: Branding Web Design Identity
+  - listitem:
+    - 'link "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design Garage Junction Web and social assets for a creative underground music outing. Web Design Animation Branding"':
+      - /url: /work/garage-junction
+      - text: "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design"
+      - heading "Garage Junction" [level=3]
+      - paragraph: Web and social assets for a creative underground music outing.
+      - text: Web Design Animation Branding
+  - listitem:
+    - 'link "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration Illustrations Collection of editorial illustrations, character designs, and visual storytelling for various clients. Illustration Character Design Editorial"':
+      - /url: /work/illustrations
+      - text: "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration"
+      - heading "Illustrations" [level=3]
+      - paragraph: Collection of editorial illustrations, character designs, and visual storytelling for various clients.
+      - text: Illustration Character Design Editorial
+  - listitem:
+    - 'link "Category: Design Systems. Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems SAP Build Apps Design System Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide. Design Systems Enterprise Low-Code Platform"':
+      - /url: /work/sap-build-apps
+      - text: "Category: Design Systems. Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems"
+      - heading "SAP Build Apps Design System" [level=3]
+      - paragraph: Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.
+      - text: Design Systems Enterprise Low-Code Platform

--- a/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--default.yaml
+++ b/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--default.yaml
@@ -1,0 +1,44 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem:
+    - 'link "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems DSharp Design System Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement. Design Systems AI Architecture Data Science"':
+      - /url: /work/dsharp-design-system
+      - text: "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems"
+      - heading "DSharp Design System" [level=3]
+      - paragraph: "Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement."
+      - text: Design Systems AI Architecture Data Science
+  - listitem:
+    - 'link "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems Helsinki Design System Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components. Design System UX Design Accessibility"':
+      - /url: /work/helsinki-design-system
+      - text: "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems"
+      - heading "Helsinki Design System" [level=3]
+      - paragraph: Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.
+      - text: Design System UX Design Accessibility
+  - listitem:
+    - 'link "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding New Things Co Brand identity and digital presence for a digital transformation consultancy based in Helsinki. Branding Web Design Identity"':
+      - /url: /work/new-things-co
+      - text: "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding"
+      - heading "New Things Co" [level=3]
+      - paragraph: Brand identity and digital presence for a digital transformation consultancy based in Helsinki.
+      - text: Branding Web Design Identity
+  - listitem:
+    - 'link "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design Garage Junction Web and social assets for a creative underground music outing. Web Design Animation Branding"':
+      - /url: /work/garage-junction
+      - text: "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design"
+      - heading "Garage Junction" [level=3]
+      - paragraph: Web and social assets for a creative underground music outing.
+      - text: Web Design Animation Branding
+  - listitem:
+    - 'link "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration Illustrations Collection of editorial illustrations, character designs, and visual storytelling for various clients. Illustration Character Design Editorial"':
+      - /url: /work/illustrations
+      - text: "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration"
+      - heading "Illustrations" [level=3]
+      - paragraph: Collection of editorial illustrations, character designs, and visual storytelling for various clients.
+      - text: Illustration Character Design Editorial
+  - listitem:
+    - 'link "Category: Design Systems. Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems SAP Build Apps Design System Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide. Design Systems Enterprise Low-Code Platform"':
+      - /url: /work/sap-build-apps
+      - text: "Category: Design Systems. Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems"
+      - heading "SAP Build Apps Design System" [level=3]
+      - paragraph: Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.
+      - text: Design Systems Enterprise Low-Code Platform

--- a/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--empty-state.yaml
+++ b/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--empty-state.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- img
+- heading "No projects found" [level=3]
+- paragraph: Try selecting a different category or browse all projects to explore our work.

--- a/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--example.dark.yaml
+++ b/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--example.dark.yaml
@@ -1,0 +1,44 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem:
+    - 'link "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems DSharp Design System Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement. Design Systems AI Architecture Data Science"':
+      - /url: /work/dsharp-design-system
+      - text: "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems"
+      - heading "DSharp Design System" [level=3]
+      - paragraph: "Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement."
+      - text: Design Systems AI Architecture Data Science
+  - listitem:
+    - 'link "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems Helsinki Design System Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components. Design System UX Design Accessibility"':
+      - /url: /work/helsinki-design-system
+      - text: "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems"
+      - heading "Helsinki Design System" [level=3]
+      - paragraph: Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.
+      - text: Design System UX Design Accessibility
+  - listitem:
+    - 'link "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding New Things Co Brand identity and digital presence for a digital transformation consultancy based in Helsinki. Branding Web Design Identity"':
+      - /url: /work/new-things-co
+      - text: "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding"
+      - heading "New Things Co" [level=3]
+      - paragraph: Brand identity and digital presence for a digital transformation consultancy based in Helsinki.
+      - text: Branding Web Design Identity
+  - listitem:
+    - 'link "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design Garage Junction Web and social assets for a creative underground music outing. Web Design Animation Branding"':
+      - /url: /work/garage-junction
+      - text: "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design"
+      - heading "Garage Junction" [level=3]
+      - paragraph: Web and social assets for a creative underground music outing.
+      - text: Web Design Animation Branding
+  - listitem:
+    - 'link "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration Illustrations Collection of editorial illustrations, character designs, and visual storytelling for various clients. Illustration Character Design Editorial"':
+      - /url: /work/illustrations
+      - text: "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration"
+      - heading "Illustrations" [level=3]
+      - paragraph: Collection of editorial illustrations, character designs, and visual storytelling for various clients.
+      - text: Illustration Character Design Editorial
+  - listitem:
+    - 'link "Category: Design Systems. Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems SAP Build Apps Design System Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide. Design Systems Enterprise Low-Code Platform"':
+      - /url: /work/sap-build-apps
+      - text: "Category: Design Systems. Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems"
+      - heading "SAP Build Apps Design System" [level=3]
+      - paragraph: Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.
+      - text: Design Systems Enterprise Low-Code Platform

--- a/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--example.forced-colors.yaml
@@ -1,0 +1,44 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem:
+    - 'link "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems DSharp Design System Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement. Design Systems AI Architecture Data Science"':
+      - /url: /work/dsharp-design-system
+      - text: "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems"
+      - heading "DSharp Design System" [level=3]
+      - paragraph: "Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement."
+      - text: Design Systems AI Architecture Data Science
+  - listitem:
+    - 'link "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems Helsinki Design System Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components. Design System UX Design Accessibility"':
+      - /url: /work/helsinki-design-system
+      - text: "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems"
+      - heading "Helsinki Design System" [level=3]
+      - paragraph: Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.
+      - text: Design System UX Design Accessibility
+  - listitem:
+    - 'link "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding New Things Co Brand identity and digital presence for a digital transformation consultancy based in Helsinki. Branding Web Design Identity"':
+      - /url: /work/new-things-co
+      - text: "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding"
+      - heading "New Things Co" [level=3]
+      - paragraph: Brand identity and digital presence for a digital transformation consultancy based in Helsinki.
+      - text: Branding Web Design Identity
+  - listitem:
+    - 'link "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design Garage Junction Web and social assets for a creative underground music outing. Web Design Animation Branding"':
+      - /url: /work/garage-junction
+      - text: "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design"
+      - heading "Garage Junction" [level=3]
+      - paragraph: Web and social assets for a creative underground music outing.
+      - text: Web Design Animation Branding
+  - listitem:
+    - 'link "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration Illustrations Collection of editorial illustrations, character designs, and visual storytelling for various clients. Illustration Character Design Editorial"':
+      - /url: /work/illustrations
+      - text: "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration"
+      - heading "Illustrations" [level=3]
+      - paragraph: Collection of editorial illustrations, character designs, and visual storytelling for various clients.
+      - text: Illustration Character Design Editorial
+  - listitem:
+    - 'link "Category: Design Systems. Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems SAP Build Apps Design System Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide. Design Systems Enterprise Low-Code Platform"':
+      - /url: /work/sap-build-apps
+      - text: "Category: Design Systems. Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems"
+      - heading "SAP Build Apps Design System" [level=3]
+      - paragraph: Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.
+      - text: Design Systems Enterprise Low-Code Platform

--- a/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--example.light.yaml
+++ b/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--example.light.yaml
@@ -1,0 +1,44 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem:
+    - 'link "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems DSharp Design System Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement. Design Systems AI Architecture Data Science"':
+      - /url: /work/dsharp-design-system
+      - text: "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems"
+      - heading "DSharp Design System" [level=3]
+      - paragraph: "Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement."
+      - text: Design Systems AI Architecture Data Science
+  - listitem:
+    - 'link "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems Helsinki Design System Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components. Design System UX Design Accessibility"':
+      - /url: /work/helsinki-design-system
+      - text: "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems"
+      - heading "Helsinki Design System" [level=3]
+      - paragraph: Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.
+      - text: Design System UX Design Accessibility
+  - listitem:
+    - 'link "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding New Things Co Brand identity and digital presence for a digital transformation consultancy based in Helsinki. Branding Web Design Identity"':
+      - /url: /work/new-things-co
+      - text: "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding"
+      - heading "New Things Co" [level=3]
+      - paragraph: Brand identity and digital presence for a digital transformation consultancy based in Helsinki.
+      - text: Branding Web Design Identity
+  - listitem:
+    - 'link "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design Garage Junction Web and social assets for a creative underground music outing. Web Design Animation Branding"':
+      - /url: /work/garage-junction
+      - text: "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design"
+      - heading "Garage Junction" [level=3]
+      - paragraph: Web and social assets for a creative underground music outing.
+      - text: Web Design Animation Branding
+  - listitem:
+    - 'link "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration Illustrations Collection of editorial illustrations, character designs, and visual storytelling for various clients. Illustration Character Design Editorial"':
+      - /url: /work/illustrations
+      - text: "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration"
+      - heading "Illustrations" [level=3]
+      - paragraph: Collection of editorial illustrations, character designs, and visual storytelling for various clients.
+      - text: Illustration Character Design Editorial
+  - listitem:
+    - 'link "Category: Design Systems. Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems SAP Build Apps Design System Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide. Design Systems Enterprise Low-Code Platform"':
+      - /url: /work/sap-build-apps
+      - text: "Category: Design Systems. Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems"
+      - heading "SAP Build Apps Design System" [level=3]
+      - paragraph: Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.
+      - text: Design Systems Enterprise Low-Code Platform

--- a/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--example.yaml
+++ b/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--example.yaml
@@ -1,0 +1,44 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem:
+    - 'link "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems DSharp Design System Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement. Design Systems AI Architecture Data Science"':
+      - /url: /work/dsharp-design-system
+      - text: "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems"
+      - heading "DSharp Design System" [level=3]
+      - paragraph: "Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement."
+      - text: Design Systems AI Architecture Data Science
+  - listitem:
+    - 'link "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems Helsinki Design System Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components. Design System UX Design Accessibility"':
+      - /url: /work/helsinki-design-system
+      - text: "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems"
+      - heading "Helsinki Design System" [level=3]
+      - paragraph: Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.
+      - text: Design System UX Design Accessibility
+  - listitem:
+    - 'link "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding New Things Co Brand identity and digital presence for a digital transformation consultancy based in Helsinki. Branding Web Design Identity"':
+      - /url: /work/new-things-co
+      - text: "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding"
+      - heading "New Things Co" [level=3]
+      - paragraph: Brand identity and digital presence for a digital transformation consultancy based in Helsinki.
+      - text: Branding Web Design Identity
+  - listitem:
+    - 'link "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design Garage Junction Web and social assets for a creative underground music outing. Web Design Animation Branding"':
+      - /url: /work/garage-junction
+      - text: "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design"
+      - heading "Garage Junction" [level=3]
+      - paragraph: Web and social assets for a creative underground music outing.
+      - text: Web Design Animation Branding
+  - listitem:
+    - 'link "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration Illustrations Collection of editorial illustrations, character designs, and visual storytelling for various clients. Illustration Character Design Editorial"':
+      - /url: /work/illustrations
+      - text: "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration"
+      - heading "Illustrations" [level=3]
+      - paragraph: Collection of editorial illustrations, character designs, and visual storytelling for various clients.
+      - text: Illustration Character Design Editorial
+  - listitem:
+    - 'link "Category: Design Systems. Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems SAP Build Apps Design System Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide. Design Systems Enterprise Low-Code Platform"':
+      - /url: /work/sap-build-apps
+      - text: "Category: Design Systems. Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems"
+      - heading "SAP Build Apps Design System" [level=3]
+      - paragraph: Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.
+      - text: Design Systems Enterprise Low-Code Platform

--- a/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--forced-colors.dark.yaml
@@ -1,0 +1,44 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem:
+    - 'link "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems DSharp Design System Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement. Design Systems AI Architecture Data Science"':
+      - /url: /work/dsharp-design-system
+      - text: "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems"
+      - heading "DSharp Design System" [level=3]
+      - paragraph: "Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement."
+      - text: Design Systems AI Architecture Data Science
+  - listitem:
+    - 'link "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems Helsinki Design System Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components. Design System UX Design Accessibility"':
+      - /url: /work/helsinki-design-system
+      - text: "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems"
+      - heading "Helsinki Design System" [level=3]
+      - paragraph: Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.
+      - text: Design System UX Design Accessibility
+  - listitem:
+    - 'link "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding New Things Co Brand identity and digital presence for a digital transformation consultancy based in Helsinki. Branding Web Design Identity"':
+      - /url: /work/new-things-co
+      - text: "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding"
+      - heading "New Things Co" [level=3]
+      - paragraph: Brand identity and digital presence for a digital transformation consultancy based in Helsinki.
+      - text: Branding Web Design Identity
+  - listitem:
+    - 'link "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design Garage Junction Web and social assets for a creative underground music outing. Web Design Animation Branding"':
+      - /url: /work/garage-junction
+      - text: "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design"
+      - heading "Garage Junction" [level=3]
+      - paragraph: Web and social assets for a creative underground music outing.
+      - text: Web Design Animation Branding
+  - listitem:
+    - 'link "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration Illustrations Collection of editorial illustrations, character designs, and visual storytelling for various clients. Illustration Character Design Editorial"':
+      - /url: /work/illustrations
+      - text: "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration"
+      - heading "Illustrations" [level=3]
+      - paragraph: Collection of editorial illustrations, character designs, and visual storytelling for various clients.
+      - text: Illustration Character Design Editorial
+  - listitem:
+    - 'link "Category: Design Systems. Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems SAP Build Apps Design System Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide. Design Systems Enterprise Low-Code Platform"':
+      - /url: /work/sap-build-apps
+      - text: "Category: Design Systems. Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems"
+      - heading "SAP Build Apps Design System" [level=3]
+      - paragraph: Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.
+      - text: Design Systems Enterprise Low-Code Platform

--- a/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--forced-colors.forced-colors.yaml
@@ -1,0 +1,44 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem:
+    - 'link "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems DSharp Design System Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement. Design Systems AI Architecture Data Science"':
+      - /url: /work/dsharp-design-system
+      - text: "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems"
+      - heading "DSharp Design System" [level=3]
+      - paragraph: "Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement."
+      - text: Design Systems AI Architecture Data Science
+  - listitem:
+    - 'link "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems Helsinki Design System Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components. Design System UX Design Accessibility"':
+      - /url: /work/helsinki-design-system
+      - text: "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems"
+      - heading "Helsinki Design System" [level=3]
+      - paragraph: Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.
+      - text: Design System UX Design Accessibility
+  - listitem:
+    - 'link "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding New Things Co Brand identity and digital presence for a digital transformation consultancy based in Helsinki. Branding Web Design Identity"':
+      - /url: /work/new-things-co
+      - text: "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding"
+      - heading "New Things Co" [level=3]
+      - paragraph: Brand identity and digital presence for a digital transformation consultancy based in Helsinki.
+      - text: Branding Web Design Identity
+  - listitem:
+    - 'link "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design Garage Junction Web and social assets for a creative underground music outing. Web Design Animation Branding"':
+      - /url: /work/garage-junction
+      - text: "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design"
+      - heading "Garage Junction" [level=3]
+      - paragraph: Web and social assets for a creative underground music outing.
+      - text: Web Design Animation Branding
+  - listitem:
+    - 'link "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration Illustrations Collection of editorial illustrations, character designs, and visual storytelling for various clients. Illustration Character Design Editorial"':
+      - /url: /work/illustrations
+      - text: "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration"
+      - heading "Illustrations" [level=3]
+      - paragraph: Collection of editorial illustrations, character designs, and visual storytelling for various clients.
+      - text: Illustration Character Design Editorial
+  - listitem:
+    - 'link "Category: Design Systems. Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems SAP Build Apps Design System Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide. Design Systems Enterprise Low-Code Platform"':
+      - /url: /work/sap-build-apps
+      - text: "Category: Design Systems. Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems"
+      - heading "SAP Build Apps Design System" [level=3]
+      - paragraph: Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.
+      - text: Design Systems Enterprise Low-Code Platform

--- a/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--forced-colors.light.yaml
@@ -1,0 +1,44 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem:
+    - 'link "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems DSharp Design System Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement. Design Systems AI Architecture Data Science"':
+      - /url: /work/dsharp-design-system
+      - text: "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems"
+      - heading "DSharp Design System" [level=3]
+      - paragraph: "Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement."
+      - text: Design Systems AI Architecture Data Science
+  - listitem:
+    - 'link "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems Helsinki Design System Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components. Design System UX Design Accessibility"':
+      - /url: /work/helsinki-design-system
+      - text: "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems"
+      - heading "Helsinki Design System" [level=3]
+      - paragraph: Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.
+      - text: Design System UX Design Accessibility
+  - listitem:
+    - 'link "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding New Things Co Brand identity and digital presence for a digital transformation consultancy based in Helsinki. Branding Web Design Identity"':
+      - /url: /work/new-things-co
+      - text: "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding"
+      - heading "New Things Co" [level=3]
+      - paragraph: Brand identity and digital presence for a digital transformation consultancy based in Helsinki.
+      - text: Branding Web Design Identity
+  - listitem:
+    - 'link "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design Garage Junction Web and social assets for a creative underground music outing. Web Design Animation Branding"':
+      - /url: /work/garage-junction
+      - text: "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design"
+      - heading "Garage Junction" [level=3]
+      - paragraph: Web and social assets for a creative underground music outing.
+      - text: Web Design Animation Branding
+  - listitem:
+    - 'link "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration Illustrations Collection of editorial illustrations, character designs, and visual storytelling for various clients. Illustration Character Design Editorial"':
+      - /url: /work/illustrations
+      - text: "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration"
+      - heading "Illustrations" [level=3]
+      - paragraph: Collection of editorial illustrations, character designs, and visual storytelling for various clients.
+      - text: Illustration Character Design Editorial
+  - listitem:
+    - 'link "Category: Design Systems. Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems SAP Build Apps Design System Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide. Design Systems Enterprise Low-Code Platform"':
+      - /url: /work/sap-build-apps
+      - text: "Category: Design Systems. Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems"
+      - heading "SAP Build Apps Design System" [level=3]
+      - paragraph: Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.
+      - text: Design Systems Enterprise Low-Code Platform

--- a/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--forced-colors.yaml
+++ b/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--forced-colors.yaml
@@ -1,0 +1,44 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem:
+    - 'link "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems DSharp Design System Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement. Design Systems AI Architecture Data Science"':
+      - /url: /work/dsharp-design-system
+      - text: "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems"
+      - heading "DSharp Design System" [level=3]
+      - paragraph: "Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement."
+      - text: Design Systems AI Architecture Data Science
+  - listitem:
+    - 'link "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems Helsinki Design System Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components. Design System UX Design Accessibility"':
+      - /url: /work/helsinki-design-system
+      - text: "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems"
+      - heading "Helsinki Design System" [level=3]
+      - paragraph: Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.
+      - text: Design System UX Design Accessibility
+  - listitem:
+    - 'link "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding New Things Co Brand identity and digital presence for a digital transformation consultancy based in Helsinki. Branding Web Design Identity"':
+      - /url: /work/new-things-co
+      - text: "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding"
+      - heading "New Things Co" [level=3]
+      - paragraph: Brand identity and digital presence for a digital transformation consultancy based in Helsinki.
+      - text: Branding Web Design Identity
+  - listitem:
+    - 'link "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design Garage Junction Web and social assets for a creative underground music outing. Web Design Animation Branding"':
+      - /url: /work/garage-junction
+      - text: "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design"
+      - heading "Garage Junction" [level=3]
+      - paragraph: Web and social assets for a creative underground music outing.
+      - text: Web Design Animation Branding
+  - listitem:
+    - 'link "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration Illustrations Collection of editorial illustrations, character designs, and visual storytelling for various clients. Illustration Character Design Editorial"':
+      - /url: /work/illustrations
+      - text: "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration"
+      - heading "Illustrations" [level=3]
+      - paragraph: Collection of editorial illustrations, character designs, and visual storytelling for various clients.
+      - text: Illustration Character Design Editorial
+  - listitem:
+    - 'link "Category: Design Systems. Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems SAP Build Apps Design System Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide. Design Systems Enterprise Low-Code Platform"':
+      - /url: /work/sap-build-apps
+      - text: "Category: Design Systems. Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems"
+      - heading "SAP Build Apps Design System" [level=3]
+      - paragraph: Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.
+      - text: Design Systems Enterprise Low-Code Platform

--- a/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--playground.yaml
+++ b/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--playground.yaml
@@ -1,0 +1,44 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem:
+    - 'link "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems DSharp Design System Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement. Design Systems AI Architecture Data Science"':
+      - /url: /work/dsharp-design-system
+      - text: "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems"
+      - heading "DSharp Design System" [level=3]
+      - paragraph: "Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement."
+      - text: Design Systems AI Architecture Data Science
+  - listitem:
+    - 'link "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems Helsinki Design System Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components. Design System UX Design Accessibility"':
+      - /url: /work/helsinki-design-system
+      - text: "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems"
+      - heading "Helsinki Design System" [level=3]
+      - paragraph: Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.
+      - text: Design System UX Design Accessibility
+  - listitem:
+    - 'link "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding New Things Co Brand identity and digital presence for a digital transformation consultancy based in Helsinki. Branding Web Design Identity"':
+      - /url: /work/new-things-co
+      - text: "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding"
+      - heading "New Things Co" [level=3]
+      - paragraph: Brand identity and digital presence for a digital transformation consultancy based in Helsinki.
+      - text: Branding Web Design Identity
+  - listitem:
+    - 'link "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design Garage Junction Web and social assets for a creative underground music outing. Web Design Animation Branding"':
+      - /url: /work/garage-junction
+      - text: "Category: Ux Design. Web and social assets for a creative underground music outing.. Tags: Web Design, Animation, Branding Ux Design"
+      - heading "Garage Junction" [level=3]
+      - paragraph: Web and social assets for a creative underground music outing.
+      - text: Web Design Animation Branding
+  - listitem:
+    - 'link "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration Illustrations Collection of editorial illustrations, character designs, and visual storytelling for various clients. Illustration Character Design Editorial"':
+      - /url: /work/illustrations
+      - text: "Category: Illustration. Collection of editorial illustrations, character designs, and visual storytelling for various clients.. Tags: Illustration, Character Design, Editorial Illustration"
+      - heading "Illustrations" [level=3]
+      - paragraph: Collection of editorial illustrations, character designs, and visual storytelling for various clients.
+      - text: Illustration Character Design Editorial
+  - listitem:
+    - 'link "Category: Design Systems. Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems SAP Build Apps Design System Led the design system for SAP''s flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide. Design Systems Enterprise Low-Code Platform"':
+      - /url: /work/sap-build-apps
+      - text: "Category: Design Systems. Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.. Tags: Design Systems, Enterprise, Low-Code Platform, SAP BTP Design Systems"
+      - heading "SAP Build Apps Design System" [level=3]
+      - paragraph: Led the design system for SAP's flagship low-code platform (formerly AppGyver). Built and maintained 100+ components across Figma and ReactTS, serving 300+ developers and designers building enterprise applications worldwide.
+      - text: Design Systems Enterprise Low-Code Platform

--- a/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--two-columns.yaml
+++ b/nextjs-app/shared/components/WorkGrid/__a11y-snapshots__/site-workgrid--two-columns.yaml
@@ -1,0 +1,23 @@
+- status: Work in progress (beta)
+- list "Project gallery":
+  - listitem:
+    - 'link "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems DSharp Design System Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement. Design Systems AI Architecture Data Science"':
+      - /url: /work/dsharp-design-system
+      - text: "Category: Design Systems. Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement.. Tags: Design Systems, AI Architecture, Data Science, MCP, React Design Systems"
+      - heading "DSharp Design System" [level=3]
+      - paragraph: "Fully AI-powered and guardrailed design-system architecture for enterprise data products: tokens, contracts, Storybook, MCP, CLI, and Rhythmguard enforcement."
+      - text: Design Systems AI Architecture Data Science
+  - listitem:
+    - 'link "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems Helsinki Design System Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components. Design System UX Design Accessibility"':
+      - /url: /work/helsinki-design-system
+      - text: "Category: Design Systems. Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.. Tags: Design System, UX Design, Accessibility, React Design Systems"
+      - heading "Helsinki Design System" [level=3]
+      - paragraph: Enterprise design system for the City of Helsinki, serving hundreds of digital services with accessible, consistent UI components.
+      - text: Design System UX Design Accessibility
+  - listitem:
+    - 'link "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding New Things Co Brand identity and digital presence for a digital transformation consultancy based in Helsinki. Branding Web Design Identity"':
+      - /url: /work/new-things-co
+      - text: "Category: Branding. Brand identity and digital presence for a digital transformation consultancy based in Helsinki.. Tags: Branding, Web Design, Identity Branding"
+      - heading "New Things Co" [level=3]
+      - paragraph: Brand identity and digital presence for a digital transformation consultancy based in Helsinki.
+      - text: Branding Web Design Identity

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -15169,8 +15169,8 @@
       "name": "WorkGrid",
       "group": "content",
       "tier": 2,
-      "status": "alpha",
-      "description": "Portfolio work index grid.",
+      "status": "beta",
+      "description": "Responsive portfolio work-index grid: one EnhancedProjectCard per project, with a friendly empty state.",
       "dense": "Portfolio index grid arranging project cards on the work page",
       "keywords": [
         "work",
@@ -15244,9 +15244,7 @@
         }
       },
       "composesWith": [
-        "Container",
-        "Section",
-        "WorkHero",
+        "EnhancedProjectCard",
         "CategoryFilter"
       ],
       "prefersOver": [],

--- a/scripts/design-system/audit-controls.mjs
+++ b/scripts/design-system/audit-controls.mjs
@@ -33,6 +33,9 @@ const EFFECTS = process.argv.includes('--effects')
 // story's default state — every entry carries its justification and how the
 // effect was verified instead.
 const EFFECT_EXEMPT = {
+    WorkGrid: {
+        animateItems: 'scroll-triggered GSAP entrance stagger — only fires on scroll into view, so it has no stable DOM signature in the static effect probe (and is gated by the AnimationProvider motion preference); stories seed it off for a settled, deterministic grid, verified by the reduced-motion guard in the component',
+    },
     Breadcrumb: {
         maxItems: 'static collapse cap — only changes layout when items.length exceeds it, and the Playground trail is short; verified by the static-collapse unit tests and the Collapsed story',
         collapseLabel: 'labels the ellipsis trigger, which only exists once the trail collapses; verified by the custom-collapseLabel unit test and the Collapsed story',


### PR DESCRIPTION
Promotes **WorkGrid** alpha→beta (fleet #6 of the remaining alpha site composites) with a real Figma component.

## Figma
Built the WorkGrid organism in `DT-Site-stuff` (node `1033-110`, Organisms page): a three-column grid of project cards (thumbnail + category + title) — replacing the placeholder `dt-work-grid` node-id.

## Component
- New `Site/WorkGrid` story: Default / TwoColumns / EmptyState / Example / ForcedColors / Playground + a play test; full controls (projects via mapped presets, columns/aspectRatio/showCategory, animateItems).
- New test file: labelled `role=list`, item-per-project, project headings, empty-state heading, axe (populated + empty).
- Contract to beta with the real node-id; columns/aspectRatio as `propSourced` variant axes; `motion` declared (GSAP stagger already gated by the AnimationProvider motion preference); JSDoc on the export.
- `audit:controls`: exempted `animateItems` (a scroll-triggered GSAP entrance has no static DOM signature) with a written justification; presence 100% / 0 inert.
- Tailwind className styling kept as an intentional per-surface owner call.

## Verification (local)
- axe clean across base + light + dark + forced-colors (2/3 columns, populated + empty)
- 4-mode AT snapshots captured + compare-clean (zero pollution)
- `validate:components`, `check:contract-props`, `check:consumers` green
- typecheck, lint, `npm test` (2020 passed), `npm run build` — all exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
