### PR TITLE
feat(design-system): promote SplitButton alpha→beta with Figma component

### DIFF
--- a/nextjs-app/shared/components/SplitButton/SplitButton.contract.json
+++ b/nextjs-app/shared/components/SplitButton/SplitButton.contract.json
@@ -3,9 +3,9 @@
     "name": "SplitButton",
     "tier": "molecule",
     "group": "interaction",
-    "status": "alpha",
+    "status": "beta",
     "description": "Primary action button paired with a dropdown toggle for related secondary actions, with collision-aware menu placement and optional nested submenus.",
-    "figma": null,
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1052-2084",
     "radixPrimitive": null,
     "element": "div",
     "variants": {
@@ -38,15 +38,15 @@
         }
     },
     "slots": [
-        "label",
-        "options",
-        "menu"
+        "label"
     ],
     "asChild": false,
     "subParts": [],
     "requiredStories": [
         "Default",
-        "Playground"
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
     "a11y": {
         "keyboard": [
@@ -66,8 +66,8 @@
         ],
         "reducedMotion": true,
         "reviewed": true,
-        "forcedColorsVerified": false,
-        "reviewedNote": "2026-07-03 — Astryx Phase 3 batch 1: keyboard/ARIA contract documented from implementation; missing splitButton.moreOptions locale keys added (en/fi/sv). Forced-colors pass still pending, stays alpha. 2026-07-05 — dropdown now consumes the shared Menu primitive (Radix dropdown-menu) incl. MenuSub submenus: hand-rolled role=menu markup, openSubIndex state, manual placement math, and focus-trap removed. Public options API unchanged; obsolete usePortal prop removed (Menu always portals). Re-verified: hover + ArrowRight/Left submenu parity and keyboard select via test-storybook play, axe-clean open, Controls 100% + 0 inert. Forced-colors + light/dark of the OPEN menu still to eyeball before beta."
+        "forcedColorsVerified": true,
+        "reviewedNote": "2026-07-03 — Astryx Phase 3 batch 1: keyboard/ARIA contract documented from implementation; missing splitButton.moreOptions locale keys added (en/fi/sv). 2026-07-05 — dropdown now consumes the shared Menu primitive (Radix dropdown-menu) incl. MenuSub submenus: hand-rolled role=menu markup, openSubIndex state, manual placement math, and focus-trap removed. Public options API unchanged; obsolete usePortal prop removed (Menu always portals). Re-verified: hover + ArrowRight/Left submenu parity and keyboard select via test-storybook play, axe-clean open, Controls 100% + 0 inert. 2026-07-06 — alpha→beta: Figma variant set built (Variant×Size, node 1052-2084, DT-Site-stuff Molecules). Light/dark AND forced-colors verified for real on the closed control AND the open menu via Playwright (globals=theme + forcedColors:active): theme flips both segments and the portaled Menu surface correctly; in forced-colors the menu draws a visible CanvasText border (not shadow-only), segment outlines and caret/option icons stay distinguishable. forcedColorsVerified + lightDarkVerified now true."
     },
     "tokens": {
         "colors": [
@@ -87,7 +87,7 @@
             "--radius-md"
         ]
     },
-    "lightDarkVerified": false,
+    "lightDarkVerified": true,
     "schemaVersion": 2,
     "displayName": "SplitButton",
     "keywords": [

--- a/nextjs-app/shared/components/SplitButton/SplitButton.stories.tsx
+++ b/nextjs-app/shared/components/SplitButton/SplitButton.stories.tsx
@@ -30,11 +30,11 @@ const basicOptions = [
 const meta: Meta<typeof SplitButton> = {
   title: "Actions/SplitButton",
   component: SplitButton,
-  tags: ["alpha", "autodocs"],
+  tags: ["beta", "autodocs"],
   parameters: {
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=406-1569",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1052-2084",
     },
     layout: "padded",
     contractStatus: contract.status,
@@ -302,6 +302,49 @@ export const DisabledState: Story = {
     label: "Save",
     options: saveOptions,
     disabled: true,
+  },
+};
+
+export const Example: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "none" },
+  name: "Example (document toolbar)",
+  parameters: { controls: { disable: true }, layout: "padded" },
+  render: () => (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "0.75rem",
+        padding: "0.5rem",
+      }}
+    >
+      <SplitButton
+        label="Save"
+        variant="primary"
+        onPrimaryClick={() => {}}
+        options={saveOptions}
+      />
+      <SplitButton
+        label="Export"
+        variant="secondary"
+        toggleLabel="Choose export format"
+        options={[
+          { id: "pdf", label: "Export as PDF", trailingIcon: "file-text" },
+          { id: "csv", label: "Export CSV", trailingIcon: "download" },
+        ]}
+      />
+    </div>
+  ),
+};
+
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "active" },
+  args: {
+    label: "Save",
+    variant: "primary",
+    options: "save" as unknown as typeof saveOptions,
   },
 };
 

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--default.dark.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--default.dark.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- button "Save"
+- button "More options"

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--default.forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- button "Save"
+- button "More options"

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--default.light.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--default.light.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- button "Save"
+- button "More options"

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--default.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--default.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- button "Save"
+- button "More options"

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--disabled-state.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--disabled-state.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- button "Save" [disabled]
+- button "More options" [disabled]

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--example.dark.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--example.dark.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- button "Save"
+- button "More options"
+- button "Export"
+- button "Choose export format"

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--example.forced-colors.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- button "Save"
+- button "More options"
+- button "Export"
+- button "Choose export format"

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--example.light.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--example.light.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- button "Save"
+- button "More options"
+- button "Export"
+- button "Choose export format"

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--example.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--example.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- button "Save"
+- button "More options"
+- button "Export"
+- button "Choose export format"

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--export-formats.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--export-formats.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- button "Export"
+- button "Choose export format"

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--forced-colors.dark.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- button "Save"
+- button "More options"

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--forced-colors.forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- button "Save"
+- button "More options"

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--forced-colors.light.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- button "Save"
+- button "More options"

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--forced-colors.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- button "Save"
+- button "More options"

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--nested-submenus.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--nested-submenus.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- button "Publish"
+- button "More options" [expanded]

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--playground.dark.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--playground.dark.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- button "Save"
+- button "More options"

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--playground.forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- button "Save"
+- button "More options"

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--playground.light.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--playground.light.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- button "Save"
+- button "More options"

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--playground.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--playground.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- button "Save"
+- button "More options"

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--variants.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--variants.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- button "Save"
+- button "More options"
+- button "Save"
+- button "More options"
+- button "Save"
+- button "More options"

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -12561,7 +12561,7 @@
       "name": "SplitButton",
       "group": "interaction",
       "tier": 1,
