### PR TITLE
feat(design-system): Image provider, decouple next/image from the catalog (roadmap 1.4)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,7 @@ import { NextThemeProvider } from "../providers/ThemeProvider";
 import { ToastProvider } from "../providers/ToastProvider";
 import { AnimationProvider } from "../providers/AnimationProvider";
 import { NextLinkProvider } from "../providers/NextLinkProvider";
+import { NextImageProvider } from "../providers/NextImageProvider";
 import { SmoothScrollProvider } from "../providers/SmoothScrollProvider";
 import { CookieConsentProvider } from "@/nextjs-app/shared/lib/cookieConsent";
 import { NextLayout } from "@dt/NextLayout";
@@ -154,6 +155,7 @@ export default function RootLayout({
         <WebMcpProvider>
           <NextThemeProvider>
             <NextLinkProvider>
+              <NextImageProvider>
               <I18nProvider>
               <HtmlLangSync />
               <AnimationProvider>
@@ -166,6 +168,7 @@ export default function RootLayout({
                 </SmoothScrollProvider>
               </AnimationProvider>
               </I18nProvider>
+              </NextImageProvider>
             </NextLinkProvider>
           </NextThemeProvider>
         </WebMcpProvider>

--- a/docs/design-system/astryx-parity-roadmap.md
+++ b/docs/design-system/astryx-parity-roadmap.md
@@ -73,7 +73,7 @@ Legend: `[ ]` todo, `[~]` in progress, `[x]` done, 🔒 checkpoint (needs record
 - [ ] 1.1 Convert to a workspace (`packages/design-system`, `packages/tokens`, `apps/site`).
 - [x] 1.2 Internalize `cn` / `@/lib/utils` into the DS boundary (moved to `nextjs-app/shared/lib/cn`, 55 imports repointed, app re-exports for back-compat); `catalogAppImports` 41 → 5.
 - [x] 1.3 **Link Provider** → `nextjs-app/shared/lib/linkComponent.tsx` (context + `LinkProvider` + DS `Link` component that renders the injected link, default `<a>`); app injects next/link via `providers/NextLinkProvider`. All 9 catalog `next/link` sites swapped (pure import swap; the one server component works because `Link` is a client component, not a hook). `catalogNextImports` 15 → 13 (rest are next/image + next/navigation). Build-verified RSC boundary.
-- [ ] 1.4 Image slot/provider → decouple `next/image`.
+- [x] 1.4 Image provider → `nextjs-app/shared/lib/imageComponent.tsx` (context + `ImageProvider` + DS `Image` + `ImageSource` type; default `<img>` maps fill/priority/sizes, drops next-only props); app injects next/image via `providers/NextImageProvider`. All 12 catalog `next/image` sites swapped (10 render + 2 type-only). `catalogNextImports` 13 → 6 (remainder is next/navigation, 1.6 checkpoint). In-app is a pass-through; a11y tree unchanged (img role + alt).
 - [ ] 🔒 1.5 i18n decoupling: injected translator / prop-driven copy with English defaults (46 files); ratchet `catalogI18nImports` down. **Checkpoint: multi-locale + browser review before merge.**
 - [ ] 🔒 1.6 Remove remaining `@/` and `next/navigation` from the catalog (ratchets to 0). **Checkpoint: navigation behavior review before merge.**
 - [ ] 1.7 `@dt/tokens` + `@dt/tokens-css` packages from the existing token pipeline.

--- a/nextjs-app/shared/components/Author/Author.tsx
+++ b/nextjs-app/shared/components/Author/Author.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { StaticImageData } from "next/image";
+import type { ImageSource as StaticImageData } from "../../lib/imageComponent";
 import Avatar, { type AvatarSize } from "@dt/Avatar";
 import styles from "./Author.module.css";
 

--- a/nextjs-app/shared/components/Avatar/Avatar.tsx
+++ b/nextjs-app/shared/components/Avatar/Avatar.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import type { StaticImageData } from "next/image";
+import type { ImageSource as StaticImageData } from "../../lib/imageComponent";
 import styles from "./avatar.module.css";
 import { Menu, MenuContent, MenuItem, MenuTrigger } from "@dt/Menu";
 

--- a/nextjs-app/shared/components/BlogMediaImage/BlogMediaImage.tsx
+++ b/nextjs-app/shared/components/BlogMediaImage/BlogMediaImage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from "next/image";
+import { Image } from "../../lib/imageComponent";
 import { cn } from "../../lib/cn";
 import { isSvgSrc } from "@/lib/media/imageSrc";
 

--- a/nextjs-app/shared/components/ChatWidget/ChatMessageBubble.tsx
+++ b/nextjs-app/shared/components/ChatWidget/ChatMessageBubble.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "../../lib/linkComponent";
-import Image from "next/image";
+import { Image } from "../../lib/imageComponent";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import styles from "./ChatWidget.module.css";

--- a/nextjs-app/shared/components/EnhancedArticleCard/EnhancedArticleCard.tsx
+++ b/nextjs-app/shared/components/EnhancedArticleCard/EnhancedArticleCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { Link } from "../../lib/linkComponent";
-import Image from "next/image";
+import { Image } from "../../lib/imageComponent";
 import { useTranslation } from "react-i18next";
 import { cn } from "../../lib/cn";
 import { BlogMediaImage } from "@dt/BlogMediaImage";

--- a/nextjs-app/shared/components/EnhancedAuthorCard/EnhancedAuthorCard.tsx
+++ b/nextjs-app/shared/components/EnhancedAuthorCard/EnhancedAuthorCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from "next/image";
+import { Image } from "../../lib/imageComponent";
 import { Link as NextLink } from "../../lib/linkComponent";
 import { useTranslation } from "react-i18next";
 import { ArrowRight } from "@phosphor-icons/react";

--- a/nextjs-app/shared/components/EnhancedProjectCard/EnhancedProjectCard.tsx
+++ b/nextjs-app/shared/components/EnhancedProjectCard/EnhancedProjectCard.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useState, useEffect } from "react";
 import { Link } from "../../lib/linkComponent";
-import Image from "next/image";
+import { Image } from "../../lib/imageComponent";
 import { cn } from "../../../../lib/utils";
 import styles from "./EnhancedProjectCard.module.css";
 

--- a/nextjs-app/shared/components/FinnishTransportAgency/ColorPalette.tsx
+++ b/nextjs-app/shared/components/FinnishTransportAgency/ColorPalette.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import Image from "next/image";
+import { Image } from "../../lib/imageComponent";
 import Text from "@dt/Text";
 import styles from "./ColorPalette.module.css";
 

--- a/nextjs-app/shared/components/LogoReveal/LogoReveal.tsx
+++ b/nextjs-app/shared/components/LogoReveal/LogoReveal.tsx
@@ -3,7 +3,7 @@
 import { useRef, useEffect } from "react";
 import { gsap } from "gsap";
 import { useGSAP } from "@gsap/react";
-import Image from "next/image";
+import { Image } from "../../lib/imageComponent";
 import { cn } from "../../../../lib/utils";
 import styles from "./LogoReveal.module.css";
 

--- a/nextjs-app/shared/components/ProjectCard/ProjectCard.tsx
+++ b/nextjs-app/shared/components/ProjectCard/ProjectCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Link } from "../../lib/linkComponent";
-import Image from "next/image";
+import { Image } from "../../lib/imageComponent";
 import { cn } from "../../lib/cn";
 
 export interface ProjectCardProps {

--- a/nextjs-app/shared/components/ProjectGallery/ProjectGallery.tsx
+++ b/nextjs-app/shared/components/ProjectGallery/ProjectGallery.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef } from "react";
-import Image from "next/image";
+import { Image } from "../../lib/imageComponent";
 import { cn } from "../../lib/cn";
 import { useGSAP } from "@gsap/react";
 import gsap from "gsap";

--- a/nextjs-app/shared/components/icons/Logo.tsx
+++ b/nextjs-app/shared/components/icons/Logo.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useTheme } from "@/nextjs-app/shared/components/ThemeProvider";
-import Image from "next/image";
+import { Image } from "../../lib/imageComponent";
 import styles from "./Logo.module.css";
 
 interface LogoProps {

--- a/nextjs-app/shared/lib/imageComponent.test.tsx
+++ b/nextjs-app/shared/lib/imageComponent.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  Image,
+  ImageProvider,
+  type ImageComponentProps,
+} from "./imageComponent";
+
+describe("imageComponent", () => {
+  it("renders a plain <img> by default, resolving a string src", () => {
+    render(<Image src="/a.png" alt="A" width={10} height={10} />);
+    const img = screen.getByAltText("A");
+    expect(img.tagName).toBe("IMG");
+    expect(img).toHaveAttribute("src", "/a.png");
+  });
+
+  it("does not leak fill/priority as invalid <img> attributes", () => {
+    render(<Image src="/b.png" alt="B" fill priority />);
+    const img = screen.getByAltText("B");
+    expect(img.getAttribute("fill")).toBeNull();
+    expect(img.getAttribute("priority")).toBeNull();
+    expect(img).toHaveAttribute("loading", "eager");
+    expect((img as HTMLElement).style.position).toBe("absolute");
+  });
+
+  it("renders through the injected component when a provider is present", () => {
+    const Injected = ({ src, alt }: ImageComponentProps) => (
+      <img data-injected="true" src={typeof src === "string" ? src : src.src} alt={alt} />
+    );
+    render(
+      <ImageProvider component={Injected}>
+        <Image src="/c.png" alt="C" />
+      </ImageProvider>,
+    );
+    expect(screen.getByAltText("C")).toHaveAttribute("data-injected", "true");
+  });
+});

--- a/nextjs-app/shared/lib/imageComponent.tsx
+++ b/nextjs-app/shared/lib/imageComponent.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  type CSSProperties,
+  type ComponentType,
+} from "react";
+
+/** A static image import (next/image's StaticImageData shape) or a URL string. */
+export type ImageSource =
+  | string
+  | {
+      src: string;
+      height: number;
+      width: number;
+      blurDataURL?: string;
+      blurWidth?: number;
+      blurHeight?: number;
+    };
+
+export interface ImageComponentProps {
+  src: ImageSource;
+  alt: string;
+  width?: number;
+  height?: number;
+  /** Absolutely fill the positioned parent (next/image `fill`). */
+  fill?: boolean;
+  sizes?: string;
+  /** Eager-load an above-the-fold image (next/image `priority`). */
+  priority?: boolean;
+  loading?: "eager" | "lazy";
+  /** next/image optimization opt-out; ignored by the plain <img> default. */
+  unoptimized?: boolean;
+  quality?: number;
+  placeholder?: "blur" | "empty";
+  blurDataURL?: string;
+  draggable?: boolean;
+  className?: string;
+  style?: CSSProperties;
+  onClick?: React.MouseEventHandler<HTMLElement>;
+  onLoad?: React.ReactEventHandler<HTMLElement>;
+  onError?: React.ReactEventHandler<HTMLElement>;
+}
+
+/**
+ * Framework-agnostic default: a plain <img> that maps the next/image-shaped
+ * props (fill, priority, sizes) to native equivalents. Loses build-time
+ * optimization; the host app injects next/image via ImageProvider to restore
+ * it. Modelled on the SVG fallback already used in BlogMediaImage.
+ */
+const DefaultImage: ComponentType<ImageComponentProps> = ({
+  src,
+  alt,
+  width,
+  height,
+  fill,
+  sizes,
+  priority,
+  loading,
+  // next/image-only props: drop from the plain <img> default.
+  unoptimized: _unoptimized,
+  quality: _quality,
+  placeholder: _placeholder,
+  blurDataURL: _blurDataURL,
+  className,
+  style,
+  ...rest
+}) => {
+  const resolvedSrc = typeof src === "string" ? src : src.src;
+  const fillStyle: CSSProperties | undefined = fill
+    ? { position: "absolute", inset: 0, width: "100%", height: "100%", objectFit: "cover" }
+    : undefined;
+  return (
+    // eslint-disable-next-line @next/next/no-img-element -- framework-agnostic default; app injects next/image
+    <img
+      src={resolvedSrc}
+      alt={alt}
+      {...(fill ? {} : { width, height })}
+      sizes={sizes}
+      loading={loading ?? (priority ? "eager" : "lazy")}
+      decoding="async"
+      className={className}
+      style={fillStyle ? { ...fillStyle, ...style } : style}
+      {...rest}
+    />
+  );
+};
+
+const ImageComponentContext =
+  createContext<ComponentType<ImageComponentProps>>(DefaultImage);
+
+/** Inject the image implementation catalog components render through. */
+export function ImageProvider({
+  component,
+  children,
+}: {
+  component: ComponentType<ImageComponentProps>;
+  children: React.ReactNode;
+}) {
+  return (
+    <ImageComponentContext.Provider value={component}>
+      {children}
+    </ImageComponentContext.Provider>
+  );
+}
+
+/**
+ * Design-system image. Import this instead of `next/image`; it renders the
+ * injected image component (a plain `<img>` when no provider is present). Being
+ * a component (not a hook) it composes inside server components too.
+ */
+export const Image: ComponentType<ImageComponentProps> = (props) => {
+  const Component = useContext(ImageComponentContext);
+  return <Component {...props} />;
+};

--- a/providers/NextImageProvider.tsx
+++ b/providers/NextImageProvider.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import NextImage from "next/image";
+import type { ReactNode } from "react";
+import {
+  ImageProvider,
+  type ImageComponentProps,
+} from "@/nextjs-app/shared/lib/imageComponent";
+
+/** Adapts next/image to the design-system ImageComponent contract. */
+function NextImageAdapter({ src, alt, ...rest }: ImageComponentProps) {
+  return <NextImage src={src} alt={alt} {...rest} />;
+}
+
+/**
+ * Injects next/image as the design system's image implementation for the app,
+ * so catalog components keep build-time image optimization while importing only
+ * the framework-agnostic DS `Image`.
+ */
+export function NextImageProvider({ children }: { children: ReactNode }) {
+  return <ImageProvider component={NextImageAdapter}>{children}</ImageProvider>;
+}

--- a/scripts/design-system/astryx-roadmap.state.json
+++ b/scripts/design-system/astryx-roadmap.state.json
@@ -17,12 +17,12 @@
         },
         {
             "key": "scalability",
-            "current": 58,
+            "current": 60,
             "target": 90
         },
         {
             "key": "futureproofness",
-            "current": 65,
+            "current": 67,
             "target": 90
         },
         {
@@ -63,7 +63,7 @@
             "desc": "catalog source files importing @/ (app root); must only decrease"
         },
         "catalogNextImports": {
-            "ceiling": 13,
+            "ceiling": 6,
             "desc": "catalog source files importing next/*; must only decrease"
         },
         "catalogI18nImports": {


### PR DESCRIPTION
feat(design-system): Image provider, decouple next/image from the catalog (roadmap 1.4)

Adds nextjs-app/shared/lib/imageComponent.tsx: an ImageProvider context and a DS
`Image` component that renders the injected image implementation, defaulting to a
plain <img> (mapping fill -> absolute-fill CSS, priority -> eager loading, sizes,
and dropping next-only props like unoptimized/quality/placeholder) when no
provider is present. The app injects next/image via providers/NextImageProvider
(client component, wired at the root layout), so in-app rendering is a pass-
through and image optimization is preserved.

All 12 catalog next/image sites swapped (10 render + 2 type-only StaticImageData
-> ImageSource). Because Image is a component (not a hook) the server component
(ChatMessageBubble) works too. a11y tree unchanged (img role + alt). Build
verifies the RSC boundary; typecheck confirms prop compatibility (surfaced +
covered next/image props: fill/priority/sizes/unoptimized/quality/placeholder/
blurDataURL).

catalogNextImports 13 -> 6 (remainder is next/navigation, the 1.6 checkpoint).
scalability 58 -> 60, futureproofness 65 -> 67.

Local gate green: typecheck, lint, lint:css, test 2095/2095, build.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
