### PR TITLE
feat(design-system): useScrollLock hook, Modal locks background scroll (roadmap 2.3)

### DIFF
--- a/docs/design-system/astryx-parity-roadmap.md
+++ b/docs/design-system/astryx-parity-roadmap.md
@@ -83,7 +83,7 @@ Legend: `[ ]` todo, `[~]` in progress, `[x]` done, 🔒 checkpoint (needs record
 ### Phase 2: Curated utilities operational → Accessibility, Futureproofness ("selected utilities operational")
 - [x] 2.1 `useMediaQuery` — SSR-safe canonical primitive at `nextjs-app/shared/hooks/useMediaQuery.ts` (+ test); operational. Migrated the one genuine responsive-breakpoint site (SocialShare `(width < 768px)`). The other `matchMedia` sites are `prefers-reduced-motion` (owned by `useHydrationSafeMotion`/`motion-safe`) and `prefers-color-scheme` (ThemeProvider), left intentionally; new responsive checks use this hook.
 - [x] 2.2 `useFocusTrap` — extracted Modal's inert-background + focus-first + restore logic into `nextjs-app/shared/hooks/useFocusTrap.ts` (+ test); Modal consumes it (behavior-identical, 40 Modal tests green). Operational.
-- [ ] 2.3 `useScrollLock` (custom overlays); flip to operational.
+- [x] 2.3 `useScrollLock` — `nextjs-app/shared/hooks/useScrollLock.ts` (+ test), restores previous overflow so nested locks compose. Wired into Modal (closed a real gap: Modal did not lock background scroll). Operational.
 - [ ] 2.4 `LinkProvider` formalized in the Utilities surface (from 1.3); flip to operational.
 - [ ] 2.5 Expose `useTheme` / `ThemeProvider` as public Utilities (already exist).
 - [ ] 2.6 Document the Utilities category in Storybook Foundations.

--- a/nextjs-app/shared/components/Modal/Modal.tsx
+++ b/nextjs-app/shared/components/Modal/Modal.tsx
@@ -8,6 +8,7 @@ import { getSemanticIcon } from "../../utils/semanticIcons";
 import Icon, { type IconProps } from "@dt/Icon";
 import { normalizeTitleSize, type TitleSizeUnified } from "../../utils/sizeNormalization";
 import { useFocusTrap } from "../../hooks/useFocusTrap";
+import { useScrollLock } from "../../hooks/useScrollLock";
 
 export type ModalSeverity = "success" | "error" | "warning" | "info";
 export type ModalAnimation = "none" | "scale" | "slide" | "fade";
@@ -141,6 +142,8 @@ const Modal: React.FC<ModalProps> = ({
 
   // Focus trap: inert the background, focus first focusable, restore on close.
   useFocusTrap(modalRef, isOpen);
+  // Lock background scroll while the modal is open.
+  useScrollLock(isOpen);
 
   useEffect(() => {
     if (!isOpen || !onClose || typeof document === "undefined") return;

--- a/nextjs-app/shared/hooks/useScrollLock.test.tsx
+++ b/nextjs-app/shared/hooks/useScrollLock.test.tsx
@@ -1,0 +1,28 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useScrollLock } from "./useScrollLock";
+
+afterEach(() => {
+  document.body.style.overflow = "";
+});
+
+describe("useScrollLock", () => {
+  it("locks body scroll while active and restores it on release", () => {
+    const { rerender, unmount } = renderHook(
+      ({ active }) => useScrollLock(active),
+      { initialProps: { active: true } },
+    );
+    expect(document.body.style.overflow).toBe("hidden");
+    rerender({ active: false });
+    expect(document.body.style.overflow).toBe("");
+    unmount();
+  });
+
+  it("restores the previous overflow value rather than clearing it", () => {
+    document.body.style.overflow = "scroll";
+    const { unmount } = renderHook(() => useScrollLock(true));
+    expect(document.body.style.overflow).toBe("hidden");
+    unmount();
+    expect(document.body.style.overflow).toBe("scroll");
+  });
+});

--- a/nextjs-app/shared/hooks/useScrollLock.ts
+++ b/nextjs-app/shared/hooks/useScrollLock.ts
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+
+/**
+ * Lock scrolling on the document body while `active`, restoring the previous
+ * `overflow` value on release (so nested locks compose). For DT's custom
+ * overlays (e.g. Modal) that would otherwise let the background scroll behind
+ * them.
+ *
+ * @param active whether the scroll lock is engaged.
+ */
+export function useScrollLock(active: boolean): void {
+  useEffect(() => {
+    if (!active || typeof document === "undefined") return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [active]);
+}

--- a/scripts/design-system/astryx-roadmap.state.json
+++ b/scripts/design-system/astryx-roadmap.state.json
@@ -27,7 +27,7 @@
         },
         {
             "key": "accessibility",
-            "current": 80,
+            "current": 81,
             "target": 90
         },
         {
@@ -96,8 +96,8 @@
         },
         {
             "name": "useScrollLock",
-            "status": "planned",
-            "file": null,
+            "status": "operational",
+            "file": "nextjs-app/shared/hooks/useScrollLock.ts",
             "note": "body scroll lock for custom overlays"
         }
     ],


### PR DESCRIPTION
feat(design-system): useScrollLock hook, Modal locks background scroll (roadmap 2.3)

Adds nextjs-app/shared/hooks/useScrollLock.ts (restores the previous body
overflow on release so nested locks compose) and wires it into Modal, closing a
real gap: Modal did not lock background scroll, so the page scrolled behind it.
Hook unit-tested; 40 Modal tests green.

Utility flipped to operational (guard locks its file). accessibility 80 -> 81.

Local gate green: typecheck, lint, lint:css, test 2090/2090, build.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
