### PR TITLE
feat(design-system): promote ArticleShareSection alpha→beta with Figma component

### DIFF
--- a/nextjs-app/shared/components/ArticleShareSection/ArticleShareSection.contract.json
+++ b/nextjs-app/shared/components/ArticleShareSection/ArticleShareSection.contract.json
@@ -3,9 +3,9 @@
     "name": "ArticleShareSection",
     "tier": "organism",
     "group": "content",
-    "status": "alpha",
-    "description": "Share links section for blog articles.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-article-share-section",
+    "status": "beta",
+    "description": "End-of-article share section: X, LinkedIn and Facebook share links plus a copy-link button, under an optional heading.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1043-110",
     "radixPrimitive": null,
     "element": "div",
     "variants": {
@@ -22,20 +22,28 @@
     "asChild": false,
     "subParts": [],
     "requiredStories": [
-        "Default"
+        "Default",
+        "Example",
+        "ForcedColors"
     ],
     "a11y": {
-        "keyboard": [],
-        "ariaRequirements": [],
+        "keyboard": [
+            "Tab reaches each share link and the copy-link button; Enter/Space activates them"
+        ],
+        "ariaRequirements": [
+            "Each share control is labelled (aria-label): Share on X/LinkedIn/Facebook and Copy link",
+            "Icons are aria-hidden; the copy button's label switches to \"Link copied!\" on success"
+        ],
         "reducedMotion": true,
-        "reviewed": false,
-        "forcedColorsVerified": false
+        "reviewed": true,
+        "reviewedNote": "2026-07-06 alpha->beta: axe clean via test-storybook a11y test:error across base + light + dark + forced-colors on all stories (horizontal + vertical, with/without heading); 4-mode AT snapshots captured and compare-clean. Every icon-only control carries an aria-label; the copied-state confirmation uses green-800 ink (green-600 is only ~3:1 on white, below AA). Figma composes cloned on-page Phosphor icon instances. Tailwind className styling retained as an intentional per-surface owner call.",
+        "forcedColorsVerified": true
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
-    "lightDarkVerified": false,
+    "lightDarkVerified": true,
     "schemaVersion": 2,
     "props": {
         "url": {
@@ -82,8 +90,8 @@
         "social",
         "blog footer"
     ],
-    "dense": "Share-links section at the end of blog articles; composes SocialShare with a heading",
+    "dense": "End-of-article share section: X/LinkedIn/Facebook share links plus a copy-link button under an optional heading",
     "usage": {
-        "description": "End-of-article share section composing SocialShare under a heading. Blog article template slot; not for arbitrary pages."
+        "description": "End-of-article share section: X, LinkedIn and Facebook share links plus a copy-link button, under an optional heading. Blog article template slot; not for arbitrary pages."
     }
 }

--- a/nextjs-app/shared/components/ArticleShareSection/ArticleShareSection.spec.md
+++ b/nextjs-app/shared/components/ArticleShareSection/ArticleShareSection.spec.md
@@ -1,19 +1,19 @@
 # ArticleShareSection
 
 ## Intent
-Share links section for blog articles.
+End-of-article share section: X, LinkedIn and Facebook share links plus a copy-link button, under an optional heading.
 
 ## Interaction contract
-- Keyboard: inherit from composed @dt/* primitives
-- Pointer: standard link/button targets where interactive
-- Screen readers: use landmarks and labels from child components
+- Keyboard: Tab reaches each share link and the copy-link button; Enter/Space activates them
+- Pointer: social links open the platform share dialog in a new tab; the copy button writes the URL to the clipboard
+- Screen readers: every icon-only control has an aria-label; icons are aria-hidden; the copy button's label switches to "Link copied!" on success
 
 ## Do / don't
-- Do: compose from cataloged @dt/* atoms and molecules for new UI in this surface
-- Do: treat this as a page assembly reference when matching production routes
+- Do: pass the article `url` and `title`; choose `layout` (horizontal | vertical)
+- Do: hide the heading with `showTitle={false}` for compact rails
 - Don't: invent parallel primitives inside this folder
-- Don't: promote to stable without production consumer evidence
+- Don't: use for arbitrary pages — this is the blog article template slot
 
 ## Design notes
-- Tokens: inherit from child components
-- Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-article-share-section
+- Tokens: Tailwind utilities mapped to theme tokens; the copied confirmation uses green-800 ink for AA
+- Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1043-110

--- a/nextjs-app/shared/components/ArticleShareSection/ArticleShareSection.stories.tsx
+++ b/nextjs-app/shared/components/ArticleShareSection/ArticleShareSection.stories.tsx
@@ -1,0 +1,86 @@
+import contract from "./ArticleShareSection.contract.json";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { within, expect } from "storybook/test";
+import { ArticleShareSection } from "./ArticleShareSection";
+
+const meta: Meta<typeof ArticleShareSection> = {
+  // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts).
+  title: "Site/ArticleShareSection",
+  component: ArticleShareSection,
+  tags: ["beta", "!autodocs"],
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-article-share-section",
+    },
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+    layout: "padded",
+  },
+  argTypes: {
+    url: { control: "text", description: "Article URL to share.", table: { category: "Content" } },
+    title: { control: "text", description: "Article title used as share text.", table: { category: "Content" } },
+    layout: {
+      options: ["horizontal", "vertical"],
+      control: { type: "inline-radio" },
+      description: "Stack the buttons in a row or a column.",
+      table: { category: "Appearance", defaultValue: { summary: "horizontal" } },
+    },
+    showTitle: {
+      control: "boolean",
+      description: "Show the \"Share this article\" heading.",
+      table: { category: "Appearance", defaultValue: { summary: "true" } },
+    },
+    className: { control: "text", description: "Extra class names merged onto the wrapper.", table: { category: "Appearance" } },
+  },
+  args: {
+    url: "https://digitaltableteur.com/blog/designing-in-2025",
+    title: "Designing in 2025",
+    layout: "horizontal",
+    showTitle: true,
+    className: "",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ArticleShareSection>;
+
+/** Horizontal share row with the section heading. */
+export const Default: Story = {
+  tags: ["beta-matrix"],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Real i18n renders "Share on Twitter"; the component's "Share on X" is a fallback.
+    expect(
+      canvas.getByRole("link", { name: /share on (x|twitter)/i }),
+    ).toBeInTheDocument();
+    expect(
+      canvas.getByRole("button", { name: /copy link/i }),
+    ).toBeInTheDocument();
+  },
+};
+
+/** Vertical layout for a sticky article rail. */
+export const Vertical: Story = {
+  args: { layout: "vertical" },
+};
+
+/** Buttons only, without the section heading. */
+export const NoTitle: Story = {
+  args: { showTitle: false },
+};
+
+export const Playground: Story = Default;
+
+export const Example: Story = {
+  tags: ["beta-matrix"],
+  parameters: { controls: { disable: true } },
+  ...Default,
+};
+
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "active" },
+  ...Default,
+};

