### PR TITLE
docs(design-system): Utilities Storybook Foundations page (roadmap 2.5, 2.6)

### DIFF
--- a/docs/design-system/astryx-parity-roadmap.md
+++ b/docs/design-system/astryx-parity-roadmap.md
@@ -85,8 +85,8 @@ Legend: `[ ]` todo, `[~]` in progress, `[x]` done, 🔒 checkpoint (needs record
 - [x] 2.2 `useFocusTrap` — extracted Modal's inert-background + focus-first + restore logic into `nextjs-app/shared/hooks/useFocusTrap.ts` (+ test); Modal consumes it (behavior-identical, 40 Modal tests green). Operational.
 - [x] 2.3 `useScrollLock` — `nextjs-app/shared/hooks/useScrollLock.ts` (+ test), restores previous overflow so nested locks compose. Wired into Modal (closed a real gap: Modal did not lock background scroll). Operational.
 - [x] 2.4 `LinkProvider` operational (built in 1.3); documented in the Utilities Storybook page as part of 2.6.
-- [ ] 2.5 Expose `useTheme` / `ThemeProvider` as public Utilities (already exist).
-- [ ] 2.6 Document the Utilities category in Storybook Foundations.
+- [x] 2.5 `useTheme` / `ThemeProvider` confirmed public (exported from the `@dt` barrel) and locked in state.
+- [x] 2.6 Utilities documented in Storybook: `nextjs-app/shared/foundations/05-Utilities.mdx` (`Overview/05-Utilities`) covering useMediaQuery / useFocusTrap / useScrollLock / LinkProvider / useTheme, plus the not-adopted rationale.
 - Deferred (adopt only when a trigger component needs them): LayerProvider/useLayer, Syntax Theme, useOverflow/useScrollOverflow, useClickableContainer, useListFocus, useKeyboardHint, useStreamingText. Skipped (app-platform only): useGridFocus, useTreeFocus, Media Theme, useImageMode.
 
 ### Phase 3: Targeted breadth → Breadth (rescoped)

--- a/nextjs-app/shared/foundations/05-Utilities.mdx
+++ b/nextjs-app/shared/foundations/05-Utilities.mdx
@@ -1,0 +1,80 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Overview/05-Utilities" />
+
+# Utilities
+
+A small, curated set of hooks and providers that the catalog composes. It is
+deliberately a fraction of an app-platform utility layer: DT adopts only the
+primitives that serve components it actually ships or that keep the design
+system framework-agnostic. See the [Astryx-parity roadmap](https://github.com/PetriLahdelma/digitaltableteur/blob/main/docs/design-system/astryx-parity-roadmap.md)
+for the adopt / defer / skip rationale.
+
+## Responsive
+
+### `useMediaQuery(query)`
+
+SSR-safe subscription to a CSS media query. Returns `false` on the server and
+the first client render (so hydration never mismatches), then syncs to the real
+match and updates on change. The sanctioned primitive for responsive breakpoint
+checks.
+
+```tsx
+import { useMediaQuery } from '@/nextjs-app/shared/hooks/useMediaQuery';
+
+const isMobile = useMediaQuery('(width < 768px)');
+```
+
+For `prefers-reduced-motion` use `useHydrationSafeMotion`; for system colour
+scheme use the theme provider below.
+
+## Overlays
+
+DT's overlays (e.g. `Modal`) are custom rather than Radix-backed, so they own
+their focus and scroll behaviour through these hooks.
+
+### `useFocusTrap(ref, active)`
+
+While `active`, records the focused element, marks the page's main content
+`inert` so Tab cannot escape, focuses the first focusable element in `ref`, and
+restores focus on release. Being effect-based it composes with any overlay.
+
+### `useScrollLock(active)`
+
+Locks body scroll while `active`, restoring the previous `overflow` value on
+release so nested locks compose. `Modal` uses both hooks together.
+
+## Navigation
+
+### `LinkProvider` + `Link`
+
+The DS `Link` renders an injected link implementation, defaulting to a plain
+`<a>` when no provider is present. The host app injects its router link (e.g.
+next/link) via `LinkProvider`, so catalog components never import a framework
+link directly and the design system stays portable.
+
+```tsx
+import { Link, LinkProvider } from '@/nextjs-app/shared/lib/linkComponent';
+
+// app root
+<LinkProvider component={NextLinkAdapter}>{children}</LinkProvider>;
+
+// anywhere in the catalog
+<Link href="/work">Work</Link>;
+```
+
+## Theming
+
+### `ThemeProvider` + `useTheme`
+
+`useTheme()` reads the current theme (light / dark / high-contrast) from
+`ThemeProvider`. Both are exported from `@dt` and back the token themes described
+in **Overview/03-Theming**.
+
+## Not adopted
+
+App-platform utilities that DT does not build (they exist to power a Table
+engine, Tree, grid focus, or media-scoped theming DT has declared out of scope):
+`useGridFocus`, `useTreeFocus`, `Media Theme`, `useImageMode`. Others are
+deferred until a consuming component needs them (`LayerProvider`, `useOverflow`,
+`useClickableContainer`, `useListFocus`, `useKeyboardHint`, `useStreamingText`).

--- a/scripts/design-system/astryx-roadmap.state.json
+++ b/scripts/design-system/astryx-roadmap.state.json
@@ -37,12 +37,12 @@
         },
         {
             "key": "agentReadiness",
-            "current": 80,
+            "current": 81,
             "target": 90
         },
         {
             "key": "theming",
-            "current": 67,
+            "current": 68,
             "target": 90
         },
         {
@@ -99,6 +99,12 @@
             "status": "operational",
             "file": "nextjs-app/shared/hooks/useScrollLock.ts",
             "note": "body scroll lock for custom overlays"
+        },
+        {
+            "name": "useTheme",
+            "status": "operational",
+            "file": "nextjs-app/shared/components/ThemeProvider/ThemeProvider.tsx",
+            "note": "already existed; exposed + documented"
         }
     ],
     "checkpoints": [


### PR DESCRIPTION
docs(design-system): Utilities Storybook Foundations page (roadmap 2.5, 2.6)

Adds nextjs-app/shared/foundations/05-Utilities.mdx (Overview/05-Utilities)
documenting the curated utilities layer: useMediaQuery, useFocusTrap,
useScrollLock, LinkProvider/Link, and useTheme/ThemeProvider, plus the
not-adopted rationale (why DT's utility layer is a fraction of Astryx's).

2.5: useTheme/ThemeProvider confirmed public (exported from the @dt barrel);
locked in the roadmap state. agentReadiness 80 -> 81, theming 67 -> 68.

Local gate green: validate:mdx (12 files), typecheck, lint, lint:css,
test 2092/2092, build.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Storybook utilities overview page covering the curated utilities layer, including responsive, focus, scroll, link, and theme helpers.
  * Updated the design-system roadmap to reflect the Utilities section as complete and confirm theme utilities as available.
* **Chores**
  * Adjusted roadmap tracking values to reflect the latest progress on agent readiness and theming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->