### PR TITLE
fix(design-system): fix AlertBanner title/description type hierarchy

### DIFF
--- a/nextjs-app/shared/components/AlertBanner/AlertBanner.module.css
+++ b/nextjs-app/shared/components/AlertBanner/AlertBanner.module.css
@@ -2,7 +2,7 @@
   display: flex;
   padding: var(--space-internal-12, 0.75rem) var(--space-internal-16, 1rem);
   align-items: flex-start;
-  gap: 0.75rem;
+  gap: var(--space-internal-8, 0.5rem);
   border-radius: var(--radius-md, 8px);
   font-family: var(--font-text);
 }
@@ -11,19 +11,30 @@
   display: flex;
   min-width: 0;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--space-internal-4, 0.25rem);
 }
 
-.title {
+/* Title/description sizing is scoped under .content so it beats the Title and
+   Text base size classes: a bare `.title` (0,1,0) only ties the component's own
+   size class and loses on source order (the module loads last), which is why
+   the heading was rendering at the 36px Title-s scale. The parent scope raises
+   specificity to (0,2,0) and wins. Hierarchy is a size + weight step at the
+   same tone colour (compact-banner pattern): 16/600 heading over 14/400 body,
+   holding the 14px text floor. */
+
+.content .title {
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
+  line-height: 1.35;
   color: inherit;
 }
 
-.description {
+.content .description {
   margin: 0;
-  font-size: 0.95rem;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.45;
   color: inherit;
 }
 


### PR DESCRIPTION
Fixes the AlertBanner title/description **type hierarchy**, per the report that its font sizes needed love (ref: [astryx Banner](https://astryx.atmeta.com/components/Banner)).

## The bug
The title was rendering at **36px** (the `Title size="s"` scale) and the description at **20px** — because the `.title` / `.description` `font-size` overrides are single-class `(0,1,0)` selectors that only *tie* the Title/Text base size classes and **lose on source order** (the CSS module loads last). So the intended 16/15px sizing never applied and title vs body had almost no contrast.

## The fix
Scope the overrides under `.content` (`(0,2,0)` beats the component size class) and set a compact, intentional hierarchy matching the reference's principle — a **size step + weight step at the same tone colour**:

| | before (rendered) | after |
|---|---|---|
| Title | 36px / 500 | **16px / 600** / lh 1.35 |
| Description | 20px / 400 | **14px / 400** / lh 1.45 |

14px holds the DT text floor. Also tightened the icon↔content gap to `--space-internal-8` (8px, matching the reference) and tokenised the content gap. **CSS-only — AT snapshots unchanged.**

## Verified
Computed sizes measured in a real browser (16/600 title, 14/400 body); light + dark rendering checked. Gates: `validate:components` · `lint` · `lint:css` (baseline unchanged) · `audit:rhythm:check` (0 new) · `typecheck` · `vitest` (2051) · `build`.

## Spun off separately (pre-existing, out of font-size scope)
- The semantic tone icon renders nothing (icon-registry resolution for the dynamic `toneIcon` names).
- Tone text colours (e.g. `#054956`) are tuned for light mode, so dark-mode contrast is weak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
