### PR TITLE
feat(design-system): Accordion upgrade — single/multiple, controlled, 3 variants

### DIFF
--- a/nextjs-app/shared/components/Accordion/Accordion.contract.json
+++ b/nextjs-app/shared/components/Accordion/Accordion.contract.json
@@ -4,11 +4,29 @@
     "tier": "molecule",
     "group": "structure",
     "status": "beta",
-    "description": "Expandable sections with keyboard-operable triggers.",
+    "description": "Coordinated disclosure group: single or multiple open sections, animated reveal, keyboard-operable triggers.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=381-17",
     "radixPrimitive": null,
     "element": "div",
-    "variants": {},
+    "variants": {
+        "type": {
+            "values": [
+                "single",
+                "multiple"
+            ],
+            "default": "single",
+            "propSourced": true
+        },
+        "variant": {
+            "values": [
+                "contained",
+                "enclosed",
+                "divided"
+            ],
+            "default": "contained",
+            "propSourced": true
+        }
+    },
     "slots": [],
     "asChild": false,
     "subParts": [],
@@ -45,7 +63,39 @@
             "optional": false,
             "type": "AccordionItem[]"
         },
+        "type": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "single",
+                "multiple"
+            ]
+        },
+        "variant": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "contained",
+                "divided"
+            ]
+        },
         "defaultOpenId": {
+            "optional": true,
+            "type": "string"
+        },
+        "defaultOpenIds": {
+            "optional": true,
+            "type": "string[]"
+        },
+        "openIds": {
+            "optional": true,
+            "type": "string[]"
+        },
+        "onOpenChange": {
+            "optional": true,
+            "type": "(openIds: string[]) => void"
+        },
+        "className": {
             "optional": true,
             "type": "string"
         }
@@ -62,11 +112,14 @@
         "faq",
         "expand",
         "collapse",
-        "progressive disclosure"
+        "progressive disclosure",
+        "single",
+        "multiple",
+        "controlled"
     ],
