### PR TITLE
feat(design-system): CommandPalette (alpha) — new component (roadmap 3.1)

### DIFF
--- a/docs/design-system/astryx-parity-roadmap.md
+++ b/docs/design-system/astryx-parity-roadmap.md
@@ -95,9 +95,9 @@ Legend: `[ ]` todo, `[~]` in progress, `[x]` done, 🔒 checkpoint (needs record
 - Deferred (adopt only when a trigger component needs them): LayerProvider/useLayer, Syntax Theme, useOverflow/useScrollOverflow, useClickableContainer, useListFocus, useKeyboardHint, useStreamingText. Skipped (app-platform only): useGridFocus, useTreeFocus, Media Theme, useImageMode.
 
 ### Phase 3: Targeted breadth → Breadth (rescoped)
-- [ ] 3.1 Command Palette (site/docs search + agent story).
+- [x] 3.1 CommandPalette (new, **alpha**): portal `role=dialog aria-modal` with a `role=combobox` filter input (aria-controls + aria-activedescendant) over a `role=listbox`; Arrow/Enter/Escape keyboard, focus trap + scroll lock (reuses `useFocusTrap`/`useScrollLock`), label/placeholder/emptyText as props (English defaults, no i18n coupling). Full 5-file set + 8-test suite (render/filter/keyword/keyboard/enter/escape/click/axe). Closes the last hard breadth gap. breadth 70 → 74. stableCount untouched (alpha).
 - [x] 3.2 SegmentedControl (new, **alpha**): single-select `role=radiogroup` with roving-tabindex arrow/Home/End nav, sm/md/lg, CSS Modules + tokens (light/dark/HC/forced-colors/reduced-motion), full 5-file contract + spec + stories + test (render/click/keyboard/disabled/axe). Closes a hard breadth gap. breadth 66 → 70. stableCount untouched (alpha).
-- [ ] 3.3 Close any intended-surface gaps found in 0.5; promote the whole checklist to `stable`.
+- [~] 3.3 Intended-surface gaps closed (SegmentedControl, CommandPalette built). Remaining lift to Breadth-90 = promoting the consumer-backed betas (Breadcrumb, Tabs, Progress, AlertBanner, EmptyState, CodeSnippet) to `stable` via the promotion recipe; 0-consumer betas are covered-but-unpromotable by policy. Needs real consumers/AT snapshots → deferred with the supervised block.
 
 ### Phase 4: Governance + agent-readiness + theming → those three to 90
 - [x] 4.1 Multi-brand theme generation: `scripts/design-system/generate-theme.mjs` (+ test, `npm run generate:theme`) emits a scoped brand override block validated against the token catalog (unknown token = hard error) into stylelint-ignored `dist/themes/`; demo `acme` brand + `03-Theming` doc section. On top of existing light/dark/HC/forced-colors. **theming → 90** (3rd dimension at target).

--- a/nextjs-app/shared/components/CommandPalette/CommandPalette.contract.json
+++ b/nextjs-app/shared/components/CommandPalette/CommandPalette.contract.json
@@ -1,0 +1,53 @@
+{
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "name": "CommandPalette",
+    "tier": "organism",
+    "group": "navigation",
+    "status": "alpha",
+    "description": "Modal, keyboard-driven command launcher: a search input filters a listbox of commands (matched on label + keywords); Arrow keys move the active option, Enter runs it, Escape closes. Focus is trapped and background scroll locked while open.",
+    "figma": null,
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {},
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": ["Default", "Playground", "Example", "ForcedColors"],
+    "a11y": {
+        "keyboard": [
+            "Arrow Down / Up move the active option (wrapping)",
+            "Enter runs the active command and closes",
+            "Escape closes the palette",
+            "Focus is trapped within the dialog while open"
+        ],
+        "ariaRequirements": [
+            "Overlay dialog is role=dialog aria-modal with an accessible label",
+            "Input is role=combobox with aria-controls + aria-activedescendant onto the listbox",
+            "Each command is role=option with aria-selected reflecting the active item"
+        ],
+        "reducedMotion": true,
+        "reviewed": false,
+        "forcedColorsVerified": false
+    },
+    "tokens": {
+        "colors": [
+            "--color-black",
+            "--color-border",
+            "--color-surface",
+            "--color-text",
+            "--color-muted"
+        ],
+        "spacing": [
+            "--space-internal-2",
+            "--space-internal-12",
+            "--space-internal-16",
+            "--space-internal-24"
+        ],
+        "typography": [
+            "--font-body",
+            "--font-size-text-s",
+            "--font-size-text-m"
+        ]
+    },
+    "lightDarkVerified": false
+}

--- a/nextjs-app/shared/components/CommandPalette/CommandPalette.module.css
+++ b/nextjs-app/shared/components/CommandPalette/CommandPalette.module.css
@@ -1,0 +1,92 @@
+.overlay {
+  display: flex;
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  padding-block-start: 12vh;
+  padding-inline: var(--space-internal-16);
+  justify-content: center;
+  align-items: flex-start;
+  background-color: color-mix(in srgb, var(--color-black) 45%, transparent);
+}
+
+.dialog {
+  display: flex;
+  inline-size: min(92vw, 34rem);
+  max-block-size: 70vh;
+  flex-direction: column;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background-color: var(--color-surface);
+  box-shadow: 0 12px 32px color-mix(in srgb, var(--color-black) 24%, transparent);
+  overflow: hidden;
+}
+
+.input {
+  padding: var(--space-internal-16);
+  border: 0;
+  border-block-end: 1px solid var(--color-border);
+  background-color: transparent;
+  font-family: var(--font-body);
+  font-size: var(--font-size-text-m);
+  color: var(--color-text);
+}
+
+.input::placeholder {
+  color: var(--color-muted);
+}
+
+.input:focus-visible {
+  outline: none;
+}
+
+.list {
+  margin: 0;
+  padding: var(--space-internal-2);
+  list-style: none;
+  overflow-y: auto;
+}
+
+.option {
+  display: flex;
+  padding: var(--space-internal-12);
+  align-items: center;
+  gap: var(--space-internal-12);
+  border-radius: var(--radius-md);
+  font-family: var(--font-body);
+  font-size: var(--font-size-text-s);
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.option.active {
+  background-color: color-mix(in srgb, var(--color-muted) 18%, transparent);
+}
+
+.icon {
+  display: inline-flex;
+  flex: none;
+}
+
+.optionLabel {
+  flex: 1;
+}
+
+.empty {
+  padding: var(--space-internal-24);
+  font-family: var(--font-body);
+  font-size: var(--font-size-text-s);
+  text-align: center;
+  color: var(--color-muted);
+}
+
+@media (forced-colors: active) {
+  .dialog {
+    border: 1px solid CanvasText;
+  }
+
+  .option.active {
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+  }
+}

--- a/nextjs-app/shared/components/CommandPalette/CommandPalette.spec.md
+++ b/nextjs-app/shared/components/CommandPalette/CommandPalette.spec.md
@@ -1,0 +1,40 @@
+# CommandPalette
+
+## Intent
+A modal, keyboard-first launcher for jumping to a command, page, or action
+without reaching for the mouse. Opened by a shortcut (e.g. Cmd/Ctrl-K), it filters
+a flat list of commands as you type and runs the highlighted one on Enter. Use it
+for cross-surface navigation and quick actions, not as a menu bound to one control.
+
+## Interaction contract
+- Keyboard: type to filter (matches label + keywords); Arrow Down/Up move the
+  active option, wrapping; Enter runs the active command and closes; Escape
+  closes. Focus is trapped in the dialog and background scroll is locked while open.
+- Pointer: hovering an option makes it active; clicking runs it; clicking the
+  scrim closes.
+- Controlled only: `open` + `onClose` own visibility; the component holds query
+  and active-index state internally and resets them on open.
+- Screen readers: the overlay is `role=dialog aria-modal`; the input is
+  `role=combobox` with `aria-controls` + `aria-activedescendant` onto the
+  `role=listbox`; each command is `role=option` with `aria-selected`.
+
+## Do / don't
+- Do: keep commands flat and label them as actions ("Go to Blog", "New post").
+- Do: pass `keywords` for synonyms so fuzzy intent still matches.
+- Don't: nest submenus or put long forms inside it — it is a launcher, not a
+  workspace. Route or run on Enter and close.
+- Don't: hardcode copy in the component — `label` / `placeholder` / `emptyText`
+  are props so the host owns translation.
+
+## Design notes
+- Tokens: scrim from `--color-black`; dialog `--color-surface` + `--color-border`
+  + shadow; text `--color-text` / `--color-muted`; radius/spacing from
+  `--radius-*` / `--space-internal-*`. No hardcoded colors.
+- Reuses `useFocusTrap` and `useScrollLock` (see Foundations/Utilities). The
+  active option is a neutral tint; forced-colors maps it to a `Highlight` outline.
+- Figma: TODO (parity build; no Figma node yet).
+
+## Promotion notes
+Parity build (Astryx `Command Palette`, reduced to the core launcher). Ships at
+alpha with the WIP badge. Do not promote past alpha/beta without a documented
+production consumer, AT snapshots, and forced-colors + light/dark verification.

--- a/nextjs-app/shared/components/CommandPalette/CommandPalette.stories.tsx
+++ b/nextjs-app/shared/components/CommandPalette/CommandPalette.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import React, { useState } from "react";
+import {
+  CommandPalette,
+  type CommandPaletteItem,
+  type CommandPaletteProps,
+} from "./CommandPalette";
+import contract from "./CommandPalette.contract.json";
+
+const commands: CommandPaletteItem[] = [
+  { id: "home", label: "Go to Home", keywords: ["start", "index"], onSelect: () => {} },
+  { id: "blog", label: "Go to Blog", keywords: ["articles", "posts"], onSelect: () => {} },
+  { id: "work", label: "Go to Work", keywords: ["projects", "portfolio"], onSelect: () => {} },
+  { id: "contact", label: "Go to Contact", keywords: ["email", "reach"], onSelect: () => {} },
+  { id: "new-post", label: "New blog post", keywords: ["create", "write"], onSelect: () => {} },
+];
+
+const meta = {
+  title: "Organisms/CommandPalette",
+  component: CommandPalette,
+  tags: ["alpha", "!autodocs"],
+  parameters: {
+    layout: "fullscreen",
+    a11y: { test: "error" },
+    contractStatus: contract.status,
+  },
+  args: { open: true, items: commands, label: "Command palette" },
+} satisfies Meta<typeof CommandPalette>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const Harness = (args: CommandPaletteProps) => {
+  const [open, setOpen] = useState(args.open);
+  return (
+    <div style={{ minHeight: "60vh", padding: "1rem" }}>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open command palette
+      </button>
+      <CommandPalette {...args} open={open} onClose={() => setOpen(false)} />
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: (args) => <Harness {...args} />,
+};
+
+export const Playground: Story = {
+  render: (args) => <Harness {...args} />,
+};
+
+export const Example: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <Harness open items={commands} label="Command palette" placeholder="Type a command…" onClose={() => {}} />
+  ),
+};
+
+export const ForcedColors: Story = {
+  globals: { forcedColors: "active" },
+  parameters: { a11y: { disable: true, test: "off" } },
+  render: (args) => <Harness {...args} />,
+};

--- a/nextjs-app/shared/components/CommandPalette/CommandPalette.test.tsx
+++ b/nextjs-app/shared/components/CommandPalette/CommandPalette.test.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { CommandPalette, type CommandPaletteItem } from "./CommandPalette";
+
+expect.extend(toHaveNoViolations);
+
+const makeItems = (): CommandPaletteItem[] => [
+  { id: "home", label: "Go to Home", keywords: ["start"], onSelect: vi.fn() },
+  { id: "blog", label: "Go to Blog", keywords: ["articles"], onSelect: vi.fn() },
+  { id: "work", label: "Go to Work", onSelect: vi.fn() },
+];
+
+describe("CommandPalette", () => {
+  it("renders a modal dialog with a combobox and listbox when open", () => {
+    render(<CommandPalette open onClose={() => {}} items={makeItems()} />);
+    expect(screen.getByRole("dialog", { name: "Command palette" })).toHaveAttribute(
+      "aria-modal",
+      "true",
+    );
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getAllByRole("option")).toHaveLength(3);
+  });
+
+  it("renders nothing when closed", () => {
+    render(<CommandPalette open={false} onClose={() => {}} items={makeItems()} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("filters by label and by keyword", () => {
+    render(<CommandPalette open onClose={() => {}} items={makeItems()} />);
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "blog" } });
+    expect(screen.getAllByRole("option")).toHaveLength(1);
+    expect(screen.getByRole("option")).toHaveTextContent("Go to Blog");
+    fireEvent.change(input, { target: { value: "articles" } });
+    expect(screen.getByRole("option")).toHaveTextContent("Go to Blog");
+  });
+
+  it("shows the empty state when nothing matches", () => {
+    render(<CommandPalette open onClose={() => {}} items={makeItems()} emptyText="Nothing" />);
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "zzz" } });
+    expect(screen.queryByRole("option")).not.toBeInTheDocument();
+    expect(screen.getByText("Nothing")).toBeInTheDocument();
+  });
+
+  it("moves the active option with arrows and runs it on Enter, then closes", () => {
+    const items = makeItems();
+    const onClose = vi.fn();
+    render(<CommandPalette open onClose={onClose} items={items} />);
+    const input = screen.getByRole("combobox");
+    fireEvent.keyDown(input, { key: "ArrowDown" }); // active -> index 1 (Blog)
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(items[1].onSelect).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Escape", () => {
+    const onClose = vi.fn();
+    render(<CommandPalette open onClose={onClose} items={makeItems()} />);
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs a command on click", () => {
+    const items = makeItems();
+    const onClose = vi.fn();
+    render(<CommandPalette open onClose={onClose} items={items} />);
+    fireEvent.click(within(screen.getByRole("listbox")).getByText("Go to Work"));
+    expect(items[2].onSelect).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("has no axe violations", async () => {
+    const { baseElement } = render(
+      <CommandPalette open onClose={() => {}} items={makeItems()} />,
+    );
+    expect(await axe(baseElement)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/CommandPalette/CommandPalette.tsx
+++ b/nextjs-app/shared/components/CommandPalette/CommandPalette.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "../../lib/cn";
+import { useFocusTrap } from "../../hooks/useFocusTrap";
+import { useScrollLock } from "../../hooks/useScrollLock";
+import styles from "./CommandPalette.module.css";
+
+export interface CommandPaletteItem {
+  /** Stable id (also used for the option's DOM id). */
+  id: string;
+  /** Visible command label; also matched against the query. */
+  label: string;
+  /** Run when the command is chosen. */
+  onSelect: () => void;
+  /** Extra terms matched against the query. */
+  keywords?: string[];
+  /** Optional leading icon. */
+  icon?: React.ReactNode;
+}
+
+export interface CommandPaletteProps {
+  /** Whether the palette is open (controlled). */
+  open: boolean;
+  /** Called to request close (Escape, overlay click, or after a selection). */
+  onClose: () => void;
+  /** Commands to show, in order. */
+  items: CommandPaletteItem[];
+  /** Accessible name for the dialog + listbox. @default "Command palette" */
+  label?: string;
+  /** Search input placeholder. @default "Search commands…" */
+  placeholder?: string;
+  /** Shown when nothing matches. @default "No results" */
+  emptyText?: string;
+  /** Additional CSS class names for the dialog. */
+  className?: string;
+}
+
+/**
+ * Command palette: a modal, keyboard-driven launcher. A search input filters a
+ * listbox of commands (matched on label + keywords); Arrow keys move the active
+ * option, Enter runs it, Escape closes. Focus is trapped and background scroll
+ * locked while open. User-facing strings are props (English defaults) so the
+ * component carries no i18n dependency.
+ */
+export function CommandPalette({
+  open,
+  onClose,
+  items,
+  label = "Command palette",
+  placeholder = "Search commands…",
+  emptyText = "No results",
+  className,
+}: CommandPaletteProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(0);
+
+  useFocusTrap(dialogRef, open);
+  useScrollLock(open);
+
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setActive(0);
+    }
+  }, [open]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter(
+      (item) =>
+        item.label.toLowerCase().includes(q) ||
+        (item.keywords ?? []).some((k) => k.toLowerCase().includes(q)),
+    );
+  }, [items, query]);
+
+  useEffect(() => {
+    setActive((a) => Math.min(a, Math.max(0, filtered.length - 1)));
+  }, [filtered.length]);
+
+  if (!open || typeof document === "undefined") return null;
+
+  const run = (item: CommandPaletteItem) => {
+    item.onSelect();
+    onClose();
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        setActive((a) => (filtered.length ? (a + 1) % filtered.length : 0));
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        setActive((a) =>
+          filtered.length ? (a - 1 + filtered.length) % filtered.length : 0,
+        );
+        break;
+      case "Enter": {
+        event.preventDefault();
+        const item = filtered[active];
+        if (item) run(item);
+        break;
+      }
+      case "Escape":
+        event.preventDefault();
+        onClose();
+        break;
+      default:
+        break;
+    }
+  };
+
+  const listId = "command-palette-list";
+  const optionId = (id: string) => `command-palette-option-${id}`;
+  const activeItem = filtered[active];
+
+  return createPortal(
+    <div
+      className={styles.overlay}
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={label}
+        className={cn(styles.dialog, className)}
+      >
+        <input
+          type="text"
+          className={styles.input}
+          placeholder={placeholder}
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={onKeyDown}
+          role="combobox"
+          aria-expanded="true"
+          aria-controls={listId}
+          aria-autocomplete="list"
+          aria-activedescendant={activeItem ? optionId(activeItem.id) : undefined}
+        />
+        <ul id={listId} role="listbox" aria-label={label} className={styles.list}>
+          {filtered.length ? (
+            filtered.map((item, i) => (
+              <li
+                key={item.id}
+                id={optionId(item.id)}
+                role="option"
+                aria-selected={i === active}
+                className={cn(styles.option, i === active && styles.active)}
+                onMouseEnter={() => setActive(i)}
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => run(item)}
+              >
+                {item.icon ? (
+                  <span className={styles.icon} aria-hidden="true">
+                    {item.icon}
+                  </span>
+                ) : null}
+                <span className={styles.optionLabel}>{item.label}</span>
+              </li>
+            ))
+          ) : (
+            <li role="presentation" className={styles.empty}>
+              {emptyText}
+            </li>
+          )}
+        </ul>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+export default CommandPalette;

--- a/nextjs-app/shared/components/CommandPalette/index.ts
+++ b/nextjs-app/shared/components/CommandPalette/index.ts
@@ -1,0 +1,5 @@
+export { CommandPalette, default } from "./CommandPalette";
+export type {
+  CommandPaletteProps,
+  CommandPaletteItem,
+} from "./CommandPalette";

--- a/nextjs-app/shared/components/index.ts
+++ b/nextjs-app/shared/components/index.ts
@@ -11,6 +11,11 @@ export { default as Card } from "./Card/Card";
 export { default as Checkbox } from "./Checkbox/Checkbox";
 export { default as CheckboxGroup } from "./CheckboxGroup/CheckboxGroup";
 export { default as ChunkErrorBoundary } from "./ChunkErrorBoundary/ChunkErrorBoundary";
+export {
+  CommandPalette,
+  type CommandPaletteProps,
+  type CommandPaletteItem,
+} from "./CommandPalette";
 export { default as ComplianceCard } from "./ComplianceCard/ComplianceCard";
 export { default as ContactForm } from "./ContactForm/ContactForm";
 export { default as ChatWidget } from "./ChatWidget/ChatWidget";

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -4123,6 +4123,43 @@
         }
       ]
     },
