### PR TITLE
fix(design-system): make AlertBanner tones theme-adaptive (AA in all 4 themes)

### DIFF
--- a/nextjs-app/shared/components/AlertBanner/AlertBanner.module.css
+++ b/nextjs-app/shared/components/AlertBanner/AlertBanner.module.css
@@ -5,6 +5,12 @@
   gap: var(--space-internal-8, 0.5rem);
   border-radius: var(--radius-md, 8px);
   font-family: var(--font-text);
+
+  /* Body copy uses the theme foreground, which is AA on every theme's surface
+     by design. The tone is carried by the tinted surface + border below, so
+     the text stays legible in all four themes instead of the old hardcoded
+     light-only ink. */
+  color: var(--color-text);
 }
 
 .content {
@@ -46,28 +52,27 @@
   margin-inline-start: auto;
 }
 
-.info {
-  border: 1px solid rgb(15 98 254 / 25%);
-  background: rgb(15 98 254 / 12%);
+/* Tone = an opaque tint of the semantic colour mixed over the page surface
+   (predictable contrast, unlike a translucent overlay on an unknown backdrop)
+   plus a tone border. Every token here is theme-adaptive, so the tint tracks
+   light, dark, and both high-contrast themes automatically. */
 
-  /* Darkened teal lifts AA contrast above 4.5:1 on the tinted bg. */
-  color: var(--alert-info-text, #054956);
+.info {
+  border: 1px solid color-mix(in srgb, var(--color-info) 40%, var(--color-surface));
+  background: color-mix(in srgb, var(--color-info) 12%, var(--color-surface));
 }
 
 .success {
-  border: 1px solid rgb(34 197 94 / 25%);
-  background: rgb(34 197 94 / 12%);
-  color: var(--alert-success-text, #045924);
+  border: 1px solid color-mix(in srgb, var(--color-success) 40%, var(--color-surface));
+  background: color-mix(in srgb, var(--color-success) 12%, var(--color-surface));
 }
 
 .warning {
-  border: 1px solid rgb(234 179 8 / 25%);
-  background: rgb(234 179 8 / 12%);
-  color: var(--color-dark);
+  border: 1px solid color-mix(in srgb, var(--color-warning) 46%, var(--color-surface));
+  background: color-mix(in srgb, var(--color-warning) 16%, var(--color-surface));
 }
 
 .error {
-  border: 1px solid rgb(239 68 68 / 25%);
-  background: rgb(239 68 68 / 12%);
-  color: var(--alert-error-text, #8b1010);
+  border: 1px solid color-mix(in srgb, var(--color-error) 40%, var(--color-surface));
+  background: color-mix(in srgb, var(--color-error) 12%, var(--color-surface));
 }


### PR DESCRIPTION
Fixes the AlertBanner theme colours — the dark-mode contrast was badly failing (the info banner measured ~1.5:1).

## Root cause
The tone styles hardcoded **light-only ink** (`#054956`, `#045924`, `#8b1010`, `--color-dark`) over translucent `rgb()` tints. The DS has four themes — light, dark, HCB (high-contrast black), HCW (high-contrast white) — each with adaptive tone tokens, but the banner ignored all of them, so in dark + HC themes the dark ink sat on a dark surface.

## Fix
Each tone now uses **theme-adaptive tokens**:
- **background** — an opaque `color-mix` of the semantic colour over `--color-surface` (predictable contrast, unlike a translucent overlay on an unknown backdrop)
- **border** — a stronger `color-mix` of the same tone
- **text** — `--color-text` (the theme foreground, AA on every theme's surface by design); the tone is carried by the tint + border

## Measured WCAG contrast (real browser, title + body)
| theme | info | success | warning | error |
|---|---|---|---|---|
| light | 15.1 | 15.0 | 16.3 | 14.9 |
| dark | 9.9 | 10.5 | 9.4 | 11.2 |
| HCB | — | — | — | 16.6 |
| HCW | — | — | — | 16.0 |

All ≫ 4.5:1. **CSS-only — AT snapshots unchanged.** Gates: `validate:components` · `lint` · `lint:css` · `audit:rhythm:check` (0 new) · `typecheck` · `vitest` · `build`.

## Known separate issue
The semantic tone icon still renders nothing — a distinct icon-registry resolution bug (registered `Info`/`CheckCircle`/… not resolving at runtime), tracked separately. Tone is currently conveyed by the tint + border; the icon will reinforce it once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
