### PR TITLE
fix(design-system): TextArea + Select inherit TextInput border color & radius

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-07-07T20:05:25.910Z",
+  "createdAt": "2026-07-07T21:07:49.376Z",
   "directory": "nextjs-app/shared",
   "findings": [
     {
@@ -4255,8 +4255,8 @@
     {
       "column": 15,
       "file": "nextjs-app/shared/components/TextArea/TextArea.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextArea/TextArea.module.css\u001f33\u001f15\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 33,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextArea/TextArea.module.css\u001f34\u001f15\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 34,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",

--- a/nextjs-app/shared/components/Select/Select.module.css
+++ b/nextjs-app/shared/components/Select/Select.module.css
@@ -15,8 +15,8 @@
 .select {
   padding: 0.5rem 2.5rem 0.5rem 0.75rem;
   width: 100%;
-  border: 1px solid var(--color-primary);
-  border-radius: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
   background: var(--color-white);
   font-family: var(--font-text);
   font-size: 1rem;

--- a/nextjs-app/shared/components/TextArea/TextArea.module.css
+++ b/nextjs-app/shared/components/TextArea/TextArea.module.css
@@ -18,7 +18,8 @@
   box-sizing: border-box;
   width: 100%;
   min-height: 2.5rem;
-  border: 1px solid var(--color-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
   background-color: var(--color-white);
   font-family: var(--font-text);
   font-size: 1rem;


### PR DESCRIPTION
TextArea and Select used `var(--color-primary)` (dark #041b23) for their resting border and had no / zero corner radius, reading heavier and sharper than TextInput. Align both to the TextInput field treatment:

- border color → `var(--color-border)` (#c0c0c0)
- border radius → `var(--radius-lg)` (8px / 0.5rem)

Focus and error states are untouched (they keep `--color-primary` / `--color-error`). Used the `--radius-lg` token rather than a raw `0.5rem` (identical 8px, proper DS token, no raw-value rhythm flag).

Verified computed style in Storybook: both now report `rgb(192,192,192)` border + `8px` radius, matching TextInput. AT snapshots unaffected (border styling isn't in the accessibility tree; TextArea 8/8 + Select 15/15 compare-clean). Gates green: typecheck, lint, lint:css, rhythm, test (2084), build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)