### PR TITLE
feat(design-system): promote BlogMediaImage alpha→beta with Figma component

### DIFF
--- a/nextjs-app/shared/components/BlogMediaImage/BlogMediaImage.contract.json
+++ b/nextjs-app/shared/components/BlogMediaImage/BlogMediaImage.contract.json
@@ -3,30 +3,44 @@
     "name": "BlogMediaImage",
     "tier": "atom",
     "group": "media",
-    "status": "alpha",
-    "description": "Blog-optimized responsive image with caption.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-blog-media-image",
+    "status": "beta",
+    "description": "Blog-optimized responsive image: renders raster sources through next/image and SVG sources as a plain img, with fill, cover/contain fit and a fluid full-bleed mode.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1036-109",
     "radixPrimitive": null,
-    "element": "div",
-    "variants": {},
+    "element": "img",
+    "variants": {
+        "fit": {
+            "values": [
+                "cover",
+                "contain"
+            ],
+            "default": "cover",
+            "propSourced": true
+        }
+    },
     "slots": [],
     "asChild": false,
     "subParts": [],
     "requiredStories": [
-        "Default"
+        "Default",
+        "Example",
+        "ForcedColors"
     ],
     "a11y": {
         "keyboard": [],
-        "ariaRequirements": [],
+        "ariaRequirements": [
+            "Requires meaningful alt text; decorative uses should pass an empty alt"
+        ],
         "reducedMotion": true,
-        "reviewed": false,
-        "forcedColorsVerified": false
+        "reviewed": true,
+        "reviewedNote": "2026-07-06 alpha->beta: axe clean via test-storybook a11y test:error across base + light + dark + forced-colors on all stories (inline, fluid, fill+contain); 4-mode AT snapshots captured and compare-clean. Alt text is a required prop; SVG sources render as a plain img with lazy loading, raster through next/image. No own animation.",
+        "forcedColorsVerified": true
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
-    "lightDarkVerified": false,
+    "lightDarkVerified": true,
     "schemaVersion": 2,
     "props": {
         "src": {
@@ -97,8 +111,8 @@
         "caption",
         "responsive media"
     ],
-    "dense": "Blog-optimized responsive image with optional caption; handles sizing presets for article layouts",
+    "dense": "Blog-optimized responsive image; raster via next/image, SVG via plain img, with fill/cover/contain/fluid modes",
     "usage": {
-        "description": "Responsive article image with optional caption, sized for the blog's prose measure. Use inside article bodies instead of raw img."
+        "description": "Responsive article image sized for the blog's prose measure. Renders raster sources through next/image and SVG sources as a plain img. Use inside article bodies instead of a raw img."
     }
 }

--- a/nextjs-app/shared/components/BlogMediaImage/BlogMediaImage.spec.md
+++ b/nextjs-app/shared/components/BlogMediaImage/BlogMediaImage.spec.md
@@ -1,19 +1,19 @@
 # BlogMediaImage
 
 ## Intent
-Blog-optimized responsive image with caption.
+Blog-optimized responsive image: renders raster sources through next/image and SVG sources as a plain img, with fill, cover/contain fit and a fluid full-bleed mode.
 
 ## Interaction contract
-- Keyboard: inherit from composed @dt/* primitives
-- Pointer: standard link/button targets where interactive
-- Screen readers: use landmarks and labels from child components
+- Keyboard: none (non-interactive image)
+- Pointer: none (wrap in a link if the image should be actionable)
+- Screen readers: exposes the required `alt` text; pass an empty `alt` for decorative images
 
 ## Do / don't
-- Do: compose from cataloged @dt/* atoms and molecules for new UI in this surface
-- Do: treat this as a page assembly reference when matching production routes
+- Do: pass meaningful `alt`; choose `fit` (contain for diagrams, cover for photos)
+- Do: use `fill` inside a positioned container, or `fluid` for full-bleed prose images
 - Don't: invent parallel primitives inside this folder
-- Don't: promote to stable without production consumer evidence
+- Don't: use a raw `<img>` in article bodies — this handles SVG, external and sizing concerns
 
 ## Design notes
-- Tokens: inherit from child components
-- Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-blog-media-image
+- Tokens: none of its own; sizing driven by width/height/fill/fluid props
+- Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1036-109

--- a/nextjs-app/shared/components/BlogMediaImage/BlogMediaImage.stories.tsx
+++ b/nextjs-app/shared/components/BlogMediaImage/BlogMediaImage.stories.tsx
@@ -1,0 +1,110 @@
+import contract from "./BlogMediaImage.contract.json";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { within, expect } from "storybook/test";
+import { BlogMediaImage } from "./BlogMediaImage";
+import photo from "../../assets/images/dt-studio.jpg";
+
+const meta: Meta<typeof BlogMediaImage> = {
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts).
+  title: "Site/BlogMediaImage",
+  component: BlogMediaImage,
+  tags: ["beta", "!autodocs"],
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-blog-media-image",
+    },
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+    layout: "padded",
+  },
+  argTypes: {
+    src: { control: "text", description: "Image source.", table: { category: "Content" } },
+    alt: { control: "text", description: "Alt text for the image.", table: { category: "Content" } },
+    fit: {
+      options: ["cover", "contain"],
+      control: { type: "inline-radio" },
+      description: "object-fit in fill mode; contain for diagrams, cover for photos.",
+      table: { category: "Appearance", defaultValue: { summary: "cover" } },
+    },
+    fluid: {
+      control: "boolean",
+      description: "Span the container full-bleed (ignore the width cap).",
+      table: { category: "Appearance", defaultValue: { summary: "false" } },
+    },
+    fill: {
+      control: "boolean",
+      description: "Absolutely fill the nearest positioned ancestor.",
+      table: { category: "Appearance", defaultValue: { summary: "false" } },
+    },
+    width: { control: "number", description: "Intrinsic width (raster).", table: { category: "Appearance" } },
+    height: { control: "number", description: "Intrinsic height (raster).", table: { category: "Appearance" } },
+    priority: {
+      control: "boolean",
+      description: "Load eagerly (above-the-fold heroes).",
+      table: { category: "Behavior", defaultValue: { summary: "false" } },
+    },
+    sizes: { control: "text", description: "next/image responsive sizes hint.", table: { category: "Behavior" } },
+    className: { control: "text", description: "Extra class names on the image.", table: { category: "Appearance" } },
+    onLoad: { table: { disable: true } },
+    onError: { table: { disable: true } },
+  },
+  args: {
+    src: photo,
+    alt: "Inside the Digitaltableteur studio",
+    fit: "cover",
+    fluid: false,
+    fill: false,
+    width: 800,
+    height: 450,
+    priority: false,
+    sizes: "",
+    className: "",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof BlogMediaImage>;
+
+/** Inline raster image sized to the prose measure. */
+export const Default: Story = {
+  tags: ["beta-matrix"],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(
+      canvas.getByRole("img", { name: "Inside the Digitaltableteur studio" }),
+    ).toBeInTheDocument();
+  },
+};
+
+/** Fluid full-bleed image that spans its container. */
+export const Fluid: Story = {
+  args: { fluid: true },
+};
+
+/** Fill mode inside a fixed 16:9 frame, using contain for a diagram-style asset. */
+export const FillContain: Story = {
+  args: { fill: true, fit: "contain" },
+  decorators: [
+    (Story) => (
+      <div style={{ position: "relative", width: 480, aspectRatio: "16 / 9" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Playground: Story = Default;
+
+export const Example: Story = {
+  tags: ["beta-matrix"],
+  parameters: { controls: { disable: true } },
+  ...Default,
+};
+
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "active" },
+  ...Default,
+};

--- a/nextjs-app/shared/components/BlogMediaImage/BlogMediaImage.test.tsx
+++ b/nextjs-app/shared/components/BlogMediaImage/BlogMediaImage.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { BlogMediaImage } from "./BlogMediaImage";
+
+expect.extend(toHaveNoViolations);
+
+describe("BlogMediaImage", () => {
+  it("renders a raster image with alt text", () => {
+    render(<BlogMediaImage src="/images/photo.jpg" alt="A photo" width={800} height={400} />);
+    expect(screen.getByRole("img", { name: "A photo" })).toBeInTheDocument();
+  });
+
+  it("renders SVG sources as a plain img (next/image is unreliable for SVG)", () => {
+    render(<BlogMediaImage src="/diagrams/flow.svg" alt="Flow diagram" width={600} height={300} />);
+    const img = screen.getByRole("img", { name: "Flow diagram" });
+    expect(img).toHaveAttribute("src", "/diagrams/flow.svg");
+  });
+
+  it("applies object-contain in fill mode when fit=contain", () => {
+    render(
+      <BlogMediaImage src="/diagrams/flow.svg" alt="Flow diagram" fill fit="contain" />,
+    );
+    expect(screen.getByRole("img", { name: "Flow diagram" })).toHaveClass(
+      "object-contain",
+    );
+  });
+
+  it("defaults to object-cover in fill mode", () => {
+    render(<BlogMediaImage src="/diagrams/flow.svg" alt="Flow diagram" fill />);
+    expect(screen.getByRole("img", { name: "Flow diagram" })).toHaveClass(
+      "object-cover",
+    );
+  });
+
+  it("fires onError when the image fails to load", () => {
+    const onError = vi.fn();
+    render(
+      <BlogMediaImage src="/diagrams/flow.svg" alt="Flow diagram" onError={onError} />,
+    );
+    fireEvent.error(screen.getByRole("img", { name: "Flow diagram" }));
+    expect(onError).toHaveBeenCalledOnce();
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(
+      <BlogMediaImage src="/images/photo.jpg" alt="A descriptive photo" width={800} height={400} />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/BlogMediaImage/BlogMediaImage.tsx
+++ b/nextjs-app/shared/components/BlogMediaImage/BlogMediaImage.tsx
@@ -21,6 +21,13 @@ export interface BlogMediaImageProps {
   fluid?: boolean;
 }
 
+/**
+ * Responsive article image for blog prose. Renders raster sources through
+ * `next/image` (external URLs unoptimised) and SVG sources as a plain `img`
+ * (next/image renders SVG unreliably), and supports fill, `cover`/`contain`
+ * fit and a fluid full-bleed mode. Use inside article bodies instead of a raw
+ * `img`.
+ */
 export function BlogMediaImage({
   src,
   alt,
@@ -110,3 +117,5 @@ export function BlogMediaImage({
     />
   );
 }
+
+BlogMediaImage.displayName = "BlogMediaImage";

--- a/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--default.dark.yaml
+++ b/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--default.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Inside the Digitaltableteur studio"

--- a/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--default.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Inside the Digitaltableteur studio"

--- a/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--default.light.yaml
+++ b/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--default.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Inside the Digitaltableteur studio"

--- a/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--default.yaml
+++ b/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--default.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Inside the Digitaltableteur studio"

--- a/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--example.dark.yaml
+++ b/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--example.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Inside the Digitaltableteur studio"

--- a/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--example.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Inside the Digitaltableteur studio"

--- a/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--example.light.yaml
+++ b/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--example.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Inside the Digitaltableteur studio"

--- a/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--example.yaml
+++ b/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--example.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Inside the Digitaltableteur studio"

--- a/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--fill-contain.yaml
+++ b/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--fill-contain.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Inside the Digitaltableteur studio"

--- a/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--fluid.yaml
+++ b/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--fluid.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Inside the Digitaltableteur studio"

--- a/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--forced-colors.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Inside the Digitaltableteur studio"

--- a/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--forced-colors.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Inside the Digitaltableteur studio"

--- a/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--forced-colors.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Inside the Digitaltableteur studio"

--- a/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--forced-colors.yaml
+++ b/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Inside the Digitaltableteur studio"

--- a/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--playground.yaml
+++ b/nextjs-app/shared/components/BlogMediaImage/__a11y-snapshots__/site-blogmediaimage--playground.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- img "Inside the Digitaltableteur studio"

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -1595,9 +1595,9 @@
       "name": "BlogMediaImage",
       "group": "media",
       "tier": 2,
-      "status": "alpha",
-      "description": "Blog-optimized responsive image with caption.",
-      "dense": "Blog-optimized responsive image with optional caption; handles sizing presets for article layouts",
+      "status": "beta",
+      "description": "Blog-optimized responsive image: renders raster sources through next/image and SVG sources as a plain img, with fill, cover/contain fit and a fluid full-bleed mode.",
+      "dense": "Blog-optimized responsive image; raster via next/image, SVG via plain img, with fill/cover/contain/fluid modes",
       "keywords": [
         "blog",
         "image",
@@ -1701,7 +1701,7 @@
         "promote to stable without production consumer evidence"
       ],
       "usage": {
-        "description": "Responsive article image with optional caption, sized for the blog's prose measure. Use inside article bodies instead of raw img."
+        "description": "Responsive article image sized for the blog's prose measure. Renders raster sources through next/image and SVG sources as a plain img. Use inside article bodies instead of a raw img."
       },
       "tokens": {
         "colors": [],

--- a/scripts/design-system/audit-controls.mjs
+++ b/scripts/design-system/audit-controls.mjs
@@ -39,6 +39,9 @@ const EFFECT_EXEMPT = {
     BlogGrid: {
         featuredSlug: 'only affects the featured-first layout (selects which article is promoted to the full-width slot); inert in the default standard layout the Playground probes; verified by the FeaturedFirst story and the featured-first unit test',
     },
+    BlogMediaImage: {
+        fit: 'object-fit class only applies in fill mode; the Playground renders inline (fill=false) so it is inert there; verified by the FillContain story and the fill-mode cover/contain unit tests',
+    },
     Breadcrumb: {
         maxItems: 'static collapse cap — only changes layout when items.length exceeds it, and the Playground trail is short; verified by the static-collapse unit tests and the Collapsed story',
         collapseLabel: 'labels the ellipsis trigger, which only exists once the trail collapses; verified by the custom-collapseLabel unit test and the Collapsed story',


### PR DESCRIPTION
Promotes **BlogMediaImage** alpha→beta (fleet #9 of the remaining alpha site composites) with a real Figma component.

## Figma
Built the BlogMediaImage organism in `DT-Site-stuff` (node `1036-109`, Organisms page): a rounded 16:9 article image — replacing the placeholder `dt-blog-media-image` node-id.

## Component
- New `Site/BlogMediaImage` story: Default / Fluid / FillContain / Example / ForcedColors / Playground + a play test; full controls (src/alt/sizes/className text, fit radio, fill/fluid/priority booleans, width/height numbers).
- New test file: raster via next/image, SVG via plain img, fill-mode cover/contain, onError, axe.
- Added the missing `displayName` + JSDoc; corrected the stale "with caption" contract wording (the component renders no caption).
- Contract to beta with the real node-id; `element` div→img; `fit` as a `propSourced` variant axis.
- `audit:controls`: exempted `fit` (only applies in fill mode) with a written justification; presence 100% / 0 inert.

## Verification (local)
- axe clean across base + light + dark + forced-colors (inline, fluid, fill+contain)
- 4-mode AT snapshots captured + compare-clean (zero pollution)
- `validate:components`, `check:contract-props`, `check:consumers` green
- typecheck, lint, `npm test` (2040 passed), `npm run build` — all exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
