### PR TITLE
docs(design-system): durable Astryx-parity roadmap + non-regression guard

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -9,6 +9,7 @@ echo "$changed" | grep -qE 'nextjs-app/shared/(components|patterns|foundations)|
 npm run build:tokens
 npm run check:contract-props
 npm run check:consumers
+npm run check:astryx-roadmap
 npm run validate:components
 npm run typecheck
 npm run lint

--- a/docs/design-system/astryx-parity-roadmap.md
+++ b/docs/design-system/astryx-parity-roadmap.md
@@ -1,0 +1,109 @@
+# Astryx-parity roadmap
+
+**Goal:** reach at least **90/100** on every rescoped Astryx-comparison dimension, and make the selected utilities operational.
+
+**Status source of truth:** this file (human) + [`scripts/design-system/astryx-roadmap.state.json`](../../scripts/design-system/astryx-roadmap.state.json) (machine). The guard [`scripts/design-system/check-astryx-roadmap.mjs`](../../scripts/design-system/check-astryx-roadmap.mjs) runs `npm run check:astryx-roadmap` and is wired into pre-push, so completed progress cannot silently regress.
+
+Benchmark: [astryx.atmeta.com/components](https://astryx.atmeta.com/components) (Meta, React + StyleX, 160+ components, powers 13k+ apps). Prior roadmap: `docs/superpowers/specs/2026-07-03-astryx-level-design-system-roadmap.md`.
+
+---
+
+## Rescoped rubric (decided 2026-07-08)
+
+DT is a portfolio-site design-system-of-record, not an app platform. "90" is measured against DT's **intended surface** and a **published, dogfooded package**, NOT against Astryx's absolute breadth or raw OSS adoption. The anti-goals below stay in force. Under this rubric all nine dimensions are reachable by engineering.
+
+| Dimension | Now | Target | What earns 90 (rescoped, checkable) |
+|---|---:|---:|---|
+| Maturity | 62 | 90 | Versioned package + semver + changelog; ≥90% of catalog at `stable`; documented, frozen public API; no `alpha` in the shipped surface. |
+| Breadth | 44 | 90 | Full coverage of the **intended-surface checklist** (below), all at `stable`. Not app-platform parity. |
+| Scalability | 54 | 90 | Workspace package boundary; catalog decoupled from the app (0 `@/`, 0 direct `next/*`, i18n injected); multi-brand-capable token pipeline; scaffolder + contracts for contributors. |
+| Futureproofness | 61 | 90 | Framework-agnostic package (Link/Image injected), DTCG tokens, agent-manifest/MCP, current stack, bus-factor mitigations (docs + scaffolder + gates). |
+| Accessibility | 78 | 90 | Every `stable` component: 4-mode AT + axe + forced-colors + reduced-motion verified; focus-trap/scroll-lock utilities operational for custom overlays; keyboard coverage documented. |
+| Governance | 88 | 90 | Contract drift-as-build-failure (have), controls audit 100% (have), rhythmguard (have) + this roadmap self-check gate + published contract schema. |
+| Agent-readiness | 80 | 90 | MCP server + CLI + agent-manifest + docs-registry all operational and documented ("agent-ready docs from CLI/MCP"). |
+| Theming | 67 | 90 | Multi-brand theme generation from DTCG; light/dark/HC/forced-colors (have); documented theming API + generator/recipe. |
+| Distribution | 20 | 90 | Published to a registry, versioned, installable, consumer-setup docs, dogfooded by the site via the package, documented second-consumer path. Not adoption count. |
+
+Scores are tracked in the state file. Where a score is backed by a measurable fact, the guard ratchets it (coupling counts, stable count) so it cannot regress.
+
+---
+
+## Anti-goals (do not build; guarded by exact-name check)
+
+App-platform surface DT will **not** build: **App Shell**, **Tree List**, **Data-grid/Table engine** (14-hook Astryx table), **Mega-menu nav**, and the full **Chat suite** (DT keeps its single ChatWidget; it will not grow Astryx's 15-part chat). The guard hard-fails if `AppShell`, `TreeList`, `DataGrid`, or `MegaMenu` appear as catalog components. Table/Chat are nuanced so they are prose anti-goals; add either only by amending this file deliberately, backed by a real use case.
+
+---
+
+## Intended-surface checklist (defines Breadth = 90)
+
+The Breadth target is "all of this present and `stable`", not Astryx parity. (Fill in during Phase 3 audit; most already exist.)
+
+- Primitives: Text, Title, Button, IconButton, Icon, Link, Badge, Label, Card, Divider, Spacer, Avatar, StatusDot, Kbd.
+- Forms: TextInput, TextArea, Select, Combobox, MultiCombobox, Checkbox(+Group), Radio(+Group), Switch, PhoneInput, FileUpload, FormField, Slider (gap?), Segmented Control (new, Phase 3).
+- Feedback: Alert/Banner, Toast, Tooltip, Progress, Spinner, Skeleton, EmptyState.
+- Overlays: Modal/Dialog, Popover (gap?), Menu, Lightbox.
+- Navigation: Breadcrumb, Tabs, Pagination, SkipLink, LanguageSwitcher, site nav.
+- Layout: Container, Section, Grid, FlexBox, Stack, Center, AspectRatio.
+- Content/site: List, Table (simple/static, not the engine), CodeBlock, blog + marketing + work composites.
+- Authority additions: **Command Palette** (Phase 3), for site/docs search + the agent story.
+
+---
+
+## Phased tasks
+
+Legend: `[ ]` todo, `[~]` in progress, `[x]` done. Check the box AND update the state file when a task lands.
+
+### Phase 0: Foundation & guardrails (the non-regression spine)
+- [x] 0.1 Commit this roadmap + machine state as the durable source of truth.
+- [x] 0.2 Declare anti-goals (above) and hard-guard the unambiguous ones.
+- [x] 0.3 Build `check:astryx-roadmap` guard (anti-goals, operational-utility locks, coupling ratchets, stable floor); wire into pre-push.
+- [x] 0.4 Seed coupling ratchets at today's values (41 `@/`, 15 `next/*`, 46 i18n, stable floor 58) so it is non-regressing from day one.
+- [ ] 0.5 Fill the intended-surface checklist against the live catalog (mark gaps).
+
+### Phase 1: Package boundary + decoupling → Maturity, Scalability, Futureproofness, Distribution
+- [ ] 1.1 Convert to a workspace (`packages/design-system`, `packages/tokens`, `apps/site`).
+- [ ] 1.2 Internalize `cn` / `@/lib/utils` into the DS boundary (38 files); ratchet `catalogAppImports` down.
+- [ ] 1.3 **Link Provider** utility → decouple `next/link` (falls back to `<a>`); ratchet `catalogNextImports` down. (Also a utility deliverable.)
+- [ ] 1.4 Image slot/provider → decouple `next/image`.
+- [ ] 1.5 i18n decoupling: injected translator / prop-driven copy with English defaults (46 files); ratchet `catalogI18nImports` down. **Needs multi-locale review; not fully autonomous.**
+- [ ] 1.6 Remove remaining `@/` and `next/navigation` from the catalog (ratchets to 0).
+- [ ] 1.7 `@dt/tokens` + `@dt/tokens-css` packages from the existing token pipeline.
+- [ ] 1.8 Library build (tsup/Vite) compiling TS + CSS Modules; `exports`/`types`; react/react-dom (+ next adapter) as peer deps.
+- [ ] 1.9 Site consumes `@dt/react` via the workspace; full gate green.
+
+### Phase 2: Curated utilities operational → Accessibility, Futureproofness ("selected utilities operational")
+- [ ] 2.1 `useMediaQuery` (consolidate 17 `matchMedia`); flip state to operational.
+- [ ] 2.2 `useFocusTrap` (custom overlays); flip to operational.
+- [ ] 2.3 `useScrollLock` (custom overlays); flip to operational.
+- [ ] 2.4 `LinkProvider` formalized in the Utilities surface (from 1.3); flip to operational.
+- [ ] 2.5 Expose `useTheme` / `ThemeProvider` as public Utilities (already exist).
+- [ ] 2.6 Document the Utilities category in Storybook Foundations.
+- Deferred (adopt only when a trigger component needs them): LayerProvider/useLayer, Syntax Theme, useOverflow/useScrollOverflow, useClickableContainer, useListFocus, useKeyboardHint, useStreamingText. Skipped (app-platform only): useGridFocus, useTreeFocus, Media Theme, useImageMode.
+
+### Phase 3: Targeted breadth → Breadth (rescoped)
+- [ ] 3.1 Command Palette (site/docs search + agent story).
+- [ ] 3.2 Segmented Control.
+- [ ] 3.3 Close any intended-surface gaps found in 0.5; promote the whole checklist to `stable`.
+
+### Phase 4: Governance + agent-readiness + theming → those three to 90
+- [ ] 4.1 Multi-brand theme generation from DTCG + a demo theme.
+- [ ] 4.2 Verify + document MCP server / CLI / agent-manifest as an operational "agent-ready" story.
+- [ ] 4.3 Publish the contract schema; keep the roadmap self-check in the gate.
+
+### Phase 5: Distribution → Distribution to 90
+- [ ] 5.1 Publish `@dt/tokens` → `@dt/tokens-css` → `@dt/react` (dep order) to a registry. **Outward-facing; needs explicit go-ahead.**
+- [ ] 5.2 Consumer-setup docs + documented second-consumer path.
+- [ ] 5.3 Site dogfoods the published (or workspace) package.
+
+---
+
+## How to update (every session)
+
+1. Do the task; run its gates.
+2. Tick the box here; update `astryx-roadmap.state.json` (tighten ratchets, flip a utility to `operational`, bump a dimension `current`).
+3. Run `npm run check:astryx-roadmap` (also runs on pre-push). Green means no completed item regressed.
+
+## Known caveats (carried from the feasibility analysis)
+
+- The gates cannot prove "zero regressions" for i18n (1.5) and navigation decoupling: AT snapshots are English-only and a11y-tree-only, the vitest CSS-module proxy hides mis-scoped classes, there is no visual/multi-locale regression suite, and CI is quota-dead. Those tasks get human/browser + multi-locale review before merge.
+- Publishing (5.1) is irreversible and waits for an explicit go-ahead.

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "sync:figma-contracts": "node scripts/design-system/sync-figma-contract-urls.mjs",
     "audit:consumers": "node scripts/design-system/audit-consumers.mjs",
     "check:consumers": "node scripts/design-system/check-consumers.mjs",
+    "check:astryx-roadmap": "node scripts/design-system/check-astryx-roadmap.mjs",
     "check:tokens": "node scripts/design-system/semantic-token-codemod.mjs --check",
     "audit:usage": "node scripts/design-system/audit-usage.mjs",
     "find-component": "node scripts/design-system/find-component.mjs",

--- a/scripts/design-system/astryx-roadmap.state.json
+++ b/scripts/design-system/astryx-roadmap.state.json
@@ -1,0 +1,104 @@
+{
+    "version": 1,
+    "goal": "At least 90/100 on every rescoped Astryx-comparison dimension, plus the selected utilities operational.",
+    "rubric": "Mission-rescoped (portfolio design-system-of-record). 90 is measured against DT's intended surface and a published/dogfooded package, NOT app-platform breadth or raw OSS adoption. Anti-goals stay in force.",
+    "humanRoadmap": "docs/design-system/astryx-parity-roadmap.md",
+    "seededOn": "2026-07-08",
+    "dimensions": [
+        {
+            "key": "maturity",
+            "current": 62,
+            "target": 90
+        },
+        {
+            "key": "breadth",
+            "current": 44,
+            "target": 90
+        },
+        {
+            "key": "scalability",
+            "current": 54,
+            "target": 90
+        },
+        {
+            "key": "futureproofness",
+            "current": 61,
+            "target": 90
+        },
+        {
+            "key": "accessibility",
+            "current": 78,
+            "target": 90
+        },
+        {
+            "key": "governance",
+            "current": 88,
+            "target": 90
+        },
+        {
+            "key": "agentReadiness",
+            "current": 80,
+            "target": 90
+        },
+        {
+            "key": "theming",
+            "current": 67,
+            "target": 90
+        },
+        {
+            "key": "distribution",
+            "current": 20,
+            "target": 90
+        }
+    ],
+    "antiGoalComponents": [
+        "AppShell",
+        "TreeList",
+        "DataGrid",
+        "MegaMenu"
+    ],
+    "ratchets": {
+        "catalogAppImports": {
+            "ceiling": 41,
+            "desc": "catalog source files importing @/ (app root); must only decrease"
+        },
+        "catalogNextImports": {
+            "ceiling": 15,
+            "desc": "catalog source files importing next/*; must only decrease"
+        },
+        "catalogI18nImports": {
+            "ceiling": 46,
+            "desc": "catalog source files coupled to i18next/useTranslation; must only decrease"
+        },
+        "stableCount": {
+            "floor": 58,
+            "desc": "stable catalog components + patterns; must not drop"
+        }
+    },
+    "utilities": [
+        {
+            "name": "LinkProvider",
+            "status": "planned",
+            "file": null,
+            "note": "decouples next/link from the catalog; part of Phase 1"
+        },
+        {
+            "name": "useMediaQuery",
+            "status": "planned",
+            "file": null,
+            "note": "consolidates 17 ad-hoc matchMedia call sites"
+        },
+        {
+            "name": "useFocusTrap",
+            "status": "planned",
+            "file": null,
+            "note": "custom overlays are not Radix-backed; real a11y value"
+        },
+        {
+            "name": "useScrollLock",
+            "status": "planned",
+            "file": null,
+            "note": "body scroll lock for custom overlays"
+        }
+    ]
+}

--- a/scripts/design-system/check-astryx-roadmap.mjs
+++ b/scripts/design-system/check-astryx-roadmap.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * Non-regression guard for the Astryx-parity roadmap.
+ *
+ * The roadmap (docs/design-system/astryx-parity-roadmap.md) is the human source
+ * of truth; astryx-roadmap.state.json is the machine state. This gate enforces
+ * the invariants that must hold once established, so completed progress cannot
+ * silently regress:
+ *
+ *   1. Anti-goal components never appear in the catalog (scope-creep guard).
+ *   2. Utilities marked "operational" keep their file present + exported.
+ *   3. Coupling ratchets: catalog imports of @/, next/*, and i18n never climb
+ *      above the recorded ceiling (decoupling can only move forward).
+ *   4. Stable-count floor: the catalog never drops below the recorded floor.
+ *
+ * Run with --report to print measured metrics without failing (used to seed
+ * the ratchets after a task lands).
+ */
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const STATE_PATH = join(ROOT, "scripts/design-system/astryx-roadmap.state.json");
+const COMPONENTS = join(ROOT, "nextjs-app/shared/components");
+const PATTERNS = join(ROOT, "nextjs-app/shared/patterns");
+const REPORT = process.argv.includes("--report");
+
+const state = existsSync(STATE_PATH)
+  ? JSON.parse(readFileSync(STATE_PATH, "utf8"))
+  : { antiGoalComponents: [], utilities: [], ratchets: {} };
+const errors = [];
+
+/** All contract dirs under a base (optionally excluding pages/). */
+function contractDirs(base, { excludePages = false } = {}) {
+  if (!existsSync(base)) return [];
+  const out = [];
+  const walk = (dir) => {
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      if (!e.isDirectory()) continue;
+      if (e.name === "__a11y-snapshots__" || e.name === "__tests__") continue;
+      const full = join(dir, e.name);
+      if (existsSync(join(full, `${e.name}.contract.json`))) out.push(full);
+      walk(full);
+    }
+  };
+  walk(base);
+  return excludePages ? out.filter((d) => !d.includes("/pages/")) : out;
+}
+
+/** Catalog source .tsx (non test/story) for the publishable catalog. */
+function catalogSourceFiles() {
+  const files = [];
+  for (const dir of contractDirs(COMPONENTS, { excludePages: true })) {
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      if (!e.isFile() || !e.name.endsWith(".tsx")) continue;
+      if (e.name.endsWith(".test.tsx") || e.name.endsWith(".stories.tsx")) continue;
+      files.push(join(dir, e.name));
+    }
+  }
+  return files;
+}
+
+function countMatching(files, re) {
+  let n = 0;
+  for (const f of files) {
+    if (re.test(readFileSync(f, "utf8"))) n += 1;
+  }
+  return n;
+}
+
+function stableCount() {
+  let n = 0;
+  for (const base of [COMPONENTS, PATTERNS]) {
+    for (const dir of contractDirs(base)) {
+      const name = dir.split("/").pop();
+      const c = JSON.parse(readFileSync(join(dir, `${name}.contract.json`), "utf8"));
+      if (c.status === "stable") n += 1;
+    }
+  }
+  return n;
+}
+
+// ---- Measurements ----
+const catalogFiles = catalogSourceFiles();
+const measured = {
+  catalogAppImports: countMatching(catalogFiles, /from "@\//),
+  catalogNextImports: countMatching(catalogFiles, /from "next\//),
+  catalogI18nImports: countMatching(catalogFiles, /i18next|react-i18next|useTranslation/),
+  stableCount: stableCount(),
+  catalogComponents: contractDirs(COMPONENTS, { excludePages: true }).length,
+};
+
+if (REPORT) {
+  console.log("Astryx-roadmap measured metrics:");
+  for (const [k, v] of Object.entries(measured)) console.log(`  ${k} = ${v}`);
+  process.exit(0);
+}
+
+// ---- 1. Anti-goal components ----
+const catalogNames = new Set(
+  [...contractDirs(COMPONENTS), ...contractDirs(PATTERNS)].map((d) => d.split("/").pop()),
+);
+for (const name of state.antiGoalComponents ?? []) {
+  if (catalogNames.has(name)) {
+    errors.push(`Anti-goal component "${name}" appeared in the catalog (scope creep). Remove it or amend the roadmap deliberately.`);
+  }
+}
+
+// ---- 2. Operational utilities present ----
+for (const u of state.utilities ?? []) {
+  if (u.status !== "operational") continue;
+  if (!u.file) {
+    errors.push(`Utility "${u.name}" is marked operational but has no file recorded in state.`);
+    continue;
+  }
+  if (!existsSync(join(ROOT, u.file))) {
+    errors.push(`Operational utility "${u.name}" file missing: ${u.file}`);
+    continue;
+  }
+  const src = readFileSync(join(ROOT, u.file), "utf8");
+  if (!new RegExp(`\\b${u.name}\\b`).test(src)) {
+    errors.push(`Operational utility "${u.name}" not found/exported in ${u.file}`);
+  }
+}
+
+// ---- 3. Coupling ratchets ----
+for (const [key, r] of Object.entries(state.ratchets ?? {})) {
+  if (r.ceiling != null && measured[key] > r.ceiling) {
+    errors.push(`Ratchet breach: ${key} = ${measured[key]} exceeds ceiling ${r.ceiling}. Coupling may only decrease.`);
+  }
+  if (r.floor != null && measured[key] < r.floor) {
+    errors.push(`Ratchet breach: ${key} = ${measured[key]} below floor ${r.floor}.`);
+  }
+}
+
+// ---- Report ----
+if (errors.length) {
+  console.error("✗ Astryx-roadmap guard FAILED:\n");
+  for (const e of errors) console.error(`  - ${e}`);
+  console.error("\nMeasured:", JSON.stringify(measured));
+  process.exit(1);
+}
+console.log(`✓ Astryx-roadmap guard passed (${JSON.stringify(measured)})`);


### PR DESCRIPTION
docs(design-system): durable Astryx-parity roadmap + non-regression guard

Adds a session-durable roadmap toward >=90/100 on every rescoped Astryx-
comparison dimension plus operational utilities, with a machine guard so
completed progress cannot silently regress.

- docs/design-system/astryx-parity-roadmap.md: mission-rescoped rubric (90
  measured against DT's intended surface + a published/dogfooded package, not
  app-platform parity or raw adoption), anti-goals, intended-surface checklist,
  phased tasks, caveats.
- scripts/design-system/astryx-roadmap.state.json: machine state (dimension
  scores, anti-goal components, coupling ratchets seeded at today's values,
  utilities registry).
- scripts/design-system/check-astryx-roadmap.mjs (check:astryx-roadmap): guards
  anti-goal components (AppShell/TreeList/DataGrid/MegaMenu never in catalog),
  operational-utility file locks, coupling ratchets (@/ 41, next/* 15, i18n 46
  can only decrease), stable-count floor (58). Wired into pre-push.

Phase 0 (foundation + guardrails) complete. Guard verified: green at seed,
fails on a ratchet breach, green after restore.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a roadmap document and state file outlining current design-system targets, guardrails, and tracking for planned work.

* **Chores**
  * Expanded pre-push checks to include a new validation step before code can be pushed.
  * Added a script to enforce roadmap rules and report measured status during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->