### PR TITLE
feat(design-system): Combobox beta→stable

### DIFF
--- a/nextjs-app/shared/components/Combobox/Combobox.contract.json
+++ b/nextjs-app/shared/components/Combobox/Combobox.contract.json
@@ -3,7 +3,7 @@
     "name": "Combobox",
     "tier": "molecule",
     "group": "form",
-    "status": "beta",
+    "status": "stable",
     "description": "Single-select combobox with portaled dropdown, shared with MultiCombobox.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-combobox",
     "radixPrimitive": null,
@@ -36,8 +36,10 @@
         ],
         "reducedMotion": true,
         "reviewed": true,
-        "reviewedNote": "Verified 2026-06-02: ARIA APG combobox — role=combobox trigger with aria-expanded/aria-controls/aria-activedescendant, aria-labelledby; portaled role=listbox with role=option/aria-selected. Full keyboard (ArrowUp/Down, Enter/Space, Escape) driven and asserted by the KeyboardSelection play function. Fixed a real contrast bug surfaced by enabling axe: the placeholder had opacity:0.7 dropping --color-muted to 2.7:1; removed it (now AA). Default/Playground/Example/KeyboardSelection pass axe with test:error; light + dark verified in Storybook.",
-        "forcedColorsVerified": true
+        "reviewedNote": "Verified 2026-06-02: ARIA APG combobox — role=combobox trigger with aria-expanded/aria-controls/aria-activedescendant, aria-labelledby; portaled role=listbox with role=option/aria-selected. Full keyboard (ArrowUp/Down, Enter/Space, Escape) driven and asserted by the KeyboardSelection play function. Fixed a real contrast bug surfaced by enabling axe: the placeholder had opacity:0.7 dropping --color-muted to 2.7:1; removed it (now AA). Default/Playground/Example/KeyboardSelection pass axe with test:error; light + dark verified in Storybook. 2026-07-07 — beta→stable: 4-mode AT (base/light/dark/forced-colors) re-verified on a non-6010 Storybook.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true
     },
     "tokens": {
         "colors": [
@@ -63,7 +65,28 @@
         ]
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/ContactPage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "label": {

--- a/nextjs-app/shared/components/Combobox/Combobox.stories.tsx
+++ b/nextjs-app/shared/components/Combobox/Combobox.stories.tsx
@@ -29,7 +29,7 @@ function ComboboxDemo(props: Partial<React.ComponentProps<typeof Combobox>>) {
 const meta = {
   title: "Forms/Combobox",
   component: Combobox,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--default.dark.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--default.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": Select…
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--default.forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": Select…
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--default.light.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--default.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": Select…
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--default.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--default.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": Select…
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--example.dark.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--example.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": 1–2 months
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--example.forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": 1–2 months
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--example.light.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--example.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": 1–2 months
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--example.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--example.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": 1–2 months
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--forced-colors.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": ASAP
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--forced-colors.forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": ASAP
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--forced-colors.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": ASAP
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--forced-colors.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": ASAP
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--keyboard-selection.dark.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--keyboard-selection.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": 1–2 months
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--keyboard-selection.forced-colors.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--keyboard-selection.forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": 1–2 months
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--keyboard-selection.light.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--keyboard-selection.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": 1–2 months
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--keyboard-selection.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--keyboard-selection.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": 1–2 months
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--playground.dark.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--playground.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": Select…
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--playground.forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": Select…
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--playground.light.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--playground.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": Select…
 - button "Toggle options"

--- a/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--playground.yaml
+++ b/nextjs-app/shared/components/Combobox/__a11y-snapshots__/forms-combobox--playground.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Timeline
 - combobox "Timeline": Select…
 - button "Toggle options"

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--default.dark.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--default.dark.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Disciplines
+- combobox "Disciplines"
+- button "Toggle options"

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--default.forced-colors.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Disciplines
+- combobox "Disciplines"
+- button "Toggle options"

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--default.light.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--default.light.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Disciplines
+- combobox "Disciplines"
+- button "Toggle options"

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--default.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--default.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Disciplines
+- combobox "Disciplines"
+- button "Toggle options"

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--example.dark.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--example.dark.yaml
@@ -1,0 +1,8 @@
+- status: Work in progress (beta)
+- text: Disciplines Design
+- button "Remove badge"
+- text: Accessibility
+- button "Remove badge"
+- combobox "Disciplines"
+- button "Toggle options"
+- paragraph: Pick all that apply

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--example.forced-colors.yaml
@@ -1,0 +1,8 @@
+- status: Work in progress (beta)
+- text: Disciplines Design
+- button "Remove badge"
+- text: Accessibility
+- button "Remove badge"
+- combobox "Disciplines"
+- button "Toggle options"
+- paragraph: Pick all that apply

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--example.light.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--example.light.yaml
@@ -1,0 +1,8 @@
+- status: Work in progress (beta)
+- text: Disciplines Design
+- button "Remove badge"
+- text: Accessibility
+- button "Remove badge"
+- combobox "Disciplines"
+- button "Toggle options"
+- paragraph: Pick all that apply

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--example.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--example.yaml
@@ -1,0 +1,8 @@
+- status: Work in progress (beta)
+- text: Disciplines Design
+- button "Remove badge"
+- text: Accessibility
+- button "Remove badge"
+- combobox "Disciplines"
+- button "Toggle options"
+- paragraph: Pick all that apply

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--forced-colors.dark.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- text: Disciplines Design
+- button "Remove badge"
+- combobox "Disciplines"
+- button "Toggle options"

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--forced-colors.forced-colors.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- text: Disciplines Design
+- button "Remove badge"
+- combobox "Disciplines"
+- button "Toggle options"

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--forced-colors.light.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- text: Disciplines Design
+- button "Remove badge"
+- combobox "Disciplines"
+- button "Toggle options"

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--forced-colors.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--forced-colors.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- text: Disciplines Design
+- button "Remove badge"
+- combobox "Disciplines"
+- button "Toggle options"

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--keyboard-multi-select.dark.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--keyboard-multi-select.dark.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- text: Disciplines Accessibility
+- button "Remove badge"
+- combobox "Disciplines" [expanded]: acc
+- button "Toggle options" [expanded]

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--keyboard-multi-select.forced-colors.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--keyboard-multi-select.forced-colors.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- text: Disciplines Accessibility
+- button "Remove badge"
+- combobox "Disciplines" [expanded]: acc
+- button "Toggle options" [expanded]

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--keyboard-multi-select.light.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--keyboard-multi-select.light.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- text: Disciplines Accessibility
+- button "Remove badge"
+- combobox "Disciplines" [expanded]: acc
+- button "Toggle options" [expanded]

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--keyboard-multi-select.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--keyboard-multi-select.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- text: Disciplines Accessibility
+- button "Remove badge"
+- combobox "Disciplines" [expanded]: acc
+- button "Toggle options" [expanded]

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--max-items.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--max-items.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (beta)
+- text: Disciplines (max 2) Research
+- button "Remove badge"
+- combobox "Disciplines (max 2)"
+- button "Toggle options"
+- paragraph: Pick up to two.

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--overflow.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--overflow.yaml
@@ -1,0 +1,12 @@
+- status: Work in progress (beta)
+- text: Disciplines Research
+- button "Remove badge"
+- text: Design
+- button "Remove badge"
+- text: Frontend
+- button "Remove badge"
+- text: Accessibility
+- button "Remove badge"
+- combobox "Disciplines"
+- button "Toggle options"
+- paragraph: The field grows with every chip.

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--playground.dark.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--playground.dark.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Disciplines
+- combobox "Disciplines"
+- button "Toggle options"

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--playground.forced-colors.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Disciplines
+- combobox "Disciplines"
+- button "Toggle options"

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--playground.light.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--playground.light.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Disciplines
+- combobox "Disciplines"
+- button "Toggle options"

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--playground.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--playground.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Disciplines
+- combobox "Disciplines"
+- button "Toggle options"

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -3906,7 +3906,7 @@
       "name": "Combobox",
       "group": "form",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "Single-select combobox with portaled dropdown, shared with MultiCombobox.",
       "dense": "controlled single-select combobox; button trigger + portaled listbox, full APG keyboard model, own label/error/helperText; options support per-option disabled; onValueChange(value)",
       "keywords": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -237,6 +237,33 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "structure",
     "import": "import CodeBlockWindow from "@dt/CodeBlockWindow";",
   },
+  "Combobox": {
+    "exampleStories": [
+      "Example",
+      "WithError",
+      "Disabled",
+      "AsyncOptions",
+      "KeyboardSelection",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "form",
+    "import": "import Combobox from "@dt/Combobox";",
+  },
   "Container": {
     "exampleStories": [
       "SizeLadder",


### PR DESCRIPTION
Promote Combobox to stable (stable count 45→46), continuing the wave (prior: Spinner #970).

- Contract `status: stable` + a11y flags after 4-mode AT verification on a non-6010 Storybook (base + light + dark + forced-colors all pass, including the dropdown-opening KeyboardSelection play).
- Story meta tag `beta`→`stable`; WipBadge dropped from AT snapshots.
- 4 production consumers (ContactPage + ContactPageContentEditorial).
- ARIA APG combobox (role=combobox trigger, portaled role=listbox); no font/color variant axis. Forced-colors trigger visually verified.

Gates all green: typecheck, lint, lint:css, rhythm, test (2084), build; contract-props, consumers, validate:components, snapshot-debt (STABLE_MISSING=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Promoted the Combobox and MultiCombobox components to stable status.
  * Added broader accessibility coverage for MultiCombobox states, including keyboard selection, max items, overflow, playground, and forced-colors views.

* **Bug Fixes**
  * Removed outdated beta status markers from Combobox accessibility snapshots.
  * Updated snapshot expectations to better reflect current rendered labels, buttons, and selected values across themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->