### PR TITLE
docs(design-system): Governance page + expose contract schema (roadmap 4.3)

### DIFF
--- a/docs/design-system/astryx-parity-roadmap.md
+++ b/docs/design-system/astryx-parity-roadmap.md
@@ -102,7 +102,7 @@ Legend: `[ ]` todo, `[~]` in progress, `[x]` done, 🔒 checkpoint (needs record
 ### Phase 4: Governance + agent-readiness + theming → those three to 90
 - [ ] 4.1 Multi-brand theme generation from DTCG + a demo theme.
 - [ ] 4.2 Verify + document MCP server / CLI / agent-manifest as an operational "agent-ready" story.
-- [ ] 4.3 Publish the contract schema; keep the roadmap self-check in the gate.
+- [x] 4.3 Contract schema exposed + documented: `06-Governance.mdx` (`Overview/06-Governance`) documents the versioned schema (public `$id`), the drift-as-build-failure gate stack, and the agent inputs. Schema was already published via its public `$id`; now discoverable. **governance → 90** (first dimension at target).
 
 ### Phase 5: Distribution → Distribution to 90
 - [ ] 🔒 5.1 Publish `@dt/tokens` → `@dt/tokens-css` → `@dt/react` (dep order) to a registry. **Checkpoint: outward-facing, needs explicit go-ahead.**

--- a/nextjs-app/shared/foundations/06-Governance.mdx
+++ b/nextjs-app/shared/foundations/06-Governance.mdx
@@ -1,0 +1,45 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Overview/06-Governance" />
+
+# Governance
+
+Every catalog component is defined by a machine-readable **contract**, and drift
+between a contract, its code, and its docs is a **build failure**, not a warning.
+This is what lets agents generate components *to spec* rather than by eyeballing.
+
+## The contract schema
+
+Each component ships `<Name>.contract.json`, validated against the versioned
+schema:
+
+- **Schema:** `scripts/design-system/contract.schema.v2.json`
+- **`$id`:** `https://raw.githubusercontent.com/PetriLahdelma/digitaltableteur/main/scripts/design-system/contract.schema.v2.json`
+- **Draft:** JSON Schema 2020-12. `additionalProperties: false` (unknown keys are
+  errors). Each contract also carries `schemaVersion` for forward migration.
+
+A contract declares tier, group, status, variants, slots, `asChild`, required
+stories, a11y metadata, declared tokens, usage docs, and (for stable) consumers.
+
+## Drift-as-build-failure gates
+
+| Gate | Enforces |
+|---|---|
+| `validate:components` | contract ↔ code ↔ story parity; a11y + doc-field completeness; status-lifecycle rules |
+| `check:contract-props` | contract props/semantic fields match the generated agent blocks |
+| `check:contract-drift` | contracts stay in sync with their `spec.md` derivation |
+| `check:consumers` | stable components' `consumers[]` match the real import graph |
+| `audit:controls` | every Storybook control is human-operable and effective (`--effects`) |
+| rhythmguard (`audit:rhythm`) | spacing/motion use `--space-*` tokens, never raw literals |
+| `audit:snapshot-debt` | stable components have 4-mode accessibility-tree snapshots |
+| `check:astryx-roadmap` | the parity roadmap's invariants (coupling ratchets, anti-goals, operational utilities) never regress |
+
+Most run in `pre-push` and CI, so a contract that diverges from its
+implementation cannot merge.
+
+## For agents
+
+The contract schema plus the generated `agent-manifest.json` /
+`docs-registry.json` (in `nextjs-app/shared/foundations/dist/`) are the
+authoritative inputs for generating or modifying components. Generate against the
+schema; the gates above verify the result.

--- a/scripts/design-system/astryx-roadmap.state.json
+++ b/scripts/design-system/astryx-roadmap.state.json
@@ -32,7 +32,7 @@
         },
         {
             "key": "governance",
-            "current": 88,
+            "current": 90,
             "target": 90
         },
         {


### PR DESCRIPTION
docs(design-system): Governance Foundations page, expose contract schema (roadmap 4.3)

Adds nextjs-app/shared/foundations/06-Governance.mdx (Overview/06-Governance)
documenting the versioned contract schema (public $id at raw.githubusercontent),
the drift-as-build-failure gate stack (validate:components, check:contract-props,
check:contract-drift, check:consumers, audit:controls, rhythmguard,
audit:snapshot-debt, check:astryx-roadmap), and the agent inputs.

The schema was already published via its public $id; this makes the governance
model discoverable. governance 88 -> 90 (first dimension at target: gates +
roadmap self-check + published+documented schema).

Local gate green: validate:mdx (all valid), typecheck, lint, lint:css,
test 2095/2095, build.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
