### PR TITLE
fix(design-system): render AlertBanner tone icon (empty-string arg leak)

### DIFF
--- a/nextjs-app/shared/components/AlertBanner/AlertBanner.test.tsx
+++ b/nextjs-app/shared/components/AlertBanner/AlertBanner.test.tsx
@@ -42,6 +42,25 @@ describe("AlertBanner", () => {
     expect(container.querySelector(`.${styles.error}`)).toBeInTheDocument();
   });
 
+  it("renders the tone icon by default", () => {
+    const { container } = render(<AlertBanner tone="info" title="Info" />);
+    expect(
+      container.querySelector('[data-icon-name="info"]'),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to the tone icon when icon is an empty string", () => {
+    // Storybook's controls-autogen seeds icon="" on every story; an empty
+    // string must be treated as absent (|| not ??) so the tone icon still
+    // renders instead of resolving to a nameless, missing glyph.
+    const { container } = render(
+      <AlertBanner tone="success" title="Saved" icon="" />,
+    );
+    expect(
+      container.querySelector('[data-icon-name="check-circle"]'),
+    ).toBeInTheDocument();
+  });
+
   it("renders dismiss button when dismissible", () => {
     render(<AlertBanner title="Message" dismissible />);
     expect(

--- a/nextjs-app/shared/components/AlertBanner/AlertBanner.tsx
+++ b/nextjs-app/shared/components/AlertBanner/AlertBanner.tsx
@@ -59,7 +59,10 @@ const AlertBanner: React.FC<AlertBannerProps> = ({
       role={role}
       aria-live={liveRegion}
     >
-      <Icon name={icon ?? toneIcon[tone]} ariaLabel={tone} size="md" />
+      {/* `||` not `??`: an empty-string icon (Storybook controls-autogen seeds
+          "" on every story) must fall through to the semantic tone icon, not
+          resolve to a nameless, missing glyph. */}
+      <Icon name={icon || toneIcon[tone]} ariaLabel={tone} size="md" />
       <div className={styles.content}>
         {title && (
           <Title size="s" className={styles.title}>

--- a/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--default.yaml
+++ b/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--default.yaml
@@ -1,4 +1,5 @@
 - status: Work in progress (beta)
 - status:
+  - img "info"
   - heading "Heads up" [level=1]
   - paragraph: This is an informational message.

--- a/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--dismissible.yaml
+++ b/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--dismissible.yaml
@@ -1,5 +1,6 @@
 - status: Work in progress (beta)
 - status:
+  - img "success"
   - heading "Saved" [level=1]
   - paragraph: Your changes have been stored.
   - button "Dismiss alert": Close

--- a/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--example.yaml
+++ b/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--example.yaml
@@ -1,5 +1,6 @@
 - status: Work in progress (beta)
 - status:
+  - img "success"
   - heading "Saved" [level=1]
   - paragraph: Your changes have been stored.
   - button "Dismiss alert": Close

--- a/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--forced-colors.yaml
+++ b/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--forced-colors.yaml
@@ -1,2 +1,3 @@
 - status: Work in progress (beta)
-- status
+- status:
+  - img "info"

--- a/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--info.yaml
+++ b/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--info.yaml
@@ -1,4 +1,5 @@
 - status: Work in progress (beta)
 - status:
+  - img "info"
   - heading "Heads up" [level=1]
   - paragraph: This is an informational message.

--- a/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--playground.yaml
+++ b/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--playground.yaml
@@ -1,4 +1,5 @@
 - status: Work in progress (beta)
 - status:
+  - img "info"
   - heading "Heads up" [level=1]
   - paragraph: This is an informational message.

--- a/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--warning.yaml
+++ b/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--warning.yaml
@@ -1,4 +1,5 @@
 - status: Work in progress (beta)
 - status:
+  - img "warning"
   - heading "Check details" [level=1]
   - paragraph: There might be something you need to review.

--- a/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--with-action.yaml
+++ b/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--with-action.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (beta)
+- status:
+  - img "info"
+  - heading "Cookie preferences updated" [level=1]
+  - paragraph: Analytics stays off until you opt back in.
+  - button "Review settings"


### PR DESCRIPTION
Fixes the AlertBanner semantic **tone icon rendering nothing**.

## Root cause — not the registry
The spun-off task assumed an icon-registry gap. A runtime probe disproved that: `resolvePhosphorIcon("info" | "check-circle" | "warning-circle" | "x-circle")` **all resolve correctly**. The real signal was the browser console: `[Icon] Unable to find Phosphor icon ""` — the name was an **empty string**.

The component computed `name={icon ?? toneIcon[tone]}` with `??`. Storybook's controls-autogen seeds `icon=""` on every story, and `"" ?? toneIcon[tone]` evaluates to `""` (an empty string is not nullish), so the tone fallback never applied and `Icon` rendered `null`. This is the same empty-string-leak class already fixed with `||` on Button / Avatar / SplitButton.

## Fix
`icon || toneIcon[tone]` — an empty string now falls through to the tone icon.

- **Regression test**: `icon=""` must still render the tone icon (failed before, passes now), plus a default-icon test.
- **AT snapshots refreshed**: the icon now appears in the accessibility tree as `img "<tone>"` (labeled by tone so colour is never the only signal — the component's stated a11y intent). Also filled a missing `WithAction` snapshot.
- Swept for the same `iconProp ?? default` pattern elsewhere — none found.

## Verified
Real browser: `check-circle` glyph renders (24px, `data-icon-name="check-circle"`, no console warning). Gates: `validate:components` · `lint` · `lint:css` · `typecheck` · `vitest` · `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alert banners now always show the appropriate default icon for each tone, even when an empty custom icon value is provided.
  * Updated alert banner snapshots to reflect the correct icon and status content across variants.

* **Tests**
  * Added coverage for default icon selection behavior in alert banners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->