### PR TITLE
feat(design-system): add SelectableCard (alpha) — Astryx parity

### DIFF
--- a/docs/plans/2026-07-07-selectable-card-design.md
+++ b/docs/plans/2026-07-07-selectable-card-design.md
@@ -1,0 +1,129 @@
+# SelectableCard — design
+
+Date: 2026-07-07
+Branch: `DT-selectable-card`
+Status target: `alpha` (WIP badge; no promotion until a real consumer exists)
+
+## Why
+
+Library parity with the Astryx reference (`@astryxdesign/core/SelectableCard`,
+https://astryx.atmeta.com/components/SelectableCard). The card-as-a-choice-tile
+pattern (plan pickers, onboarding options, settings tiles) is a common design
+system primitive we lack.
+
+This is a **parity** build, not a consumer-driven one. Per the roadmap rule
+(components are not promoted past alpha/beta without a genuine prod consumer —
+the same bar currently blocking ArticleCard), SelectableCard ships at `alpha`
+with the WIP badge and is not promoted until a real screen adopts it.
+
+## Existing building blocks
+
+- `Card` (stable): presentational container — `variant` (default/muted/transparent),
+  `href`, header/footer slots (#875), skeleton, `titleProps`/`descriptionProps`.
+- `Radio` / `RadioGroup` (beta): native-input single-select. Group API is
+  options-array driven (`options`, `value`/`defaultValue`/`onValueChange`,
+  `name`, `orientation`, `error`).
+- `Checkbox` / `CheckboxGroup` (beta): native-input multi-select.
+
+## Architecture
+
+Two components mirroring the Group/Item convention, but **compound children**
+(not options-array) because each card is rich content — title, description,
+media, and Card's slots — which a `{value,label}[]` array cannot express. This is
+the one deliberate divergence from `RadioGroup`/`CheckboxGroup` house style, and
+it is unavoidable given the content model.
+
+```tsx
+import { SelectableCardGroup, SelectableCard } from "@dt/SelectableCard";
+
+<SelectableCardGroup type="single" value={plan} onValueChange={setPlan} name="plan">
+  <SelectableCard value="starter" title="Starter" description="For solo work" />
+  <SelectableCard value="team"    title="Team"    description="Up to 10 seats" />
+</SelectableCardGroup>
+```
+
+### `SelectableCardGroup`
+
+Owns selection state and exposes it via React context.
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `type` | `"single" \| "multiple"` | Selection model. Default `"single"`. |
+| `value` | `string` (single) / `string[]` (multiple) | Controlled. `""`/`[]` treated as absent. |
+| `defaultValue` | same | Uncontrolled initial. |
+| `onValueChange` | `(v: string) => void` / `(v: string[]) => void` | Fires with next value. |
+| `name` | `string` | Native radio group name (single); auto-generated when omitted. |
+| `disabled` | `boolean` | Disables the whole group. |
+| `orientation` | `"vertical" \| "horizontal"` | Layout of the card stack. Default `"vertical"`. |
+| `error` | `string` | Announced via `role="alert"` + `aria-invalid`, matching RadioGroup. |
+
+The group renders `role="radiogroup"` (single) implicitly via native radios; for
+`multiple` it is a labelled `group`. Vocab (`value`/`onValueChange`) is reused
+verbatim from RadioGroup so consumers switch between them without relearning.
+
+### `SelectableCard`
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `value` | `string` (required) | Submitted value / selection key. |
+| `disabled` | `boolean` | Per-card disable; choice stays visible. |
+| `selected` | `boolean` | Standalone controlled use outside a group (optional). |
+| ...Card props | | `variant`, `title`, `description`, `children`, slots pass through to `Card`. |
+
+Reads selected state from group context when present.
+
+## Accessibility
+
+Each card is a `<label>` wrapping a **visually-hidden native `<input>`**
+(`type="radio"` for single, `type="checkbox"` for multiple), with `Card` as the
+visual. This is preferred over `role="radio"` + roving-tabindex because it buys,
+for free and correctly:
+
+- keyboard: Tab into the group, Arrow to move within a single-select set, Space
+  to toggle in multiple;
+- focus management and `:focus-visible`;
+- native form submission (`name`/`value`);
+- correct screen-reader semantics.
+
+Consistent with how `Radio`/`Checkbox` already work in this system.
+
+## States (all token-driven; dark / HCB / HCW / forced-colors)
+
+- **Unselected**: normal `Card` surface.
+- **Selected**: token ring/border + indicator — radio dot (`single`) or checkmark
+  (`multiple`) — so the mode is legible.
+- **Focus**: visible ring on the card via the hidden input's `:focus-visible`
+  (`:has()`), not just the input.
+- **Disabled**: dimmed, `aria-disabled`, non-interactive, still readable.
+- **Hover**: subtle surface shift; suppressed under `prefers-reduced-motion` and
+  when disabled.
+
+## Files
+
+```
+nextjs-app/shared/components/SelectableCard/
+  SelectableCard.tsx            Group + Card + context
+  SelectableCard.module.css
+  SelectableCard.stories.tsx    Single, Multiple, Disabled, WithMedia, Error, ForcedColors
+  SelectableCard.test.tsx       selection, keyboard, form name/value, controlled + uncontrolled
+  SelectableCard.a11y.test.tsx
+  SelectableCard.contract.json  status: alpha
+  SelectableCard.spec.md
+  schema.json
+  index.ts
+```
+
+## Verification bar
+
+- `axe` clean in all stories.
+- Keyboard drive confirmed live in Storybook (Tab in / Arrow within single / Space toggle).
+- 4-mode AT snapshots.
+- light / dark / forced-colors.
+- getComputedStyle check per selection state (selected ring), not just DOM diff —
+  per the `--effects` lesson (a class swap with identical DOM reads as inert).
+- Pre-PR gate: typecheck, lint, test, build.
+
+## Out of scope (YAGNI)
+
+- Options-array convenience API (rich content makes it a poor fit).
+- Drag-reorder, async loading, nested groups.

--- a/nextjs-app/shared/components/SelectableCard/SelectableCard.a11y.test.tsx
+++ b/nextjs-app/shared/components/SelectableCard/SelectableCard.a11y.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { SelectableCard, SelectableCardGroup } from "./SelectableCard";
+
+expect.extend(toHaveNoViolations);
+
+describe("SelectableCard accessibility", () => {
+  it("single-select group has no axe violations", async () => {
+    const { container } = render(
+      <SelectableCardGroup
+        type="single"
+        legend="Choose a plan"
+        defaultValue="team"
+        name="plan"
+      >
+        <SelectableCard value="starter" title="Starter" description="1 seat." />
+        <SelectableCard
+          value="team"
+          title="Team"
+          description="Up to 10 seats."
+        />
+      </SelectableCardGroup>,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("multiple-select group with helper text has no axe violations", async () => {
+    const { container } = render(
+      <SelectableCardGroup
+        type="multiple"
+        legend="Add-ons"
+        helperText="Pick any that apply."
+      >
+        <SelectableCard
+          value="analytics"
+          title="Analytics"
+          description="Dashboards."
+        />
+        <SelectableCard value="sso" title="SSO" description="SAML / OIDC." />
+      </SelectableCardGroup>,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("error state has no axe violations", async () => {
+    const { container } = render(
+      <SelectableCardGroup
+        type="single"
+        legend="Choose a plan"
+        error="Select a plan to continue."
+      >
+        <SelectableCard value="starter" title="Starter" description="1 seat." />
+      </SelectableCardGroup>,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/SelectableCard/SelectableCard.contract.json
+++ b/nextjs-app/shared/components/SelectableCard/SelectableCard.contract.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "SelectableCard",
+    "tier": "molecule",
+    "group": "form",
+    "status": "alpha",
+    "description": "A Card that is one selectable option; grouped into single (radio) or multiple (checkbox) sets via SelectableCardGroup.",
+    "figma": null,
+    "radixPrimitive": null,
+    "element": "label",
+    "variants": {},
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": ["Default", "Playground", "Example", "ForcedColors"],
+    "a11y": {
+        "keyboard": [
+            "Tab moves focus into the group",
+            "Arrow keys move within a single-select set (native radio)",
+            "Space toggles the focused option"
+        ],
+        "ariaRequirements": [
+            "Group renders a fieldset with a legend for the accessible name",
+            "Each card is a label wrapping a native radio/checkbox input",
+            "Error announces via role=alert and sets aria-invalid on the group"
+        ],
+        "reducedMotion": true,
+        "reviewed": false,
+        "forcedColorsVerified": false
+    },
+    "tokens": {
+        "colors": [
+            "--color-primary",
+            "--color-focus-ring",
+            "--color-border",
+            "--color-border-light",
+            "--color-surface"
+        ],
+        "spacing": [
+            "--space-internal-8",
+            "--space-internal-12",
+            "--space-internal-16",
+            "--space-internal-24"
+        ]
+    },
+    "lightDarkVerified": false
+}

--- a/nextjs-app/shared/components/SelectableCard/SelectableCard.mdx
+++ b/nextjs-app/shared/components/SelectableCard/SelectableCard.mdx
@@ -1,0 +1,47 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './SelectableCard.stories.tsx';
+
+<Meta of={Stories} />
+
+# SelectableCard
+
+**Status:** alpha · **Tier:** molecule · **Group:** form
+
+A Card that is one selectable option. `SelectableCardGroup` owns the selection and
+renders the group's legend, helper, and error; `SelectableCard` is one option.
+
+## In use
+See the **Example** story for a single-select set and **MultiSelect** for
+independent toggles.
+
+## How to use
+
+```tsx
+import { SelectableCard, SelectableCardGroup } from '@dt/SelectableCard';
+
+<SelectableCardGroup type="single" legend="Choose a plan" value={plan} onValueChange={setPlan} name="plan">
+  <SelectableCard value="starter" title="Starter" description="1 seat" />
+  <SelectableCard value="team" title="Team" description="Up to 10 seats" />
+</SelectableCardGroup>
+```
+
+For a single standalone toggle outside a group, use `selected` / `onSelectedChange`.
+
+## When to use
+- An exclusive choice among a few rich options (plans, tiers) — `type="single"`.
+- Independent add-ons or filters presented as cards — `type="multiple"`.
+
+## When not to use
+- Bare text options with no supporting content — use RadioGroup / CheckboxGroup.
+- Action or navigation cards — use a plain Card; selection must not commit or route.
+
+## Accessibility
+- Group is a fieldset named by its legend; each option is a native radio (single)
+  or checkbox (multiple) wrapped by a label, so keyboard, focus, and form
+  submission are native. Arrow keys move within a single set; Space toggles.
+- Error announces via role=alert and sets aria-invalid on the group.
+- Selected ring and indicator map to system `Highlight` under forced-colors.
+
+## Promotion notes
+- Parity build (Astryx). Promote past alpha only after AT snapshots, a documented
+  production consumer, and forced-colors + light/dark verification.

--- a/nextjs-app/shared/components/SelectableCard/SelectableCard.module.css
+++ b/nextjs-app/shared/components/SelectableCard/SelectableCard.module.css
@@ -1,0 +1,169 @@
+/* SelectableCard — a Card that is one selectable option. The label wraps a
+   visually-hidden native input; the Card is the visual, an indicator shows the
+   selected state, and the whole surface is the hit area. */
+
+/* Group (fieldset) reset + legend */
+
+.group {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  min-inline-size: 0;
+}
+
+.legend {
+  margin: 0 0 var(--space-internal-8);
+  padding: 0;
+  color: var(--color-title, var(--color-primary));
+  font-weight: 600;
+}
+
+.options {
+  display: flex;
+  gap: var(--space-internal-12);
+}
+
+.vertical {
+  flex-direction: column;
+}
+
+.horizontal {
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+/* Card as label */
+
+.card {
+  display: block;
+  position: relative;
+  cursor: pointer;
+  border-radius: 12px;
+}
+
+.card.disabled {
+  cursor: not-allowed;
+}
+
+/* Visually-hidden native input — stays in the DOM and focusable so keyboard,
+   focus, and form submission come from the platform. */
+
+.input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Surface — the Card visual. Reserve room on the trailing edge for the
+   indicator so content never sits under it. */
+
+.surface {
+  padding-inline-end: calc(var(--space-internal-24) + 20px);
+  border-color: var(--color-border-light);
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.card:hover:not(.disabled) .surface {
+  border-color: var(--color-border);
+}
+
+.card[data-selected="true"] .surface {
+  border-color: var(--color-primary);
+  box-shadow: inset 0 0 0 1px var(--color-primary);
+}
+
+/* Focus ring travels from the hidden input to the visible surface. */
+
+.card:has(.input:focus-visible) .surface {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.card.disabled .surface {
+  opacity: 0.55;
+}
+
+/* Selection indicator — outline dot (radio) or check (checkbox), always drawn
+   in --color-primary so it stays legible in every theme without a fill. */
+
+.indicator {
+  position: absolute;
+  inset-block-start: var(--space-internal-16);
+  inset-inline-end: var(--space-internal-16);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  box-sizing: border-box;
+  border: 2px solid var(--color-border);
+  background-color: var(--color-surface);
+  transition: border-color 120ms ease;
+}
+
+.indicator[data-type="radio"] {
+  border-radius: 50%;
+}
+
+.indicator[data-type="checkbox"] {
+  border-radius: 6px;
+}
+
+.card[data-selected="true"] .indicator {
+  border-color: var(--color-primary);
+}
+
+/* Radio: filled inner dot */
+.card[data-selected="true"] .indicator[data-type="radio"]::after {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: var(--color-primary);
+}
+
+/* Checkbox: check glyph drawn as two strokes in --color-primary */
+.card[data-selected="true"] .indicator[data-type="checkbox"]::after {
+  content: "";
+  width: 5px;
+  height: 10px;
+  margin-block-start: -2px;
+  border: solid var(--color-primary);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .surface,
+  .indicator {
+    transition: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .card[data-selected="true"] .surface {
+    border-color: Highlight;
+    box-shadow: inset 0 0 0 1px Highlight;
+  }
+
+  .card[data-selected="true"] .indicator {
+    border-color: Highlight;
+  }
+
+  .card[data-selected="true"] .indicator[data-type="radio"]::after,
+  .card[data-selected="true"] .indicator[data-type="checkbox"]::after {
+    background-color: Highlight;
+    border-color: Highlight;
+  }
+
+  .card.disabled .surface {
+    opacity: 1;
+    color: GrayText;
+  }
+}

--- a/nextjs-app/shared/components/SelectableCard/SelectableCard.spec.md
+++ b/nextjs-app/shared/components/SelectableCard/SelectableCard.spec.md
@@ -1,0 +1,36 @@
+# SelectableCard
+
+## Intent
+Turn a Card into a selectable option so a set of rich choices (plan pickers,
+onboarding options, add-ons, settings tiles) reads as cards rather than bare
+radios or checkboxes. `SelectableCardGroup` owns the selection; `SelectableCard`
+is one option in it.
+
+## Interaction contract
+- Keyboard: Tab moves focus into the group; Arrow keys move within a single-select
+  set (native radio behavior); Space toggles the focused option.
+- Pointer: the whole card is the hit area — clicking anywhere toggles the option.
+- Screen readers: the group is a fieldset announced by its legend; each option is
+  a native radio (single) or checkbox (multiple) whose accessible name is the
+  card content; errors announce via role=alert and set aria-invalid on the group.
+
+## Do / don't
+- Do: write the legend as the question; keep each card's title short and scannable.
+- Do: use `type="single"` for an exclusive choice, `type="multiple"` for add-ons.
+- Don't: nest interactive controls (buttons, links) inside a SelectableCard — the
+  label already owns the click. Use a plain Card for action cards.
+- Don't: use it for navigation; selecting must not commit or route on click.
+
+## Design notes
+- Tokens: `--color-primary` (selected ring + indicator), `--color-focus-ring`
+  (focus), `--color-border` / `--color-border-light` (rest/hover), `--color-surface`;
+  spacing from `--space-internal-*`. No hardcoded colors.
+- The selected state is shown by a ring on the surface plus an indicator (radio
+  dot / checkbox check) drawn in `--color-primary`, with a forced-colors mapping
+  to `Highlight`.
+- Figma: TODO (parity build; no Figma node yet).
+
+## Promotion notes
+Parity build (Astryx `SelectableCard`). Ships at alpha with the WIP badge. Do not
+promote past alpha/beta without a documented production consumer, AT snapshots,
+and forced-colors + light/dark verification.

--- a/nextjs-app/shared/components/SelectableCard/SelectableCard.stories.tsx
+++ b/nextjs-app/shared/components/SelectableCard/SelectableCard.stories.tsx
@@ -1,0 +1,193 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { SelectableCard, SelectableCardGroup } from "./SelectableCard";
+import contract from "./SelectableCard.contract.json";
+
+const meta = {
+  title: "Molecules/SelectableCard",
+  component: SelectableCard,
+  parameters: {
+    layout: "padded",
+    a11y: { test: "error" },
+    contractStatus: contract.status,
+    docs: { description: { component: contract.description } },
+  },
+  // Custom MDX docs page exists; do not also enable autodocs.
+  tags: ["!autodocs"],
+  argTypes: {
+    value: {
+      control: "text",
+      description: "Submitted value / selection key.",
+      table: { category: "Content" },
+    },
+    title: {
+      control: "text",
+      description: "Card heading passed through to Card.",
+      table: { category: "Content" },
+    },
+    description: {
+      control: "text",
+      description: "Supporting line passed through to Card.",
+      table: { category: "Content" },
+    },
+    selected: {
+      control: "boolean",
+      description: "Standalone selected state (outside a group).",
+      table: { category: "Behavior", defaultValue: { summary: "false" } },
+    },
+    disabled: {
+      control: "boolean",
+      description: "Per-card disable; the choice stays visible.",
+      table: { category: "Behavior", defaultValue: { summary: "false" } },
+    },
+  },
+  args: {
+    value: "starter",
+    title: "Starter",
+    description: "For solo work — 1 seat, community support.",
+    selected: false,
+    disabled: false,
+  },
+} satisfies Meta<typeof SelectableCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A standalone card toggles as a controlled checkbox-style option. */
+export const Default: Story = {
+  globals: { forcedColors: "none" },
+  render: (args) => {
+    const [on, setOn] = useState(Boolean(args.selected));
+    return (
+      <div style={{ maxWidth: 360 }}>
+        <SelectableCard
+          {...args}
+          selected={on}
+          onSelectedChange={setOn}
+        />
+      </div>
+    );
+  },
+};
+
+export const Playground: Story = {
+  globals: { forcedColors: "none" },
+  render: Default.render,
+};
+
+/** Single-select set: an exclusive radio group rendered as cards. */
+export const Example: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => {
+    const [plan, setPlan] = useState("team");
+    return (
+      <div style={{ maxWidth: 420 }}>
+        <SelectableCardGroup
+          type="single"
+          legend="Choose a plan"
+          value={plan}
+          onValueChange={(v) => setPlan(v as string)}
+          name="plan"
+        >
+          <SelectableCard value="starter" title="Starter" description="1 seat, community support." />
+          <SelectableCard value="team" title="Team" description="Up to 10 seats, priority support." />
+          <SelectableCard value="scale" title="Scale" description="Unlimited seats, SLA." />
+        </SelectableCardGroup>
+      </div>
+    );
+  },
+};
+
+/** Multiple-select: each card toggles independently (checkbox semantics). */
+export const MultiSelect: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => {
+    const [addons, setAddons] = useState<string[]>(["analytics"]);
+    return (
+      <div style={{ maxWidth: 420 }}>
+        <SelectableCardGroup
+          type="multiple"
+          legend="Add-ons"
+          value={addons}
+          onValueChange={(v) => setAddons(v as string[])}
+          helperText="Pick any that apply."
+        >
+          <SelectableCard value="analytics" title="Analytics" description="Usage dashboards." />
+          <SelectableCard value="audit" title="Audit log" description="Exportable event history." />
+          <SelectableCard value="sso" title="SSO" description="SAML / OIDC single sign-on." />
+        </SelectableCardGroup>
+      </div>
+    );
+  },
+};
+
+/** Horizontal orientation for a few short options. */
+export const Horizontal: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => {
+    const [size, setSize] = useState("m");
+    return (
+      <SelectableCardGroup
+        type="single"
+        legend="T-shirt size"
+        orientation="horizontal"
+        value={size}
+        onValueChange={(v) => setSize(v as string)}
+        name="tshirt"
+      >
+        <SelectableCard value="s" title="S" />
+        <SelectableCard value="m" title="M" />
+        <SelectableCard value="l" title="L" />
+      </SelectableCardGroup>
+    );
+  },
+};
+
+/** Group-level disabled and a per-card disabled option; choices stay visible. */
+export const Disabled: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div style={{ display: "grid", gap: "1.5rem", maxWidth: 420 }}>
+      <SelectableCardGroup type="single" legend="Whole group disabled" disabled defaultValue="a">
+        <SelectableCard value="a" title="Option A" description="Selected but disabled." />
+        <SelectableCard value="b" title="Option B" />
+      </SelectableCardGroup>
+      <SelectableCardGroup type="single" legend="One option disabled" defaultValue="x" name="mixed">
+        <SelectableCard value="x" title="Available" />
+        <SelectableCard value="y" title="Unavailable" description="Out of stock." disabled />
+      </SelectableCardGroup>
+    </div>
+  ),
+};
+
+/** Error state announces via role=alert and sets aria-invalid on the group. */
+export const WithError: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div style={{ maxWidth: 420 }}>
+      <SelectableCardGroup type="single" legend="Choose a plan" error="Select a plan to continue." name="plan-err">
+        <SelectableCard value="starter" title="Starter" description="1 seat." />
+        <SelectableCard value="team" title="Team" description="Up to 10 seats." />
+      </SelectableCardGroup>
+    </div>
+  ),
+};
+
+export const ForcedColors: Story = {
+  globals: { forcedColors: "active" },
+  parameters: {
+    controls: { disable: true },
+    docs: { description: { story: "Forced-colors verification: selected ring and indicator map to system Highlight." } },
+  },
+  render: () => {
+    const [plan, setPlan] = useState("team");
+    return (
+      <div style={{ maxWidth: 420 }}>
+        <SelectableCardGroup type="single" legend="Choose a plan" value={plan} onValueChange={(v) => setPlan(v as string)} name="plan-fc">
+          <SelectableCard value="starter" title="Starter" description="1 seat." />
+          <SelectableCard value="team" title="Team" description="Up to 10 seats." />
+        </SelectableCardGroup>
+      </div>
+    );
+  },
+};

--- a/nextjs-app/shared/components/SelectableCard/SelectableCard.test.tsx
+++ b/nextjs-app/shared/components/SelectableCard/SelectableCard.test.tsx
@@ -1,0 +1,176 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { SelectableCard, SelectableCardGroup } from "./SelectableCard";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(join(here, "SelectableCard.module.css"), "utf8");
+
+describe("SelectableCardGroup — single (radio)", () => {
+  it("renders one radio per card, named as a set", () => {
+    render(
+      <SelectableCardGroup type="single" legend="Plan" name="plan">
+        <SelectableCard value="a" title="A" />
+        <SelectableCard value="b" title="B" />
+      </SelectableCardGroup>,
+    );
+    const radios = screen.getAllByRole("radio");
+    expect(radios).toHaveLength(2);
+    expect(radios.every((r) => (r as HTMLInputElement).name === "plan")).toBe(
+      true,
+    );
+  });
+
+  it("selecting one option is exclusive and reports the value", () => {
+    const onValueChange = vi.fn();
+    render(
+      <SelectableCardGroup
+        type="single"
+        legend="Plan"
+        onValueChange={onValueChange}
+      >
+        <SelectableCard value="a" title="A" />
+        <SelectableCard value="b" title="B" />
+      </SelectableCardGroup>,
+    );
+    fireEvent.click(screen.getByRole("radio", { name: /A/ }));
+    expect(onValueChange).toHaveBeenLastCalledWith("a");
+    fireEvent.click(screen.getByRole("radio", { name: /B/ }));
+    expect(onValueChange).toHaveBeenLastCalledWith("b");
+    expect(
+      (screen.getByRole("radio", { name: /A/ }) as HTMLInputElement).checked,
+    ).toBe(false);
+    expect(
+      (screen.getByRole("radio", { name: /B/ }) as HTMLInputElement).checked,
+    ).toBe(true);
+  });
+
+  it("honors defaultValue when uncontrolled", () => {
+    render(
+      <SelectableCardGroup type="single" legend="Plan" defaultValue="b">
+        <SelectableCard value="a" title="A" />
+        <SelectableCard value="b" title="B" />
+      </SelectableCardGroup>,
+    );
+    expect(
+      (screen.getByRole("radio", { name: /B/ }) as HTMLInputElement).checked,
+    ).toBe(true);
+  });
+
+  it("marks the selected card with data-selected", () => {
+    render(
+      <SelectableCardGroup type="single" legend="Plan" defaultValue="a">
+        <SelectableCard value="a" title="A" />
+      </SelectableCardGroup>,
+    );
+    const label = screen.getByRole("radio", { name: /A/ }).closest("label");
+    expect(label).toHaveAttribute("data-selected", "true");
+  });
+});
+
+describe("SelectableCardGroup — multiple (checkbox)", () => {
+  it("toggles options independently and reports an array", () => {
+    const onValueChange = vi.fn();
+    render(
+      <SelectableCardGroup
+        type="multiple"
+        legend="Add-ons"
+        onValueChange={onValueChange}
+      >
+        <SelectableCard value="x" title="X" />
+        <SelectableCard value="y" title="Y" />
+      </SelectableCardGroup>,
+    );
+    fireEvent.click(screen.getByRole("checkbox", { name: /X/ }));
+    expect(onValueChange).toHaveBeenLastCalledWith(["x"]);
+    fireEvent.click(screen.getByRole("checkbox", { name: /Y/ }));
+    expect(onValueChange).toHaveBeenLastCalledWith(["x", "y"]);
+    fireEvent.click(screen.getByRole("checkbox", { name: /X/ }));
+    expect(onValueChange).toHaveBeenLastCalledWith(["y"]);
+  });
+});
+
+describe("SelectableCardGroup — disabled", () => {
+  it("disables every input and blocks selection", () => {
+    const onValueChange = vi.fn();
+    render(
+      <SelectableCardGroup
+        type="single"
+        legend="Plan"
+        disabled
+        onValueChange={onValueChange}
+      >
+        <SelectableCard value="a" title="A" />
+      </SelectableCardGroup>,
+    );
+    const radio = screen.getByRole("radio", { name: /A/ }) as HTMLInputElement;
+    expect(radio).toBeDisabled();
+    fireEvent.click(radio);
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it("supports a single disabled option inside an enabled group", () => {
+    render(
+      <SelectableCardGroup type="single" legend="Plan">
+        <SelectableCard value="a" title="A" />
+        <SelectableCard value="b" title="B" disabled />
+      </SelectableCardGroup>,
+    );
+    expect(screen.getByRole("radio", { name: /A/ })).not.toBeDisabled();
+    expect(screen.getByRole("radio", { name: /B/ })).toBeDisabled();
+  });
+});
+
+describe("SelectableCardGroup — error", () => {
+  it("announces the error and marks the group invalid", () => {
+    render(
+      <SelectableCardGroup type="single" legend="Plan" error="Pick one.">
+        <SelectableCard value="a" title="A" />
+      </SelectableCardGroup>,
+    );
+    expect(screen.getByText("Pick one.")).toBeInTheDocument();
+    expect(screen.getByRole("group")).toHaveAttribute("aria-invalid", "true");
+  });
+});
+
+describe("SelectableCard — standalone", () => {
+  it("toggles as a checkbox via selected / onSelectedChange", () => {
+    const onSelectedChange = vi.fn();
+    render(
+      <SelectableCard
+        value="solo"
+        title="Solo"
+        selected={false}
+        onSelectedChange={onSelectedChange}
+      />,
+    );
+    const input = screen.getByRole("checkbox", {
+      name: /Solo/,
+    }) as HTMLInputElement;
+    expect(input.name).toBe("");
+    fireEvent.click(input);
+    expect(onSelectedChange).toHaveBeenCalledWith(true);
+  });
+});
+
+// Guard the class names the component actually applies. Vitest's CSS-module
+// proxy fabricates a class for any `styles.x`, so a typo'd/missing class is
+// invisible to render tests and only shows as class="undefined" in prod.
+describe("SelectableCard — CSS module classes exist", () => {
+  it.each([
+    "group",
+    "legend",
+    "options",
+    "vertical",
+    "horizontal",
+    "card",
+    "disabled",
+    "input",
+    "surface",
+    "indicator",
+  ])("defines .%s", (cls) => {
+    expect(css).toContain(`.${cls}`);
+  });
+});

--- a/nextjs-app/shared/components/SelectableCard/SelectableCard.tsx
+++ b/nextjs-app/shared/components/SelectableCard/SelectableCard.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import React, { createContext, useContext, useId, useState } from "react";
+import Card, { type CardProps } from "@dt/Card";
+import HelperText from "@dt/HelperText";
+import styles from "./SelectableCard.module.css";
+
+export type SelectableCardSelectionType = "single" | "multiple";
+
+interface GroupContextValue {
+  type: SelectableCardSelectionType;
+  name: string;
+  disabled: boolean;
+  isSelected: (value: string) => boolean;
+  toggle: (value: string) => void;
+}
+
+const GroupContext = createContext<GroupContextValue | null>(null);
+
+/** Normalize a controlled/default value (string | string[]) to an array. */
+function toArray(value: string | string[] | undefined): string[] {
+  if (value === undefined) return [];
+  if (Array.isArray(value)) return value.filter(Boolean);
+  return value === "" ? [] : [value];
+}
+
+export interface SelectableCardGroupProps {
+  /** Selection model — single is an exclusive set (radio), multiple toggles independently (checkbox). @default "single" */
+  type?: SelectableCardSelectionType;
+  /** Group label rendered as the fieldset legend (required for an accessible name). */
+  legend: string;
+  /** Native radio group name shared by the set (single); auto-generated when omitted. */
+  name?: string;
+  /** Controlled selection: `string` for single, `string[]` for multiple. `""` / `[]` treated as absent (uncontrolled). */
+  value?: string | string[];
+  /** Initial selection when uncontrolled. */
+  defaultValue?: string | string[];
+  /** Fired with the next selection — a `string` for single, a `string[]` for multiple. */
+  onValueChange?: (value: string | string[]) => void;
+  /** Stack direction. @default "vertical" */
+  orientation?: "vertical" | "horizontal";
+  /** Disables the whole set; per-card disabled still keeps individual choices visible. @default false */
+  disabled?: boolean;
+  /** Error message; announces via role=alert and sets aria-invalid. */
+  error?: string;
+  /** Helper copy below the group; suppressed while error is set. */
+  helperText?: string;
+  /** Merged onto the fieldset. */
+  className?: string;
+  /** SelectableCard children. */
+  children: React.ReactNode;
+}
+
+/**
+ * A set of selectable cards. Single-select behaves as an exclusive radio set;
+ * multiple toggles each card independently. Selection is owned here (controlled
+ * or uncontrolled) and shared with the cards through context.
+ */
+export const SelectableCardGroup: React.FC<SelectableCardGroupProps> = ({
+  type = "single",
+  legend,
+  name: nameProp,
+  value,
+  defaultValue,
+  onValueChange,
+  orientation = "vertical",
+  disabled = false,
+  error,
+  helperText,
+  className,
+  children,
+}) => {
+  const autoName = useId();
+  const name = nameProp || `selectable-card-group-${autoName}`;
+  // "" / [] mean absent — the group stays uncontrolled and clickable, matching
+  // the RadioGroup controls convention.
+  const providedValue = toArray(value);
+  const isControlled = value !== undefined && providedValue.length > 0;
+  const [internal, setInternal] = useState<string[]>(toArray(defaultValue));
+  const selected = isControlled ? providedValue : internal;
+  const helperId = `${name}-helper`;
+  const errorId = `${name}-error`;
+
+  const emit = (next: string[]) => {
+    if (!isControlled) setInternal(next);
+    onValueChange?.(type === "single" ? (next[0] ?? "") : next);
+  };
+
+  const toggle = (val: string) => {
+    if (type === "single") {
+      emit([val]);
+      return;
+    }
+    emit(
+      selected.includes(val)
+        ? selected.filter((v) => v !== val)
+        : [...selected, val],
+    );
+  };
+
+  const ctx: GroupContextValue = {
+    type,
+    name,
+    disabled,
+    isSelected: (val) => selected.includes(val),
+    toggle,
+  };
+
+  return (
+    <fieldset
+      className={[styles.group, className].filter(Boolean).join(" ")}
+      aria-describedby={
+        [helperText ? helperId : null, error ? errorId : null]
+          .filter(Boolean)
+          .join(" ") || undefined
+      }
+      aria-invalid={error ? true : undefined}
+      disabled={disabled}
+    >
+      <legend className={styles.legend}>{legend}</legend>
+      <div
+        className={[
+          styles.options,
+          orientation === "horizontal" ? styles.horizontal : styles.vertical,
+        ].join(" ")}
+      >
+        <GroupContext.Provider value={ctx}>{children}</GroupContext.Provider>
+      </div>
+      {helperText ? <HelperText id={helperId}>{helperText}</HelperText> : null}
+      {error ? (
+        <HelperText id={errorId} state="error">
+          {error}
+        </HelperText>
+      ) : null}
+    </fieldset>
+  );
+};
+
+SelectableCardGroup.displayName = "SelectableCardGroup";
+
+export interface SelectableCardProps extends Omit<
+  CardProps,
+  "onChange" | "link" | "linkLabel"
+> {
+  /** Submitted value / selection key. */
+  value: string;
+  /** Per-card disable; the choice stays visible. @default false */
+  disabled?: boolean;
+  /** Standalone selected state when used outside a SelectableCardGroup. */
+  selected?: boolean;
+  /** Standalone change handler when used outside a SelectableCardGroup. */
+  onSelectedChange?: (selected: boolean) => void;
+}
+
+/**
+ * A Card that is one selectable option. Inside a SelectableCardGroup it reads
+ * its selected state from context and submits `value`; standalone it is a
+ * controlled checkbox-style toggle via `selected` / `onSelectedChange`. The
+ * whole card is a label wrapping a visually-hidden native input, so keyboard,
+ * focus, and form submission come from the platform.
+ */
+export const SelectableCard: React.FC<SelectableCardProps> = ({
+  value,
+  disabled = false,
+  selected,
+  onSelectedChange,
+  className,
+  children,
+  ...cardProps
+}) => {
+  const group = useContext(GroupContext);
+  const inGroup = group !== null;
+  const checked = inGroup ? group.isSelected(value) : Boolean(selected);
+  const isDisabled = disabled || (inGroup ? group.disabled : false);
+  const inputType: "radio" | "checkbox" =
+    inGroup && group.type === "single" ? "radio" : "checkbox";
+  const inputId = useId();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (isDisabled) return;
+    if (inGroup) group.toggle(value);
+    else onSelectedChange?.(e.target.checked);
+  };
+
+  return (
+    <label
+      className={[styles.card, isDisabled ? styles.disabled : ""]
+        .filter(Boolean)
+        .join(" ")}
+      data-selected={checked ? "true" : "false"}
+      data-disabled={isDisabled ? "true" : undefined}
+    >
+      <input
+        id={inputId}
+        type={inputType}
+        className={styles.input}
+        name={inGroup ? group.name : undefined}
+        value={value}
+        checked={checked}
+        // Mirror the controlled state as an attribute so CSS/tests (and the
+        // controls effect audit) can observe it, matching Radio/Checkbox.
+        data-checked={String(checked)}
+        disabled={isDisabled}
+        onChange={handleChange}
+      />
+      <Card {...cardProps} className={styles.surface}>
+        {children}
+        <span
+          className={styles.indicator}
+          data-type={inputType}
+          aria-hidden="true"
+        />
+      </Card>
+    </label>
+  );
+};
+
+SelectableCard.displayName = "SelectableCard";
+
+export default SelectableCard;

--- a/nextjs-app/shared/components/SelectableCard/index.ts
+++ b/nextjs-app/shared/components/SelectableCard/index.ts
@@ -1,0 +1,6 @@
+export { SelectableCard, SelectableCardGroup, default } from "./SelectableCard";
+export type {
+  SelectableCardProps,
+  SelectableCardGroupProps,
+  SelectableCardSelectionType,
+} from "./SelectableCard";

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -160,8 +160,8 @@
           "required": false
         },
         {
-          "name": "icon",
-          "type": "string",
+          "name": "showIcon",
+          "type": "boolean",
           "required": false
         }
       ],
@@ -188,9 +188,9 @@
           "optional": true,
           "type": "React.ReactNode"
         },
-        "icon": {
+        "showIcon": {
           "optional": true,
-          "type": "string"
+          "type": "boolean"
         },
         "dismissible": {
           "optional": true,
@@ -309,6 +309,11 @@
           "story": "WithAction",
           "description": "The action slot carries one follow-up under the description — a tertiary Button, not a link buried in prose.",
           "source": "export const WithAction: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: {\n      description: {\n        story:\n          \"The action slot carries one follow-up under the description — a tertiary Button, not a link buried in prose.\",\n      },\n    },\n  },\n  args: {\n    tone: \"info\",\n    title: \"Cookie preferences updated\",\n    description: \"Analytics stays off until you opt back in.\",\n    action: (\n      <Button variant=\"tertiary\" size=\"sm\">\n        Review settings\n      </Button>\n    ),\n  },\n};"
+        },
+        {
+          "story": "TextOnly",
+          "description": "showIcon={false} drops the tone icon for a compact, text-only banner. The icon is always the semantic tone glyph — there is no per-instance icon override, so this boolean is the only icon control.",
+          "source": "export const TextOnly: Story = {\n  tags: [\"example\"],\n  parameters: {\n    docs: {\n      description: {\n        story:\n          \"showIcon={false} drops the tone icon for a compact, text-only banner. The icon is always the semantic tone glyph — there is no per-instance icon override, so this boolean is the only icon control.\",\n      },\n    },\n  },\n  args: {\n    tone: \"info\",\n    title: \"Heads up\",\n    description: \"This is an informational message.\",\n    showIcon: false,\n  },\n};"
         },
         {
           "story": "Example",
@@ -2656,7 +2661,7 @@
       "name": "CategoryFilter",
       "group": "navigation",
       "tier": 2,
-      "status": "beta",
+      "status": "stable",
       "description": "Filter pill row for list pages (blog archive, work index). Multiple visual treatments (pills, underline, minimal) for different surface densities.",
       "dense": "Filter pill row for list pages (blog archive, work index) with selected state and multiple visual treatments",
       "keywords": [
@@ -6659,7 +6664,7 @@
       "name": "HelperText",
       "group": "form",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "Semantic helper or validation copy below form controls.",
       "dense": "semantic helper copy under a form control; neutral or error/warning/success/info with auto icon; error becomes role=alert; id feeds aria-describedby",
       "keywords": [
@@ -10680,7 +10685,7 @@
       "name": "ProjectGallery",
       "group": "media",
       "tier": 2,
-      "status": "beta",
+      "status": "stable",
       "description": "Responsive case-study image gallery: a labelled grid of figures where each thumbnail opens a shared lightbox.",
       "dense": "Case-study image gallery arranging project shots within article layouts",
       "keywords": [
@@ -10781,7 +10786,7 @@
       "name": "ProjectNav",
       "group": "navigation",
       "tier": 2,
-      "status": "beta",
+      "status": "stable",
       "description": "Previous/next navigation between case studies, with a back-to-work action, for the foot of work detail pages.",
       "dense": "Prev/next case-study navigation with back-to-work action for work detail pages",
       "keywords": [
@@ -11611,6 +11616,38 @@
           "source": "export const WithError = Template.bind({});\nWithError.args = {\n  label: \"storySelectLabel\",\n  options: [\n    { value: \"option1\", label: \"storyCheckboxOption1\" },\n    { value: \"option2\", label: \"storyCheckboxOption2\" },\n    { value: \"option3\", label: \"storyCheckboxOption3\" },\n  ],\n  value: \"option1\",\n  error: \"storySelectErrorRequired\",\n};\n\nWithError.tags = [\"example\"];\nWithError.parameters = {\n  docs: {\n    description: {\n      story: \"error replaces the helper line, sets aria-invalid, and announces via role=alert.\",\n    },\n  },\n};"
         }
       ]
+    },
+    "SelectableCard": {
+      "name": "SelectableCard",
+      "group": "form",
+      "tier": 2,
+      "status": "alpha",
+      "description": "A Card that is one selectable option; grouped into single (radio) or multiple (checkbox) sets via SelectableCardGroup.",
+      "dense": "",
+      "keywords": [],
+      "importLine": "import { SelectableCard } from \"@dt/SelectableCard\";",
+      "keyProps": [],
+      "props": {},
+      "composesWith": [],
+      "prefersOver": [],
+      "forbiddenUse": [],
+      "usage": null,
+      "tokens": {
+        "colors": [
+          "--color-primary",
+          "--color-focus-ring",
+          "--color-border",
+          "--color-border-light",
+          "--color-surface"
+        ],
+        "spacing": [
+          "--space-internal-8",
+          "--space-internal-12",
+          "--space-internal-16",
+          "--space-internal-24"
+        ]
+      },
+      "examples": []
     },
     "SentrySummaryCard": {
       "name": "SentrySummaryCard",
@@ -15169,7 +15206,7 @@
       "name": "WorkGrid",
       "group": "content",
       "tier": 2,
-      "status": "beta",
+      "status": "stable",
       "description": "Responsive portfolio work-index grid: one EnhancedProjectCard per project, with a friendly empty state.",
       "dense": "Portfolio index grid arranging project cards on the work page",
       "keywords": [


### PR DESCRIPTION
## What

Adds `SelectableCard` + `SelectableCardGroup`, the card-as-a-choice-tile primitive (Astryx `@astryxdesign/core/SelectableCard` parity). SelectableCardGroup owns selection (`single`=radio / `multiple`=checkbox); SelectableCard is one option that composes `Card`. Each card is a `<label>` wrapping a visually-hidden native input, so keyboard, focus, and form submission are native.

- single + multiple, controlled + uncontrolled, group + per-card disabled
- error/helper via HelperText; fieldset+legend group label
- selected ring + radio-dot/checkmark indicator (token-driven, forced-colors → Highlight)
- separate component, not a Card variant (selection is behavioral state, keeps stable Card presentational)

## Status

`alpha` (WIP badge). No promotion until a real consumer exists.

## Verification (local, all exit 0)

- typecheck, lint, full test suite (2079/2079), build
- validate:components, check:contract-props, check:consumers
- 22 unit tests (behavior + axe) + CSS-class guard
- visual in Storybook: single (radio dot + ring), multiple (checkmarks), interaction moves selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new selectable card component for rich, card-based choices.
  * Supports single and multiple selection, grouped or standalone use, disabled and error states, and horizontal or vertical layouts.
  * Includes improved accessibility with keyboard navigation, screen-reader-friendly labeling, and native form behavior.

* **Bug Fixes**
  * Added coverage to help prevent selection, focus, and accessibility regressions.

* **Documentation**
  * Added usage guidance, examples, and a component specification for Storybook and design review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->