### PR TITLE
fix(design-system): IconButton forwards all props (Tooltip/Popover asChild)

### DIFF
--- a/nextjs-app/shared/components/IconButton/IconButton.test.tsx
+++ b/nextjs-app/shared/components/IconButton/IconButton.test.tsx
@@ -16,12 +16,7 @@ describe("IconButton", () => {
   });
 
   it("accepts a rendered icon element and keeps it hidden from AT", () => {
-    render(
-      <IconButton
-        icon={<svg data-testid="glyph" />}
-        label="Share"
-      />,
-    );
+    render(<IconButton icon={<svg data-testid="glyph" />} label="Share" />);
     const button = screen.getByRole("button", { name: "Share" });
     expect(button).toBeInTheDocument();
     // the accessible name comes from label, never from the glyph
@@ -61,10 +56,36 @@ describe("IconButton", () => {
 
   it("exposes tooltip as a native title without changing the accessible name", () => {
     render(
-      <IconButton icon="clipboard" label="Copy link" tooltip="Copy link to clipboard" />,
+      <IconButton
+        icon="clipboard"
+        label="Copy link"
+        tooltip="Copy link to clipboard"
+      />,
     );
     const button = screen.getByRole("button", { name: "Copy link" });
     expect(button).toHaveAttribute("title", "Copy link to clipboard");
+  });
+
+  it("forwards arbitrary props to the underlying button (asChild/Slot composition)", async () => {
+    // Radix Slot (e.g. Tooltip/Popover asChild) injects handlers and
+    // data-/aria- attributes onto the child; IconButton must pass them through
+    // or hover-driven tooltips never open.
+    const user = userEvent.setup();
+    const onPointerEnter = vi.fn();
+    render(
+      <IconButton
+        icon="star"
+        label="Favorite"
+        onPointerEnter={onPointerEnter}
+        aria-describedby="hint-1"
+        data-state="closed"
+      />,
+    );
+    const button = screen.getByRole("button", { name: "Favorite" });
+    expect(button).toHaveAttribute("aria-describedby", "hint-1");
+    expect(button).toHaveAttribute("data-state", "closed");
+    await user.hover(button);
+    expect(onPointerEnter).toHaveBeenCalled();
   });
 
   it("wraps in a span only when className is given", () => {
@@ -92,7 +113,12 @@ describe("IconButton", () => {
       const { container } = render(
         <>
           <IconButton icon="x" label="Close" disabled />
-          <IconButton icon="trash" label="Delete row" tone="error" variant="secondary" />
+          <IconButton
+            icon="trash"
+            label="Delete row"
+            tone="error"
+            variant="secondary"
+          />
         </>,
       );
       expect(await axe(container)).toHaveNoViolations();

--- a/nextjs-app/shared/components/IconButton/IconButton.tsx
+++ b/nextjs-app/shared/components/IconButton/IconButton.tsx
@@ -7,8 +7,10 @@ import {
 } from "react";
 import Button, { type ButtonProps } from "@dt/Button";
 
-export interface IconButtonProps
-  extends Omit<ComponentPropsWithoutRef<"button">, "children"> {
+export interface IconButtonProps extends Omit<
+  ComponentPropsWithoutRef<"button">,
+  "children"
+> {
   /** Icon glyph: a rendered element (e.g. <CaretRight />) or a Phosphor icon name (e.g. "x"). */
   icon: ReactNode | string;
   /** Accessible name when `aria-labelledby` is not set */
@@ -46,26 +48,16 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
       className,
       type = "button",
       "aria-labelledby": ariaLabelledBy,
-      disabled,
-      onClick,
-      onBlur,
-      onFocus,
-      onKeyDown,
-      onKeyUp,
-      onMouseDown,
-      onMouseUp,
-      "aria-expanded": ariaExpanded,
-      "aria-controls": ariaControls,
-      "aria-haspopup": ariaHaspopup,
-      "aria-pressed": ariaPressed,
-      tabIndex,
-      id,
-      name,
-      value,
-      form,
+      ...rest
     },
     ref,
   ) => {
+    // Spread every remaining prop onto Button (which forwards unknown props to
+    // the DOM node). This keeps IconButton transparent to composition wrappers
+    // like Radix Slot (Tooltip/Popover `asChild`), which inject pointer
+    // handlers and data-/aria- attributes that must reach the button — an
+    // earlier fixed allowlist silently dropped them, so hover tooltips never
+    // opened.
     const button = (
       <Button
         ref={ref}
@@ -79,23 +71,7 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
         tooltip={tooltip}
         rounded
         icon={icon}
-        disabled={disabled}
-        onClick={onClick}
-        onBlur={onBlur}
-        onFocus={onFocus}
-        onKeyDown={onKeyDown}
-        onKeyUp={onKeyUp}
-        onMouseDown={onMouseDown}
-        onMouseUp={onMouseUp}
-        aria-expanded={ariaExpanded}
-        aria-controls={ariaControls}
-        aria-haspopup={ariaHaspopup}
-        aria-pressed={ariaPressed}
-        tabIndex={tabIndex}
-        id={id}
-        name={name}
-        value={value}
-        form={form}
+        {...(rest as ButtonProps)}
       />
     );
 


### PR DESCRIPTION
IconButton used a fixed prop allowlist, so Radix Slot composition (`Tooltip`/`Popover` `asChild`) had its injected pointer handlers and data-/aria- attributes silently dropped — hover tooltips never opened. Replaced with a `...rest` spread onto Button. Adds a regression test.

Gate (local, all exit 0): typecheck, lint, tests 2082/2082 (incl. AT snapshots), build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)