### PR TITLE
feat(design-system): promote BlogCategoryFilter alpha→beta with Figma component

### DIFF
--- a/nextjs-app/shared/components/BlogCategoryFilter/BlogCategoryFilter.contract.json
+++ b/nextjs-app/shared/components/BlogCategoryFilter/BlogCategoryFilter.contract.json
@@ -3,9 +3,9 @@
     "name": "BlogCategoryFilter",
     "tier": "molecule",
     "group": "navigation",
-    "status": "alpha",
-    "description": "Blog category filter control.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-blog-category-filter",
+    "status": "beta",
+    "description": "Single-select tag filter for the blog archive: a labelled tablist with an implicit All tab, three visual treatments and optional per-tag counts.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1035-110",
     "radixPrimitive": null,
     "element": "div",
     "variants": {
@@ -24,7 +24,7 @@
                 "md",
                 "lg"
             ],
-            "default": "sm",
+            "default": "md",
             "propSourced": true
         }
     },
@@ -32,20 +32,30 @@
     "asChild": false,
     "subParts": [],
     "requiredStories": [
-        "Default"
+        "Default",
+        "Example",
+        "ForcedColors"
     ],
     "a11y": {
-        "keyboard": [],
-        "ariaRequirements": [],
+        "keyboard": [
+            "Arrow Left/Right (and Up/Down) move between tabs with automatic activation",
+            "Home/End jump to the first/last tab",
+            "Enter/Space or click activates the focused tab"
+        ],
+        "ariaRequirements": [
+            "role=tablist labelled via blogFilterByTag; each filter is a role=tab with aria-selected",
+            "Roving tabindex: only the active tab is in the tab order"
+        ],
         "reducedMotion": true,
-        "reviewed": false,
-        "forcedColorsVerified": false
+        "reviewed": true,
+        "reviewedNote": "2026-07-06 alpha->beta: axe clean via test-storybook a11y test:error across base + light + dark + forced-colors on all stories and all three variants; 4-mode AT snapshots captured and compare-clean. Added roving-tabindex + arrow/Home/End keyboard navigation with automatic activation to make the role=tablist honest (previously buttons-only); covered by new unit tests. Tailwind className styling retained as an intentional per-surface owner call.",
+        "forcedColorsVerified": true
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
-    "lightDarkVerified": false,
+    "lightDarkVerified": true,
     "schemaVersion": 2,
     "props": {
         "tags": {

--- a/nextjs-app/shared/components/BlogCategoryFilter/BlogCategoryFilter.spec.md
+++ b/nextjs-app/shared/components/BlogCategoryFilter/BlogCategoryFilter.spec.md
@@ -1,19 +1,20 @@
 # BlogCategoryFilter
 
 ## Intent
-Blog category filter control.
+Single-select tag filter for the blog archive: a labelled tablist with an implicit All tab, three visual treatments and optional per-tag counts.
 
 ## Interaction contract
-- Keyboard: inherit from composed @dt/* primitives
-- Pointer: standard link/button targets where interactive
-- Screen readers: use landmarks and labels from child components
+- Keyboard: Arrow keys (and Up/Down) move between tabs with automatic activation; Home/End jump to the ends; Enter/Space or click activates the focused tab
+- Pointer: click a tab to select that tag (or All)
+- Screen readers: `role="tablist"` labelled via blogFilterByTag; each filter is a `role="tab"` with `aria-selected`; roving tabindex keeps only the active tab in the tab order
+- Controlled: `selectedTag` and `onTagChange` are supplied by the parent
 
 ## Do / don't
-- Do: compose from cataloged @dt/* atoms and molecules for new UI in this surface
-- Do: treat this as a page assembly reference when matching production routes
+- Do: pass the tag list plus the current `selectedTag` (null = All) and an `onTagChange` handler
+- Do: enable `showCounts` with a `tagCounts` map to show per-tag totals
 - Don't: invent parallel primitives inside this folder
-- Don't: promote to stable without production consumer evidence
+- Don't: use this for generic list pages — that is CategoryFilter
 
 ## Design notes
-- Tokens: inherit from child components
-- Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-blog-category-filter
+- Tokens: Tailwind utilities mapped to theme tokens (foreground/background/muted/border)
+- Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1035-110

--- a/nextjs-app/shared/components/BlogCategoryFilter/BlogCategoryFilter.stories.tsx
+++ b/nextjs-app/shared/components/BlogCategoryFilter/BlogCategoryFilter.stories.tsx
@@ -1,0 +1,141 @@
+import contract from "./BlogCategoryFilter.contract.json";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useArgs } from "storybook/preview-api";
+import { within, userEvent, expect, waitFor } from "storybook/test";
+import { BlogCategoryFilter } from "./BlogCategoryFilter";
+
+const tags = ["Design", "Tooling", "Process", "Branding"];
+const tagCountPresets = {
+  None: {},
+  Sample: { Design: 6, Tooling: 3, Process: 4, Branding: 2 },
+};
+const selectedTagPresets = {
+  "All Posts": null,
+  Design: "Design",
+  Tooling: "Tooling",
+  Process: "Process",
+  Branding: "Branding",
+};
+
+const meta: Meta<typeof BlogCategoryFilter> = {
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts).
+  title: "Site/BlogCategoryFilter",
+  component: BlogCategoryFilter,
+  tags: ["beta", "!autodocs"],
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-blog-category-filter",
+    },
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+    layout: "padded",
+  },
+  argTypes: {
+    tags: {
+      options: ["Two", "Four"],
+      mapping: { Two: ["Design", "Tooling"], Four: tags },
+      control: { type: "select" },
+      description: "Tags to expose as filters, in addition to the All tab.",
+      table: { category: "Content" },
+    },
+    selectedTag: {
+      options: Object.keys(selectedTagPresets),
+      mapping: selectedTagPresets,
+      control: { type: "select" },
+      description: "Active tag; the All tab corresponds to null.",
+      table: { category: "Content" },
+    },
+    showCounts: {
+      control: "boolean",
+      description: "Show a post count beside each tag.",
+      table: { category: "Content", defaultValue: { summary: "false" } },
+    },
+    tagCounts: {
+      options: Object.keys(tagCountPresets),
+      mapping: tagCountPresets,
+      control: { type: "select" },
+      description: "Per-tag post counts, used when showCounts is on.",
+      table: { category: "Content" },
+    },
+    variant: {
+      options: ["pills", "underline", "minimal"],
+      control: { type: "inline-radio" },
+      description: "Visual treatment of the filter row.",
+      table: { category: "Appearance", defaultValue: { summary: "pills" } },
+    },
+    size: {
+      options: ["sm", "md", "lg"],
+      control: { type: "inline-radio" },
+      description: "Control size.",
+      table: { category: "Appearance", defaultValue: { summary: "md" } },
+    },
+    className: {
+      control: "text",
+      description: "Extra class names merged onto the tablist.",
+      table: { category: "Appearance" },
+    },
+    onTagChange: { table: { disable: true } },
+  },
+  args: {
+    tags,
+    selectedTag: null,
+    showCounts: true,
+    tagCounts: tagCountPresets.Sample,
+    variant: "pills",
+    size: "md",
+    className: "",
+  },
+  render: function Render(args) {
+    const [{ selectedTag }, updateArgs] = useArgs();
+    return (
+      <BlogCategoryFilter
+        {...args}
+        selectedTag={selectedTag}
+        onTagChange={(tag) => updateArgs({ selectedTag: tag })}
+      />
+    );
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof BlogCategoryFilter>;
+
+/** Pill-style filter with post counts; clicking a tab updates the selection. */
+export const Default: Story = {
+  tags: ["beta-matrix"],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const tab = canvas.getByRole("tab", { name: /Design/ });
+    await userEvent.click(tab);
+    // Selection is written back through Storybook args (async channel).
+    await waitFor(() =>
+      expect(tab).toHaveAttribute("aria-selected", "true"),
+    );
+  },
+};
+
+/** Underline treatment for in-page section filtering. */
+export const Underline: Story = {
+  args: { variant: "underline", showCounts: false },
+};
+
+/** Minimal text-only treatment. */
+export const Minimal: Story = {
+  args: { variant: "minimal", showCounts: false, selectedTag: "Tooling" },
+};
+
+export const Playground: Story = Default;
+
+export const Example: Story = {
+  tags: ["beta-matrix"],
+  parameters: { controls: { disable: true } },
+  ...Default,
+};
+
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "active" },
+  ...Default,
+};

