### PR TITLE
docs(design-system): Agent-Readiness Foundations page (roadmap 4.2)

### DIFF
--- a/docs/design-system/astryx-parity-roadmap.md
+++ b/docs/design-system/astryx-parity-roadmap.md
@@ -101,7 +101,7 @@ Legend: `[ ]` todo, `[~]` in progress, `[x]` done, 🔒 checkpoint (needs record
 
 ### Phase 4: Governance + agent-readiness + theming → those three to 90
 - [ ] 4.1 Multi-brand theme generation from DTCG + a demo theme.
-- [ ] 4.2 Verify + document MCP server / CLI / agent-manifest as an operational "agent-ready" story.
+- [x] 4.2 Agent-readiness verified + documented: `07-Agent-Readiness.mdx`. `find-component` CLI (intent-ranked) and `ds:mcp` stdio MCP server (`digitaltableteur-design-system`, tools+resources+docs-registry) both smoke-tested working; dist artifacts (agent-manifest 158 comps, docs-registry, agent-blocks, zod catalog) + `agent:eval` harness documented. **agentReadiness → 90** (2nd dimension at target).
 - [x] 4.3 Contract schema exposed + documented: `06-Governance.mdx` (`Overview/06-Governance`) documents the versioned schema (public `$id`), the drift-as-build-failure gate stack, and the agent inputs. Schema was already published via its public `$id`; now discoverable. **governance → 90** (first dimension at target).
 
 ### Phase 5: Distribution → Distribution to 90

--- a/nextjs-app/shared/foundations/07-Agent-Readiness.mdx
+++ b/nextjs-app/shared/foundations/07-Agent-Readiness.mdx
@@ -1,0 +1,60 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Overview/07-Agent-Readiness" />
+
+# Agent readiness
+
+The design system is built to be consumed by coding agents, not just humans:
+every component is discoverable and machine-described from both a CLI and an MCP
+server, and generation is verified against the [governance](?path=/docs/overview-06-governance--docs)
+gates.
+
+## Generated artifacts
+
+`npm run build:tokens` regenerates the agent inputs into
+`nextjs-app/shared/foundations/dist/`:
+
+| Artifact | What it is |
+|---|---|
+| `agent-manifest.json` | Every catalog component (158) with tokens, coverage, and the relationship graph |
+| `component-agent-blocks.json` | Per-component agent block (props, variants, usage, examples) |
+| `docs-registry.json` | Rendered doc blocks + example sources per component |
+| `component-catalog.zod.ts` | Zod schema of the catalog for typed consumption |
+| `tokens-manifest.json` | Design tokens as data |
+
+## CLI discovery
+
+```bash
+npm run find-component -- "button"
+```
+
+Returns intent-ranked matches with status, tier, `@dt/*` import, description, and
+real production-usage counts, so an agent can pick the right existing component
+before writing anything.
+
+## MCP server
+
+```bash
+npm run ds:mcp
+```
+
+Starts the `digitaltableteur-design-system` stdio MCP server (for Cursor / Claude
+Desktop), exposing design-system tools, resources, and docs-registry tools backed
+by the artifacts above. Run `build:tokens` first if the manifest is missing.
+
+## Eval harness
+
+The retrieval and composition quality is measured, not assumed:
+
+```bash
+npm run agent:eval            # full agent eval
+npm run agent:eval:intents    # intent -> component retrieval
+npm run agent:eval:patterns   # pattern composition
+```
+
+## The loop
+
+An agent discovers via CLI or MCP, reads the contract + docs, generates against
+the [contract schema](?path=/docs/overview-06-governance--docs), and the
+drift-as-build-failure gates verify the result. Discovery, specification, and
+verification are all machine-readable.

--- a/scripts/design-system/astryx-roadmap.state.json
+++ b/scripts/design-system/astryx-roadmap.state.json
@@ -37,7 +37,7 @@
         },
         {
             "key": "agentReadiness",
-            "current": 81,
+            "current": 90,
             "target": 90
         },
         {


### PR DESCRIPTION
docs(design-system): Agent-Readiness Foundations page (roadmap 4.2)

Adds nextjs-app/shared/foundations/07-Agent-Readiness.mdx documenting the
operational agent surface: the find-component CLI (intent-ranked discovery,
smoke-tested), the ds:mcp stdio MCP server (digitaltableteur-design-system:
tools + resources + docs-registry tools, for Cursor/Claude Desktop), the dist
artifacts (agent-manifest 158 components, docs-registry, agent-blocks, zod
catalog, tokens-manifest), and the agent:eval retrieval/composition harness,
plus the discover -> spec -> verify loop tied to the governance gates.

All surfaces verified present and working. agentReadiness 81 -> 90 (2nd
dimension at target).

Local gate green: validate:mdx, typecheck, lint, lint:css, test 2095/2095, build.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
