### PR TITLE
fix(design-system): AlertBanner title is strong, not a heading

### DIFF
--- a/nextjs-app/shared/components/AlertBanner/AlertBanner.tsx
+++ b/nextjs-app/shared/components/AlertBanner/AlertBanner.tsx
@@ -6,7 +6,6 @@ import styles from "./AlertBanner.module.css";
 import Icon from "@dt/Icon";
 import Button from "@dt/Button";
 import Text from "@dt/Text";
-import Title from "@dt/Title";
 
 type Tone = "info" | "success" | "warning" | "error";
 
@@ -65,9 +64,13 @@ const AlertBanner: React.FC<AlertBannerProps> = ({
       <Icon name={icon || toneIcon[tone]} ariaLabel={tone} size="md" />
       <div className={styles.content}>
         {title && (
-          <Title size="s" className={styles.title}>
+          // A status/alert label, not a document heading: rendering it as a
+          // heading (Title is always h1-h6) injects a stray heading into the
+          // page outline wherever a banner appears. `strong` carries the
+          // emphasis without the heading semantics (cf. Radix Toast.Title).
+          <Text as="strong" className={styles.title}>
             {title}
-          </Title>
+          </Text>
         )}
         {description && (
           <Text size="m" className={styles.description}>

--- a/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--default.yaml
+++ b/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--default.yaml
@@ -1,5 +1,5 @@
 - status: Work in progress (beta)
 - status:
   - img "info"
-  - heading "Heads up" [level=1]
+  - strong: Heads up
   - paragraph: This is an informational message.

--- a/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--dismissible.yaml
+++ b/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--dismissible.yaml
@@ -1,6 +1,6 @@
 - status: Work in progress (beta)
 - status:
   - img "success"
-  - heading "Saved" [level=1]
+  - strong: Saved
   - paragraph: Your changes have been stored.
   - button "Dismiss alert": Close

--- a/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--example.yaml
+++ b/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--example.yaml
@@ -1,6 +1,6 @@
 - status: Work in progress (beta)
 - status:
   - img "success"
-  - heading "Saved" [level=1]
+  - strong: Saved
   - paragraph: Your changes have been stored.
   - button "Dismiss alert": Close

--- a/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--info.yaml
+++ b/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--info.yaml
@@ -1,5 +1,5 @@
 - status: Work in progress (beta)
 - status:
   - img "info"
-  - heading "Heads up" [level=1]
+  - strong: Heads up
   - paragraph: This is an informational message.

--- a/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--playground.yaml
+++ b/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--playground.yaml
@@ -1,5 +1,5 @@
 - status: Work in progress (beta)
 - status:
   - img "info"
-  - heading "Heads up" [level=1]
+  - strong: Heads up
   - paragraph: This is an informational message.

--- a/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--warning.yaml
+++ b/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--warning.yaml
@@ -1,5 +1,5 @@
 - status: Work in progress (beta)
 - status:
   - img "warning"
-  - heading "Check details" [level=1]
+  - strong: Check details
   - paragraph: There might be something you need to review.

--- a/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--with-action.yaml
+++ b/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--with-action.yaml
@@ -1,6 +1,6 @@
 - status: Work in progress (beta)
 - status:
   - img "info"
-  - heading "Cookie preferences updated" [level=1]
+  - strong: Cookie preferences updated
   - paragraph: Analytics stays off until you opt back in.
   - button "Review settings"


### PR DESCRIPTION
Fixes a semantic issue in AlertBanner: the title rendered as an **`<h1>`** inside the `role="status"` region.

## Why it's a problem
The title used `<Title size="s">`, and `Title` always renders `h1`–`h6` (defaulting to `h1`). AlertBanner is a reusable component that can appear anywhere on a page, so every banner injected a stray — often duplicate top-level — heading into the document outline.

## Fix
Render the title as `<Text as="strong">`. It keeps the emphasis and the compact-title styling (`.content .title` — 16px/600) but carries **no heading semantics**, so it no longer pollutes the page outline. This mirrors how Radix `Toast.Title` is a non-heading element. The alert is still conveyed by the `role="status"`/`alert` live region plus the tone icon.

- **AT snapshots refreshed**: `heading "…" [level=1]` → `strong: …`; verified zero headings in the banner via a real browser.
- Removed the now-unused `Title` import.

Gates: `validate:components` · `lint` · `lint:css` · `typecheck` · `vitest` · `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
