### PR TITLE
feat(design-system): StatusDot beta→stable

### DIFF
--- a/nextjs-app/shared/components/StatusDot/StatusDot.contract.json
+++ b/nextjs-app/shared/components/StatusDot/StatusDot.contract.json
@@ -3,7 +3,7 @@
     "name": "StatusDot",
     "tier": "atom",
     "group": "feedback",
-    "status": "beta",
+    "status": "stable",
     "description": "Tiny semantic status indicator: colored dot with visible or sr-only label.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1004-1677",
     "radixPrimitive": null,
@@ -47,8 +47,10 @@
         ],
         "reducedMotion": true,
         "reviewed": true,
-        "reviewedNote": "2026-07-06 — alpha→beta: created the Figma component (tone×size variant set, dot fill bound to DT/Color tone tokens) at node 1004-1677, the only remaining beta blocker. Pulse animation disabled under prefers-reduced-motion (CSS guard verified); axe asserted in unit test; forced-colors + light/dark re-verified.",
-        "forcedColorsVerified": true
+        "reviewedNote": "2026-07-06 — alpha→beta: created the Figma component (tone×size variant set, dot fill bound to DT/Color tone tokens) at node 1004-1677, the only remaining beta blocker. Pulse animation disabled under prefers-reduced-motion (CSS guard verified); axe asserted in unit test; forced-colors + light/dark re-verified. 2026-07-08 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified on a non-6010 Storybook; accessibility tree and real-browser forced-colors confirmed; each tone's dot background-color verified distinct via computed style (color axis).",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true
     },
     "tokens": {
         "colors": [
@@ -168,5 +170,67 @@
         "Text",
         "List",
         "Avatar"
+    ],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/dev/tailwind-test/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/layout.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/ContactPage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Pseo/PseoClusterBadges.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Pseo/PseoPillarMetaBadgeLinks.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/Illustrations/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts",
+            "since": "2026-06-04"
+        }
     ]
 }

--- a/nextjs-app/shared/components/StatusDot/StatusDot.stories.tsx
+++ b/nextjs-app/shared/components/StatusDot/StatusDot.stories.tsx
@@ -6,7 +6,7 @@ import contract from "./StatusDot.contract.json";
 const meta = {
   title: "Feedback/StatusDot",
   component: StatusDot,
-  tags: ["beta", "autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     layout: "centered",
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--default.dark.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--default.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--default.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--default.light.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--default.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--default.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--default.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--example.dark.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--example.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--example.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--example.light.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--example.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--example.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--example.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--forced-colors.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--forced-colors.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--forced-colors.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--forced-colors.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--live.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--live.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Live

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--playground.dark.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--playground.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--playground.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--playground.light.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--playground.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--playground.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--playground.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Operational

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--sr-only-label.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--sr-only-label.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Connection lost

--- a/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--tones.yaml
+++ b/nextjs-app/shared/components/StatusDot/__a11y-snapshots__/feedback-statusdot--tones.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - text: Idle Operational Degraded Down Maintenance

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -13227,7 +13227,7 @@
       "name": "StatusDot",
       "group": "feedback",
       "tier": 2,
-      "status": "beta",
+      "status": "stable",
       "description": "Tiny semantic status indicator: colored dot with visible or sr-only label.",
       "dense": "colored semantic dot + label (visible children or sr-only label); tone x sm/md/lg, optional pulse for live states",
       "keywords": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -1119,6 +1119,32 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "layout",
     "import": "import { Stack } from "@dt/Stack";",
   },
+  "StatusDot": {
+    "exampleStories": [
+      "Default",
+      "Tones",
+      "Live",
+      "SrOnlyLabel",
+    ],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "feedback",
+    "import": "import StatusDot from "@dt/StatusDot";",
+  },
   "Text": {
     "exampleStories": [
       "AllTags",


### PR DESCRIPTION
feat(design-system): StatusDot beta→stable

StatusDot promoted to stable. 8 real prod-page consumers (Pseo x4, ContactPage,
Illustrations, layout) confirmed via the dynamic-import-aware consumers audit.

Re-verify, not a flag-flip:
- 4-mode AT snapshots base/light/dark/forced-colors recaptured; only delta is
  the WIP badge line dropping.
- audit:controls 5/5 operable, 0 inert; tone/size/pulse all effective.
- tone color axis verified distinct in light and dark; intentionally monochrome
  under forced-colors and the high-contrast themes, where the text label carries
  meaning per the a11y contract.
- a11y flags accessibilityTreeVerified + realBrowserForcedColorsVerified set.

Local gate green: typecheck, lint, lint:css, test 2084/2084, build.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
