### PR TITLE
feat(design-system): FileUpload beta→stable

### DIFF
--- a/nextjs-app/shared/components/FileUpload/FileUpload.contract.json
+++ b/nextjs-app/shared/components/FileUpload/FileUpload.contract.json
@@ -3,7 +3,7 @@
     "name": "FileUpload",
     "tier": "molecule",
     "group": "form",
-    "status": "beta",
+    "status": "stable",
     "description": "File picker with size validation and clear control.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=384-26",
     "radixPrimitive": null,
@@ -30,8 +30,10 @@
         ],
         "reducedMotion": true,
         "reviewed": true,
-        "reviewedNote": "2026-05-26 — production behavior verified in Storybook; argTypes and required stories aligned with validate:components.",
-        "forcedColorsVerified": true
+        "reviewedNote": "2026-07-07 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified on a non-6010 Storybook; accessibility tree and real-browser forced-colors confirmed.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true
     },
     "tokens": {
         "colors": [
@@ -48,7 +50,33 @@
         ]
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/layout.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/ContactPage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "label": {

--- a/nextjs-app/shared/components/FileUpload/FileUpload.stories.tsx
+++ b/nextjs-app/shared/components/FileUpload/FileUpload.stories.tsx
@@ -8,7 +8,7 @@ import schema from "./schema.json";
 export default {
   title: "Forms/FileUpload",
   component: FileUpload,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/FileUpload/__a11y-snapshots__/forms-fileupload--default.yaml
+++ b/nextjs-app/shared/components/FileUpload/__a11y-snapshots__/forms-fileupload--default.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Attachment (optional)
 - textbox "Attachment (optional)":
   - /placeholder: No file selected

--- a/nextjs-app/shared/components/FileUpload/__a11y-snapshots__/forms-fileupload--example.yaml
+++ b/nextjs-app/shared/components/FileUpload/__a11y-snapshots__/forms-fileupload--example.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Attachment (optional)
 - textbox "Attachment (optional)":
   - /placeholder: No file selected

--- a/nextjs-app/shared/components/FileUpload/__a11y-snapshots__/forms-fileupload--forced-colors.yaml
+++ b/nextjs-app/shared/components/FileUpload/__a11y-snapshots__/forms-fileupload--forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Attachment (optional)
 - textbox "Attachment (optional)":
   - /placeholder: No file selected

--- a/nextjs-app/shared/components/FileUpload/__a11y-snapshots__/forms-fileupload--playground.yaml
+++ b/nextjs-app/shared/components/FileUpload/__a11y-snapshots__/forms-fileupload--playground.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Attachment (optional)
 - textbox "Attachment (optional)":
   - /placeholder: No file selected

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -5659,7 +5659,7 @@
       "name": "FileUpload",
       "group": "form",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "File picker with size validation and clear control.",
       "dense": "single-file picker: readonly summary + Browse/Clear over a hidden input; accept filter, maxSizeInBytes rejection (localized), default/editorial looks; onFileChange(File | null)",
       "keywords": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -333,6 +333,32 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "structure",
     "import": "import { ExpandableSection } from "@dt/ExpandableSection";",
   },
+  "FileUpload": {
+    "exampleStories": [
+      "Default",
+      "SelectAndClear",
+      "SizeRejection",
+      "Editorial",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "form",
+    "import": "import FileUpload from "@dt/FileUpload";",
+  },
   "FlexBox": {
     "exampleStories": [
       "InlineCluster",


### PR DESCRIPTION
Promote FileUpload to stable (stable count 43→44), continuing the wave (prior: TextArea #968).

- Contract `status: stable` + a11y flags after 4-mode AT verification on a non-6010 Storybook (base + light + dark + forced-colors all pass).
- Story meta tag `beta`→`stable`; WipBadge dropped from the 4 base AT snapshots.
- 5 production consumers (ContactPage + ContactPageContentEditorial + app/layout.tsx via ChatWidget).
- Forced-colors story visually verified (bordered field, Choose-file button with visible border, legible helper text).
- No variant axes → no computed-style check needed.

Gates all green: typecheck, lint, lint:css, rhythm, test (2084), build; contract-props, consumers, validate:components, snapshot-debt (STABLE_MISSING=0). docs-registry snapshot refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)