### PR TITLE
feat(design-system): useMediaQuery canonical hook (roadmap 2.1)

### DIFF
--- a/docs/design-system/astryx-parity-roadmap.md
+++ b/docs/design-system/astryx-parity-roadmap.md
@@ -81,7 +81,7 @@ Legend: `[ ]` todo, `[~]` in progress, `[x]` done, 🔒 checkpoint (needs record
 - [ ] 1.9 Site consumes `@dt/react` via the workspace; full gate green.
 
 ### Phase 2: Curated utilities operational → Accessibility, Futureproofness ("selected utilities operational")
-- [ ] 2.1 `useMediaQuery` (consolidate 17 `matchMedia`); flip state to operational.
+- [x] 2.1 `useMediaQuery` — SSR-safe canonical primitive at `nextjs-app/shared/hooks/useMediaQuery.ts` (+ test); operational. Migrated the one genuine responsive-breakpoint site (SocialShare `(width < 768px)`). The other `matchMedia` sites are `prefers-reduced-motion` (owned by `useHydrationSafeMotion`/`motion-safe`) and `prefers-color-scheme` (ThemeProvider), left intentionally; new responsive checks use this hook.
 - [ ] 2.2 `useFocusTrap` (custom overlays); flip to operational.
 - [ ] 2.3 `useScrollLock` (custom overlays); flip to operational.
 - [ ] 2.4 `LinkProvider` formalized in the Utilities surface (from 1.3); flip to operational.

--- a/nextjs-app/shared/components/SocialShare/SocialShare.tsx
+++ b/nextjs-app/shared/components/SocialShare/SocialShare.tsx
@@ -7,6 +7,7 @@ import Toast from "@dt/Toast/Toast";
 import { useTranslation } from "react-i18next";
 import Icon from "@dt/Icon";
 import Text from "@dt/Text";
+import { useMediaQuery } from "../../hooks/useMediaQuery";
 
 export type SocialShareChannel =
   | "linkedin"
@@ -146,27 +147,13 @@ export const SocialShare = ({
   const encodedUrl = encodeURIComponent(url);
   const encodedTitle = encodeURIComponent(title);
   const [toastOpen, setToastOpen] = useState(false);
-  const [isMobile, setIsMobile] = useState(false);
   const [supportsNativeShare, setSupportsNativeShare] = useState(false);
+  const isMobile = useMediaQuery("(width < 768px)");
 
   const resolvedChannels = useMemo(
     () => channels.filter((channel) => CHANNEL_META[channel]),
     [channels],
   );
-
-  useEffect(() => {
-    if (typeof window !== "undefined" && window.matchMedia) {
-      const mediaQuery = window.matchMedia("(width < 768px)");
-      setIsMobile(mediaQuery.matches);
-
-      const handleChange = (e: MediaQueryListEvent) => {
-        setIsMobile(e.matches);
-      };
-
-      mediaQuery.addEventListener("change", handleChange);
-      return () => mediaQuery.removeEventListener("change", handleChange);
-    }
-  }, []);
 
   useEffect(() => {
     if (typeof window !== "undefined" && "share" in navigator) {

--- a/nextjs-app/shared/hooks/useMediaQuery.test.tsx
+++ b/nextjs-app/shared/hooks/useMediaQuery.test.tsx
@@ -1,0 +1,48 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useMediaQuery } from "./useMediaQuery";
+
+type Listener = (event: MediaQueryListEvent) => void;
+
+function mockMatchMedia(initialMatches: boolean) {
+  let listener: Listener | null = null;
+  const mql = {
+    matches: initialMatches,
+    addEventListener: (_: string, cb: Listener) => {
+      listener = cb;
+    },
+    removeEventListener: () => {
+      listener = null;
+    },
+  };
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn(() => mql),
+  );
+  return {
+    emit(matches: boolean) {
+      mql.matches = matches;
+      listener?.({ matches } as MediaQueryListEvent);
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useMediaQuery", () => {
+  it("syncs to the current match after mount", () => {
+    mockMatchMedia(true);
+    const { result } = renderHook(() => useMediaQuery("(width < 768px)"));
+    expect(result.current).toBe(true);
+  });
+
+  it("updates when the query result changes", () => {
+    const mm = mockMatchMedia(false);
+    const { result } = renderHook(() => useMediaQuery("(width < 768px)"));
+    expect(result.current).toBe(false);
+    act(() => mm.emit(true));
+    expect(result.current).toBe(true);
+  });
+});

--- a/nextjs-app/shared/hooks/useMediaQuery.ts
+++ b/nextjs-app/shared/hooks/useMediaQuery.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Subscribe to a CSS media query and track whether it currently matches.
+ *
+ * SSR-safe: returns `false` on the server and the first client render (so
+ * hydration never mismatches), then syncs to the real match after mount and
+ * updates on every change. This is the sanctioned primitive for responsive
+ * breakpoint checks; for reduced-motion use `useHydrationSafeMotion`, and for
+ * system color scheme use the ThemeProvider.
+ *
+ * @param query a media query string, e.g. `"(width < 768px)"`.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia(query);
+    setMatches(mql.matches);
+    const onChange = (event: MediaQueryListEvent) => setMatches(event.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [query]);
+
+  return matches;
+}

--- a/scripts/design-system/astryx-roadmap.state.json
+++ b/scripts/design-system/astryx-roadmap.state.json
@@ -22,7 +22,7 @@
         },
         {
             "key": "futureproofness",
-            "current": 61,
+            "current": 63,
             "target": 90
         },
         {
@@ -84,8 +84,8 @@
         },
         {
             "name": "useMediaQuery",
-            "status": "planned",
-            "file": null,
+            "status": "operational",
+            "file": "nextjs-app/shared/hooks/useMediaQuery.ts",
             "note": "consolidates 17 ad-hoc matchMedia call sites"
         },
         {


### PR DESCRIPTION
feat(design-system): useMediaQuery canonical hook (roadmap 2.1)

Adds nextjs-app/shared/hooks/useMediaQuery.ts, the SSR-safe sanctioned primitive
for responsive breakpoint checks (returns false on server + first render to
avoid hydration mismatch, then syncs and subscribes). Unit-tested.

Migrated the one genuine responsive site (SocialShare, `(width < 768px)`) to it,
behavior-identical. The other matchMedia call sites are prefers-reduced-motion
(owned by useHydrationSafeMotion/motion-safe) and prefers-color-scheme
(ThemeProvider), left intentionally rather than fragmenting those abstractions.

Utility flipped to operational in the roadmap state (guard now locks its file).
futureproofness 61 -> 63.

Local gate green: typecheck, lint, lint:css, test 2086/2086, build.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
