### PR TITLE
chore(design-system): rebaseline rhythmguard to current CSS

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,27 +1,7 @@
 {
-  "createdAt": "2026-07-06T06:59:33.909Z",
+  "createdAt": "2026-07-07T20:05:25.910Z",
   "directory": "nextjs-app/shared",
   "findings": [
-    {
-      "column": 8,
-      "file": "nextjs-app/shared/components/AlertBanner/AlertBanner.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/AlertBanner/AlertBanner.module.css\u001f5\u001f8\u001f0.75rem\u001fUnexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 5,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "0.75rem"
-    },
-    {
-      "column": 8,
-      "file": "nextjs-app/shared/components/AlertBanner/AlertBanner.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/AlertBanner/AlertBanner.module.css\u001f14\u001f8\u001f0.25rem\u001fUnexpected raw scale value \"0.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 14,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"0.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "0.25rem"
-    },
     {
       "column": 18,
       "file": "nextjs-app/shared/components/ArticleCard/ArticleCard.module.css",
@@ -273,26 +253,6 @@
       "value": "0.5rem"
     },
     {
-      "column": 11,
-      "file": "nextjs-app/shared/components/BlogNav/blognav.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/BlogNav/blognav.module.css\u001f25\u001f11\u001f1.5rem\u001fUnexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 25,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "1.5rem"
-    },
-    {
-      "column": 20,
-      "file": "nextjs-app/shared/components/BlogNav/blognav.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/BlogNav/blognav.module.css\u001f25\u001f20\u001f2rem\u001fUnexpected raw scale value \"2rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 25,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"2rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "2rem"
-    },
-    {
       "column": 8,
       "file": "nextjs-app/shared/components/Breadcrumb/Breadcrumb.module.css",
       "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Breadcrumb/Breadcrumb.module.css\u001f4\u001f8\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
@@ -305,8 +265,8 @@
     {
       "column": 8,
       "file": "nextjs-app/shared/components/Breadcrumb/Breadcrumb.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Breadcrumb/Breadcrumb.module.css\u001f21\u001f8\u001f0.25rem\u001fUnexpected raw scale value \"0.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 21,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Breadcrumb/Breadcrumb.module.css\u001f27\u001f8\u001f0.25rem\u001fUnexpected raw scale value \"0.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 27,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -315,8 +275,8 @@
     {
       "column": 8,
       "file": "nextjs-app/shared/components/Breadcrumb/Breadcrumb.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Breadcrumb/Breadcrumb.module.css\u001f29\u001f8\u001f0.25rem\u001fUnexpected raw scale value \"0.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 29,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Breadcrumb/Breadcrumb.module.css\u001f35\u001f8\u001f0.25rem\u001fUnexpected raw scale value \"0.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 35,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -325,8 +285,8 @@
     {
       "column": 22,
       "file": "nextjs-app/shared/components/Button/Button.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/Button/Button.module.css\u001f341\u001f22\u001f-1px\u001fUnexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "line": 341,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/Button/Button.module.css\u001f344\u001f22\u001f-1px\u001fUnexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 344,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -335,8 +295,8 @@
     {
       "column": 22,
       "file": "nextjs-app/shared/components/Button/Button.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/Button/Button.module.css\u001f350\u001f22\u001f-2px\u001fUnexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "line": 350,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/Button/Button.module.css\u001f353\u001f22\u001f-2px\u001fUnexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 353,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -345,8 +305,8 @@
     {
       "column": 22,
       "file": "nextjs-app/shared/components/Button/Button.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Button/Button.module.css\u001f341\u001f22\u001f-1px\u001fUnexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 341,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Button/Button.module.css\u001f344\u001f22\u001f-1px\u001fUnexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 344,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -355,8 +315,8 @@
     {
       "column": 22,
       "file": "nextjs-app/shared/components/Button/Button.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Button/Button.module.css\u001f350\u001f22\u001f-2px\u001fUnexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 350,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Button/Button.module.css\u001f353\u001f22\u001f-2px\u001fUnexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 353,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -365,8 +325,8 @@
     {
       "column": 16,
       "file": "nextjs-app/shared/components/Button/Button.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Button/Button.module.css\u001f363\u001f16\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 363,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Button/Button.module.css\u001f366\u001f16\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 366,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -2755,16 +2715,6 @@
     {
       "column": 23,
       "file": "nextjs-app/shared/components/HelperText/HelperText.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/HelperText/HelperText.module.css\u001f14\u001f23\u001f0.125rem\u001fUnexpected off-scale value \"0.125rem\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "line": 14,
-      "rule": "rhythmguard/use-scale",
-      "text": "Unexpected off-scale value \"0.125rem\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "type": "off-scale",
-      "value": "0.125rem"
-    },
-    {
-      "column": 23,
-      "file": "nextjs-app/shared/components/HelperText/HelperText.module.css",
       "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/HelperText/HelperText.module.css\u001f3\u001f23\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "line": 3,
       "rule": "rhythmguard/prefer-token",
@@ -2781,16 +2731,6 @@
       "text": "Unexpected raw scale value \"0.375rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
       "value": "0.375rem"
-    },
-    {
-      "column": 23,
-      "file": "nextjs-app/shared/components/HelperText/HelperText.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/HelperText/HelperText.module.css\u001f14\u001f23\u001f0.125rem\u001fUnexpected raw scale value \"0.125rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 14,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"0.125rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "0.125rem"
     },
     {
       "column": 23,
@@ -2835,8 +2775,8 @@
     {
       "column": 11,
       "file": "nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.module.css\u001f55\u001f11\u001f-1px\u001fUnexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "line": 55,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.module.css\u001f59\u001f11\u001f-1px\u001fUnexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 59,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -2875,8 +2815,8 @@
     {
       "column": 11,
       "file": "nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.module.css\u001f55\u001f11\u001f-1px\u001fUnexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 55,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.module.css\u001f59\u001f11\u001f-1px\u001fUnexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 59,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -3535,8 +3475,8 @@
     {
       "column": 27,
       "file": "nextjs-app/shared/components/Progress/Progress.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Progress/Progress.module.css\u001f37\u001f27\u001f-100%\u001fUnexpected raw scale value \"-100%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 37,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Progress/Progress.module.css\u001f40\u001f27\u001f-100%\u001fUnexpected raw scale value \"-100%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 40,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"-100%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -3545,8 +3485,8 @@
     {
       "column": 27,
       "file": "nextjs-app/shared/components/Progress/Progress.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Progress/Progress.module.css\u001f41\u001f27\u001f250%\u001fUnexpected raw scale value \"250%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 41,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Progress/Progress.module.css\u001f44\u001f27\u001f250%\u001fUnexpected raw scale value \"250%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 44,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"250%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -3913,6 +3853,46 @@
       "value": "0.875rem"
     },
     {
+      "column": 11,
+      "file": "nextjs-app/shared/components/SelectableCard/SelectableCard.module.css",
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/SelectableCard/SelectableCard.module.css\u001f52\u001f11\u001f-1px\u001fUnexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 52,
+      "rule": "rhythmguard/use-scale",
+      "text": "Unexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "type": "off-scale",
+      "value": "-1px"
+    },
+    {
+      "column": 23,
+      "file": "nextjs-app/shared/components/SelectableCard/SelectableCard.module.css",
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/SelectableCard/SelectableCard.module.css\u001f134\u001f23\u001f-2px\u001fUnexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 134,
+      "rule": "rhythmguard/use-scale",
+      "text": "Unexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "type": "off-scale",
+      "value": "-2px"
+    },
+    {
+      "column": 11,
+      "file": "nextjs-app/shared/components/SelectableCard/SelectableCard.module.css",
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/SelectableCard/SelectableCard.module.css\u001f52\u001f11\u001f-1px\u001fUnexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 52,
+      "rule": "rhythmguard/prefer-token",
+      "text": "Unexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "type": "token-opportunity",
+      "value": "-1px"
+    },
+    {
+      "column": 23,
+      "file": "nextjs-app/shared/components/SelectableCard/SelectableCard.module.css",
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/SelectableCard/SelectableCard.module.css\u001f134\u001f23\u001f-2px\u001fUnexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 134,
+      "rule": "rhythmguard/prefer-token",
+      "text": "Unexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "type": "token-opportunity",
+      "value": "-2px"
+    },
+    {
       "column": 18,
       "file": "nextjs-app/shared/components/SentrySummaryCard/SentrySummaryCard.module.css",
       "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/SentrySummaryCard/SentrySummaryCard.module.css\u001f51\u001f18\u001f2px\u001fUnexpected off-scale value \"2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
@@ -4075,8 +4055,8 @@
     {
       "column": 22,
       "file": "nextjs-app/shared/components/SkipLink/SkipLink.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/SkipLink/SkipLink.module.css\u001f22\u001f22\u001f-4rem\u001fUnexpected off-scale value \"-4rem\". Use scale values (nearest: 32px or 32px). (rhythmguard/use-scale)",
-      "line": 22,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/SkipLink/SkipLink.module.css\u001f26\u001f22\u001f-4rem\u001fUnexpected off-scale value \"-4rem\". Use scale values (nearest: 32px or 32px). (rhythmguard/use-scale)",
+      "line": 26,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"-4rem\". Use scale values (nearest: 32px or 32px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -4085,8 +4065,8 @@
     {
       "column": 22,
       "file": "nextjs-app/shared/components/SkipLink/SkipLink.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/SkipLink/SkipLink.module.css\u001f22\u001f22\u001f-4rem\u001fUnexpected raw scale value \"-4rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 22,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/SkipLink/SkipLink.module.css\u001f26\u001f22\u001f-4rem\u001fUnexpected raw scale value \"-4rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 26,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"-4rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -4153,24 +4133,44 @@
       "value": "1rem"
     },
     {
-      "column": 17,
+      "column": 20,
       "file": "nextjs-app/shared/components/Tabs/Tabs.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/Tabs/Tabs.module.css\u001f149\u001f17\u001f-2px\u001fUnexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "line": 149,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/Tabs/Tabs.module.css\u001f159\u001f20\u001f-1px\u001fUnexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 159,
       "rule": "rhythmguard/use-scale",
-      "text": "Unexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "text": "Unexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
       "type": "off-scale",
-      "value": "-2px"
+      "value": "-1px"
     },
     {
-      "column": 17,
+      "column": 19,
       "file": "nextjs-app/shared/components/Tabs/Tabs.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Tabs/Tabs.module.css\u001f149\u001f17\u001f-2px\u001fUnexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 149,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/Tabs/Tabs.module.css\u001f187\u001f19\u001f0.4em\u001fUnexpected off-scale value \"0.4em\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
+      "line": 187,
+      "rule": "rhythmguard/use-scale",
+      "text": "Unexpected off-scale value \"0.4em\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
+      "type": "off-scale",
+      "value": "0.4em"
+    },
+    {
+      "column": 20,
+      "file": "nextjs-app/shared/components/Tabs/Tabs.module.css",
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Tabs/Tabs.module.css\u001f159\u001f20\u001f-1px\u001fUnexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 159,
       "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "text": "Unexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
-      "value": "-2px"
+      "value": "-1px"
+    },
+    {
+      "column": 19,
+      "file": "nextjs-app/shared/components/Tabs/Tabs.module.css",
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Tabs/Tabs.module.css\u001f187\u001f19\u001f0.4em\u001fUnexpected raw scale value \"0.4em\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 187,
+      "rule": "rhythmguard/prefer-token",
+      "text": "Unexpected raw scale value \"0.4em\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "type": "token-opportunity",
+      "value": "0.4em"
     },
     {
       "column": 12,
@@ -4265,8 +4265,8 @@
     {
       "column": 12,
       "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f32\u001f12\u001f0.375rem\u001fUnexpected off-scale value \"0.375rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
-      "line": 32,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f33\u001f12\u001f0.375rem\u001fUnexpected off-scale value \"0.375rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
+      "line": 33,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"0.375rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -4275,8 +4275,8 @@
     {
       "column": 12,
       "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f44\u001f12\u001f0.625rem\u001fUnexpected off-scale value \"0.625rem\". Use scale values (nearest: 8px or 12px). (rhythmguard/use-scale)",
-      "line": 44,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f45\u001f12\u001f0.625rem\u001fUnexpected off-scale value \"0.625rem\". Use scale values (nearest: 8px or 12px). (rhythmguard/use-scale)",
+      "line": 45,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"0.625rem\". Use scale values (nearest: 8px or 12px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -4315,8 +4315,8 @@
     {
       "column": 12,
       "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f32\u001f12\u001f0.375rem\u001fUnexpected raw scale value \"0.375rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 32,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f33\u001f12\u001f0.375rem\u001fUnexpected raw scale value \"0.375rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 33,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.375rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -4325,8 +4325,8 @@
     {
       "column": 12,
       "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f38\u001f12\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 38,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f39\u001f12\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 39,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -4335,8 +4335,8 @@
     {
       "column": 12,
       "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f44\u001f12\u001f0.625rem\u001fUnexpected raw scale value \"0.625rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 44,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f45\u001f12\u001f0.625rem\u001fUnexpected raw scale value \"0.625rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 45,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.625rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -4345,8 +4345,8 @@
     {
       "column": 15,
       "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f53\u001f15\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 53,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f54\u001f15\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 54,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -4355,8 +4355,8 @@
     {
       "column": 17,
       "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f103\u001f17\u001f1.5rem\u001fUnexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 103,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f104\u001f17\u001f1.5rem\u001fUnexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 104,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -4451,16 +4451,6 @@
       "text": "Unexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
       "value": "1rem"
-    },
-    {
-      "column": 18,
-      "file": "nextjs-app/shared/components/WorkNav/worknav.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/WorkNav/worknav.module.css\u001f20\u001f18\u001f2rem\u001fUnexpected raw scale value \"2rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 20,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"2rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "2rem"
     },
     {
       "column": 18,
@@ -7735,8 +7725,8 @@
     {
       "column": 19,
       "file": "nextjs-app/shared/styles/variables.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/styles/variables.css\u001f703\u001f19\u001f6px\u001fUnexpected off-scale value \"6px\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
-      "line": 703,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/styles/variables.css\u001f708\u001f19\u001f6px\u001fUnexpected off-scale value \"6px\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
+      "line": 708,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"6px\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -7745,8 +7735,8 @@
     {
       "column": 19,
       "file": "nextjs-app/shared/styles/variables.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/styles/variables.css\u001f703\u001f19\u001f6px\u001fUnexpected raw scale value \"6px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 703,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/styles/variables.css\u001f708\u001f19\u001f6px\u001fUnexpected raw scale value \"6px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 708,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"6px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -7756,6 +7746,6 @@
   "formatVersion": 1,
   "summary": {
     "scaleCleanliness": 91,
-    "totalFindings": 775
+    "totalFindings": 774
   }
 }


### PR DESCRIPTION
Line-keyed rhythmguard baseline drifted out of sync on main (30 new / 31 resolved across ~38 files, from disabled-token CSS work #957–964 shifting lines) — main's own pre-commit `audit:rhythm:check` was failing on itself. Regenerate the baseline from current CSS. Baseline-only change, no source edits; check now passes 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)