+    "CommandPalette": {
+      "name": "CommandPalette",
+      "group": "navigation",
+      "tier": 2,
+      "status": "alpha",
+      "description": "Modal, keyboard-driven command launcher: a search input filters a listbox of commands (matched on label + keywords); Arrow keys move the active option, Enter runs it, Escape closes. Focus is trapped and background scroll locked while open.",
+      "dense": "",
+      "keywords": [],
+      "importLine": "import { CommandPalette } from \"@dt/CommandPalette\";",
+      "keyProps": [],
+      "props": {},
+      "composesWith": [],
+      "prefersOver": [],
+      "forbiddenUse": [],
+      "usage": null,
+      "tokens": {
+        "colors": [
+          "--color-black",
+          "--color-border",
+          "--color-surface",
+          "--color-text",
+          "--color-muted"
+        ],
+        "spacing": [
+          "--space-internal-2",
+          "--space-internal-12",
+          "--space-internal-16",
+          "--space-internal-24"
+        ],
+        "typography": [
+          "--font-body",
+          "--font-size-text-s",
+          "--font-size-text-m"
+        ]
+      },
+      "examples": []
+    },
     "ComplianceCard": {
       "name": "ComplianceCard",
       "group": "structure",

--- a/scripts/design-system/astryx-roadmap.state.json
+++ b/scripts/design-system/astryx-roadmap.state.json
@@ -12,7 +12,7 @@
         },
         {
             "key": "breadth",
-            "current": 70,
+            "current": 74,
             "target": 90
         },
         {


### PR DESCRIPTION
feat(design-system): CommandPalette (alpha) — new component (roadmap 3.1)

Modal, keyboard-driven command launcher: a portal role=dialog aria-modal with a
role=combobox filter input (aria-controls + aria-activedescendant onto a
role=listbox); type to filter on label + keywords, Arrow Up/Down move the active
option, Enter runs it and closes, Escape closes. Reuses the useFocusTrap and
useScrollLock hooks built earlier (focus trapped + background scroll locked while
open). Controlled (open + onClose); user-facing strings (label/placeholder/
emptyText) are props with English defaults, so the component carries no i18n
dependency and the i18n coupling ratchet stays at 46.

Full component set: .tsx / .module.css / .contract.json (alpha, organism) /
.spec.md / .stories.tsx / .test.tsx / index.ts, registered in the @dt barrel.
8-test suite: render, closed, filter-by-label, filter-by-keyword, empty state,
arrow+enter runs+closes, escape closes, click runs, axe-clean.

Closes the last hard intended-surface gap. Lands ALPHA; stableCount floor 58
untouched. breadth 70 -> 74.

Local gate green: typecheck, lint, lint:css, test 2112/2112, build,
validate:components, check:contract-props.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
