### PR TITLE
feat(design-system): SegmentedControl (alpha) — new component (roadmap 3.2)

### DIFF
--- a/docs/design-system/astryx-parity-roadmap.md
+++ b/docs/design-system/astryx-parity-roadmap.md
@@ -96,7 +96,7 @@ Legend: `[ ]` todo, `[~]` in progress, `[x]` done, 🔒 checkpoint (needs record
 
 ### Phase 3: Targeted breadth → Breadth (rescoped)
 - [ ] 3.1 Command Palette (site/docs search + agent story).
-- [ ] 3.2 Segmented Control.
+- [x] 3.2 SegmentedControl (new, **alpha**): single-select `role=radiogroup` with roving-tabindex arrow/Home/End nav, sm/md/lg, CSS Modules + tokens (light/dark/HC/forced-colors/reduced-motion), full 5-file contract + spec + stories + test (render/click/keyboard/disabled/axe). Closes a hard breadth gap. breadth 66 → 70. stableCount untouched (alpha).
 - [ ] 3.3 Close any intended-surface gaps found in 0.5; promote the whole checklist to `stable`.
 
 ### Phase 4: Governance + agent-readiness + theming → those three to 90

--- a/nextjs-app/shared/components/SegmentedControl/SegmentedControl.contract.json
+++ b/nextjs-app/shared/components/SegmentedControl/SegmentedControl.contract.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "name": "SegmentedControl",
+    "tier": "molecule",
+    "group": "form",
+    "status": "alpha",
+    "description": "Single-select segmented control: a compact row of mutually exclusive options with one visibly selected, as a radiogroup with roving-tabindex arrow-key navigation.",
+    "figma": null,
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "size": {
+            "values": ["sm", "md", "lg"],
+            "default": "md",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": ["Default", "Playground", "Example", "ForcedColors"],
+    "a11y": {
+        "keyboard": [
+            "Tab moves focus to the selected segment (roving tabindex)",
+            "Arrow Left/Up and Right/Down move selection to the previous/next enabled segment",
+            "Home/End select the first/last enabled segment"
+        ],
+        "ariaRequirements": [
+            "Container is role=radiogroup with a required aria-label",
+            "Each segment is role=radio with aria-checked reflecting selection",
+            "Disabled segments are skipped by keyboard navigation"
+        ],
+        "reducedMotion": true,
+        "reviewed": false,
+        "forcedColorsVerified": false
+    },
+    "tokens": {
+        "colors": [
+            "--color-muted",
+            "--color-muted-light",
+            "--color-text",
+            "--color-surface",
+            "--focus-ring-color"
+        ],
+        "spacing": [
+            "--space-internal-2",
+            "--space-internal-12",
+            "--space-internal-16",
+            "--space-internal-24"
+        ],
+        "typography": [
+            "--font-body",
+            "--font-size-text-xs",
+            "--font-size-text-s",
+            "--font-size-text-m"
+        ]
+    },
+    "lightDarkVerified": false
+}

--- a/nextjs-app/shared/components/SegmentedControl/SegmentedControl.module.css
+++ b/nextjs-app/shared/components/SegmentedControl/SegmentedControl.module.css
@@ -1,0 +1,81 @@
+.root {
+  display: inline-flex;
+  padding: var(--space-internal-2);
+  gap: var(--space-internal-2);
+  border-radius: var(--radius-md);
+  background-color: color-mix(in srgb, var(--color-muted) 14%, transparent);
+}
+
+.segment {
+  padding-block: var(--space-internal-2);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background-color: transparent;
+  font-family: var(--font-body);
+  font-weight: 500;
+  white-space: nowrap;
+  color: var(--color-muted);
+  cursor: pointer;
+  transition:
+    color 0.15s var(--ease-out-cubic),
+    background-color 0.15s var(--ease-out-cubic),
+    box-shadow 0.15s var(--ease-out-cubic);
+  appearance: none;
+}
+
+.segment[data-selected] {
+  background-color: var(--color-surface);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--color-text) 16%, transparent);
+  color: var(--color-text);
+}
+
+.segment:disabled {
+  color: var(--color-muted-light);
+  cursor: not-allowed;
+}
+
+.segment:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+}
+
+/* Sizes */
+
+.sm .segment {
+  padding-inline: var(--space-internal-12);
+  min-block-size: 1.75rem;
+  font-size: var(--font-size-text-xs);
+}
+
+.md .segment {
+  padding-inline: var(--space-internal-16);
+  min-block-size: 2.25rem;
+  font-size: var(--font-size-text-s);
+}
+
+.lg .segment {
+  padding-inline: var(--space-internal-24);
+  min-block-size: 2.75rem;
+  font-size: var(--font-size-text-m);
+}
+
+.segment:hover:not([data-selected], :disabled) {
+  color: var(--color-text);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .segment {
+    transition: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .root {
+    border: 1px solid CanvasText;
+  }
+
+  .segment[data-selected] {
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+  }
+}

--- a/nextjs-app/shared/components/SegmentedControl/SegmentedControl.spec.md
+++ b/nextjs-app/shared/components/SegmentedControl/SegmentedControl.spec.md
@@ -1,0 +1,40 @@
+# SegmentedControl
+
+## Intent
+A compact row of mutually exclusive options with one visibly selected, for
+switching a small closed set of views or modes (e.g. list/grid, day/week/month)
+inline without opening a menu. It is the single-select counterpart to
+`ButtonGroup`, which is a non-exclusive row of actions.
+
+## Interaction contract
+- Keyboard: Tab moves focus to the selected segment (roving tabindex — exactly one
+  segment is tabbable); Arrow Left/Up and Right/Down move selection to the
+  previous/next enabled segment, wrapping; Home/End jump to the first/last enabled
+  segment. Disabled segments are skipped.
+- Pointer: clicking a segment selects it.
+- Controlled only: `value` + `onValueChange` own the selection; the component
+  holds no selection state.
+- Screen readers: the container is `role=radiogroup` with a required `ariaLabel`;
+  each segment is `role=radio` with `aria-checked` reflecting selection.
+
+## Do / don't
+- Do: keep to 2–5 short segments; it is a glance-and-switch control, not a menu.
+- Do: give a meaningful `ariaLabel` naming what is being switched.
+- Don't: use it for actions or navigation that commits/routes — use `ButtonGroup`
+  or links. Selecting must only change the bound value.
+- Don't: overflow it; if the options do not fit on one line, use `Select`.
+
+## Design notes
+- Tokens: track fill from `--color-muted`; segment text `--color-muted` →
+  `--color-text` (hover/selected); selected surface `--color-surface` with a
+  subtle shadow; focus via `--focus-ring-*`; spacing/radius from `--space-internal-*`
+  / `--radius-*`. No hardcoded colors.
+- Selection is shown by a raised neutral surface, not a brand fill, so it reads
+  consistently across light/dark; forced-colors maps the selected segment to a
+  `Highlight` outline. Motion respects `prefers-reduced-motion`.
+- Figma: TODO (parity build; no Figma node yet).
+
+## Promotion notes
+Parity build (Astryx `Segmented Control`). Ships at alpha with the WIP badge. Do
+not promote past alpha/beta without a documented production consumer, AT
+snapshots, and forced-colors + light/dark verification.

--- a/nextjs-app/shared/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/nextjs-app/shared/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import React, { useState } from "react";
+import SegmentedControl, {
+  type SegmentedControlItem,
+  type SegmentedControlProps,
+} from "./SegmentedControl";
+import contract from "./SegmentedControl.contract.json";
+
+const items: SegmentedControlItem[] = [
+  { value: "list", label: "List" },
+  { value: "grid", label: "Grid" },
+  { value: "board", label: "Board" },
+];
+
+const meta = {
+  title: "Molecules/SegmentedControl",
+  component: SegmentedControl,
+  tags: ["alpha", "!autodocs"],
+  parameters: {
+    layout: "centered",
+    a11y: { test: "error" },
+    contractStatus: contract.status,
+  },
+  args: { items, value: "list", size: "md", ariaLabel: "View" },
+} satisfies Meta<typeof SegmentedControl>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const Controlled = (args: SegmentedControlProps) => {
+  const [value, setValue] = useState(args.value);
+  return <SegmentedControl {...args} value={value} onValueChange={setValue} />;
+};
+
+export const Default: Story = {
+  render: (args) => <Controlled {...args} />,
+};
+
+export const Playground: Story = {
+  render: (args) => <Controlled {...args} />,
+};
+
+export const Example: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => {
+    const withDisabled: SegmentedControlItem[] = [
+      { value: "day", label: "Day" },
+      { value: "week", label: "Week" },
+      { value: "month", label: "Month", disabled: true },
+    ];
+    return <Controlled items={withDisabled} value="day" ariaLabel="Range" size="md" onValueChange={() => {}} />;
+  },
+};
+
+export const ForcedColors: Story = {
+  globals: { forcedColors: "active" },
+  parameters: { a11y: { disable: true, test: "off" } },
+  render: (args) => <Controlled {...args} />,
+};