--- a/nextjs-app/shared/components/BlogCategoryFilter/BlogCategoryFilter.test.tsx
+++ b/nextjs-app/shared/components/BlogCategoryFilter/BlogCategoryFilter.test.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { BlogCategoryFilter } from "./BlogCategoryFilter";
+
+expect.extend(toHaveNoViolations);
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+const tags = ["Design", "Tooling", "Process"];
+
+describe("BlogCategoryFilter", () => {
+  it("renders an All tab plus one tab per tag inside a labelled tablist", () => {
+    render(
+      <BlogCategoryFilter tags={tags} selectedTag={null} onTagChange={vi.fn()} />,
+    );
+    expect(
+      screen.getByRole("tablist", { name: "Filter by topic" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("tab")).toHaveLength(tags.length + 1);
+    expect(screen.getByRole("tab", { name: "All Posts" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("marks the selected tag as active", () => {
+    render(
+      <BlogCategoryFilter
+        tags={tags}
+        selectedTag="Tooling"
+        onTagChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("tab", { name: "Tooling" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: "All Posts" })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+  });
+
+  it("calls onTagChange with the tag or null", async () => {
+    const onTagChange = vi.fn();
+    render(
+      <BlogCategoryFilter tags={tags} selectedTag={null} onTagChange={onTagChange} />,
+    );
+    await userEvent.click(screen.getByRole("tab", { name: "Design" }));
+    expect(onTagChange).toHaveBeenLastCalledWith("Design");
+    await userEvent.click(screen.getByRole("tab", { name: "All Posts" }));
+    expect(onTagChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it("shows per-tag counts when enabled", () => {
+    render(
+      <BlogCategoryFilter
+        tags={tags}
+        selectedTag={null}
+        onTagChange={vi.fn()}
+        showCounts
+        tagCounts={{ Design: 4, Tooling: 2, Process: 1 }}
+      />,
+    );
+    // "All Posts" total = 4 + 2 + 1 = 7; each tab shows its own count.
+    expect(screen.getByText("(7)")).toBeInTheDocument();
+    expect(screen.getByText("(4)")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /All Posts/ })).toBeInTheDocument();
+  });
+
+  it("moves between tabs with arrow keys (automatic activation)", async () => {
+    const onTagChange = vi.fn();
+    render(
+      <BlogCategoryFilter tags={tags} selectedTag={null} onTagChange={onTagChange} />,
+    );
+    const allTab = screen.getByRole("tab", { name: "All Posts" });
+    allTab.focus();
+    await userEvent.keyboard("{ArrowRight}");
+    expect(onTagChange).toHaveBeenLastCalledWith("Design");
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(onTagChange).toHaveBeenLastCalledWith(null);
+    await userEvent.keyboard("{End}");
+    expect(onTagChange).toHaveBeenLastCalledWith("Process");
+  });
+
+  it("uses roving tabindex so only the active tab is in the tab order", () => {
+    render(
+      <BlogCategoryFilter tags={tags} selectedTag="Design" onTagChange={vi.fn()} />,
+    );
+    expect(screen.getByRole("tab", { name: "Design" })).toHaveAttribute(
+      "tabindex",
+      "0",
+    );
+    expect(screen.getByRole("tab", { name: "All Posts" })).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
+  });
+
+  it.each(["pills", "underline", "minimal"] as const)(
+    "has no axe violations (%s)",
+    async (variant) => {
+      const { container } = render(
+        <BlogCategoryFilter
+          tags={tags}
+          selectedTag="Design"
+          onTagChange={vi.fn()}
+          variant={variant}
+        />,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    },
+  );
+});

--- a/nextjs-app/shared/components/BlogCategoryFilter/BlogCategoryFilter.tsx
+++ b/nextjs-app/shared/components/BlogCategoryFilter/BlogCategoryFilter.tsx
@@ -28,6 +28,12 @@ const sizeClasses = {
   lg: "text-base px-5 py-2.5",
 } as const;
 
+/**
+ * Single-select tag filter for the blog archive, rendered as a labelled
+ * `role="tablist"` with an implicit "All" tab. Controlled via `selectedTag` /
+ * `onTagChange`; ships pills, underline and minimal treatments and optional
+ * per-tag counts. Arrow keys move between tabs with automatic activation.
+ */
 export function BlogCategoryFilter({
   tags,
   selectedTag,
@@ -57,6 +63,32 @@ export function BlogCategoryFilter({
 
   const options = [allOption, ...tagOptions];
 
+  // Roving-tabindex keyboard support for the tablist: arrows move focus and
+  // activate (automatic activation), Home/End jump to the ends.
+  const handleTabKeyDown = (
+    e: React.KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
+    let next = index;
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+      next = (index + 1) % options.length;
+    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+      next = (index - 1 + options.length) % options.length;
+    } else if (e.key === "Home") {
+      next = 0;
+    } else if (e.key === "End") {
+      next = options.length - 1;
+    } else {
+      return;
+    }
+    e.preventDefault();
+    onTagChange(options[next].value);
+    const tabs = e.currentTarget.parentElement?.querySelectorAll<HTMLButtonElement>(
+      '[role="tab"]',
+    );
+    tabs?.[next]?.focus();
+  };
+
   const renderPills = () => (
     <div
       role="tablist"
@@ -68,7 +100,7 @@ export function BlogCategoryFilter({
         className
       )}
     >
-      {options.map((option) => {
+      {options.map((option, index) => {
         const isActive =
           option.value === selectedTag ||
           (option.value === null && selectedTag === null);
@@ -78,7 +110,9 @@ export function BlogCategoryFilter({
             key={option.value ?? "all"}
             role="tab"
             aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
             onClick={() => onTagChange(option.value)}
+            onKeyDown={(e) => handleTabKeyDown(e, index)}
             className={cn(
               "font-body whitespace-nowrap rounded-full",
               "border transition-all duration-200",
@@ -117,7 +151,7 @@ export function BlogCategoryFilter({
         className
       )}
     >
-      {options.map((option) => {
+      {options.map((option, index) => {
         const isActive =
           option.value === selectedTag ||
           (option.value === null && selectedTag === null);
@@ -127,7 +161,9 @@ export function BlogCategoryFilter({
             key={option.value ?? "all"}
             role="tab"
             aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
             onClick={() => onTagChange(option.value)}
+            onKeyDown={(e) => handleTabKeyDown(e, index)}
             className={cn(
               "font-body whitespace-nowrap pb-3",
               "border-b-2 -mb-px transition-colors duration-200",
@@ -161,7 +197,7 @@ export function BlogCategoryFilter({
         className
       )}
     >
-      {options.map((option) => {
+      {options.map((option, index) => {
         const isActive =
           option.value === selectedTag ||
           (option.value === null && selectedTag === null);
@@ -171,7 +207,9 @@ export function BlogCategoryFilter({
             key={option.value ?? "all"}
             role="tab"
             aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
             onClick={() => onTagChange(option.value)}
+            onKeyDown={(e) => handleTabKeyDown(e, index)}
             className={cn(
               "font-body whitespace-nowrap transition-colors duration-200",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded",

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--default.dark.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--default.dark.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- tablist "Filter by topic":
+  - tab "All Posts(15)"
+  - tab "Design(6)" [selected]
+  - tab "Tooling(3)"
+  - tab "Process(4)"
+  - tab "Branding(2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--default.forced-colors.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- tablist "Filter by topic":
+  - tab "All Posts(15)"
+  - tab "Design(6)" [selected]
+  - tab "Tooling(3)"
+  - tab "Process(4)"
+  - tab "Branding(2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--default.light.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--default.light.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- tablist "Filter by topic":
+  - tab "All Posts(15)"
+  - tab "Design(6)" [selected]
+  - tab "Tooling(3)"
+  - tab "Process(4)"
+  - tab "Branding(2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--default.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--default.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- tablist "Filter by topic":
+  - tab "All Posts(15)"
+  - tab "Design(6)" [selected]
+  - tab "Tooling(3)"
+  - tab "Process(4)"
+  - tab "Branding(2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--example.dark.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--example.dark.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- tablist "Filter by topic":
+  - tab "All Posts(15)"
+  - tab "Design(6)" [selected]
+  - tab "Tooling(3)"
+  - tab "Process(4)"
+  - tab "Branding(2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--example.forced-colors.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- tablist "Filter by topic":
+  - tab "All Posts(15)"
+  - tab "Design(6)" [selected]
+  - tab "Tooling(3)"
+  - tab "Process(4)"
+  - tab "Branding(2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--example.light.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--example.light.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- tablist "Filter by topic":
+  - tab "All Posts(15)"
+  - tab "Design(6)" [selected]
+  - tab "Tooling(3)"
+  - tab "Process(4)"
+  - tab "Branding(2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--example.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--example.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- tablist "Filter by topic":
+  - tab "All Posts(15)"
+  - tab "Design(6)" [selected]
+  - tab "Tooling(3)"
+  - tab "Process(4)"
+  - tab "Branding(2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--forced-colors.dark.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- tablist "Filter by topic":
+  - tab "All Posts(15)"
+  - tab "Design(6)" [selected]
+  - tab "Tooling(3)"
+  - tab "Process(4)"
+  - tab "Branding(2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--forced-colors.forced-colors.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- tablist "Filter by topic":
+  - tab "All Posts(15)"
+  - tab "Design(6)" [selected]
+  - tab "Tooling(3)"
+  - tab "Process(4)"
+  - tab "Branding(2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--forced-colors.light.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- tablist "Filter by topic":
+  - tab "All Posts(15)"
+  - tab "Design(6)" [selected]
+  - tab "Tooling(3)"
+  - tab "Process(4)"
+  - tab "Branding(2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--forced-colors.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--forced-colors.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- tablist "Filter by topic":
+  - tab "All Posts(15)"
+  - tab "Design(6)" [selected]
+  - tab "Tooling(3)"
+  - tab "Process(4)"
+  - tab "Branding(2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--minimal.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--minimal.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- tablist "Filter by topic":
+  - tab "All Posts"
+  - tab "Design"
+  - tab "Tooling" [selected]
+  - tab "Process"
+  - tab "Branding"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--playground.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--playground.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- tablist "Filter by topic":
+  - tab "All Posts(15)"
+  - tab "Design(6)" [selected]
+  - tab "Tooling(3)"
+  - tab "Process(4)"
+  - tab "Branding(2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--underline.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--underline.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- tablist "Filter by topic":
+  - tab "All Posts" [selected]
+  - tab "Design"
+  - tab "Tooling"
+  - tab "Process"
+  - tab "Branding"

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -1386,8 +1386,8 @@
       "name": "BlogCategoryFilter",
       "group": "navigation",
       "tier": 2,
-      "status": "alpha",
-      "description": "Blog category filter control.",
+      "status": "beta",
+      "description": "Single-select tag filter for the blog archive: a labelled tablist with an implicit All tab, three visual treatments and optional per-tag counts.",
       "dense": "Blog-specific category filter control; wraps CategoryFilter conventions for the blog archive",
       "keywords": [
         "blog",


### PR DESCRIPTION
Promotes **BlogCategoryFilter** alpha→beta (fleet #8 of the remaining alpha site composites) with a real Figma component.

## Figma
Built the BlogCategoryFilter organism in `DT-Site-stuff` (node `1035-110`, Organisms page): a pill filter row with an active All tab plus outlined tag pills — replacing the placeholder `dt-blog-category-filter` node-id.

## Component
- New `Site/BlogCategoryFilter` story: Default / Underline / Minimal / Example / ForcedColors / Playground + a play test; full controls (tags/selectedTag/tagCounts via mapped presets, variant/size, showCounts), controlled via `useArgs`.
- New test file: labelled tablist, All + per-tag tabs, active state, `onTagChange` with tag/null, counts, keyboard arrow/Home/End navigation, roving tabindex, axe across all three variants.
- **A11y fix**: added roving-tabindex + arrow/Home/End keyboard navigation with automatic activation so the `role="tablist"` is honest (it was buttons-only); documented in the contract keyboard list.
- Contract to beta with the real node-id; variant/size as `propSourced` variant axes; JSDoc on the export.
- Tailwind className styling kept as an intentional per-surface owner call.

## Verification (local)
- axe clean across base + light + dark + forced-colors, all three variants
- 4-mode AT snapshots captured + compare-clean (zero pollution)
- `audit:controls --only BlogCategoryFilter --effects`: 100% operable, 0 inert
- `validate:components`, `check:contract-props`, `check:consumers` green
- typecheck, lint, `npm test` (2034 passed), `npm run build` — all exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