-    "dense": "Exclusive disclosure group: items {id,title,content}, one open at a time (click open item to close), optional defaultOpenId; trigger button wires aria-expanded/aria-controls to its region",
+    "dense": "Disclosure group: items {id,title,content}; type single|multiple; variant contained|enclosed|divided; controlled openIds or defaultOpenId(s); animated grid-rows reveal; aria per region",
     "usage": {
-        "description": "Accordion is the exclusive disclosure group: pass `items` ({id, title, content}) and at most one stays open — opening another closes the previous, clicking the open one closes it. Use it for FAQs and reference content where users need one answer at a time. For a single independent \"show more\" use ExpandableSection; if most readers need all the content, use plain headings instead of hiding it.",
+        "description": "Accordion coordinates a set of disclosure sections. In the default `type=\"single\"` at most one stays open (opening another closes the previous); `type=\"multiple\"` lets any number stay open for side-by-side reading. Pass `items` ({id, title, content}); drive it uncontrolled with `defaultOpenId`/`defaultOpenIds` or controlled with `openIds` + `onOpenChange`. `variant` switches between a bordered card group (contained) and flush hairlines (divided). For a single independent \"show more\" use ExpandableSection; if most readers need all the content, use plain headings instead of hiding it.",
         "bestPractices": [
             {
                 "guidance": true,
@@ -89,8 +142,12 @@
                 "description": "Do not hide task-critical content in an accordion; required steps must be visible by default."
             },
             {
+                "guidance": true,
+                "description": "Use type=\"multiple\" when users compare sections side by side (feature lists, pricing tiers); keep the default type=\"single\" for FAQs and settings where one at a time is the point."
+            },
+            {
                 "guidance": false,
-                "description": "Do not use it when users need to compare sections side by side — exclusive open forbids that; use headings."
+                "description": "Do not put a single short paragraph behind a section — the click costs more than it saves; show the text directly."
             }
         ],
         "anatomy": [

--- a/nextjs-app/shared/components/Accordion/Accordion.module.css
+++ b/nextjs-app/shared/components/Accordion/Accordion.module.css
@@ -1,36 +1,107 @@
+/* ==========================================================================
+   Accordion — coordinated disclosure group. One shared reveal animation
+   (grid-template-rows 0fr → 1fr) keeps every panel mounted so aria-controls
+   always resolves; closed panels are inert + aria-hidden.
+   ========================================================================== */
+
 .accordion {
-  border: 1px solid var(--color-primary);
-  border-radius: var(--radius-md, 8px);
+  font-family: var(--font-text);
+  color: var(--primary-text-color);
+}
+
+/* ---- Variants ------------------------------------------------------------- */
+
+/* contained + enclosed share the outer border; only contained (and divided)
+   draw hairlines between rows. enclosed is seamless inside. */
+
+.contained,
+.enclosed {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
   overflow: hidden;
 }
 
-.item + .item {
-  border-top: 1px solid var(--color-primary);
+.contained .item + .item,
+.divided .item + .item {
+  border-block-start: 1px solid var(--color-border);
 }
+
+/* ---- Trigger -------------------------------------------------------------- */
 
 .trigger {
   display: flex;
-  padding: var(--space-internal-12, 0.75rem) var(--space-internal-16, 1rem);
-  width: 100%;
+  padding: var(--space-internal-12) var(--space-internal-16);
+  inline-size: 100%;
   justify-content: space-between;
   align-items: center;
+  gap: var(--space-internal-12);
   border: none;
   background: transparent;
-  font-family: var(--font-text);
-  font-size: 1rem;
-  text-align: left;
-  color: var(--color-primary);
+  font: inherit;
+  font-weight: 500;
+  text-align: start;
+  color: inherit;
   cursor: pointer;
+  transition: background-color var(--duration-fast) var(--ease-out-cubic);
 }
 
-/* Focus states for accessibility (WCAG 2.4.7 Focus Visible) */
+@media (hover: hover) and (pointer: fine) {
+  .trigger:hover:not(:disabled) {
+    background: var(--color-light-bg);
+  }
+}
 
 .trigger:focus-visible {
-  outline: var(--focus-ring-width, 2px) solid var(--focus-ring-color, var(--color-primary));
-  outline-offset: var(--focus-ring-offset, 2px);
+  outline: 2px solid var(--focus-ring-color, var(--color-primary));
+  outline-offset: -2px;
 }
 
-/* Windows High Contrast Mode support */
+.trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.title {
+  min-inline-size: 0;
+}
+
+/* ---- Chevron -------------------------------------------------------------- */
+
+.icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: var(--color-muted);
+  transition: transform var(--duration-fast) var(--ease-out-cubic);
+}
+
+.open .icon {
+  transform: rotate(90deg);
+}
+
+/* ---- Panel (animated) ----------------------------------------------------- */
+
+.panel {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--duration-normal) var(--ease-out-cubic);
+}
+
+.panel[data-open="true"] {
+  grid-template-rows: 1fr;
+}
+
+.panelInner {
+  overflow: hidden;
+}
+
+.content {
+  /* Symmetric block padding so the revealed text is vertically centred within
+     the content container (not pinned to the top). */
+  padding: var(--space-internal-12) var(--space-internal-16);
+  color: var(--secondary-text-color);
+}
+
+/* ---- Forced colours ------------------------------------------------------- */
 @media (forced-colors: active) {
   .trigger:focus-visible {
     outline: 3px solid Highlight;
@@ -39,22 +110,11 @@
   }
 }
 
-.content {
-  padding: var(--space-internal-12, 0.75rem) var(--space-internal-16, 1rem);
-  background: var(--color-light-bg);
-  font-family: var(--font-text);
-  color: var(--color-primary);
-}
-
-.content[hidden] {
-  display: none;
-}
-
-.icon {
-  margin-inline-start: var(--space-internal-12, 0.75rem);
-  transition: transform 0.2s ease;
-}
-
-.open .icon {
-  transform: rotate(90deg);
+/* ---- Reduced motion ------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  .panel,
+  .icon,
+  .trigger {
+    transition: none;
+  }
 }

--- a/nextjs-app/shared/components/Accordion/Accordion.spec.md
+++ b/nextjs-app/shared/components/Accordion/Accordion.spec.md
@@ -1,10 +1,11 @@
 # Accordion
 
 ## Intent
-Hide secondary content behind a labelled toggle so primary content stays
-scannable. Accordion is the canonical disclosure pattern for FAQ,
-"learn more" expansions, and configurable detail panels where the user
-should be able to scan headings before committing to a section.
+Hide secondary content behind labelled toggles so primary content stays
+scannable. Accordion coordinates a set of disclosure sections: the default
+`type="single"` keeps one section open at a time (FAQ / settings), while
+`type="multiple"` lets several stay open for side-by-side comparison (feature
+lists, pricing tiers). Users can scan headings before committing to a section.
 
 ## Interaction contract
 - Keyboard: Enter and Space activate the focused trigger. Tab moves to
@@ -16,7 +17,15 @@ should be able to scan headings before committing to a section.
   links and buttons inside remain operable.
 - Screen readers: state is announced via `aria-expanded` on the
   trigger; the panel is announced as a region labelled by the trigger
-  text. Closing a panel removes it from the AT tree via `hidden`.
+  text. A closed panel stays in the DOM (so `aria-controls` always
+  resolves) but is removed from the AT tree and the tab order via
+  `inert` + `aria-hidden`, and collapsed to zero height.
+
+## State model
+- Uncontrolled: `defaultOpenId` (single) or `defaultOpenIds` (one or more)
+  seed the initial open set; the component owns state thereafter.
+- Controlled: pass `openIds` and `onOpenChange`; the parent owns the open
+  set. Use this to sync with a URL param, form, or external control.
 
 ## Do / don't
 - Do: keep `item.id` stable across renders. Re-using ids between
@@ -24,21 +33,28 @@ should be able to scan headings before committing to a section.
   `aria-controls` / `aria-labelledby` reference.
 - Do: phrase the `title` as the question or the topic, not the action.
   "Pricing" reads better than "Click to see pricing".
+- Do: use `type="multiple"` when readers compare sections; keep the
+  default `type="single"` for FAQs and settings.
 - Don't: put primary navigation inside an accordion. AT users land on
   a closed panel and assume the link is gone.
 - Don't: nest accordions more than one level deep. Two-level
   disclosure becomes unreadable in screen reader linear mode.
-- Don't: ship long, scrollable panels. If the content scrolls inside
-  a single section, promote it to a sibling page instead.
+- Don't: put a single short paragraph behind a section — the click
+  costs more than it saves; show the text directly.
 
 ## Design notes
+- Variants: `contained` (default) is a bordered, rounded card group with
+  hairline dividers between rows; `enclosed` keeps that outer border but is
+  seamless inside (no dividers); `divided` is flush with hairline separators
+  only, for inline disclosure in sidebars or detail panels.
+- Reveal: panel height animates via `grid-template-rows: 0fr → 1fr` with
+  `overflow: hidden` on the inner wrapper; the caret rotates 90°. Both
+  transitions are dropped under `prefers-reduced-motion`.
 - Tokens: trigger row uses `--space-internal-12` block padding and
-  `--space-internal-16` inline padding. Border between items uses
-  `--color-border`. The open-state caret rotates `transform: rotate(90deg)`
-  via CSS — no JS animation.
-- Figma: https://www.figma.com/design/digitaltableteur/accordion — single
-  variant; states are open / closed only.
-- Single-expansion is enforced in component state (`useState<string | null>`),
-  not via DOM. Two siblings cannot both be open at once.
+  `--space-internal-16` inline padding; item separators and the contained
+  border use `--color-border`; title is `--primary-text-color`, content
+  `--secondary-text-color`.
 - The `Icon name="caret-right"` is `aria-hidden` because the
   `aria-expanded` attribute already communicates state to assistive tech.
+- Sibling: for a single independent "show more", use `ExpandableSection`;
+  Accordion is for a coordinated group.

--- a/nextjs-app/shared/components/Accordion/Accordion.stories.tsx
+++ b/nextjs-app/shared/components/Accordion/Accordion.stories.tsx
@@ -57,6 +57,19 @@ const meta: Meta<typeof Accordion> = {
       description: "Initially expanded item id (preset ids: one/two/three)",
       table: { category: "Content" },
     },
+    type: {
+      control: { type: "inline-radio" },
+      options: ["single", "multiple"],
+      description: "single keeps one section open; multiple allows several",
+      table: { category: "Behavior", defaultValue: { summary: "single" } },
+    },
+    variant: {
+      control: { type: "inline-radio" },
+      options: ["contained", "enclosed", "divided"],
+      description:
+        "contained: border + dividers; enclosed: outer border only, seamless inside; divided: flush hairlines, no border",
+      table: { category: "Appearance", defaultValue: { summary: "contained" } },
+    },
   },
 };
 
@@ -172,6 +185,110 @@ export const DefaultOpen: Story = {
       items={[
         { id: "pricing", title: "How is the work priced?", content: "Fixed-scope engagements with a written definition of done." },
         { id: "timeline", title: "How long does an engagement take?", content: "Typical system audits run two to four weeks." },
+      ]}
+    />
+  ),
+};
+
+/** type="multiple" lets several sections stay open so users can compare content. */
+export const Multiple: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: { description: { story: "type=\"multiple\" keeps any number of sections open at once — use it when readers compare content across sections, like feature lists or pricing tiers." } },
+  },
+  render: () => (
+    <Accordion
+      type="multiple"
+      defaultOpenIds={["features", "pricing"]}
+      items={[
+        { id: "features", title: "Features", content: "Real-time collaboration, version history, and granular permissions." },
+        { id: "pricing", title: "Pricing", content: "Free for up to 5 users. Pro starts at €12/user/month billed annually." },
+        { id: "integrations", title: "Integrations", content: "Connects to the tools your team already uses." },
+      ]}
+    />
+  ),
+};
+
+/** Controlled: the parent owns open state via openIds + onOpenChange. */
+export const Controlled: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: { description: { story: "Pass openIds + onOpenChange to drive the accordion from parent state — when open sections should sync with a URL param, form, or external control." } },
+  },
+  render: () => {
+    const ControlledDemo = () => {
+      const [openIds, setOpenIds] = React.useState<string[]>(["shipping"]);
+      return (
+        <Accordion
+          type="multiple"
+          openIds={openIds}
+          onOpenChange={setOpenIds}
+          items={[
+            { id: "shipping", title: "Shipping", content: "Standard shipping takes 3–5 business days." },
+            { id: "returns", title: "Returns", content: "Free returns within 30 days of delivery." },
+            { id: "warranty", title: "Warranty", content: "Two-year limited warranty on all hardware." },
+          ]}
+        />
+      );
+    };
+    return <ControlledDemo />;
+  },
+};
+
+/** variant="enclosed" keeps the outer border but drops the between-row dividers. */
+export const Enclosed: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: { description: { story: "variant=\"enclosed\" wraps the group in a single rounded border with no dividers between rows — a seamless card. Row separation comes from spacing and the open/closed state." } },
+  },
+  render: () => (
+    <Accordion
+      variant="enclosed"
+      defaultOpenId="notifications"
+      items={[
+        { id: "general", title: "General settings", content: "Language, timezone, and display options." },
+        { id: "notifications", title: "Notifications", content: "Choose which email and push notifications you want to receive." },
+        { id: "privacy", title: "Privacy", content: "Control who can see your profile and activity." },
+      ]}
+    />
+  ),
+};
+
+/** variant="divided" drops the card border for flush hairline separators. */
+export const Divided: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: { description: { story: "variant=\"divided\" removes the container border for flush hairline separators — lighter weight for inline disclosure in sidebars or detail panels." } },
+  },
+  render: () => (
+    <Accordion
+      variant="divided"
+      items={[
+        { id: "deploy", title: "Deployment details", content: "Last deployed April 18, 2026 at 3:42 PM. Build duration 2m 14s." },
+        { id: "env", title: "Environment variables", content: "12 variables configured across 3 environments." },
+        { id: "logs", title: "Build logs", content: "No warnings. All checks passed." },
+      ]}
+    />
+  ),
+};
+
+/** A disabled item stays visible but its trigger is inert. */
+export const Disabled: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: { description: { story: "Mark an item disabled to show it in the set while its trigger is inert — for sections that are not yet available." } },
+  },
+  render: () => (
+    <Accordion
+      items={[
+        { id: "available", title: "Available section", content: "This one opens normally." },
+        { id: "soon", title: "Coming soon", content: "Not reachable yet.", disabled: true },
+        { id: "also", title: "Another section", content: "This one opens too." },
       ]}
     />
   ),

