### PR TITLE
feat(design-system): useFocusTrap hook, Modal consumes it (roadmap 2.2)

### DIFF
--- a/docs/design-system/astryx-parity-roadmap.md
+++ b/docs/design-system/astryx-parity-roadmap.md
@@ -82,7 +82,7 @@ Legend: `[ ]` todo, `[~]` in progress, `[x]` done, 🔒 checkpoint (needs record
 
 ### Phase 2: Curated utilities operational → Accessibility, Futureproofness ("selected utilities operational")
 - [x] 2.1 `useMediaQuery` — SSR-safe canonical primitive at `nextjs-app/shared/hooks/useMediaQuery.ts` (+ test); operational. Migrated the one genuine responsive-breakpoint site (SocialShare `(width < 768px)`). The other `matchMedia` sites are `prefers-reduced-motion` (owned by `useHydrationSafeMotion`/`motion-safe`) and `prefers-color-scheme` (ThemeProvider), left intentionally; new responsive checks use this hook.
-- [ ] 2.2 `useFocusTrap` (custom overlays); flip to operational.
+- [x] 2.2 `useFocusTrap` — extracted Modal's inert-background + focus-first + restore logic into `nextjs-app/shared/hooks/useFocusTrap.ts` (+ test); Modal consumes it (behavior-identical, 40 Modal tests green). Operational.
 - [ ] 2.3 `useScrollLock` (custom overlays); flip to operational.
 - [ ] 2.4 `LinkProvider` formalized in the Utilities surface (from 1.3); flip to operational.
 - [ ] 2.5 Expose `useTheme` / `ThemeProvider` as public Utilities (already exist).

--- a/nextjs-app/shared/components/Modal/Modal.tsx
+++ b/nextjs-app/shared/components/Modal/Modal.tsx
@@ -7,6 +7,7 @@ import Title from "@dt/Title";
 import { getSemanticIcon } from "../../utils/semanticIcons";
 import Icon, { type IconProps } from "@dt/Icon";
 import { normalizeTitleSize, type TitleSizeUnified } from "../../utils/sizeNormalization";
+import { useFocusTrap } from "../../hooks/useFocusTrap";
 
 export type ModalSeverity = "success" | "error" | "warning" | "info";
 export type ModalAnimation = "none" | "scale" | "slide" | "fade";
@@ -90,7 +91,6 @@ const Modal: React.FC<ModalProps> = ({
   const normalizedTitleSize = normalizeTitleSize(titleSize);
   const titleId = useId();
   const descriptionId = useId();
-  const previousActiveElement = useRef<HTMLElement | null>(null);
   const modalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -139,46 +139,8 @@ const Modal: React.FC<ModalProps> = ({
     return () => ctx.revert();
   }, [isOpen, animation]);
 
-  // Apply inert attribute to main content when modal is open
-  // This prevents focus from escaping the modal to background content
-  useEffect(() => {
-    if (!isOpen || typeof document === "undefined") return;
-
-    // Store the currently focused element to restore focus on close
-    previousActiveElement.current = document.activeElement as HTMLElement;
-
-    // Find the main content container (try common IDs)
-    const mainContent =
-      document.getElementById("main-content") ||
-      document.getElementById("__next") ||
-      document.querySelector("main") ||
-      document.body.firstElementChild;
-
-    if (mainContent && mainContent !== document.body) {
-      // Set inert on main content to prevent focus escape
-      mainContent.setAttribute("inert", "");
-    }
-
-    // Focus the modal or first focusable element
-    const focusFirst = () => {
-      if (!modalRef.current) return;
-      const focusable = modalRef.current.querySelector<HTMLElement>(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-      );
-      focusable?.focus();
-    };
-
-    // Use requestAnimationFrame to ensure DOM is ready
-    requestAnimationFrame(focusFirst);
-
-    return () => {
-      if (mainContent && mainContent !== document.body) {
-        mainContent.removeAttribute("inert");
-      }
-      // Restore focus to previously focused element
-      previousActiveElement.current?.focus();
-    };
-  }, [isOpen]);
+  // Focus trap: inert the background, focus first focusable, restore on close.
+  useFocusTrap(modalRef, isOpen);
 
   useEffect(() => {
     if (!isOpen || !onClose || typeof document === "undefined") return;

--- a/nextjs-app/shared/hooks/useFocusTrap.test.tsx
+++ b/nextjs-app/shared/hooks/useFocusTrap.test.tsx
@@ -1,0 +1,57 @@
+import { createRef } from "react";
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useFocusTrap } from "./useFocusTrap";
+
+let main: HTMLElement;
+let container: HTMLDivElement;
+let trigger: HTMLButtonElement;
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  main = document.createElement("main");
+  main.innerHTML = '<button id="bg">bg</button>';
+  document.body.appendChild(main);
+
+  trigger = document.createElement("button");
+  trigger.id = "trigger";
+  document.body.appendChild(trigger);
+  trigger.focus();
+
+  container = document.createElement("div");
+  container.innerHTML = '<button id="first">first</button>';
+  document.body.appendChild(container);
+  vi.useFakeTimers();
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) =>
+    setTimeout(() => cb(0), 0) as unknown as number,
+  );
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => clearTimeout(id));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("useFocusTrap", () => {
+  it("marks main content inert while active and removes it on deactivate", () => {
+    const ref = createRef<HTMLDivElement>();
+    (ref as { current: HTMLDivElement }).current = container;
+    const { rerender } = renderHook(({ active }) => useFocusTrap(ref, active), {
+      initialProps: { active: true },
+    });
+    expect(main.hasAttribute("inert")).toBe(true);
+    rerender({ active: false });
+    expect(main.hasAttribute("inert")).toBe(false);
+  });
+
+  it("restores focus to the previously focused element on deactivate", () => {
+    const ref = createRef<HTMLDivElement>();
+    (ref as { current: HTMLDivElement }).current = container;
+    const { rerender } = renderHook(({ active }) => useFocusTrap(ref, active), {
+      initialProps: { active: true },
+    });
+    rerender({ active: false });
+    expect(document.activeElement).toBe(trigger);
+  });
+});

--- a/nextjs-app/shared/hooks/useFocusTrap.ts
+++ b/nextjs-app/shared/hooks/useFocusTrap.ts
@@ -1,0 +1,49 @@
+import { useEffect, type RefObject } from "react";
+
+const FOCUSABLE =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Trap focus within `ref` while `active`.
+ *
+ * On activation it records the currently focused element, marks the page's main
+ * content `inert` so Tab cannot escape to the background, and focuses the first
+ * focusable element inside the container. On deactivation it removes `inert` and
+ * restores focus to where it was. Built for DT's custom overlays (e.g. Modal),
+ * which are not Radix-backed and would otherwise leak focus.
+ *
+ * @param ref container whose focusable descendants should hold focus.
+ * @param active whether the trap is engaged.
+ */
+export function useFocusTrap(
+  ref: RefObject<HTMLElement | null>,
+  active: boolean,
+): void {
+  useEffect(() => {
+    if (!active || typeof document === "undefined") return;
+
+    const previousActiveElement = document.activeElement as HTMLElement | null;
+
+    const mainContent =
+      document.getElementById("main-content") ||
+      document.getElementById("__next") ||
+      document.querySelector("main") ||
+      document.body.firstElementChild;
+
+    if (mainContent && mainContent !== document.body) {
+      mainContent.setAttribute("inert", "");
+    }
+
+    const raf = requestAnimationFrame(() => {
+      ref.current?.querySelector<HTMLElement>(FOCUSABLE)?.focus();
+    });
+
+    return () => {
+      cancelAnimationFrame(raf);
+      if (mainContent && mainContent !== document.body) {
+        mainContent.removeAttribute("inert");
+      }
+      previousActiveElement?.focus();
+    };
+  }, [active, ref]);
+}

--- a/scripts/design-system/astryx-roadmap.state.json
+++ b/scripts/design-system/astryx-roadmap.state.json
@@ -27,7 +27,7 @@
         },
         {
             "key": "accessibility",
-            "current": 78,
+            "current": 80,
             "target": 90
         },
         {
@@ -90,8 +90,8 @@
         },
         {
             "name": "useFocusTrap",
-            "status": "planned",
-            "file": null,
+            "status": "operational",
+            "file": "nextjs-app/shared/hooks/useFocusTrap.ts",
             "note": "custom overlays are not Radix-backed; real a11y value"
         },
         {


### PR DESCRIPTION
feat(design-system): useFocusTrap hook, Modal consumes it (roadmap 2.2)

Extracts Modal's focus-trap logic (record previous focus, inert the page's main
content so Tab cannot escape, focus the first focusable, restore on close) into
nextjs-app/shared/hooks/useFocusTrap.ts, the sanctioned trap for DT's custom
(non-Radix) overlays. Modal now calls useFocusTrap(modalRef, isOpen); behavior
is identical (40 Modal tests green, a11y tree unchanged). Hook unit-tested.

Utility flipped to operational (guard locks its file). accessibility 78 -> 80.

Local gate green: typecheck, lint, lint:css, test 2088/2088, build.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
