### PR TITLE
feat(design-system): multi-brand theme generation (roadmap 4.1)

### DIFF
--- a/docs/design-system/astryx-parity-roadmap.md
+++ b/docs/design-system/astryx-parity-roadmap.md
@@ -100,7 +100,7 @@ Legend: `[ ]` todo, `[~]` in progress, `[x]` done, 🔒 checkpoint (needs record
 - [ ] 3.3 Close any intended-surface gaps found in 0.5; promote the whole checklist to `stable`.
 
 ### Phase 4: Governance + agent-readiness + theming → those three to 90
-- [ ] 4.1 Multi-brand theme generation from DTCG + a demo theme.
+- [x] 4.1 Multi-brand theme generation: `scripts/design-system/generate-theme.mjs` (+ test, `npm run generate:theme`) emits a scoped brand override block validated against the token catalog (unknown token = hard error) into stylelint-ignored `dist/themes/`; demo `acme` brand + `03-Theming` doc section. On top of existing light/dark/HC/forced-colors. **theming → 90** (3rd dimension at target).
 - [x] 4.2 Agent-readiness verified + documented: `07-Agent-Readiness.mdx`. `find-component` CLI (intent-ranked) and `ds:mcp` stdio MCP server (`digitaltableteur-design-system`, tools+resources+docs-registry) both smoke-tested working; dist artifacts (agent-manifest 158 comps, docs-registry, agent-blocks, zod catalog) + `agent:eval` harness documented. **agentReadiness → 90** (2nd dimension at target).
 - [x] 4.3 Contract schema exposed + documented: `06-Governance.mdx` (`Overview/06-Governance`) documents the versioned schema (public `$id`), the drift-as-build-failure gate stack, and the agent inputs. Schema was already published via its public `$id`; now discoverable. **governance → 90** (first dimension at target).
 

--- a/nextjs-app/shared/foundations/03-Theming.mdx
+++ b/nextjs-app/shared/foundations/03-Theming.mdx
@@ -25,3 +25,23 @@ High-contrast themes widen focus rings (`--focus-ring-width: 3px`) and adjust se
 
 See **Foundations/Themes** for a side-by-side semantic matrix.
 
+## Multi-brand theming
+
+A brand is an override layer over the same catalog, exactly like `.themeDark`. To
+generate one, write a brand file that re-points semantic tokens:
+
+```json
+{ "name": "acme", "selector": "[data-brand=\"acme\"]",
+  "tokens": { "--color-primary": "#5b21b6", "--color-info": "#0ea5e9" } }
+```
+
+```bash
+npm run generate:theme scripts/design-system/themes/acme.brand.json
+```
+
+This validates every token against the production catalog (an unknown token is a
+hard error, never a silent no-op) and emits a scoped block to
+`foundations/dist/themes/<name>.css`. Load it and set `data-brand="acme"` on a
+subtree; the light / dark / high-contrast overrides still apply on top. A demo
+`acme` brand ships as the worked example.
+

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "build:icons": "tsx scripts/design-system/build-icon-registry.ts",
     "build:tokens": "npm run build:icons && node scripts/design-system/extract-variables-catalog.mjs && node scripts/design-system/export-dtcg-from-css.mjs && node scripts/design-system/build-tokens.mjs && node scripts/design-system/sync-tailwind-theme.mjs && node scripts/design-system/generate-relationship-graph.mjs && npm run build:agent-blocks && node scripts/design-system/generate-agent-manifest.mjs && node scripts/design-system/build-docs-registry.mjs",
     "build:agent-blocks": "tsx scripts/design-system/build-component-agent-blocks.ts",
+    "generate:theme": "node scripts/design-system/generate-theme.mjs",
     "build:relationship-graph": "node scripts/design-system/generate-relationship-graph.mjs",
     "build:figma-variables": "node scripts/design-system/build-figma-variables-payload.mjs && node scripts/design-system/generate-figma-phase-scripts.mjs",
     "figma:apply-variables": "node scripts/design-system/apply-figma-variables-local.mjs",

--- a/scripts/design-system/astryx-roadmap.state.json
+++ b/scripts/design-system/astryx-roadmap.state.json
@@ -42,7 +42,7 @@
         },
         {
             "key": "theming",
-            "current": 68,
+            "current": 90,
             "target": 90
         },
         {

--- a/scripts/design-system/generate-theme.mjs
+++ b/scripts/design-system/generate-theme.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Multi-brand theme generation.
+ *
+ * Emits a scoped block of semantic-token overrides for an alternate brand from a
+ * brand override file, validated against the production token catalog so a brand
+ * can only re-point tokens that actually exist. Output goes to the stylelint-
+ * ignored dist dir. variables.css remains the source of truth; a brand theme is
+ * an override layer, exactly like `.themeDark`.
+ *
+ * Usage: node scripts/design-system/generate-theme.mjs <brand.json>
+ *
+ * Brand file shape:
+ *   { "name": "acme", "selector": "[data-brand=\"acme\"]",
+ *     "tokens": { "--color-primary": "#123456", ... } }
+ */
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const CATALOG = resolve(ROOT, "nextjs-app/shared/foundations/token-catalog.json");
+const OUT_DIR = resolve(ROOT, "nextjs-app/shared/foundations/dist/themes");
+
+/** All defined token names (`--foo`) from the production catalog. */
+export function loadTokenNames(catalogPath = CATALOG) {
+  const catalog = JSON.parse(readFileSync(catalogPath, "utf8"));
+  const names = new Set();
+  for (const group of catalog.groups ?? []) {
+    for (const token of group.tokens ?? []) {
+      if (token.name) names.add(token.name);
+    }
+  }
+  return names;
+}
+
+/**
+ * Build the scoped CSS for a brand override. Throws if any token is unknown
+ * (a typo would silently do nothing at runtime otherwise).
+ * @returns {string} CSS text.
+ */
+export function generateThemeCss(brand, validNames) {
+  if (!brand || typeof brand !== "object") throw new Error("brand must be an object");
+  const name = brand.name;
+  if (!name) throw new Error("brand.name is required");
+  const selector = brand.selector ?? `[data-brand="${name}"]`;
+  const entries = Object.entries(brand.tokens ?? {});
+  if (!entries.length) throw new Error(`brand "${name}" has no token overrides`);
+
+  const unknown = entries.map(([k]) => k).filter((k) => !validNames.has(k));
+  if (unknown.length) {
+    throw new Error(`brand "${name}" overrides unknown tokens: ${unknown.join(", ")}`);
+  }
+
+  const decls = entries
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `  ${k}: ${v};`)
+    .join("\n");
+  return `/* Generated brand theme: ${name}. Do not edit; run \`npm run generate:theme <file>\`. */\n${selector} {\n${decls}\n}\n`;
+}
+
+// CLI
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const file = process.argv[2];
+  if (!file) {
+    console.error("Usage: generate-theme.mjs <brand.json>");
+    process.exit(1);
+  }
+  const brand = JSON.parse(readFileSync(resolve(process.cwd(), file), "utf8"));
+  const css = generateThemeCss(brand, loadTokenNames());
+  if (!existsSync(OUT_DIR)) mkdirSync(OUT_DIR, { recursive: true });
+  const out = resolve(OUT_DIR, `${brand.name}.css`);
+  writeFileSync(out, css);
+  console.log(`✓ theme "${brand.name}" → ${out.replace(ROOT + "/", "")}`);
+}

