### PR TITLE
refactor(design-system): AlertBanner icon prop → showIcon boolean

### DIFF
--- a/nextjs-app/shared/components/AlertBanner/AlertBanner.contract.json
+++ b/nextjs-app/shared/components/AlertBanner/AlertBanner.contract.json
@@ -78,9 +78,9 @@
             "optional": true,
             "type": "React.ReactNode"
         },
-        "icon": {
+        "showIcon": {
             "optional": true,
-            "type": "string"
+            "type": "boolean"
         },
         "dismissible": {
             "optional": true,

--- a/nextjs-app/shared/components/AlertBanner/AlertBanner.stories.tsx
+++ b/nextjs-app/shared/components/AlertBanner/AlertBanner.stories.tsx
@@ -128,6 +128,24 @@ export const WithAction: Story = {
   },
 };
 
+export const TextOnly: Story = {
+  tags: ["example"],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "showIcon={false} drops the tone icon for a compact, text-only banner. The icon is always the semantic tone glyph — there is no per-instance icon override, so this boolean is the only icon control.",
+      },
+    },
+  },
+  args: {
+    tone: "info",
+    title: "Heads up",
+    description: "This is an informational message.",
+    showIcon: false,
+  },
+};
+
 export const Default = Info;
 
 export const Playground: Story = {

--- a/nextjs-app/shared/components/AlertBanner/AlertBanner.test.tsx
+++ b/nextjs-app/shared/components/AlertBanner/AlertBanner.test.tsx
@@ -49,16 +49,11 @@ describe("AlertBanner", () => {
     ).toBeInTheDocument();
   });
 
-  it("falls back to the tone icon when icon is an empty string", () => {
-    // Storybook's controls-autogen seeds icon="" on every story; an empty
-    // string must be treated as absent (|| not ??) so the tone icon still
-    // renders instead of resolving to a nameless, missing glyph.
+  it("hides the icon when showIcon is false", () => {
     const { container } = render(
-      <AlertBanner tone="success" title="Saved" icon="" />,
+      <AlertBanner tone="success" title="Saved" showIcon={false} />,
     );
-    expect(
-      container.querySelector('[data-icon-name="check-circle"]'),
-    ).toBeInTheDocument();
+    expect(container.querySelector("[data-icon-name]")).not.toBeInTheDocument();
   });
 
   it("renders dismiss button when dismissible", () => {
@@ -145,12 +140,6 @@ describe("AlertBanner", () => {
     expect(
       screen.getByRole("button", { name: "Review settings" }),
     ).toBeInTheDocument();
-  });
-
-  it("overrides the tone icon via the icon prop", () => {
-    render(<AlertBanner tone="info" title="Custom" icon="star" />);
-    // The accessible tone word stays even when the glyph changes.
-    expect(screen.getByRole("img", { name: "info" })).toBeInTheDocument();
   });
 
   it("every styles.x reference has a matching .x rule", () => {

--- a/nextjs-app/shared/components/AlertBanner/AlertBanner.tsx
+++ b/nextjs-app/shared/components/AlertBanner/AlertBanner.tsx
@@ -18,8 +18,8 @@ export type AlertBannerProps = {
   description?: React.ReactNode;
   /** Optional action slot rendered under the description (e.g. a tertiary Button). */
   action?: React.ReactNode;
-  /** Override the tone icon with another registered icon name. */
-  icon?: string;
+  /** Show the semantic tone icon. The icon is derived from `tone`; set false for a text-only banner. @default true */
+  showIcon?: boolean;
   /** Shows a localized dismiss control when true. @default false */
   dismissible?: boolean;
   /** Called when the user dismisses the banner. */
@@ -41,7 +41,7 @@ const AlertBanner: React.FC<AlertBannerProps> = ({
   title,
   description,
   action,
-  icon,
+  showIcon = true,
   dismissible = false,
   onDismiss,
   "aria-live": ariaLive,
@@ -58,10 +58,11 @@ const AlertBanner: React.FC<AlertBannerProps> = ({
       role={role}
       aria-live={liveRegion}
     >
-      {/* `||` not `??`: an empty-string icon (Storybook controls-autogen seeds
-          "" on every story) must fall through to the semantic tone icon, not
-          resolve to a nameless, missing glyph. */}
-      <Icon name={icon || toneIcon[tone]} ariaLabel={tone} size="md" />
+      {/* The icon is always the semantic tone icon; showIcon only toggles its
+          presence (there is no per-instance icon override — the tone owns it). */}
+      {showIcon && (
+        <Icon name={toneIcon[tone]} ariaLabel={tone} size="md" />
+      )}
       <div className={styles.content}>
         {title && (
           // A status/alert label, not a document heading: rendering it as a

--- a/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--text-only.yaml
+++ b/nextjs-app/shared/components/AlertBanner/__a11y-snapshots__/feedback-alertbanner--text-only.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- status:
+  - strong: Heads up
+  - paragraph: This is an informational message.


### PR DESCRIPTION
Reworks the AlertBanner `icon` prop per the report that it "doesn't work and has no functionality".

## Why it looked broken
`icon` was a free-string **override** of the tone icon. The tone already maps to the correct semantic glyph (info / success / warning / error), and the Storybook text control silently rendered **nothing** for any unregistered name — so changing it appeared to do nothing. No production code used it.

## Change
Replace `icon?: string` with **`showIcon?: boolean`** (default `true`): the tone always owns the icon; the boolean just shows or hides it for a compact, text-only banner.

- `AlertBannerProps`: `icon: string` → `showIcon: boolean` (destructured `= true`, so the controls-autogen seeds `true` and every story keeps its icon).
- Contract props updated to match.
- **Tests**: dropped the icon-override + empty-string-icon cases; added a `showIcon={false}` hides-the-icon test.
- New **TextOnly** example story documents the variant.
- **Default rendering unchanged** (showIcon defaults true) → existing AT snapshots untouched; only the new TextOnly snapshot is added.
- `audit:controls`: 100% operable / 0 inert (toggling `showIcon` shows/hides the icon in the real panel).

## Verified
Real browser: `showIcon=true` renders the tone icon, `showIcon=false` hides it (text-only banner). Gates: `validate:components` · `check:contract-props` · `audit:controls` · `lint` · `lint:css` · `typecheck` · `vitest` · `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
