### PR TITLE
feat(design-system): TextArea beta→stable

### DIFF
--- a/nextjs-app/shared/components/TextArea/TextArea.contract.json
+++ b/nextjs-app/shared/components/TextArea/TextArea.contract.json
@@ -3,7 +3,7 @@
     "name": "TextArea",
     "tier": "atom",
     "group": "form",
-    "status": "beta",
+    "status": "stable",
     "description": "Multi-line text field with label, error/helper text, and optional animated auto-grow.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=374-17",
     "radixPrimitive": null,
@@ -30,7 +30,9 @@
         "reducedMotion": true,
         "reviewed": true,
         "reviewedNote": "2026-07-05 — alpha→beta a11y review (Petri/Claude). Brought to TextInput/PhoneInput parity: label association now uses useId() (was the raw label string → duplicate-id + broke on spaces); error wired through aria-invalid + aria-describedby to a role=alert HelperText (was unassociated, and the story falsely claimed aria-invalid); required marker now driven by the required prop, not the error state; error no longer leaks into the label title tooltip. Keyboard = native textarea Tab/Shift+Tab. Verified axe-clean on Default/WithHelperCopy/WithError via test-storybook; light + dark + emulated forced-colors eyeballed in a real browser (visible CanvasText border, readable label/placeholder/error). reduced-motion drops the auto-grow height transition (CSS @media). Unit tests assert the aria wiring, required-from-prop, and unique-id behavior.",
-        "forcedColorsVerified": true
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true
     },
     "tokens": {
         "colors": [
@@ -48,7 +50,18 @@
         ]
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/dev/tailwind-test/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/layout.tsx",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "label": {

--- a/nextjs-app/shared/components/TextArea/TextArea.stories.tsx
+++ b/nextjs-app/shared/components/TextArea/TextArea.stories.tsx
@@ -8,7 +8,7 @@ import { expect, userEvent, within } from "storybook/test";
 const meta = {
   title: "Forms/TextArea",
   component: TextArea,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--default.dark.yaml
+++ b/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--default.dark.yaml
@@ -1,0 +1,3 @@
+- text: Message
+- textbox "Message":
+  - /placeholder: Share more details…

--- a/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--default.forced-colors.yaml
@@ -1,0 +1,3 @@
+- text: Message
+- textbox "Message":
+  - /placeholder: Share more details…

--- a/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--default.light.yaml
+++ b/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--default.light.yaml
@@ -1,0 +1,3 @@
+- text: Message
+- textbox "Message":
+  - /placeholder: Share more details…

--- a/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--default.yaml
+++ b/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--default.yaml
@@ -1,0 +1,3 @@
+- text: Message
+- textbox "Message":
+  - /placeholder: Share more details…

--- a/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--example.dark.yaml
+++ b/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--example.dark.yaml
@@ -1,0 +1,6 @@
+- text: Message with validation
+- textbox "Message with validation" [invalid]:
+  - /placeholder: Share more details…
+- alert:
+  - img
+  - text: Please enter a short message.

--- a/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--example.forced-colors.yaml
@@ -1,0 +1,6 @@
+- text: Message with validation
+- textbox "Message with validation" [invalid]:
+  - /placeholder: Share more details…
+- alert:
+  - img
+  - text: Please enter a short message.

--- a/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--example.light.yaml
+++ b/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--example.light.yaml
@@ -1,0 +1,6 @@
+- text: Message with validation
+- textbox "Message with validation" [invalid]:
+  - /placeholder: Share more details…
+- alert:
+  - img
+  - text: Please enter a short message.

--- a/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--example.yaml
+++ b/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--example.yaml
@@ -1,0 +1,6 @@
+- text: Message with validation
+- textbox "Message with validation" [invalid]:
+  - /placeholder: Share more details…
+- alert:
+  - img
+  - text: Please enter a short message.

--- a/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--forced-colors.dark.yaml
@@ -1,0 +1,3 @@
+- text: Message
+- textbox "Message":
+  - /placeholder: Share more details…

--- a/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--forced-colors.forced-colors.yaml
@@ -1,0 +1,3 @@
+- text: Message
+- textbox "Message":
+  - /placeholder: Share more details…

--- a/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--forced-colors.light.yaml
@@ -1,0 +1,3 @@
+- text: Message
+- textbox "Message":
+  - /placeholder: Share more details…

--- a/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--forced-colors.yaml
+++ b/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--forced-colors.yaml
@@ -1,0 +1,3 @@
+- text: Message
+- textbox "Message":
+  - /placeholder: Share more details…

--- a/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--playground.dark.yaml
+++ b/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--playground.dark.yaml
@@ -1,0 +1,4 @@
+- text: Message
+- textbox "Message":
+  - /placeholder: Share more details…
+  - text: Line 1 Line 2 Line 3 Line 4 Line 5 Line 6 Line 7 Line 8 Line 9 Line 10

--- a/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--playground.forced-colors.yaml
@@ -1,0 +1,4 @@
+- text: Message
+- textbox "Message":
+  - /placeholder: Share more details…
+  - text: Line 1 Line 2 Line 3 Line 4 Line 5 Line 6 Line 7 Line 8 Line 9 Line 10

--- a/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--playground.light.yaml
+++ b/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--playground.light.yaml
@@ -1,0 +1,4 @@
+- text: Message
+- textbox "Message":
+  - /placeholder: Share more details…
+  - text: Line 1 Line 2 Line 3 Line 4 Line 5 Line 6 Line 7 Line 8 Line 9 Line 10

--- a/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--playground.yaml
+++ b/nextjs-app/shared/components/TextArea/__a11y-snapshots__/forms-textarea--playground.yaml
@@ -1,0 +1,4 @@
+- text: Message
+- textbox "Message":
+  - /placeholder: Share more details…
+  - text: Line 1 Line 2 Line 3 Line 4 Line 5 Line 6 Line 7 Line 8 Line 9 Line 10

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -14028,7 +14028,7 @@
       "name": "TextArea",
       "group": "form",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "Multi-line text field with label, error/helper text, and optional animated auto-grow.",
       "dense": "labelled multi-line field with optional animated auto-grow (minRows/maxRows), own error + helperText; onChange(value)",
       "keywords": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -962,6 +962,32 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "display",
     "import": "import Text from "@dt/Text";",
   },
+  "TextArea": {
+    "exampleStories": [
+      "WithHelperCopy",
+      "WithError",
+      "AnimatedResize",
+      "KeyboardEntry",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "form",
+    "import": "import TextArea from "@dt/TextArea";",
+  },
   "TextInput": {
     "exampleStories": [
       "TextInputStory",


### PR DESCRIPTION
Promote TextArea to stable (stable count 42→43), continuing the wave (prior: Skeleton #967).

- Contract `status: stable` + a11y flags after 4-mode AT verification on a non-6010 Storybook (base + light + dark + forced-colors all pass).
- Story meta tag `beta`→`stable`.
- 2 production consumers (app/layout.tsx via ChatWidget, tailwind-test).
- **Bootstrapped the AT-snapshot set** — the dir was absent (beta passed because compare-mode tolerates missing snapshots). 16 files matching the TextInput convention: {default, playground, example, forced-colors} × 4 modes, captured while already-stable so they carry no WipBadge line.
- Forced-colors story visually verified (visible border, legible label/placeholder/resize handle).
- No variant axes → no computed-style check needed.

Gates all green: typecheck, lint, lint:css, rhythm, test (2084), build; contract-props, consumers, validate:components, snapshot-debt (STABLE_MISSING=0). docs-registry snapshot refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)