### PR TITLE
fix(design-system): visualize Spacer in Default/Playground previews

### DIFF
--- a/nextjs-app/shared/components/Spacer/Spacer.stories.module.css
+++ b/nextjs-app/shared/components/Spacer/Spacer.stories.module.css
@@ -1,0 +1,28 @@
+/* Story-only visualization: Spacer renders nothing on its own, so the Default
+   and Playground previews tint the spacer box and give it cross-axis extent so
+   the size/axis controls drive a visible gap. */
+
+.viz {
+  display: flex;
+  padding: 1rem;
+  justify-content: center;
+  align-items: stretch;
+  border: 1px dashed var(--color-border);
+  border-radius: 8px;
+}
+
+.viz[data-axis="vertical"] {
+  inline-size: 16rem;
+  flex-direction: column;
+}
+
+.viz[data-axis="horizontal"] {
+  block-size: 5rem;
+  flex-direction: row;
+}
+
+.gap {
+  outline: 1px dashed color-mix(in srgb, var(--color-info) 55%, transparent);
+  outline-offset: -1px;
+  background-color: color-mix(in srgb, var(--color-info) 16%, transparent);
+}

--- a/nextjs-app/shared/components/Spacer/Spacer.stories.tsx
+++ b/nextjs-app/shared/components/Spacer/Spacer.stories.tsx
@@ -1,11 +1,20 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Spacer } from "./Spacer";
+import { Spacer, type SpacerProps } from "./Spacer";
 import contract from "./Spacer.contract.json";
+import styles from "./Spacer.stories.module.css";
 
 const defaultArgs = {
   size: "md" as const,
   axis: "vertical" as const,
 };
+
+// Spacer is invisible by design; the control-driven previews tint the spacer
+// box inside a container that supplies cross-axis extent so size/axis are legible.
+const renderVisualized = (args: SpacerProps) => (
+  <div className={styles.viz} data-axis={args.axis ?? "vertical"}>
+    <Spacer {...args} className={styles.gap} />
+  </div>
+);
 
 const meta = {
   title: "Layout/Spacer",
@@ -31,10 +40,12 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   tags: ["beta-matrix"],
   globals: { forcedColors: "none" },
+  render: renderVisualized,
 };
 export const Playground: Story = {
   tags: ["beta-matrix"],
   globals: { forcedColors: "none" },
+  render: renderVisualized,
 };
 
 export const Example: Story = {


### PR DESCRIPTION
fix(design-system): visualize Spacer in Default/Playground previews

Spacer renders an aria-hidden, backgroundless div, so its primary Storybook
preview (centered, no siblings) was a blank canvas that read as broken. The
Default and Playground stories now render the spacer with a tinted fill +
dashed outline inside a container that supplies cross-axis extent, so the
size/axis controls drive a visible gap. Story-only CSS module; the component
is unchanged.

a11y tree unchanged (spacer + wrapper are non-semantic) so AT snapshots are
identical. Spacer stays beta (zero prod consumers) — docs-quality only.

Local gate green: typecheck, lint, lint:css, test 2084/2084, build.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
