### PR TITLE
feat(design-system): Select beta→stable

### DIFF
--- a/nextjs-app/shared/components/Select/Select.contract.json
+++ b/nextjs-app/shared/components/Select/Select.contract.json
@@ -3,7 +3,7 @@
     "name": "Select",
     "tier": "atom",
     "group": "form",
-    "status": "beta",
+    "status": "stable",
     "description": "Native select with label, options, error state, and size tokens.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=383-23",
     "radixPrimitive": null,
@@ -45,8 +45,10 @@
         ],
         "reducedMotion": true,
         "reviewed": true,
-        "reviewedNote": "2026-05-26 — production behavior verified in Storybook; argTypes and required stories aligned with validate:components.",
-        "forcedColorsVerified": true
+        "reviewedNote": "2026-07-07 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified on a non-6010 Storybook; accessibility tree and real-browser forced-colors confirmed.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true
     },
     "tokens": {
         "colors": [
@@ -62,7 +64,13 @@
         ]
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/layout.tsx",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "label": {

--- a/nextjs-app/shared/components/Select/Select.stories.tsx
+++ b/nextjs-app/shared/components/Select/Select.stories.tsx
@@ -78,7 +78,7 @@ const selectComplianceRules: ComplianceRule[] = [
 export default {
   title: "Forms/Select",
   component: Select,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--controlled.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--controlled.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Select an option
 - combobox "Select an option":
   - option "Option 1" [selected]

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--default.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--default.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Select an option
 - combobox "Select an option":
   - option "Option 1" [selected]

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--disabled.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--disabled.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Disabled Select
 - combobox "Disabled Select" [disabled]:
   - option "Option 1" [selected]

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--example.dark.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--example.dark.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Select an option
 - combobox "Select an option":
   - option "Option 1" [selected]

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--example.forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Select an option
 - combobox "Select an option":
   - option "Option 1" [selected]

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--example.light.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--example.light.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Select an option
 - combobox "Select an option":
   - option "Option 1" [selected]

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--example.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--example.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Select an option
 - combobox "Select an option":
   - option "Option 1" [selected]

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--forced-colors.dark.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - combobox
 - img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--forced-colors.forced-colors.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - combobox
 - img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--forced-colors.light.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - combobox
 - img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--forced-colors.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--forced-colors.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - combobox
 - img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--playground.dark.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--playground.dark.yaml
@@ -1,3 +1,6 @@
-- status: Work in progress (beta)
-- combobox
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1" [selected]
+  - option "Option 2"
+  - option "Option 3"
 - img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--playground.forced-colors.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Select an option
 - combobox "Select an option":
   - option "Option 1" [selected]

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--playground.light.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--playground.light.yaml
@@ -1,3 +1,6 @@
-- status: Work in progress (beta)
-- combobox
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1" [selected]
+  - option "Option 2"
+  - option "Option 3"
 - img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--playground.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--playground.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Select an option
 - combobox "Select an option":
   - option "Option 1" [selected]

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--size-large.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--size-large.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Select an option
 - combobox "Select an option":
   - option "Option 1" [selected]

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--size-medium.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--size-medium.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Select an option
 - combobox "Select an option":
   - option "Option 1" [selected]

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--size-small.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--size-small.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Select an option
 - combobox "Select an option":
   - option "Option 1" [selected]

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--with-custom-children.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--with-custom-children.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Select an option
 - combobox "Select an option":
   - option "Select..." [disabled] [selected]

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--with-error.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--with-error.yaml
@@ -1,6 +1,5 @@
-- status: Work in progress (beta)
 - text: Select an option
-- combobox "Select an option":
+- combobox "Select an option" [invalid]:
   - option "Option 1" [selected]
   - option "Option 2"
   - option "Option 3"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--with-helper-text.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--with-helper-text.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - text: Select an option
 - combobox "Select an option":
   - option "Option 1" [selected]

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--z-select-compliance.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-select--z-select-compliance.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (beta)
 - 'heading "Compliance: 11/11" [level=2]'
 - text: Complete file structure
 - img "Pass"

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -11537,7 +11537,7 @@
       "name": "Select",
       "group": "form",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "Native select with label, options, error state, and size tokens.",
       "dense": "native select with label, options array or option children, own error + helperText, sm/md/lg; onValueChange(value)",
       "keywords": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -854,6 +854,32 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "layout",
     "import": "import { Section } from "@dt/Section";",
   },
+  "Select": {
+    "exampleStories": [
+      "Disabled",
+      "WithCustomChildren",
+      "Controlled",
+      "WithError",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "form",
+    "import": "import Select from "@dt/Select";",
+  },
   "ServiceCard": {
     "exampleStories": [],
     "fields": [


### PR DESCRIPTION
Promote Select to stable (stable count 47→48), continuing the wave (prior: MultiCombobox #972).

- Contract `status: stable` + a11y flags after 4-mode AT verification on a non-6010 Storybook (base + light + dark + forced-colors all pass).
- Story meta tag `beta`→`stable`; WipBadge dropped from AT snapshots.
- 1 production consumer (app/layout.tsx via ChatWidget email workflow).
- Also corrected two **stale** themed snapshots: playground.dark/.light held a bare `- combobox` (captured before options were seeded); now match the base/forced-colors render (labelled combobox + 3 options).
- `size` variant is geometry not font/color → no computed-style check. Forced-colors verified.

Gates all green: typecheck, lint, lint:css, rhythm, test (2084), build; contract-props, consumers, validate:components, snapshot-debt (STABLE_MISSING=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)