### PR TITLE
fix(design-system): LanguageSwitcher hover shows bg only, no border

### DIFF
--- a/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.tsx
@@ -13,7 +13,7 @@ export type LanguageSwitcherOption = {
 };
 
 const defaultButtonClassName =
-  "shrink-0 whitespace-nowrap px-2.5 py-1.5 text-sm font-heading font-semibold uppercase tracking-widest transition-colors motion-reduce:transition-none cursor-pointer rounded-sm border border-transparent bg-transparent text-muted-foreground hover:text-foreground hover:bg-foreground/5 hover:border-border";
+  "shrink-0 whitespace-nowrap px-2.5 py-1.5 text-sm font-heading font-semibold uppercase tracking-widest transition-colors motion-reduce:transition-none cursor-pointer rounded-sm border border-transparent bg-transparent text-muted-foreground hover:text-foreground hover:bg-foreground/5";
 
 const defaultActiveButtonClassName =
   "font-bold text-foreground hover:text-foreground";


### PR DESCRIPTION
Removes `hover:border-border` from the language button; keeps `hover:bg-foreground/5` and the transparent resting border (so no layout shift).

Verified in Storybook (computed): EN button has hover bg class, no hover-border class, resting border transparent.

Gate (local, all exit 0): typecheck, lint, lint:css, tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)