-      "status": "alpha",
+      "status": "beta",
       "description": "Primary action button paired with a dropdown toggle for related secondary actions, with collision-aware menu placement and optional nested submenus.",
       "dense": "primary action + menu toggle for related actions; Button-matched variant/size/surface, collision-aware menu, nested submenus, roving-tabindex keyboard model",
       "keywords": [


### PR DESCRIPTION
Promotes **SplitButton** from alpha→beta. It was the **last remaining alpha** in the catalog (roadmap 4.1: build properly or delete — it has a real production consumer in `CodeSnippet`, so it was built out, not deleted).

## What changed
- **Figma component built** in DT-Site-stuff Molecules (node `1052-2084`): a `Variant×Size` (9) `COMPONENT_SET` composed from Button atom instances with an attached caret toggle. Primary/tertiary fold the seam; secondary keeps its divider — matching the code. Node-id wired into `contract.figma` + the story `design.url`.
- **Real verification, not a flag flip** (each gate surfaced a genuine gap):
  - Light/dark **and** forced-colors verified on the closed control **and** the open portaled Menu (the one item the a11y note left pending). Theme flips both segments and the menu surface; in forced-colors the menu draws a visible `CanvasText` border, not shadow-only. `forcedColorsVerified` + `lightDarkVerified` now true.
  - `slots` reduced `[label, options, menu]` → `[label]` to match the interface (only `label` is a ReactNode slot; `options` is structured data, `menu` is internal). Fixes a real contract/interface mismatch the beta gate caught.
  - Added `Example` (document toolbar) + `ForcedColors` stories; `requiredStories` extended to meet the beta bar.
  - Bootstrapped 4-mode AT snapshots (20 files, deterministic across reruns).

## Local verification (all green)
`validate:components` · `check:contract-props` · `check:consumers` · `audit:controls --only SplitButton --effects` (100% operable / 0 inert) · 4-mode AT compare · `typecheck` · `lint` · `lint:css` · `vitest` (2051 passed) · `build` · `check:generated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new SplitButton story examples, including a forced-colors variant.
  * Expanded visual and accessibility coverage across light, dark, and forced-colors states.
* **Bug Fixes**
  * Updated SplitButton status to beta and refreshed related metadata.
  * Improved documented button states for default, disabled, export, nested submenu, playground, and variants scenarios.
* **Documentation**
  * Added updated verification notes and design reference links for SplitButton.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->