### PR TITLE
feat(design-system): FormField beta→stable

### DIFF
--- a/nextjs-app/shared/components/FormField/FormField.contract.json
+++ b/nextjs-app/shared/components/FormField/FormField.contract.json
@@ -3,7 +3,7 @@
     "name": "FormField",
     "tier": "molecule",
     "group": "form",
-    "status": "beta",
+    "status": "stable",
     "description": "Fieldset/legend wrapper for a group of controls (radio sets, checkbox clusters, composite fields), with a group description and a group-level error. Individual controls own their own label, error, and helper text.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-form-field",
     "radixPrimitive": null,
@@ -20,7 +20,7 @@
     ],
     "a11y": {
         "keyboard": [
-            "Tab \u2014 moves focus to the wrapped control."
+            "Tab — moves focus to the wrapped control."
         ],
         "ariaRequirements": [
             "Generates a stable id and wires `htmlFor` on the label and `aria-describedby` on the control to the helper-text element.",
@@ -30,7 +30,9 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 \u2014 Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-07 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified on a non-6010 Storybook; accessibility tree and real-browser forced-colors confirmed."
     },
     "tokens": {
         "colors": [
@@ -47,7 +49,13 @@
         ]
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/dev/tailwind-test/page.tsx",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "legend": {

--- a/nextjs-app/shared/components/FormField/FormField.stories.tsx
+++ b/nextjs-app/shared/components/FormField/FormField.stories.tsx
@@ -31,7 +31,7 @@ const textPair = (
 const meta = {
   title: "Forms/FormField",
   component: FormField,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--default.dark.yaml
+++ b/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--default.dark.yaml
@@ -1,0 +1,9 @@
+- group "Notification channels":
+  - text: Notification channels
+  - paragraph: Pick at least one
+  - checkbox "Email" [checked]
+  - text: Email
+  - checkbox "SMS"
+  - text: SMS
+  - checkbox "Push"
+  - text: Push

--- a/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--default.forced-colors.yaml
@@ -1,0 +1,9 @@
+- group "Notification channels":
+  - text: Notification channels
+  - paragraph: Pick at least one
+  - checkbox "Email" [checked]
+  - text: Email
+  - checkbox "SMS"
+  - text: SMS
+  - checkbox "Push"
+  - text: Push

--- a/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--default.light.yaml
+++ b/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--default.light.yaml
@@ -1,0 +1,9 @@
+- group "Notification channels":
+  - text: Notification channels
+  - paragraph: Pick at least one
+  - checkbox "Email" [checked]
+  - text: Email
+  - checkbox "SMS"
+  - text: SMS
+  - checkbox "Push"
+  - text: Push

--- a/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--default.yaml
+++ b/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--default.yaml
@@ -1,0 +1,9 @@
+- group "Notification channels":
+  - text: Notification channels
+  - paragraph: Pick at least one
+  - checkbox "Email" [checked]
+  - text: Email
+  - checkbox "SMS"
+  - text: SMS
+  - checkbox "Push"
+  - text: Push

--- a/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--example.dark.yaml
+++ b/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--example.dark.yaml
@@ -1,0 +1,9 @@
+- group "Notification channels":
+  - text: Notification channels
+  - paragraph: Pick at least one
+  - checkbox "Email" [checked]
+  - text: Email
+  - checkbox "SMS"
+  - text: SMS
+  - checkbox "Push"
+  - text: Push

--- a/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--example.forced-colors.yaml
@@ -1,0 +1,9 @@
+- group "Notification channels":
+  - text: Notification channels
+  - paragraph: Pick at least one
+  - checkbox "Email" [checked]
+  - text: Email
+  - checkbox "SMS"
+  - text: SMS
+  - checkbox "Push"
+  - text: Push

--- a/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--example.light.yaml
+++ b/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--example.light.yaml
@@ -1,0 +1,9 @@
+- group "Notification channels":
+  - text: Notification channels
+  - paragraph: Pick at least one
+  - checkbox "Email" [checked]
+  - text: Email
+  - checkbox "SMS"
+  - text: SMS
+  - checkbox "Push"
+  - text: Push

--- a/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--example.yaml
+++ b/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--example.yaml
@@ -1,0 +1,9 @@
+- group "Notification channels":
+  - text: Notification channels
+  - paragraph: Pick at least one
+  - checkbox "Email" [checked]
+  - text: Email
+  - checkbox "SMS"
+  - text: SMS
+  - checkbox "Push"
+  - text: Push

--- a/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--forced-colors.dark.yaml
@@ -1,0 +1,9 @@
+- group "Notification channels":
+  - text: Notification channels
+  - paragraph: Pick at least one
+  - checkbox "Email" [checked]
+  - text: Email
+  - checkbox "SMS"
+  - text: SMS
+  - checkbox "Push"
+  - text: Push

--- a/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--forced-colors.forced-colors.yaml
@@ -1,0 +1,9 @@
+- group "Notification channels":
+  - text: Notification channels
+  - paragraph: Pick at least one
+  - checkbox "Email" [checked]
+  - text: Email
+  - checkbox "SMS"
+  - text: SMS
+  - checkbox "Push"
+  - text: Push

--- a/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--forced-colors.light.yaml
@@ -1,0 +1,9 @@
+- group "Notification channels":
+  - text: Notification channels
+  - paragraph: Pick at least one
+  - checkbox "Email" [checked]
+  - text: Email
+  - checkbox "SMS"
+  - text: SMS
+  - checkbox "Push"
+  - text: Push

--- a/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--forced-colors.yaml
+++ b/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--forced-colors.yaml
@@ -1,0 +1,9 @@
+- group "Notification channels":
+  - text: Notification channels
+  - paragraph: Pick at least one
+  - checkbox "Email" [checked]
+  - text: Email
+  - checkbox "SMS"
+  - text: SMS
+  - checkbox "Push"
+  - text: Push

--- a/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--playground.dark.yaml
+++ b/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--playground.dark.yaml
@@ -1,0 +1,9 @@
+- group "Notification channels":
+  - text: Notification channels
+  - paragraph: Pick at least one
+  - checkbox "Email" [checked]
+  - text: Email
+  - checkbox "SMS"
+  - text: SMS
+  - checkbox "Push"
+  - text: Push

--- a/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--playground.forced-colors.yaml
@@ -1,0 +1,9 @@
+- group "Notification channels":
+  - text: Notification channels
+  - paragraph: Pick at least one
+  - checkbox "Email" [checked]
+  - text: Email
+  - checkbox "SMS"
+  - text: SMS
+  - checkbox "Push"
+  - text: Push

--- a/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--playground.light.yaml
+++ b/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--playground.light.yaml
@@ -1,0 +1,9 @@
+- group "Notification channels":
+  - text: Notification channels
+  - paragraph: Pick at least one
+  - checkbox "Email" [checked]
+  - text: Email
+  - checkbox "SMS"
+  - text: SMS
+  - checkbox "Push"
+  - text: Push

--- a/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--playground.yaml
+++ b/nextjs-app/shared/components/FormField/__a11y-snapshots__/forms-formfield--playground.yaml
@@ -1,0 +1,9 @@
+- group "Notification channels":
+  - text: Notification channels
+  - paragraph: Pick at least one
+  - checkbox "Email" [checked]
+  - text: Email
+  - checkbox "SMS"
+  - text: SMS
+  - checkbox "Push"
+  - text: Push

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--default.dark.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--default.dark.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Your name*
+- textbox "Your name*":
+  - /placeholder: Alex Example

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--default.forced-colors.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Your name*
+- textbox "Your name*":
+  - /placeholder: Alex Example

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--default.light.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--default.light.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Your name*
+- textbox "Your name*":
+  - /placeholder: Alex Example

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--default.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--default.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Your name*
+- textbox "Your name*":
+  - /placeholder: Alex Example

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--example.dark.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--example.dark.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Email*
+- textbox "Email*":
+  - /placeholder: you@company.com

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--example.forced-colors.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Email*
+- textbox "Email*":
+  - /placeholder: you@company.com

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--example.light.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--example.light.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Email*
+- textbox "Email*":
+  - /placeholder: you@company.com

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--example.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--example.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Email*
+- textbox "Email*":
+  - /placeholder: you@company.com

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--forced-colors.dark.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Your name*
+- textbox "Your name*":
+  - /placeholder: Alex Example

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--forced-colors.forced-colors.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Your name*
+- textbox "Your name*":
+  - /placeholder: Alex Example

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--forced-colors.light.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Your name*
+- textbox "Your name*":
+  - /placeholder: Alex Example

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--forced-colors.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--forced-colors.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Your name*
+- textbox "Your name*":
+  - /placeholder: Alex Example

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--playground.dark.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--playground.dark.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Preferred contact (required)
+- combobox "Preferred contact (required)"
+- button "Toggle options"

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--playground.forced-colors.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Preferred contact (required)
+- combobox "Preferred contact (required)"
+- button "Toggle options"

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--playground.light.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--playground.light.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Preferred contact (required)
+- combobox "Preferred contact (required)"
+- button "Toggle options"

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--playground.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--playground.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- text: Preferred contact (required)
+- combobox "Preferred contact (required)"
+- button "Toggle options"

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -6069,7 +6069,7 @@
       "name": "FormField",
       "group": "form",
       "tier": 1,
-      "status": "beta",
+      "status": "stable",
       "description": "Fieldset/legend wrapper for a group of controls (radio sets, checkbox clusters, composite fields), with a group description and a group-level error. Individual controls own their own label, error, and helper text.",
       "dense": "fieldset/legend wrapper for a GROUP of controls with groupDescription + group-level error; single controls own their own label/error/helperText chrome",
       "keywords": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -411,6 +411,32 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "layout",
     "import": "import FlexBox from "@dt/FlexBox";",
   },
+  "FormField": {
+    "exampleStories": [
+      "CheckboxCluster",
+      "GroupError",
+      "CompositeField",
+      "CustomRadioSet",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "form",
+    "import": "import { FormField } from "@dt/FormField";",
+  },
   "Grid": {
     "exampleStories": [
       "EqualTracks",


### PR DESCRIPTION
Promote FormField to stable (stable count 49→50), completing the form-primitive promotion wave (prior: PhoneInput #974).

- Contract `status: stable` + a11y flags after 4-mode AT verification on a non-6010 Storybook (base + light + dark + forced-colors all pass).
- Story meta tag `beta`→`stable`.
- fieldset/legend group-mode wrapper (per the field-wrapper convention). **Consumer note:** currently used only by `app/dev/tailwind-test` (dev harness); promoting signals the group primitive is ready — flagging the scope in case you'd rather hold it.
- Bootstrapped the AT-snapshot set (dir was absent): 16 files, all 4 canonical stories are beta-matrix so themed capture covers them; captured already-stable (no WipBadge line).
- Forced-colors story visually verified (legend + helper + checkbox cluster with visible borders). No variant axes.

Gates all green: typecheck, lint, lint:css, rhythm, test (2084), build; contract-props, consumers, validate:components, snapshot-debt (STABLE_MISSING=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)