### PR TITLE
fix(storybook): keep AnatomySection table headers on one line

### DIFF
--- a/.storybook/blocks/AnatomySection.module.css
+++ b/.storybook/blocks/AnatomySection.module.css
@@ -14,6 +14,7 @@
 
 .table thead th {
   font-weight: 600;
+  white-space: nowrap;
   color: var(--color-muted);
 }
 


### PR DESCRIPTION
white-space:nowrap on the anatomy doc-block table headers so column labels do not wrap in narrow docs viewports.

Gate (local, all exit 0): typecheck, lint, tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)