### PR TITLE
feat(design-system): bake the roadmap stopping contract into the guard

### DIFF
--- a/docs/design-system/astryx-parity-roadmap.md
+++ b/docs/design-system/astryx-parity-roadmap.md
@@ -49,9 +49,18 @@ The Breadth target is "all of this present and `stable`", not Astryx parity. (Fi
 
 ---
 
+## Stopping contract (enforced by the guard)
+
+An autonomous loop may drive this roadmap, but three tasks are **checkpoints** that require explicit human clearance and are marked 🔒 below. They are listed in `state.json` under `checkpoints`, and the guard **hard-fails** if any checkpoint task is marked `done` in `state.tasks` without an `approval: { clearedBy, on }` record. So the loop structurally cannot auto-complete them; it must stop, ask, and record the clearance.
+
+- 🔒 **1.5 i18n decoupling** and **1.6 navigation decoupling** (`unverifiable-regression`): correctness across EN/FI/SV and routing/active-link behavior is not provable by the gates (English-only snapshots, no visual/multi-locale suite, CSS-module proxy hides mis-scoped classes). Needs browser + multi-locale review before merge.
+- 🔒 **5.1 publish** (`authorization`): outward-facing and irreversible.
+
+Everything else the loop may chain autonomously (branch, gate, PR, admin-merge, tick box, tighten ratchet) until all boxes are checked and all nine dimensions reach ≥90.
+
 ## Phased tasks
 
-Legend: `[ ]` todo, `[~]` in progress, `[x]` done. Check the box AND update the state file when a task lands.
+Legend: `[ ]` todo, `[~]` in progress, `[x]` done, 🔒 checkpoint (needs recorded clearance). Check the box AND update the state file when a task lands.
 
 ### Phase 0: Foundation & guardrails (the non-regression spine)
 - [x] 0.1 Commit this roadmap + machine state as the durable source of truth.
@@ -65,8 +74,8 @@ Legend: `[ ]` todo, `[~]` in progress, `[x]` done. Check the box AND update the 
 - [ ] 1.2 Internalize `cn` / `@/lib/utils` into the DS boundary (38 files); ratchet `catalogAppImports` down.
 - [ ] 1.3 **Link Provider** utility → decouple `next/link` (falls back to `<a>`); ratchet `catalogNextImports` down. (Also a utility deliverable.)
 - [ ] 1.4 Image slot/provider → decouple `next/image`.
-- [ ] 1.5 i18n decoupling: injected translator / prop-driven copy with English defaults (46 files); ratchet `catalogI18nImports` down. **Needs multi-locale review; not fully autonomous.**
-- [ ] 1.6 Remove remaining `@/` and `next/navigation` from the catalog (ratchets to 0).
+- [ ] 🔒 1.5 i18n decoupling: injected translator / prop-driven copy with English defaults (46 files); ratchet `catalogI18nImports` down. **Checkpoint: multi-locale + browser review before merge.**
+- [ ] 🔒 1.6 Remove remaining `@/` and `next/navigation` from the catalog (ratchets to 0). **Checkpoint: navigation behavior review before merge.**
 - [ ] 1.7 `@dt/tokens` + `@dt/tokens-css` packages from the existing token pipeline.
 - [ ] 1.8 Library build (tsup/Vite) compiling TS + CSS Modules; `exports`/`types`; react/react-dom (+ next adapter) as peer deps.
 - [ ] 1.9 Site consumes `@dt/react` via the workspace; full gate green.
@@ -91,7 +100,7 @@ Legend: `[ ]` todo, `[~]` in progress, `[x]` done. Check the box AND update the 
 - [ ] 4.3 Publish the contract schema; keep the roadmap self-check in the gate.
 
 ### Phase 5: Distribution → Distribution to 90
-- [ ] 5.1 Publish `@dt/tokens` → `@dt/tokens-css` → `@dt/react` (dep order) to a registry. **Outward-facing; needs explicit go-ahead.**
+- [ ] 🔒 5.1 Publish `@dt/tokens` → `@dt/tokens-css` → `@dt/react` (dep order) to a registry. **Checkpoint: outward-facing, needs explicit go-ahead.**
 - [ ] 5.2 Consumer-setup docs + documented second-consumer path.
 - [ ] 5.3 Site dogfoods the published (or workspace) package.
 

--- a/scripts/design-system/astryx-roadmap.state.json
+++ b/scripts/design-system/astryx-roadmap.state.json
@@ -100,5 +100,37 @@
             "file": null,
             "note": "body scroll lock for custom overlays"
         }
-    ]
+    ],
+    "checkpoints": [
+        {
+            "id": "1.5",
+            "type": "unverifiable-regression",
+            "reason": "i18n decoupling: EN/FI/SV correctness is not provable by the gates (English-only snapshots, no multi-locale/visual suite). Needs browser + multi-locale review.",
+            "requiresApproval": true
+        },
+        {
+            "id": "1.6",
+            "type": "unverifiable-regression",
+            "reason": "navigation decoupling: routing/active-link behavior is not exercised by unit tests or a11y snapshots. Needs browser review.",
+            "requiresApproval": true
+        },
+        {
+            "id": "5.1",
+            "type": "authorization",
+            "reason": "publishing to a registry is outward-facing and irreversible.",
+            "requiresApproval": true
+        }
+    ],
+    "tasks": {
+        "1.5": {
+            "status": "todo"
+        },
+        "1.6": {
+            "status": "todo"
+        },
+        "5.1": {
+            "status": "todo"
+        }
+    },
+    "approvalFormat": "To clear a checkpoint: set tasks.<id>.status=done AND tasks.<id>.approval={clearedBy:<name>,on:<YYYY-MM-DD>,note?}. The guard rejects done without this."
 }

--- a/scripts/design-system/check-astryx-roadmap.mjs
+++ b/scripts/design-system/check-astryx-roadmap.mjs
@@ -134,6 +134,25 @@ for (const [key, r] of Object.entries(state.ratchets ?? {})) {
   }
 }
 
+// ---- 4. Checkpoint tasks cannot be "done" without recorded human clearance ----
+// Structural enforcement of the stopping contract: publishing (authorization)
+// and the i18n / navigation decoupling (unverifiable-regression) may not be
+// auto-completed by an autonomous loop. Marking one done requires an explicit
+// approval record, which forces a stop-and-ask before it can pass this gate.
+const tasks = state.tasks ?? {};
+for (const cp of state.checkpoints ?? []) {
+  const t = tasks[cp.id];
+  if (t && t.status === "done") {
+    const a = t.approval;
+    if (!a || !a.clearedBy || !a.on) {
+      errors.push(
+        `Checkpoint task ${cp.id} (${cp.type}) is marked done without a recorded approval {clearedBy, on}. ` +
+          `It requires explicit human clearance before it can pass: ${cp.reason}`,
+      );
+    }
+  }
+}
+
 // ---- Report ----
 if (errors.length) {
   console.error("✗ Astryx-roadmap guard FAILED:\n");


### PR DESCRIPTION
feat(design-system): bake the roadmap stopping contract into the guard

Checkpoint tasks (1.5 i18n decouple, 1.6 navigation decouple, 5.1 publish)
now structurally cannot be auto-completed by an autonomous loop. state.json
gains `checkpoints` + `tasks`; check:astryx-roadmap hard-fails if a checkpoint
task is marked done without an approval {clearedBy, on} record. Roadmap marks
them 🔒 and documents the contract.

Verified: guard fails on a checkpoint marked done without approval, passes with
one, green when todo.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
