### PR TITLE
feat(design-system): promote TextInput beta→stable

### DIFF
--- a/nextjs-app/shared/components/TextInput/TextInput.contract.json
+++ b/nextjs-app/shared/components/TextInput/TextInput.contract.json
@@ -3,7 +3,7 @@
     "name": "TextInput",
     "tier": "atom",
     "group": "form",
-    "status": "beta",
+    "status": "stable",
     "description": "Labeled text input with validation, helper text, and size tokens.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=374-10",
     "radixPrimitive": null,
@@ -39,8 +39,10 @@
         ],
         "reducedMotion": true,
         "reviewed": true,
-        "reviewedNote": "2026-05-26 — production behavior verified in Storybook; argTypes and required stories aligned with validate:components.",
-        "forcedColorsVerified": true
+        "reviewedNote": "2026-05-26 \u2014 production behavior verified in Storybook; argTypes and required stories aligned with validate:components.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true
     },
     "tokens": {
         "colors": [
@@ -58,7 +60,48 @@
         ]
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/dev/tailwind-test/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/ContactPage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/CVDownloadSection/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/index.ts",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "label": {

--- a/nextjs-app/shared/components/TextInput/TextInput.stories.tsx
+++ b/nextjs-app/shared/components/TextInput/TextInput.stories.tsx
@@ -8,7 +8,7 @@ import schema from "./schema.json";
 const meta = {
   title: "Forms/TextInput",
   component: TextInput,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--default.dark.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--default.dark.yaml
@@ -1,0 +1,4 @@
+- text: Text Input
+- textbox "Text Input":
+  - /placeholder: Enter text
+  - text: Hello

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--default.forced-colors.yaml
@@ -1,0 +1,4 @@
+- text: Text Input
+- textbox "Text Input":
+  - /placeholder: Enter text
+  - text: Hello

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--default.light.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--default.light.yaml
@@ -1,0 +1,4 @@
+- text: Text Input
+- textbox "Text Input":
+  - /placeholder: Enter text
+  - text: Hello

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--default.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--default.yaml
@@ -1,0 +1,4 @@
+- text: Text Input
+- textbox "Text Input":
+  - /placeholder: Enter text
+  - text: Hello

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--example.dark.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--example.dark.yaml
@@ -1,0 +1,6 @@
+- text: Input with Error
+- textbox "Input with Error" [invalid]:
+  - /placeholder: Enter text
+- alert:
+  - img
+  - text: This field is required

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--example.forced-colors.yaml
@@ -1,0 +1,6 @@
+- text: Input with Error
+- textbox "Input with Error" [invalid]:
+  - /placeholder: Enter text
+- alert:
+  - img
+  - text: This field is required

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--example.light.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--example.light.yaml
@@ -1,0 +1,6 @@
+- text: Input with Error
+- textbox "Input with Error" [invalid]:
+  - /placeholder: Enter text
+- alert:
+  - img
+  - text: This field is required

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--example.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--example.yaml
@@ -1,0 +1,6 @@
+- text: Input with Error
+- textbox "Input with Error" [invalid]:
+  - /placeholder: Enter text
+- alert:
+  - img
+  - text: This field is required

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--forced-colors.dark.yaml
@@ -1,0 +1,3 @@
+- text: Text Input
+- textbox "Text Input":
+  - /placeholder: Enter text

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--forced-colors.forced-colors.yaml
@@ -1,0 +1,3 @@
+- text: Text Input
+- textbox "Text Input":
+  - /placeholder: Enter text

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--forced-colors.light.yaml
@@ -1,0 +1,3 @@
+- text: Text Input
+- textbox "Text Input":
+  - /placeholder: Enter text

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--forced-colors.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--forced-colors.yaml
@@ -1,0 +1,3 @@
+- text: Text Input
+- textbox "Text Input":
+  - /placeholder: Enter text

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--playground.dark.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--playground.dark.yaml
@@ -1,0 +1,3 @@
+- text: Text Input
+- textbox "Text Input":
+  - /placeholder: Enter text

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--playground.forced-colors.yaml
@@ -1,0 +1,3 @@
+- text: Text Input
+- textbox "Text Input":
+  - /placeholder: Enter text

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--playground.light.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--playground.light.yaml
@@ -1,0 +1,3 @@
+- text: Text Input
+- textbox "Text Input":
+  - /placeholder: Enter text

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--playground.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--playground.yaml
@@ -1,0 +1,3 @@
+- text: Text Input
+- textbox "Text Input":
+  - /placeholder: Enter text

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -14185,7 +14185,7 @@
       "name": "TextInput",
       "group": "form",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "Labeled text input with validation, helper text, and size tokens.",
       "dense": "labelled single-line field: text/number/email/password/search/tel, built-in email + phone validation, own error/helperText, sm/md/lg; onValueChange(value)",
       "keywords": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -883,6 +883,31 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "display",
     "import": "import Text from "@dt/Text";",
   },
+  "TextInput": {
+    "exampleStories": [
+      "TextInputStory",
+      "EmailInput",
+      "InputWithError",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "form",
+    "import": "import TextInput from "@dt/TextInput";",
+  },
   "Title": {
     "exampleStories": [
       "AllSizes",


### PR DESCRIPTION
Promotes **TextInput** beta→stable. 8 production consumers (ContactPage, CVDownloadSection, ContactPageContentEditorial patterns, a dev page) confirmed via `audit:consumers`.

- Captured 4-mode AT snapshots (base/dark/light/forced-colors) for all required stories (Default/Playground/Example/ForcedColors)
- Set `accessibilityTreeVerified` + `realBrowserForcedColorsVerified`; flipped meta tag beta→stable
- Refreshed the docs-registry stable-shape snapshot (TextInput newly included)

Gate (local, all exit 0): typecheck, lint, lint:css, tests 2084/2084, build; validate:components, check:consumers, check:contract-props, `STABLE_MISSING_SNAPSHOTS=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