--- a/nextjs-app/shared/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/nextjs-app/shared/components/SegmentedControl/SegmentedControl.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import SegmentedControl, { type SegmentedControlItem } from "./SegmentedControl";
+
+expect.extend(toHaveNoViolations);
+
+const items: SegmentedControlItem[] = [
+  { value: "list", label: "List" },
+  { value: "grid", label: "Grid" },
+  { value: "board", label: "Board" },
+];
+
+describe("SegmentedControl", () => {
+  it("renders a radiogroup with the selected radio checked and tabbable", () => {
+    render(<SegmentedControl items={items} value="grid" onValueChange={() => {}} ariaLabel="View" />);
+    expect(screen.getByRole("radiogroup", { name: "View" })).toBeInTheDocument();
+    const grid = screen.getByRole("radio", { name: "Grid" });
+    expect(grid).toHaveAttribute("aria-checked", "true");
+    expect(grid).toHaveAttribute("tabindex", "0");
+    expect(screen.getByRole("radio", { name: "List" })).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("selects on click", () => {
+    const onValueChange = vi.fn();
+    render(<SegmentedControl items={items} value="list" onValueChange={onValueChange} ariaLabel="View" />);
+    fireEvent.click(screen.getByRole("radio", { name: "Board" }));
+    expect(onValueChange).toHaveBeenCalledWith("board");
+  });
+
+  it("moves selection with arrow keys, wrapping", () => {
+    const onValueChange = vi.fn();
+    render(<SegmentedControl items={items} value="list" onValueChange={onValueChange} ariaLabel="View" />);
+    const list = screen.getByRole("radio", { name: "List" });
+    fireEvent.keyDown(list, { key: "ArrowRight" });
+    expect(onValueChange).toHaveBeenCalledWith("grid");
+    fireEvent.keyDown(list, { key: "ArrowLeft" });
+    expect(onValueChange).toHaveBeenCalledWith("board");
+    fireEvent.keyDown(list, { key: "End" });
+    expect(onValueChange).toHaveBeenCalledWith("board");
+  });
+
+  it("skips disabled segments in keyboard navigation", () => {
+    const onValueChange = vi.fn();
+    const withDisabled: SegmentedControlItem[] = [
+      { value: "a", label: "A" },
+      { value: "b", label: "B", disabled: true },
+      { value: "c", label: "C" },
+    ];
+    render(<SegmentedControl items={withDisabled} value="a" onValueChange={onValueChange} ariaLabel="X" />);
+    fireEvent.keyDown(screen.getByRole("radio", { name: "A" }), { key: "ArrowRight" });
+    expect(onValueChange).toHaveBeenCalledWith("c");
+    expect(screen.getByRole("radio", { name: "B" })).toBeDisabled();
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(
+      <SegmentedControl items={items} value="list" onValueChange={() => {}} ariaLabel="View" />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/SegmentedControl/SegmentedControl.tsx
+++ b/nextjs-app/shared/components/SegmentedControl/SegmentedControl.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import React, { useRef } from "react";
+import { cn } from "../../lib/cn";
+import styles from "./SegmentedControl.module.css";
+
+export interface SegmentedControlItem {
+  /** Stable value emitted on selection. */
+  value: string;
+  /** Visible segment label. */
+  label: React.ReactNode;
+  /** Disable this segment (skipped by keyboard navigation). */
+  disabled?: boolean;
+}
+
+export interface SegmentedControlProps {
+  /** Segments to render, in order. */
+  items: SegmentedControlItem[];
+  /** Currently selected value (controlled). */
+  value: string;
+  /** Called with the new value when a segment is selected. */
+  onValueChange: (value: string) => void;
+  /** Size token. @default "md" */
+  size?: "sm" | "md" | "lg";
+  /** Accessible name for the group (required; announced by screen readers). */
+  ariaLabel: string;
+  /** Additional CSS class names. */
+  className?: string;
+}
+
+/**
+ * Single-select segmented control: a compact row of mutually exclusive options,
+ * one visibly selected. Implemented as a `radiogroup` with roving tabindex and
+ * arrow-key navigation. For a non-exclusive row of actions use `ButtonGroup`.
+ */
+export const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedControlProps>(
+  ({ items, value, onValueChange, size = "md", ariaLabel, className }, ref) => {
+    const segmentRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+    const enabled = items.reduce<number[]>((acc, item, i) => {
+      if (!item.disabled) acc.push(i);
+      return acc;
+    }, []);
+
+    // Exactly one segment is tabbable (the selection, else the first enabled).
+    const selectedIndex = items.findIndex((item) => item.value === value && !item.disabled);
+    const tabbableIndex = selectedIndex >= 0 ? selectedIndex : (enabled[0] ?? -1);
+
+    const select = (index: number) => {
+      const item = items[index];
+      if (!item || item.disabled) return;
+      segmentRefs.current[index]?.focus();
+      onValueChange(item.value);
+    };
+
+    const onKeyDown = (event: React.KeyboardEvent, index: number) => {
+      const pos = enabled.indexOf(index);
+      if (pos === -1) return;
+      let next: number | undefined;
+      switch (event.key) {
+        case "ArrowRight":
+        case "ArrowDown":
+          next = enabled[(pos + 1) % enabled.length];
+          break;
+        case "ArrowLeft":
+        case "ArrowUp":
+          next = enabled[(pos - 1 + enabled.length) % enabled.length];
+          break;
+        case "Home":
+          next = enabled[0];
+          break;
+        case "End":
+          next = enabled[enabled.length - 1];
+          break;
+        default:
+          return;
+      }
+      event.preventDefault();
+      if (next !== undefined) select(next);
+    };
+
+    return (
+      <div
+        ref={ref}
+        role="radiogroup"
+        aria-label={ariaLabel}
+        className={cn(styles.root, styles[size], className)}
+      >
+        {items.map((item, i) => {
+          const selected = item.value === value;
+          return (
+            <button
+              key={item.value}
+              ref={(el) => {
+                segmentRefs.current[i] = el;
+              }}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              disabled={item.disabled}
+              tabIndex={i === tabbableIndex ? 0 : -1}
+              data-selected={selected || undefined}
+              className={styles.segment}
+              onClick={() => !item.disabled && onValueChange(item.value)}
+              onKeyDown={(event) => onKeyDown(event, i)}
+            >
+              {item.label}
+            </button>
+          );
+        })}
+      </div>
+    );
+  },
+);
+
+SegmentedControl.displayName = "SegmentedControl";
+
+export default SegmentedControl;

--- a/nextjs-app/shared/components/SegmentedControl/index.ts
+++ b/nextjs-app/shared/components/SegmentedControl/index.ts
@@ -1,0 +1,5 @@
+export { SegmentedControl, default } from "./SegmentedControl";
+export type {
+  SegmentedControlProps,
+  SegmentedControlItem,
+} from "./SegmentedControl";

--- a/nextjs-app/shared/components/index.ts
+++ b/nextjs-app/shared/components/index.ts
@@ -58,6 +58,11 @@ export { default as OpenHours } from "./OpenHours/OpenHours";
 export { default as PersonCard } from "./PersonCard/PersonCard";
 export { default as PhoneInput } from "./PhoneInput/PhoneInput";
 export { default as SecureCVDownload } from "./SecureCVDownload/SecureCVDownload";
+export {
+  SegmentedControl,
+  type SegmentedControlProps,
+  type SegmentedControlItem,
+} from "./SegmentedControl";
 export { default as Select } from "./Select/Select";
 export { default as SelectOption } from "./Select/SelectOption";
 export { default as ServicesGrid } from "./ServicesGrid/ServicesGrid";

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -11533,6 +11533,44 @@
       },
       "examples": []
     },
+    "SegmentedControl": {
+      "name": "SegmentedControl",
+      "group": "form",
+      "tier": 2,
+      "status": "alpha",
+      "description": "Single-select segmented control: a compact row of mutually exclusive options with one visibly selected, as a radiogroup with roving-tabindex arrow-key navigation.",
+      "dense": "",
+      "keywords": [],
+      "importLine": "import { SegmentedControl } from \"@dt/SegmentedControl\";",
+      "keyProps": [],
+      "props": {},
+      "composesWith": [],
+      "prefersOver": [],
+      "forbiddenUse": [],
+      "usage": null,
+      "tokens": {
+        "colors": [
+          "--color-muted",
+          "--color-muted-light",
+          "--color-text",
+          "--color-surface",
+          "--focus-ring-color"
+        ],
+        "spacing": [
+          "--space-internal-2",
+          "--space-internal-12",
+          "--space-internal-16",
+          "--space-internal-24"
+        ],
+        "typography": [
+          "--font-body",
+          "--font-size-text-xs",
+          "--font-size-text-s",
+          "--font-size-text-m"
+        ]
+      },
+      "examples": []
+    },
     "Select": {
       "name": "Select",
       "group": "form",

--- a/scripts/design-system/astryx-roadmap.state.json
+++ b/scripts/design-system/astryx-roadmap.state.json
@@ -12,7 +12,7 @@
         },
         {
             "key": "breadth",
-            "current": 66,
+            "current": 70,
             "target": 90
         },
         {


### PR DESCRIPTION
feat(design-system): SegmentedControl (alpha) — new component (roadmap 3.2)

Single-select segmented control: a compact row of mutually exclusive options,
implemented as role=radiogroup with roving tabindex and Arrow/Home/End keyboard
navigation (disabled segments skipped). Controlled (value + onValueChange), sizes
sm/md/lg, CSS Modules + design tokens only, with light/dark/high-contrast/forced-
colors and reduced-motion handling. The single-select counterpart to ButtonGroup.

Full component set: .tsx / .module.css / .contract.json (alpha) / .spec.md /
.stories.tsx / .test.tsx / index.ts, registered in the @dt barrel. Tests cover
render, aria-checked, roving tabindex, click select, arrow-key wrap, Home/End,
disabled-skip, and axe-clean.

Closes a hard intended-surface gap. Lands ALPHA (no consumers/AT snapshots
required); stableCount floor 58 untouched. breadth 66 -> 70.

Local gate green: typecheck, lint, lint:css, test 2104/2104, build,
validate:components, check:contract-props.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
