### PR TITLE
fix(design-system): TextInput 8px radius + neutral resting border

### DIFF
--- a/nextjs-app/shared/components/TextInput/TextInput.module.css
+++ b/nextjs-app/shared/components/TextInput/TextInput.module.css
@@ -18,7 +18,8 @@
   box-sizing: border-box;
   width: 100%;
   min-height: 2.5rem;
-  border: 1px solid var(--color-primary);
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
   background-color: var(--color-white);
   font-family: var(--font-text);
   font-size: 1rem;


### PR DESCRIPTION
Resting border `--color-primary` → `--color-border` (rgb 192,192,192); primary only on focus. Adds `border-radius: 0.5rem` (was 0).

Verified in Storybook (computed): resting rgb(192,192,192) + 8px radius; focus → primary.

Gate (local, all exit 0): typecheck, lint, lint:css, tests, build; validate:components (TextInput stable) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)