### PR TITLE
chore(design-system): drop stray FormFieldEditorial AT snapshots

### DIFF
--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--default.dark.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--default.dark.yaml
@@ -1,4 +1,0 @@
-- status: Work in progress (beta)
-- text: Your name*
-- textbox "Your name*":
-  - /placeholder: Alex Example

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--default.forced-colors.yaml
@@ -1,4 +1,0 @@
-- status: Work in progress (beta)
-- text: Your name*
-- textbox "Your name*":
-  - /placeholder: Alex Example

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--default.light.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--default.light.yaml
@@ -1,4 +1,0 @@
-- status: Work in progress (beta)
-- text: Your name*
-- textbox "Your name*":
-  - /placeholder: Alex Example

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--default.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--default.yaml
@@ -1,4 +1,0 @@
-- status: Work in progress (beta)
-- text: Your name*
-- textbox "Your name*":
-  - /placeholder: Alex Example

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--example.dark.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--example.dark.yaml
@@ -1,4 +1,0 @@
-- status: Work in progress (beta)
-- text: Email*
-- textbox "Email*":
-  - /placeholder: you@company.com

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--example.forced-colors.yaml
@@ -1,4 +1,0 @@
-- status: Work in progress (beta)
-- text: Email*
-- textbox "Email*":
-  - /placeholder: you@company.com

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--example.light.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--example.light.yaml
@@ -1,4 +1,0 @@
-- status: Work in progress (beta)
-- text: Email*
-- textbox "Email*":
-  - /placeholder: you@company.com

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--example.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--example.yaml
@@ -1,4 +1,0 @@
-- status: Work in progress (beta)
-- text: Email*
-- textbox "Email*":
-  - /placeholder: you@company.com

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--forced-colors.dark.yaml
@@ -1,4 +1,0 @@
-- status: Work in progress (beta)
-- text: Your name*
-- textbox "Your name*":
-  - /placeholder: Alex Example

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--forced-colors.forced-colors.yaml
@@ -1,4 +1,0 @@
-- status: Work in progress (beta)
-- text: Your name*
-- textbox "Your name*":
-  - /placeholder: Alex Example

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--forced-colors.light.yaml
@@ -1,4 +1,0 @@
-- status: Work in progress (beta)
-- text: Your name*
-- textbox "Your name*":
-  - /placeholder: Alex Example

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--forced-colors.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--forced-colors.yaml
@@ -1,4 +1,0 @@
-- status: Work in progress (beta)
-- text: Your name*
-- textbox "Your name*":
-  - /placeholder: Alex Example

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--playground.dark.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--playground.dark.yaml
@@ -1,4 +1,0 @@
-- status: Work in progress (beta)
-- text: Preferred contact (required)
-- combobox "Preferred contact (required)"
-- button "Toggle options"

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--playground.forced-colors.yaml
@@ -1,4 +1,0 @@
-- status: Work in progress (beta)
-- text: Preferred contact (required)
-- combobox "Preferred contact (required)"
-- button "Toggle options"

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--playground.light.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--playground.light.yaml
@@ -1,4 +1,0 @@
-- status: Work in progress (beta)
-- text: Preferred contact (required)
-- combobox "Preferred contact (required)"
-- button "Toggle options"

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--playground.yaml
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-snapshots__/site-formfieldeditorial--playground.yaml
@@ -1,4 +1,0 @@
-- status: Work in progress (beta)
-- text: Preferred contact (required)
-- combobox "Preferred contact (required)"
-- button "Toggle options"


### PR DESCRIPTION
The FormField beta→stable capture (#975) ran test-storybook with positional pattern `FormField`, a substring of `FormFieldEditorial`, so the DT_UPDATE run also bootstrapped 14 FormFieldEditorial (still-beta) snapshot yamls that got swept into the PR. They are valid live captures (main stayed green), but FormFieldEditorial had no snapshot dir before and is not being promoted — remove them to keep the tree intentional. A beta with no snapshots passes the matrix gate (compare-mode tolerates absent snapshots).

Lesson recorded: the test-storybook positional arg is a substring testPathPattern — scope with a unique fragment (`FormField/FormField`), and don't filter the stray-file check with the same prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)