### PR TITLE
feat(design-system): Spinner beta→stable

### DIFF
--- a/nextjs-app/shared/components/Spinner/Spinner.contract.json
+++ b/nextjs-app/shared/components/Spinner/Spinner.contract.json
@@ -3,7 +3,7 @@
     "name": "Spinner",
     "tier": "atom",
     "group": "feedback",
-    "status": "beta",
+    "status": "stable",
     "description": "Indeterminate loading spinner for async UI.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=368-16",
     "radixPrimitive": null,
@@ -38,7 +38,9 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-03 (batch 4) — BusyIndicator deleted (duplicate loading indicator with off-convention s/m/l sizes); its consumers migrated here."
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-03 (batch 4) — BusyIndicator deleted (duplicate loading indicator with off-convention s/m/l sizes); its consumers migrated here. 2026-07-07 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified on a non-6010 Storybook."
     },
     "tokens": {
         "colors": [
@@ -48,7 +50,23 @@
         "spacing": []
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/CVDownloadSection/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/index.ts",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "label": {

--- a/nextjs-app/shared/components/Spinner/Spinner.stories.tsx
+++ b/nextjs-app/shared/components/Spinner/Spinner.stories.tsx
@@ -5,7 +5,7 @@ import contract from "./Spinner.contract.json";
 const meta = {
   title: "Feedback/Spinner",
   component: Spinner,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--default.dark.yaml
+++ b/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--default.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status "Loading content"

--- a/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--default.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status "Loading content"

--- a/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--default.light.yaml
+++ b/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--default.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status "Loading content"

--- a/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--default.yaml
+++ b/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--default.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status "Loading content"

--- a/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--example.dark.yaml
+++ b/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--example.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status "Loading"

--- a/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--example.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status "Loading"

--- a/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--example.light.yaml
+++ b/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--example.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status "Loading"

--- a/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--example.yaml
+++ b/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--example.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status "Loading"

--- a/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--forced-colors.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status "Loading content"

--- a/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--forced-colors.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status "Loading content"

--- a/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--forced-colors.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status "Loading content"

--- a/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--forced-colors.yaml
+++ b/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status "Loading content"

--- a/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--playground.dark.yaml
+++ b/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--playground.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status "Loading content"

--- a/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--playground.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status "Loading content"

--- a/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--playground.light.yaml
+++ b/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--playground.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status "Loading content"

--- a/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--playground.yaml
+++ b/nextjs-app/shared/components/Spinner/__a11y-snapshots__/feedback-spinner--playground.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - status "Loading content"

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -12561,7 +12561,7 @@
       "name": "Spinner",
       "group": "feedback",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "Indeterminate loading spinner for async UI.",
       "dense": "bare indeterminate ring (role=status, aria-label); sm/md/lg; for sub-second unknown waits — Progress for known/long work, Skeleton for layouts",
       "keywords": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -938,6 +938,31 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "structure",
     "import": "import { SocialShare } from "@dt/SocialShare";",
   },
+  "Spinner": {
+    "exampleStories": [
+      "Sizes",
+      "Example",
+      "WithVisibleLabel",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "feedback",
+    "import": "import Spinner from "@dt/Spinner";",
+  },
   "Stack": {
     "exampleStories": [
       "GapScale",


### PR DESCRIPTION
Promote Spinner to stable (stable count 44→45), continuing the wave (prior: FileUpload #969).

- Contract `status: stable` + a11y flags after 4-mode AT verification on a non-6010 Storybook (base + light + dark + forced-colors all pass).
- Story meta tag `beta`→`stable`; WipBadge dropped from AT snapshots.
- 3 production consumers (CVDownloadSection pattern).
- `size` variant is geometry not font/color → no computed-style check. role=status indicator; forced-colors verified via passing AT run.

Gates all green: typecheck, lint, lint:css, rhythm, test (2084), build; contract-props, consumers, validate:components, snapshot-debt (STABLE_MISSING=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)