### PR TITLE
fix(design-system): theme toggle icon back to bold stroke (not fill)

### DIFF
--- a/nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx
+++ b/nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx
@@ -220,7 +220,7 @@ export function MobileDrawer({
               {t("navMenuTheme")}
             </span>
             <IconButton
-              icon={<ThemeIcon weight="fill" className="size-4" />}
+              icon={<ThemeIcon weight="bold" className="size-4" />}
               label={t("navMenuThemeToggle")}
               onClick={onThemeToggle}
               variant="secondary"

--- a/nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx
+++ b/nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx
@@ -306,7 +306,7 @@ export function SiteHeader({
                     )}
                     aria-hidden
                   >
-                    <ThemeIcon weight="fill" className="size-4" />
+                    <ThemeIcon weight="bold" className="size-4" />
                   </span>
                 }
                 label={t("toggleDarkMode")}


### PR DESCRIPTION
Corrects #963: the ask was the heavier `stroke` weight (`weight="bold"`), not the solid `fill` variant. Reverts the SiteHeader + MobileDrawer theme icons to `weight="bold"`. (The LanguageSwitcher active-weight 500 change from #963 stays.)

Gate (local, all exit 0): typecheck, lint, tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the theme toggle icon appearance in the site header and mobile drawer to use a bolder icon style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->