--- a/nextjs-app/shared/components/ArticleShareSection/ArticleShareSection.test.tsx
+++ b/nextjs-app/shared/components/ArticleShareSection/ArticleShareSection.test.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { ArticleShareSection } from "./ArticleShareSection";
+
+expect.extend(toHaveNoViolations);
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+const props = {
+  url: "https://digitaltableteur.com/blog/designing-in-2025",
+  title: "Designing in 2025",
+};
+
+describe("ArticleShareSection", () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it("renders labelled share links pointing at the encoded url", () => {
+    render(<ArticleShareSection {...props} />);
+    const x = screen.getByRole("link", { name: "Share on X" });
+    const linkedin = screen.getByRole("link", { name: "Share on LinkedIn" });
+    const facebook = screen.getByRole("link", { name: "Share on Facebook" });
+    expect(x).toHaveAttribute("href", expect.stringContaining(encodeURIComponent(props.url)));
+    expect(linkedin).toHaveAttribute("target", "_blank");
+    expect(facebook).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("copies the url to the clipboard and confirms", async () => {
+    render(<ArticleShareSection {...props} />);
+    await userEvent.click(screen.getByRole("button", { name: "Copy link" }));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(props.url);
+    await waitFor(() =>
+      expect(screen.getByText("Link copied!")).toBeInTheDocument(),
+    );
+  });
+
+  it("hides the section title when showTitle is false", () => {
+    render(<ArticleShareSection {...props} showTitle={false} />);
+    expect(
+      screen.queryByRole("heading", { name: /share this article/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the section title by default", () => {
+    render(<ArticleShareSection {...props} />);
+    expect(
+      screen.getByRole("heading", { name: /share this article/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(<ArticleShareSection {...props} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("has no axe violations in the vertical layout", async () => {
+    const { container } = render(<ArticleShareSection {...props} layout="vertical" />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--default.dark.yaml
+++ b/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--default.dark.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- heading "Share this article" [level=3]
+- link "Share on Twitter":
+  - /url: https://twitter.com/intent/tweet?url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&text=Designing%20in%202025
+- link "Share on LinkedIn":
+  - /url: https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&title=Designing%20in%202025
+- link "Share on Facebook":
+  - /url: https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025
+- button "Copy link"

--- a/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--default.forced-colors.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- heading "Share this article" [level=3]
+- link "Share on Twitter":
+  - /url: https://twitter.com/intent/tweet?url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&text=Designing%20in%202025
+- link "Share on LinkedIn":
+  - /url: https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&title=Designing%20in%202025
+- link "Share on Facebook":
+  - /url: https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025
+- button "Copy link"

--- a/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--default.light.yaml
+++ b/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--default.light.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- heading "Share this article" [level=3]
+- link "Share on Twitter":
+  - /url: https://twitter.com/intent/tweet?url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&text=Designing%20in%202025
+- link "Share on LinkedIn":
+  - /url: https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&title=Designing%20in%202025
+- link "Share on Facebook":
+  - /url: https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025
+- button "Copy link"

--- a/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--default.yaml
+++ b/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--default.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- heading "Share this article" [level=3]
+- link "Share on Twitter":
+  - /url: https://twitter.com/intent/tweet?url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&text=Designing%20in%202025
+- link "Share on LinkedIn":
+  - /url: https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&title=Designing%20in%202025
+- link "Share on Facebook":
+  - /url: https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025
+- button "Copy link"

--- a/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--example.dark.yaml
+++ b/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--example.dark.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- heading "Share this article" [level=3]
+- link "Share on Twitter":
+  - /url: https://twitter.com/intent/tweet?url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&text=Designing%20in%202025
+- link "Share on LinkedIn":
+  - /url: https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&title=Designing%20in%202025
+- link "Share on Facebook":
+  - /url: https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025
+- button "Copy link"

--- a/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--example.forced-colors.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- heading "Share this article" [level=3]
+- link "Share on Twitter":
+  - /url: https://twitter.com/intent/tweet?url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&text=Designing%20in%202025
+- link "Share on LinkedIn":
+  - /url: https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&title=Designing%20in%202025
+- link "Share on Facebook":
+  - /url: https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025
+- button "Copy link"

--- a/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--example.light.yaml
+++ b/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--example.light.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- heading "Share this article" [level=3]
+- link "Share on Twitter":
+  - /url: https://twitter.com/intent/tweet?url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&text=Designing%20in%202025
+- link "Share on LinkedIn":
+  - /url: https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&title=Designing%20in%202025
+- link "Share on Facebook":
+  - /url: https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025
+- button "Copy link"

--- a/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--example.yaml
+++ b/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--example.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- heading "Share this article" [level=3]
+- link "Share on Twitter":
+  - /url: https://twitter.com/intent/tweet?url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&text=Designing%20in%202025
+- link "Share on LinkedIn":
+  - /url: https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&title=Designing%20in%202025
+- link "Share on Facebook":
+  - /url: https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025
+- button "Copy link"

--- a/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--forced-colors.dark.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- heading "Share this article" [level=3]
+- link "Share on Twitter":
+  - /url: https://twitter.com/intent/tweet?url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&text=Designing%20in%202025
+- link "Share on LinkedIn":
+  - /url: https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&title=Designing%20in%202025
+- link "Share on Facebook":
+  - /url: https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025
+- button "Copy link"

--- a/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--forced-colors.forced-colors.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- heading "Share this article" [level=3]
+- link "Share on Twitter":
+  - /url: https://twitter.com/intent/tweet?url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&text=Designing%20in%202025
+- link "Share on LinkedIn":
+  - /url: https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&title=Designing%20in%202025
+- link "Share on Facebook":
+  - /url: https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025
+- button "Copy link"

--- a/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--forced-colors.light.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- heading "Share this article" [level=3]
+- link "Share on Twitter":
+  - /url: https://twitter.com/intent/tweet?url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&text=Designing%20in%202025
+- link "Share on LinkedIn":
+  - /url: https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&title=Designing%20in%202025
+- link "Share on Facebook":
+  - /url: https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025
+- button "Copy link"

--- a/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--forced-colors.yaml
+++ b/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--forced-colors.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- heading "Share this article" [level=3]
+- link "Share on Twitter":
+  - /url: https://twitter.com/intent/tweet?url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&text=Designing%20in%202025
+- link "Share on LinkedIn":
+  - /url: https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&title=Designing%20in%202025
+- link "Share on Facebook":
+  - /url: https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025
+- button "Copy link"

--- a/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--no-title.yaml
+++ b/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--no-title.yaml
@@ -1,0 +1,8 @@
+- status: Work in progress (beta)
+- link "Share on Twitter":
+  - /url: https://twitter.com/intent/tweet?url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&text=Designing%20in%202025
+- link "Share on LinkedIn":
+  - /url: https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&title=Designing%20in%202025
+- link "Share on Facebook":
+  - /url: https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025
+- button "Copy link"

--- a/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--playground.yaml
+++ b/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--playground.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- heading "Share this article" [level=3]
+- link "Share on Twitter":
+  - /url: https://twitter.com/intent/tweet?url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&text=Designing%20in%202025
+- link "Share on LinkedIn":
+  - /url: https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&title=Designing%20in%202025
+- link "Share on Facebook":
+  - /url: https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025
+- button "Copy link"

--- a/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--vertical.yaml
+++ b/nextjs-app/shared/components/ArticleShareSection/__a11y-snapshots__/site-articlesharesection--vertical.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- heading "Share this article" [level=3]
+- link "Share on Twitter":
+  - /url: https://twitter.com/intent/tweet?url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&text=Designing%20in%202025
+- link "Share on LinkedIn":
+  - /url: https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025&title=Designing%20in%202025
+- link "Share on Facebook":
+  - /url: https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdigitaltableteur.com%2Fblog%2Fdesigning-in-2025
+- button "Copy link"

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -488,9 +488,9 @@
       "name": "ArticleShareSection",
       "group": "content",
       "tier": 2,
-      "status": "alpha",
-      "description": "Share links section for blog articles.",
-      "dense": "Share-links section at the end of blog articles; composes SocialShare with a heading",
+      "status": "beta",
+      "description": "End-of-article share section: X, LinkedIn and Facebook share links plus a copy-link button, under an optional heading.",
+      "dense": "End-of-article share section: X/LinkedIn/Facebook share links plus a copy-link button under an optional heading",
       "keywords": [
         "share",
         "article",
@@ -565,7 +565,7 @@
         "promote to stable without production consumer evidence"
       ],
       "usage": {
-        "description": "End-of-article share section composing SocialShare under a heading. Blog article template slot; not for arbitrary pages."
+        "description": "End-of-article share section: X, LinkedIn and Facebook share links plus a copy-link button, under an optional heading. Blog article template slot; not for arbitrary pages."
       },
       "tokens": {
         "colors": [],


### PR DESCRIPTION
Promotes **ArticleShareSection** alpha→beta (fleet #11, the last of the remaining alpha site composites) with a real Figma component.

## Figma
Built the ArticleShareSection organism in `DT-Site-stuff` (node `1043-110`, Organisms page): a share row (X / LinkedIn / Facebook / copy-link) under a heading. **Icons are cloned from the on-page Phosphor library instances — no imports.**

## Component
- New `Site/ArticleShareSection` story: Default / Vertical / NoTitle / Example / ForcedColors / Playground + a play test; full controls (url/title/className text, layout radio, showTitle boolean).
- New test file: labelled encoded share links, clipboard copy + "Link copied!" confirmation, showTitle toggle, axe (horizontal + vertical).
- Contract to beta with the real node-id; corrected the stale "composes SocialShare" wording (the component has its own inline buttons); documented the keyboard + aria-label contract and the AA green-800 copied ink.

## Verification (local)
- axe clean across base + light + dark + forced-colors (horizontal + vertical, with/without heading)
- 4-mode AT snapshots captured + compare-clean (zero pollution)
- `audit:controls --only ArticleShareSection --effects`: 100% operable, 0 inert
- `validate:components`, `check:contract-props`, `check:consumers` green
- typecheck, lint, `npm test` (2051 passed), `npm run build` — all exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