--- a/scripts/design-system/generate-theme.test.mjs
+++ b/scripts/design-system/generate-theme.test.mjs
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { generateThemeCss } from "./generate-theme.mjs";
+
+const valid = new Set(["--color-primary", "--color-info", "--color-focus-ring"]);
+
+describe("generateThemeCss", () => {
+  it("emits a scoped block with sorted, overridden tokens", () => {
+    const css = generateThemeCss(
+      {
+        name: "acme",
+        selector: '[data-brand="acme"]',
+        tokens: { "--color-primary": "#5b21b6", "--color-info": "#0ea5e9" },
+      },
+      valid,
+    );
+    expect(css).toContain('[data-brand="acme"] {');
+    expect(css).toContain("--color-info: #0ea5e9;");
+    expect(css).toContain("--color-primary: #5b21b6;");
+    // sorted: info before primary
+    expect(css.indexOf("--color-info")).toBeLessThan(css.indexOf("--color-primary"));
+  });
+
+  it("defaults the selector to a data-brand attribute", () => {
+    const css = generateThemeCss(
+      { name: "beta", tokens: { "--color-primary": "#000" } },
+      valid,
+    );
+    expect(css).toContain('[data-brand="beta"] {');
+  });
+
+  it("throws on an unknown token (a typo would be a silent no-op otherwise)", () => {
+    expect(() =>
+      generateThemeCss({ name: "x", tokens: { "--color-nope": "#000" } }, valid),
+    ).toThrow(/unknown tokens/);
+  });
+
+  it("throws when name or overrides are missing", () => {
+    expect(() => generateThemeCss({ tokens: { "--color-primary": "#000" } }, valid)).toThrow(
+      /name is required/,
+    );
+    expect(() => generateThemeCss({ name: "empty", tokens: {} }, valid)).toThrow(
+      /no token overrides/,
+    );
+  });
+});

--- a/scripts/design-system/themes/acme.brand.json
+++ b/scripts/design-system/themes/acme.brand.json
@@ -1,0 +1,10 @@
+{
+  "name": "acme",
+  "selector": "[data-brand=\"acme\"]",
+  "description": "Demo alternate brand: re-points a handful of semantic tokens to show multi-brand theming from the same catalog.",
+  "tokens": {
+    "--color-primary": "#5b21b6",
+    "--color-info": "#0ea5e9",
+    "--color-focus-ring": "#5b21b6"
+  }
+}


### PR DESCRIPTION
feat(design-system): multi-brand theme generation from the token catalog (roadmap 4.1)

Adds scripts/design-system/generate-theme.mjs (+ test, npm run generate:theme):
a brand override file re-points semantic tokens, and the generator validates
every token against the production catalog (an unknown token is a hard error,
never a silent no-op) and emits a scoped `[data-brand="x"]` block to the
stylelint-ignored foundations/dist/themes/. A brand is an override layer over the
same catalog, exactly like .themeDark, so light/dark/high-contrast still apply.

Ships a worked demo brand (acme) + a Multi-brand section in 03-Theming.mdx.

theming 68 -> 90 (3rd dimension at target: multi-brand generation + demo +
documented API on top of existing light/dark/HC/forced-colors).

Local gate green: validate:mdx, typecheck, lint, lint:css, test 2099/2099,
build, check:generated.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