--- a/nextjs-app/shared/components/Accordion/Accordion.test.tsx
+++ b/nextjs-app/shared/components/Accordion/Accordion.test.tsx
@@ -1,16 +1,24 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import Accordion from "./Accordion";
 
-describe("Accordion", () => {
-  const items = [
-    { id: "1", title: "First Item", content: "First content" },
-    { id: "2", title: "Second Item", content: "Second content" },
-    { id: "3", title: "Third Item", content: "Third content" },
-  ];
+const items = [
+  { id: "1", title: "First Item", content: "First content" },
+  { id: "2", title: "Second Item", content: "Second content" },
+  { id: "3", title: "Third Item", content: "Third content" },
+];
 
+/** Panels stay mounted; open state is read from the trigger + panel wrapper. */
+const trigger = (name: RegExp | string) => screen.getByRole("button", { name });
+const isOpen = (id: string) =>
+  document
+    .getElementById(`panel-${id}`)
+    ?.closest("[data-open]")
+    ?.getAttribute("data-open") === "true";
+
+describe("Accordion", () => {
   it("renders all accordion items", () => {
     render(<Accordion items={items} />);
     expect(screen.getByText("First Item")).toBeInTheDocument();
@@ -18,84 +26,135 @@ describe("Accordion", () => {
     expect(screen.getByText("Third Item")).toBeInTheDocument();
   });
 
-  it("all items are closed by default with hidden attribute", () => {
+  it("keeps every panel mounted for valid aria-controls, closed by default", () => {
     render(<Accordion items={items} />);
-    // Panels are in DOM but hidden (accessibility pattern for valid aria-controls)
-    const panel1 = document.getElementById("panel-1");
-    const panel2 = document.getElementById("panel-2");
-    const panel3 = document.getElementById("panel-3");
-    expect(panel1).toHaveAttribute("hidden");
-    expect(panel2).toHaveAttribute("hidden");
-    expect(panel3).toHaveAttribute("hidden");
+    items.forEach((item) => {
+      expect(document.getElementById(`panel-${item.id}`)).toBeInTheDocument();
+      expect(isOpen(item.id)).toBe(false);
+    });
+  });
+
+  it("marks closed panels inert and aria-hidden; open panels neither", async () => {
+    const user = userEvent.setup();
+    render(<Accordion items={items} />);
+    const panel1 = document.getElementById("panel-1")!;
+    expect(panel1).toHaveAttribute("aria-hidden", "true");
+    await user.click(trigger("First Item"));
+    expect(panel1).not.toHaveAttribute("aria-hidden");
+    expect(panel1).not.toHaveAttribute("inert");
   });
 
   it("opens item with defaultOpenId", () => {
     render(<Accordion items={items} defaultOpenId="2" />);
-    const openPanel = document.getElementById("panel-2");
-    const closedPanel = document.getElementById("panel-1");
-    expect(openPanel).not.toHaveAttribute("hidden");
-    expect(closedPanel).toHaveAttribute("hidden");
-    expect(screen.getByText("Second content")).toBeVisible();
+    expect(isOpen("2")).toBe(true);
+    expect(isOpen("1")).toBe(false);
   });
 
-  it("opens item when clicked", async () => {
+  it("toggles open and closed on repeated clicks", async () => {
     const user = userEvent.setup();
     render(<Accordion items={items} />);
-
-    await user.click(screen.getByText("First Item"));
-    const panel = document.getElementById("panel-1");
-    expect(panel).not.toHaveAttribute("hidden");
-    expect(screen.getByText("First content")).toBeVisible();
+    await user.click(trigger("First Item"));
+    expect(isOpen("1")).toBe(true);
+    await user.click(trigger("First Item"));
+    expect(isOpen("1")).toBe(false);
   });
 
-  it("closes open item when clicked again", async () => {
+  it("single mode closes the previous item when opening a new one", async () => {
     const user = userEvent.setup();
     render(<Accordion items={items} defaultOpenId="1" />);
-
-    const panel = document.getElementById("panel-1");
-    expect(panel).not.toHaveAttribute("hidden");
-    await user.click(screen.getByText("First Item"));
-    expect(panel).toHaveAttribute("hidden");
+    expect(isOpen("1")).toBe(true);
+    await user.click(trigger("Second Item"));
+    expect(isOpen("1")).toBe(false);
+    expect(isOpen("2")).toBe(true);
   });
 
-  it("closes previous item when opening new one", async () => {
+  it("multiple mode keeps several sections open at once", async () => {
     const user = userEvent.setup();
-    render(<Accordion items={items} defaultOpenId="1" />);
-
-    const panel1 = document.getElementById("panel-1");
-    const panel2 = document.getElementById("panel-2");
-    expect(panel1).not.toHaveAttribute("hidden");
-    await user.click(screen.getByText("Second Item"));
-    expect(panel1).toHaveAttribute("hidden");
-    expect(panel2).not.toHaveAttribute("hidden");
+    render(<Accordion items={items} type="multiple" />);
+    await user.click(trigger("First Item"));
+    await user.click(trigger("Second Item"));
+    expect(isOpen("1")).toBe(true);
+    expect(isOpen("2")).toBe(true);
   });
 
-  it("has correct aria-expanded attributes", async () => {
+  it("supports controlled open state via openIds + onOpenChange", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const { rerender } = render(
+      <Accordion
+        items={items}
+        type="multiple"
+        openIds={["1"]}
+        onOpenChange={onOpenChange}
+      />,
+    );
+    expect(isOpen("1")).toBe(true);
+    // Controlled: click reports intent but does not self-update.
+    await user.click(trigger("Second Item"));
+    expect(onOpenChange).toHaveBeenCalledWith(["1", "2"]);
+    expect(isOpen("2")).toBe(false);
+    // Parent applies the new state.
+    rerender(
+      <Accordion
+        items={items}
+        type="multiple"
+        openIds={["1", "2"]}
+        onOpenChange={onOpenChange}
+      />,
+    );
+    expect(isOpen("2")).toBe(true);
+  });
+
+  it("does not toggle a disabled item", async () => {
+    const user = userEvent.setup();
+    const disabledItems = [
+      {
+        id: "1",
+        title: "First Item",
+        content: "First content",
+        disabled: true,
+      },
+      { id: "2", title: "Second Item", content: "Second content" },
+    ];
+    render(<Accordion items={disabledItems} />);
+    const first = trigger("First Item");
+    expect(first).toBeDisabled();
+    await user.click(first);
+    expect(isOpen("1")).toBe(false);
+  });
+
+  it("applies the variant class", () => {
+    const { container, rerender } = render(
+      <Accordion items={items} variant="divided" />,
+    );
+    expect((container.firstChild as HTMLElement).className).toContain(
+      "divided",
+    );
+    rerender(<Accordion items={items} variant="contained" />);
+    expect((container.firstChild as HTMLElement).className).toContain(
+      "contained",
+    );
+  });
+
+  it("reflects aria-expanded on the trigger", async () => {
     const user = userEvent.setup();
     render(<Accordion items={items} />);
-
-    const firstButton = screen.getByText("First Item").closest("button");
-    expect(firstButton).toHaveAttribute("aria-expanded", "false");
-
-    await user.click(firstButton!);
-    expect(firstButton).toHaveAttribute("aria-expanded", "true");
+    const first = trigger("First Item");
+    expect(first).toHaveAttribute("aria-expanded", "false");
+    await user.click(first);
+    expect(first).toHaveAttribute("aria-expanded", "true");
   });
 
-  it("has correct aria-controls attribute", () => {
+  it("wires aria-controls to the region panel", () => {
     render(<Accordion items={items} />);
-    const firstButton = screen.getByText("First Item").closest("button");
-    expect(firstButton).toHaveAttribute("aria-controls", "panel-1");
-  });
-
-  it("content has correct region role", () => {
-    render(<Accordion items={items} />);
-    // Panel is always in DOM for valid aria-controls reference
+    const first = trigger("First Item");
+    expect(first).toHaveAttribute("aria-controls", "panel-1");
     const panel = document.getElementById("panel-1");
     expect(panel).toHaveAttribute("role", "region");
+    expect(panel).toHaveAttribute("aria-labelledby", "trigger-1");
   });
 
-  it("renders content as React node", async () => {
-    const user = userEvent.setup();
+  it("renders content as a React node", () => {
     const complexItems = [
       {
         id: "1",
@@ -107,50 +166,18 @@ describe("Accordion", () => {
         ),
       },
     ];
-    render(<Accordion items={complexItems} />);
-
-    await user.click(screen.getByText("Item"));
+    render(<Accordion items={complexItems} defaultOpenId="1" />);
     expect(screen.getByText("Bold")).toBeInTheDocument();
-    expect(screen.getByText("text")).toBeInTheDocument();
   });
 
-  it("renders icon for each item", () => {
+  it("renders a chevron icon for each item", () => {
     const { container } = render(<Accordion items={items} />);
     const icons = container.querySelectorAll("svg");
     expect(icons.length).toBeGreaterThanOrEqual(items.length);
   });
 
-  // Accessibility tests for hidden attribute behavior
-  describe("accessibility", () => {
-    it("should always have panels in DOM for aria-controls validity", () => {
-      render(<Accordion items={items} />);
-      // All panels should exist even when closed
-      items.forEach((item) => {
-        const panel = document.getElementById(`panel-${item.id}`);
-        expect(panel).toBeInTheDocument();
-      });
-    });
-
-    it("should use hidden attribute on closed panels", () => {
-      render(<Accordion items={items} />);
-      const panel = document.getElementById("panel-1");
-      expect(panel).toHaveAttribute("hidden");
-    });
-
-    it("should not have hidden attribute on open panel", () => {
-      render(<Accordion items={items} defaultOpenId="1" />);
-      const openPanel = document.getElementById("panel-1");
-      const closedPanel = document.getElementById("panel-2");
-      expect(openPanel).not.toHaveAttribute("hidden");
-      expect(closedPanel).toHaveAttribute("hidden");
-    });
-
-    it("should have valid aria-controls reference when panel is hidden", () => {
-      render(<Accordion items={items} />);
-      const trigger = screen.getByRole("button", { name: "First Item" });
-      const controlsId = trigger.getAttribute("aria-controls");
-      const panel = document.getElementById(controlsId!);
-      expect(panel).toBeInTheDocument();
-    });
+  it("returns null when no items are provided", () => {
+    const { container } = render(<Accordion items={[]} />);
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/nextjs-app/shared/components/Accordion/Accordion.tsx
+++ b/nextjs-app/shared/components/Accordion/Accordion.tsx
@@ -8,29 +8,89 @@ export type AccordionItem = {
   id: string;
   title: string;
   content: React.ReactNode;
+  /** Render the section trigger as non-interactive. */
+  disabled?: boolean;
 };
 
 export type AccordionProps = {
-  /** Accordion sections (id, title, content). */
+  /** Accordion sections (id, title, content, optional disabled). */
   items: AccordionItem[];
-  /** Initially expanded item id. */
+  /**
+   * "single" (default) keeps at most one section open — opening another closes
+   * the previous. "multiple" lets any number stay open for side-by-side reading.
+   * @default "single"
+   */
+  type?: "single" | "multiple";
+  /**
+   * "contained" (default) is a bordered card group with dividers between rows;
+   * "enclosed" is the same outer border but seamless inside (no dividers);
+   * "divided" is flush with hairline separators only, for inline disclosure.
+   * @default "contained"
+   */
+  variant?: "contained" | "enclosed" | "divided";
+  /** Initially open id (uncontrolled, single). */
   defaultOpenId?: string;
+  /** Initially open ids (uncontrolled); wins over defaultOpenId when set. */
+  defaultOpenIds?: string[];
+  /** Controlled open ids. When set, the parent owns open state. */
+  openIds?: string[];
+  /** Called with the full set of open ids whenever it changes. */
+  onOpenChange?: (openIds: string[]) => void;
+  /** Optional utility classes on the container. */
+  className?: string;
 };
 
-/** Expandable accordion sections with keyboard-operable triggers. */
-const Accordion: React.FC<AccordionProps> = ({ items, defaultOpenId }) => {
-  const [openId, setOpenId] = React.useState<string | null>(
-    defaultOpenId ?? null,
-  );
+/** Expandable accordion sections with keyboard-operable triggers and a sliding reveal. */
+const Accordion: React.FC<AccordionProps> = ({
+  items,
+  type = "single",
+  variant = "contained",
+  defaultOpenId,
+  defaultOpenIds,
+  openIds: controlledOpenIds,
+  onOpenChange,
+  className = "",
+}) => {
+  const isControlled = controlledOpenIds !== undefined;
 
-  const toggle = (id: string) => {
-    setOpenId((current) => (current === id ? null : id));
+  const [internalOpen, setInternalOpen] = React.useState<Set<string>>(() => {
+    if (defaultOpenIds && defaultOpenIds.length > 0) {
+      return new Set(
+        type === "single" ? defaultOpenIds.slice(0, 1) : defaultOpenIds,
+      );
+    }
+    if (defaultOpenId) return new Set([defaultOpenId]);
+    return new Set<string>();
+  });
+
+  const openSet = isControlled ? new Set(controlledOpenIds) : internalOpen;
+
+  const toggle = (id: string, disabled?: boolean) => {
+    if (disabled) return;
+    const next = new Set(openSet);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      // Single mode is exclusive: opening one closes the rest.
+      if (type === "single") next.clear();
+      next.add(id);
+    }
+    if (!isControlled) setInternalOpen(next);
+    onOpenChange?.(Array.from(next));
   };
 
+  if (!items || items.length === 0) {
+    return null;
+  }
+
   return (
-    <div className={styles.accordion}>
+    <div
+      className={[styles.accordion, styles[variant], className]
+        .filter(Boolean)
+        .join(" ")}
+    >
       {items.map((item) => {
-        const open = item.id === openId;
+        const open = openSet.has(item.id);
         return (
           <div
             key={item.id}
@@ -42,21 +102,30 @@ const Accordion: React.FC<AccordionProps> = ({ items, defaultOpenId }) => {
               className={styles.trigger}
               aria-expanded={open}
               aria-controls={`panel-${item.id}`}
-              onClick={() => toggle(item.id)}
+              disabled={item.disabled}
+              onClick={() => toggle(item.id, item.disabled)}
             >
-              <span>{item.title}</span>
-              <span className={styles.icon} aria-hidden>
-                <Icon name="caret-right" />
+              <span className={styles.title}>{item.title}</span>
+              <span className={styles.icon} aria-hidden="true">
+                <Icon name="caret-right" size={16} weight="bold" />
               </span>
             </button>
-            <div
-              id={`panel-${item.id}`}
-              className={styles.content}
-              role="region"
-              aria-labelledby={`trigger-${item.id}`}
-              hidden={!open}
-            >
-              {item.content}
+            {/* Panel stays mounted (so aria-controls always resolves) and its
+                height animates via grid-template-rows. Closed panels are inert
+                and hidden from assistive tech. */}
+            <div className={styles.panel} data-open={open}>
+              <div className={styles.panelInner}>
+                <div
+                  id={`panel-${item.id}`}
+                  role="region"
+                  aria-labelledby={`trigger-${item.id}`}
+                  className={styles.content}
+                  aria-hidden={!open || undefined}
+                  inert={!open || undefined}
+                >
+                  {item.content}
+                </div>
+              </div>
             </div>
           </div>
         );

--- a/nextjs-app/shared/components/Accordion/schema.json
+++ b/nextjs-app/shared/components/Accordion/schema.json
@@ -3,15 +3,15 @@
   "component": {
     "name": "Accordion",
     "type": "interaction",
-    "description": "Stacked disclosure list where only one panel is open at a time.",
+    "description": "Coordinated disclosure list: single (one open) or multiple (any number open) mode, with an animated reveal.",
     "source": "nextjs-app/shared/components/Accordion/Accordion.tsx"
   },
   "anatomy": {
     "container": "accordion",
     "item": "accordion item",
     "trigger": "button with title text",
-    "icon": "caret-right icon",
-    "panel": "content region"
+    "icon": "caret-right icon (rotates on open)",
+    "panel": "content region (mounted always; inert + aria-hidden when closed)"
   },
   "semanticRole": {
     "container": "div",
@@ -21,57 +21,63 @@
   "layout": {
     "direction": "vertical stack",
     "width": "fills parent width",
-    "height": "content-driven; no fixed min-height",
+    "height": "content-driven; panel height animates via grid-template-rows",
     "spacing": {
       "triggerPadding": "var(--space-internal-12) var(--space-internal-16)",
-      "panelPadding": "var(--space-internal-12) var(--space-internal-16)",
-      "itemSeparator": "border-top 1px solid var(--color-primary)",
-      "iconMarginInlineStart": "var(--space-internal-12)"
+      "panelPadding": "0 var(--space-internal-16) var(--space-internal-16)",
+      "itemSeparator": "border-block-start 1px solid var(--color-border)"
     }
   },
   "visualStyle": {
     "surface": "flat",
-    "border": "1px solid var(--color-primary)",
-    "radius": "var(--radius-md)",
+    "variants": {
+      "contained": "bordered, rounded card group (1px var(--color-border), var(--radius-lg)) with hairline dividers between rows",
+      "enclosed": "same outer border and radius as contained but seamless inside — no dividers between rows",
+      "divided": "flush with hairline separators between items; no container border"
+    },
     "backgrounds": {
-      "trigger": "transparent",
-      "panel": "var(--color-light-bg)"
+      "trigger": "transparent; var(--color-light-bg) on hover",
+      "panel": "transparent"
     },
     "typography": {
       "fontFamily": "var(--font-text)",
-      "fontSize": "1rem",
-      "color": "var(--color-primary)"
+      "title": "var(--primary-text-color), weight 500",
+      "content": "var(--secondary-text-color)"
     },
-    "iconMotion": "rotate 90deg on open; transition 0.2s ease"
+    "iconMotion": "rotate 90deg on open; transition var(--duration-fast)"
   },
   "behavior": {
-    "interaction": "Clicking a trigger toggles its panel. Opening one item closes any other open item.",
-    "defaultOpen": "defaultOpenId opens the matching item on initial render.",
-    "stateModel": "uncontrolled; internal openId state",
-    "rendering": "Panels render only when open (unmounted when closed).",
-    "animation": "Icon rotates on open; no panel height animation."
+    "interaction": "Clicking a trigger toggles its panel. In type=single, opening one closes any other; in type=multiple, sections toggle independently.",
+    "defaultOpen": "defaultOpenId / defaultOpenIds set the initially open section(s) on mount.",
+    "stateModel": "uncontrolled (internal Set) or controlled (openIds + onOpenChange)",
+    "rendering": "Panels stay mounted so aria-controls always resolves; closed panels are inert + aria-hidden and collapsed to 0 height.",
+    "animation": "Icon rotates and panel height animates via grid-template-rows 0fr->1fr; disabled under prefers-reduced-motion."
   },
   "accessibility": {
     "trigger": {
       "ariaExpanded": "true when open",
-      "ariaControls": "panel-id"
+      "ariaControls": "panel-id",
+      "disabled": "item.disabled renders the trigger disabled"
     },
     "panel": {
       "role": "region",
-      "ariaLabelledBy": "trigger-id"
+      "ariaLabelledBy": "trigger-id",
+      "ariaHidden": "true when closed",
+      "inert": "true when closed"
     },
     "keyboard": "native button behavior (Enter/Space toggles)"
   },
   "states": {
-    "default": "all items closed unless defaultOpenId matches",
-    "open": "single open item at a time",
-    "disabled": "not supported (no disabled prop or styles)"
+    "default": "closed unless defaultOpenId / defaultOpenIds match",
+    "open": "one section (single) or any number (multiple)",
+    "disabled": "per item via item.disabled; trigger is dimmed and inert"
   },
   "responsiveness": {
     "rules": "Responsive by container width; text wraps; no fixed breakpoints."
   },
   "usageNotes": [
-    "Provide unique, stable item ids.",
-    "Provide concise titles; content can be any React node."
+    "Provide unique, stable item ids — they key open state and the trigger/region ARIA pairing.",
+    "Provide concise titles; content can be any React node.",
+    "Use type=multiple for side-by-side comparison; keep the default single for FAQs and settings."
   ]
 }

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -5,15 +5,18 @@
       "group": "structure",
       "tier": 1,
       "status": "beta",
-      "description": "Expandable sections with keyboard-operable triggers.",
-      "dense": "Exclusive disclosure group: items {id,title,content}, one open at a time (click open item to close), optional defaultOpenId; trigger button wires aria-expanded/aria-controls to its region",
+      "description": "Coordinated disclosure group: single or multiple open sections, animated reveal, keyboard-operable triggers.",
+      "dense": "Disclosure group: items {id,title,content}; type single|multiple; variant contained|enclosed|divided; controlled openIds or defaultOpenId(s); animated grid-rows reveal; aria per region",
       "keywords": [
         "accordion",
         "disclosure",
         "faq",
         "expand",
         "collapse",
-        "progressive disclosure"
+        "progressive disclosure",
+        "single",
+        "multiple",
+        "controlled"
       ],
       "importLine": "import Accordion from \"@dt/Accordion\";",
       "keyProps": [
@@ -23,8 +26,28 @@
           "required": true
         },
         {
+          "name": "type",
+          "type": "single | multiple",
+          "required": false
+        },
+        {
+          "name": "variant",
+          "type": "contained | divided",
+          "required": false
+        },
+        {
           "name": "defaultOpenId",
           "type": "string",
+          "required": false
+        },
+        {
+          "name": "defaultOpenIds",
+          "type": "string[]",
+          "required": false
+        },
+        {
+          "name": "openIds",
+          "type": "string[]",
           "required": false
         }
       ],
@@ -33,7 +56,39 @@
           "optional": false,
           "type": "AccordionItem[]"
         },
+        "type": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "single",
+            "multiple"
+          ]
+        },
+        "variant": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "contained",
+            "divided"
+          ]
+        },
         "defaultOpenId": {
+          "optional": true,
+          "type": "string"
+        },
+        "defaultOpenIds": {
+          "optional": true,
+          "type": "string[]"
+        },
+        "openIds": {
+          "optional": true,
+          "type": "string[]"
+        },
+        "onOpenChange": {
+          "optional": true,
+          "type": "(openIds: string[]) => void"
+        },
+        "className": {
           "optional": true,
           "type": "string"
         }
@@ -49,7 +104,7 @@
         "ship long, scrollable panels. If the content scrolls inside"
       ],
       "usage": {
-        "description": "Accordion is the exclusive disclosure group: pass `items` ({id, title, content}) and at most one stays open — opening another closes the previous, clicking the open one closes it. Use it for FAQs and reference content where users need one answer at a time. For a single independent \"show more\" use ExpandableSection; if most readers need all the content, use plain headings instead of hiding it.",
+        "description": "Accordion coordinates a set of disclosure sections. In the default `type=\"single\"` at most one stays open (opening another closes the previous); `type=\"multiple\"` lets any number stay open for side-by-side reading. Pass `items` ({id, title, content}); drive it uncontrolled with `defaultOpenId`/`defaultOpenIds` or controlled with `openIds` + `onOpenChange`. `variant` switches between a bordered card group (contained) and flush hairlines (divided). For a single independent \"show more\" use ExpandableSection; if most readers need all the content, use plain headings instead of hiding it.",
         "bestPractices": [
           {
             "guidance": true,
@@ -72,8 +127,12 @@
             "description": "Do not hide task-critical content in an accordion; required steps must be visible by default."
           },
           {
+            "guidance": true,
+            "description": "Use type=\"multiple\" when users compare sections side by side (feature lists, pricing tiers); keep the default type=\"single\" for FAQs and settings where one at a time is the point."
+          },
+          {
             "guidance": false,
-            "description": "Do not use it when users need to compare sections side by side — exclusive open forbids that; use headings."
+            "description": "Do not put a single short paragraph behind a section — the click costs more than it saves; show the text directly."
           }
         ],
         "anatomy": [
@@ -107,7 +166,32 @@
         {
           "story": "DefaultOpen",
           "description": "defaultOpenId lands visitors on the entry most of them came for, with the rest one keypress away.",
-          "source": "export const DefaultOpen: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: { description: { story: \"defaultOpenId lands visitors on the entry most of them came for, with the rest one keypress away.\" } },\n  },\n  render: () => (\n    <Accordion\n      defaultOpenId=\"pricing\"\n      items={[\n        { id: \"pricing\", title: \"How is the work priced?\", content: \"Fixed-scope engagements with a written definition of done.\" },\n        { id: \"timeline\", title: \"How long does an engagement take?\", content: \"Typical system audits run two to four weeks.\" },\n      ]}\n    />\n  ),\n};\n\n/** Triggers are real buttons: Tab reaches them, Enter or Space toggles, aria-expanded and aria-controls wire each trigger to its region — asserted by the play function. */"
+          "source": "export const DefaultOpen: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: { description: { story: \"defaultOpenId lands visitors on the entry most of them came for, with the rest one keypress away.\" } },\n  },\n  render: () => (\n    <Accordion\n      defaultOpenId=\"pricing\"\n      items={[\n        { id: \"pricing\", title: \"How is the work priced?\", content: \"Fixed-scope engagements with a written definition of done.\" },\n        { id: \"timeline\", title: \"How long does an engagement take?\", content: \"Typical system audits run two to four weeks.\" },\n      ]}\n    />\n  ),\n};\n\n/** type=\"multiple\" lets several sections stay open so users can compare content. */"
+        },
+        {
+          "story": "Multiple",
+          "description": "type=\\\"multiple\\\" keeps any number of sections open at once — use it when readers compare content across sections, like feature lists or pricing tiers.",
+          "source": "export const Multiple: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: { description: { story: \"type=\\\"multiple\\\" keeps any number of sections open at once — use it when readers compare content across sections, like feature lists or pricing tiers.\" } },\n  },\n  render: () => (\n    <Accordion\n      type=\"multiple\"\n      defaultOpenIds={[\"features\", \"pricing\"]}\n      items={[\n        { id: \"features\", title: \"Features\", content: \"Real-time collaboration, version history, and granular permissions.\" },\n        { id: \"pricing\", title: \"Pricing\", content: \"Free for up to 5 users. Pro starts at €12/user/month billed annually.\" },\n        { id: \"integrations\", title: \"Integrations\", content: \"Connects to the tools your team already uses.\" },\n      ]}\n    />\n  ),\n};\n\n/** Controlled: the parent owns open state via openIds + onOpenChange. */"
+        },
+        {
+          "story": "Controlled",
+          "description": "Pass openIds + onOpenChange to drive the accordion from parent state — when open sections should sync with a URL param, form, or external control.",
+          "source": "export const Controlled: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: { description: { story: \"Pass openIds + onOpenChange to drive the accordion from parent state — when open sections should sync with a URL param, form, or external control.\" } },\n  },\n  render: () => {\n    const ControlledDemo = () => {\n      const [openIds, setOpenIds] = React.useState<string[]>([\"shipping\"]);\n      return (\n        <Accordion\n          type=\"multiple\"\n          openIds={openIds}\n          onOpenChange={setOpenIds}\n          items={[\n            { id: \"shipping\", title: \"Shipping\", content: \"Standard shipping takes 3–5 business days.\" },\n            { id: \"returns\", title: \"Returns\", content: \"Free returns within 30 days of delivery.\" },\n            { id: \"warranty\", title: \"Warranty\", content: \"Two-year limited warranty on all hardware.\" },\n          ]}\n        />\n      );\n    };\n    return <ControlledDemo />;\n  },\n};\n\n/** variant=\"enclosed\" keeps the outer border but drops the between-row dividers. */"
+        },
+        {
+          "story": "Enclosed",
+          "description": "variant=\\\"enclosed\\\" wraps the group in a single rounded border with no dividers between rows — a seamless card. Row separation comes from spacing and the open/closed state.",
+          "source": "export const Enclosed: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: { description: { story: \"variant=\\\"enclosed\\\" wraps the group in a single rounded border with no dividers between rows — a seamless card. Row separation comes from spacing and the open/closed state.\" } },\n  },\n  render: () => (\n    <Accordion\n      variant=\"enclosed\"\n      defaultOpenId=\"notifications\"\n      items={[\n        { id: \"general\", title: \"General settings\", content: \"Language, timezone, and display options.\" },\n        { id: \"notifications\", title: \"Notifications\", content: \"Choose which email and push notifications you want to receive.\" },\n        { id: \"privacy\", title: \"Privacy\", content: \"Control who can see your profile and activity.\" },\n      ]}\n    />\n  ),\n};\n\n/** variant=\"divided\" drops the card border for flush hairline separators. */"
+        },
+        {
+          "story": "Divided",
+          "description": "variant=\\\"divided\\\" removes the container border for flush hairline separators — lighter weight for inline disclosure in sidebars or detail panels.",
+          "source": "export const Divided: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: { description: { story: \"variant=\\\"divided\\\" removes the container border for flush hairline separators — lighter weight for inline disclosure in sidebars or detail panels.\" } },\n  },\n  render: () => (\n    <Accordion\n      variant=\"divided\"\n      items={[\n        { id: \"deploy\", title: \"Deployment details\", content: \"Last deployed April 18, 2026 at 3:42 PM. Build duration 2m 14s.\" },\n        { id: \"env\", title: \"Environment variables\", content: \"12 variables configured across 3 environments.\" },\n        { id: \"logs\", title: \"Build logs\", content: \"No warnings. All checks passed.\" },\n      ]}\n    />\n  ),\n};\n\n/** A disabled item stays visible but its trigger is inert. */"
+        },
+        {
+          "story": "Disabled",
+          "description": "Mark an item disabled to show it in the set while its trigger is inert — for sections that are not yet available.",
+          "source": "export const Disabled: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: { description: { story: \"Mark an item disabled to show it in the set while its trigger is inert — for sections that are not yet available.\" } },\n  },\n  render: () => (\n    <Accordion\n      items={[\n        { id: \"available\", title: \"Available section\", content: \"This one opens normally.\" },\n        { id: \"soon\", title: \"Coming soon\", content: \"Not reachable yet.\", disabled: true },\n        { id: \"also\", title: \"Another section\", content: \"This one opens too.\" },\n      ]}\n    />\n  ),\n};\n\n/** Triggers are real buttons: Tab reaches them, Enter or Space toggles, aria-expanded and aria-controls wire each trigger to its region — asserted by the play function. */"
         },
         {
           "story": "KeyboardContract",


### PR DESCRIPTION
Upgrades Accordion with single/multiple open modes, controlled mode, and default/enclosed/divided variants. Panels now stay mounted and animate via `grid-template-rows`; closed panels are `inert` + `aria-hidden` so `aria-controls` always resolves. The a11y tree is unchanged (closed panels are absent from it either way — previously unmounted, now aria-hidden), so beta-matrix AT snapshots stay valid.

Gate (local, all exit 0): typecheck, lint, lint:css, tests, build; validate:components pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
