### PR TITLE
fix(design-system): vertically center HelperText icon with text

### DIFF
--- a/nextjs-app/shared/components/HelperText/HelperText.module.css
+++ b/nextjs-app/shared/components/HelperText/HelperText.module.css
@@ -1,7 +1,7 @@
 .helperText {
   display: flex;
   margin-block-start: 0.5rem;
-  align-items: flex-start;
+  align-items: center;
   gap: 0.375rem;
   background-color: transparent;
   font-family: var(--primary-body-font, sans-serif);
@@ -11,7 +11,6 @@
 
 .icon {
   display: inline-flex;
-  margin-block-start: 0.125rem;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
align-items flex-start → center and drop the icon margin-block-start nudge, so the tone icon centers on the label line.

Verified in Storybook (computed): icon center = wrap center, delta 0.

Gate (local, all exit 0): typecheck, lint, lint:css, tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)