### PR TITLE
feat(design-system): --radius-full token; Progress track uses pill radius

### DIFF
--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -179,6 +179,7 @@
   --text-dt-title-xxl: var(--font-size-title-xxl);
   --text-dt-title-xxs: var(--font-size-title-xxs);
   --color-dt-link: var(--link-color);
+  --radius-dt-full: var(--radius-full);
   --radius-dt-lg: var(--radius-lg);
   --radius-dt-md: var(--radius-md);
   --radius-dt-sm: var(--radius-sm);

--- a/nextjs-app/shared/components/Progress/Progress.module.css
+++ b/nextjs-app/shared/components/Progress/Progress.module.css
@@ -1,7 +1,10 @@
 .root {
   position: relative;
   inline-size: 100%;
-  border-radius: var(--radius-md);
+
+  /* Pill radius (not a fixed px) so the track ends stay fully rounded at every
+     height — a fixed radius under-rounds the taller lg track. */
+  border-radius: var(--radius-full);
   background: var(--color-neutral-bg);
   overflow: hidden;
 }

--- a/nextjs-app/shared/foundations/token-catalog.json
+++ b/nextjs-app/shared/foundations/token-catalog.json
@@ -1,8 +1,8 @@
 {
   "source": "nextjs-app/shared/styles/variables.css",
-  "generatedAt": "2026-07-03T03:43:49.197Z",
-  "tokenCount": 172,
-  "usageCoverage": 139,
+  "generatedAt": "2026-07-07T15:57:51.697Z",
+  "tokenCount": 173,
+  "usageCoverage": 140,
   "themes": [
     {
       "id": "light",
@@ -1425,6 +1425,13 @@
           "name": "--radius-lg",
           "value": "8px",
           "usage": "Border radius (lg).",
+          "category": "radius",
+          "subgroup": "General"
+        },
+        {
+          "name": "--radius-full",
+          "value": "9999px",
+          "usage": "Border radius (full).",
           "category": "radius",
           "subgroup": "General"
         }

--- a/nextjs-app/shared/foundations/tokens/production/radius.json
+++ b/nextjs-app/shared/foundations/tokens/production/radius.json
@@ -12,6 +12,10 @@
     "lg": {
       "$value": "8px",
       "$description": "Border radius (lg)."
+    },
+    "full": {
+      "$value": "9999px",
+      "$description": "Border radius (full)."
     }
   }
 }

--- a/nextjs-app/shared/styles/variables.css
+++ b/nextjs-app/shared/styles/variables.css
@@ -196,6 +196,10 @@
   --radius-md: 0.25rem;
   --radius-lg: 8px;
 
+  /* Pill / full radius: clamps to half the smaller dimension, so ends stay
+     fully rounded at any height (progress tracks, pills, toggles). */
+  --radius-full: 9999px;
+
   /* Sizing */
 
   --size-width-md: 320px;


### PR DESCRIPTION
Adds `--radius-full` (9999px) so ends stay fully rounded at any height, and switches the Progress track from `--radius-md` (which under-rounds the taller `lg` track) to `--radius-full`. Regenerates token-catalog, radius tokens, and the tailwind theme.

Gate (local, all exit 0): typecheck, lint, tests 2082/2082, build. (rhythmguard drift is a pre-existing repo-wide baseline staleness, not introduced here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “full” radius style for fully rounded UI elements.

* **Bug Fixes**
  * Updated progress indicators to keep their ends smoothly rounded at different heights.
  * Improved consistency across rounded components by using a shared full-radius value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->