### PR TITLE
fix(design-system): restore disabled color tokens to neutral (were blue drifts)

### DIFF
--- a/nextjs-app/shared/foundations/token-catalog.json
+++ b/nextjs-app/shared/foundations/token-catalog.json
@@ -1,6 +1,6 @@
 {
   "source": "nextjs-app/shared/styles/variables.css",
-  "generatedAt": "2026-07-07T15:57:51.697Z",
+  "generatedAt": "2026-07-07T17:41:16.939Z",
   "tokenCount": 173,
   "usageCoverage": 140,
   "themes": [
@@ -660,7 +660,7 @@
         },
         {
           "name": "--color-muted-light",
-          "value": "#4949a7",
+          "value": "#909090",
           "usage": "Color token (muted-light).",
           "category": "color",
           "subgroup": "Greyscale & borders"
@@ -695,7 +695,7 @@
         },
         {
           "name": "--color-primary-disabled",
-          "value": "#0000ff50",
+          "value": "#041b2350",
           "usage": "Color token (primary-disabled).",
           "category": "color",
           "subgroup": "Greyscale & borders"

--- a/nextjs-app/shared/foundations/tokens/production/color.json
+++ b/nextjs-app/shared/foundations/tokens/production/color.json
@@ -58,7 +58,7 @@
       "$description": "Color token (muted).",
       "$type": "color",
       "light": {
-        "$value": "#4949a7",
+        "$value": "#909090",
         "$description": "Color token (muted-light).",
         "$type": "color"
       }

--- a/nextjs-app/shared/styles/variables.css
+++ b/nextjs-app/shared/styles/variables.css
@@ -126,7 +126,7 @@
   --color-gray-dark: #333;
   --color-gray: #5e5e5e;
   --color-muted: #626a72; /* AA on #f5f6f6 field surfaces (5.07:1) AND their hover mix #ebeded (4.67:1), not just on white */
-  --color-muted-light: #4949a7;
+  --color-muted-light: #909090;
   --color-border: #c0c0c0;
   --color-border-light: #ccc;
   --color-disabled-bg: #e0e0e0;
@@ -141,7 +141,7 @@
   /* Functional colors */
   --main-body-background-color: #fff;
   --color-primary: #041b23;
-  --color-primary-disabled: #0000ff50;
+  --color-primary-disabled: #041b2350;
   --color-success: #068338;
   --color-info: #0c7a8b;
   --color-error: #dc3545;


### PR DESCRIPTION
Two light-theme disabled tokens had drifted to accidental blues (same family as the 2025-07-10 "new build" commit that broke `--color-muted-light`):

- `--color-muted-light`: `#4949a7` → `#909090` (disabled Label/Badge text)
- `--color-primary-disabled`: `#0000ff50` (pure blue) → `#041b2350` (primary teal, matching the dark theme's `primary@alpha` convention; used as disabled input borders)

This is the foundation for unifying disabled state onto the dedicated `--color-disabled-*` token family across components (follow-up PRs migrate the opacity-based components).

Gate (local, all exit 0): typecheck, lint, lint:css, tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
