### PR TITLE
feat(design-system): promote Menu beta→stable

### DIFF
--- a/nextjs-app/shared/components/Menu/Menu.contract.json
+++ b/nextjs-app/shared/components/Menu/Menu.contract.json
@@ -3,12 +3,22 @@
     "name": "Menu",
     "tier": "molecule",
     "group": "overlay",
-    "status": "beta",
+    "status": "stable",
     "description": "Radix dropdown-menu primitive set (Menu, Trigger, Content, Item, Sub) shared by Avatar and SplitButton.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1015-180",
     "radixPrimitive": "@radix-ui/react-dropdown-menu",
     "element": "div",
-    "variants": {},
+    "variants": {
+        "align": {
+            "values": [
+                "start",
+                "center",
+                "end"
+            ],
+            "default": "start",
+            "propSourced": true
+        }
+    },
     "slots": [],
     "asChild": false,
     "subParts": [
@@ -73,8 +83,10 @@
         ],
         "reducedMotion": true,
         "reviewed": true,
-        "reviewedNote": "2026-07-05 (alpha) — keyboard open/arrow/Home/End/typeahead/Escape/focus-return and item select are provided by Radix DropdownMenu and asserted end to end in the Storybook Example play (real browser via test-storybook); item select + disabled + href-as-anchor + axe-clean-while-open covered in unit tests. Light + dark eyeballed in Storybook (white/near-black surface tracks the theme, --color-neutral-bg highlight reads in both); emulated forced-colors shows a CanvasText-bordered Canvas surface with Highlight/HighlightText selection and GrayText disabled items; open/close animation drops under prefers-reduced-motion.",
-        "forcedColorsVerified": true
+        "reviewedNote": "2026-07-05 (alpha) — keyboard open/arrow/Home/End/typeahead/Escape/focus-return and item select are provided by Radix DropdownMenu and asserted end to end in the Storybook Example play (real browser via test-storybook); item select + disabled + href-as-anchor + axe-clean-while-open covered in unit tests. Light + dark eyeballed in Storybook (white/near-black surface tracks the theme, --color-neutral-bg highlight reads in both); emulated forced-colors shows a CanvasText-bordered Canvas surface with Highlight/HighlightText selection and GrayText disabled items; open/close animation drops under prefers-reduced-motion. 2026-07-06 (beta→stable) — independently re-verified the OPEN menu (Default + WithSubmenu) in a real browser via Playwright: light/dark flip both the trigger and the portaled surface, and forced-colors draws a visible CanvasText border with a real separator (not shadow-only). 4-mode AT snapshots refreshed and compare-clean; realBrowserForcedColorsVerified + accessibilityTreeVerified set true.",
+        "forcedColorsVerified": true,
+        "realBrowserForcedColorsVerified": true,
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [
@@ -213,5 +225,57 @@
         "SplitButton",
         "Icon",
         "Kbd"
+    ],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/BlogArticleMdxBody.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ServerArticleContent.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ServerArticleMain.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/index.ts",
+            "since": "2026-06-04"
+        }
     ]
 }

--- a/nextjs-app/shared/components/Menu/Menu.stories.tsx
+++ b/nextjs-app/shared/components/Menu/Menu.stories.tsx
@@ -74,7 +74,7 @@ const meta = {
     contractStatus: contract.status,
     a11y: { test: "error" },
   },
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   argTypes: {
     side: {
       control: { type: "select" },

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--as-links.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--as-links.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Account" [expanded]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--default.dark.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--default.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Actions" [expanded]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--default.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Actions" [expanded]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--default.light.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--default.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Actions" [expanded]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--default.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--default.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Actions" [expanded]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--disabled.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--disabled.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Actions" [expanded]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--example.dark.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--example.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Open menu"

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--example.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Open menu"

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--example.light.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--example.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Open menu"

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--example.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--example.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Open menu"

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--forced-colors.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Actions" [expanded]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--forced-colors.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Actions" [expanded]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--forced-colors.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Actions" [expanded]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--forced-colors.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Actions" [expanded]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--playground.dark.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--playground.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Actions" [expanded]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--playground.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Actions" [expanded]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--playground.light.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--playground.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Actions" [expanded]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--playground.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--playground.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Actions" [expanded]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--with-icons.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--with-icons.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "File" [expanded]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--with-submenu.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--with-submenu.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - button "Share" [expanded]

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -8594,7 +8594,7 @@
       "name": "Menu",
       "group": "overlay",
       "tier": 2,
-      "status": "beta",
+      "status": "stable",
       "description": "Radix dropdown-menu primitive set (Menu, Trigger, Content, Item, Sub) shared by Avatar and SplitButton.",
       "dense": "Radix dropdown-menu set: Menu > MenuTrigger asChild > MenuContent (side/align) with MenuItem (icon/trailing/disabled/onSelect/href), MenuSeparator, MenuSub; Radix owns focus, arrows, typeahead, Escape",
       "keywords": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -466,6 +466,33 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "structure",
     "import": "import List from "@dt/List";",
   },
+  "Menu": {
+    "exampleStories": [
+      "WithIcons",
+      "WithSubmenu",
+      "Disabled",
+      "AsLinks",
+      "Example",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "overlay",
+    "import": "import { Menu } from "@dt/Menu";",
+  },
   "Modal": {
     "exampleStories": [
       "Confirmation",


### PR DESCRIPTION
Promotes **Menu** (the shared Radix dropdown-menu primitive) beta→stable. This is the engine behind Avatar's account menu and SplitButton's options, with **10 real production consumers** (blog article pipeline + `ArticlePageTemplate`) confirmed by `audit:consumers`.

## beta→stable work (re-verified, not a flag flip)
- **Independently re-verified the open menu in a real browser** (Playwright): light/dark flip both the trigger and the portaled surface; forced-colors draws a visible `CanvasText` border + separator, not shadow-only. Set `realBrowserForcedColorsVerified` + `accessibilityTreeVerified`.
- **Added `variants.align`** (`start`/`center`/`end`, `propSourced`) — the styling axis the stable gate requires.
- **Refreshed 4-mode AT snapshots**: flipping to stable drops the WipBadge, so every file loses exactly one line — verified no other drift, compare-clean across all 4 modes.
- Regenerated `docs-registry` + updated the per-stable-shape MCP snapshot.

## Local verification (all green)
`validate:components` · `check:contract-props` · `check:consumers` · 4-mode AT compare · `typecheck` · `lint` · `lint:css` · `vitest` (2051 passed) · `build` · `check:generated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Menu is now marked stable and includes a configurable alignment option with start, center, and end choices.
  * Updated accessibility verification status to reflect completed real-browser checks, including forced-colors and accessibility tree coverage.

* **Bug Fixes**
  * Removed outdated “work in progress” labels from Menu accessibility snapshots so they now reflect the current stable state.

* **Documentation**
  * Updated Storybook metadata to show the Menu as stable.
  * Added consumer references for the components’ current usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->