### PR TITLE
Fix production context and version regressions

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ import { NextLinkProvider } from "../providers/NextLinkProvider";
 import { NextImageProvider } from "../providers/NextImageProvider";
 import { NextNavigationProvider } from "../providers/NextNavigationProvider";
 import { SmoothScrollProvider } from "../providers/SmoothScrollProvider";
-import { CookieConsentProvider } from "@digitaltableteur/react";
+import { CookieConsentProvider } from "@/nextjs-app/shared/lib/cookieConsent";
 import { NextLayout } from "@dt/NextLayout";
 import { WebMcpProvider } from "../providers/WebMcpProvider";
 import { HtmlLangSync } from "./components/HtmlLangSync";

--- a/nextjs-app/shared/components/NextLayout/NextLayout.tsx
+++ b/nextjs-app/shared/components/NextLayout/NextLayout.tsx
@@ -12,7 +12,7 @@ const ChatWidget = dynamic(() => import("../ChatWidget/ChatWidget"), {
   ssr: false,
 });
 const CookieConsentModal = dynamic(
-  () => import("@digitaltableteur/react").then((module) => module.CookieConsent),
+  () => import("../CookieConsent/CookieConsent"),
   { ssr: false },
 );
 

--- a/nextjs-app/shared/components/pages/Work/FinnishTransportAgency/finnishTransportAgency.module.css
+++ b/nextjs-app/shared/components/pages/Work/FinnishTransportAgency/finnishTransportAgency.module.css
@@ -443,7 +443,7 @@
   font-weight: 600;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: inherit;
+  color: var(--color-white);
 }
 
 .resultDetail {
@@ -451,7 +451,7 @@
   font-family: var(--font-sans);
   font-size: var(--font-size-text-s);
   line-height: 1.5;
-  color: rgb(255 255 255 / 90%);
+  color: var(--color-white);
 }
 
 /* Responsive */

--- a/nextjs-app/shared/data/designSystemPackageVersions.ts
+++ b/nextjs-app/shared/data/designSystemPackageVersions.ts
@@ -1,6 +1,6 @@
-import reactPackage from "../../../packages/react/package.json";
-import tokensPackage from "../../../packages/tokens/package.json";
-import tokensCssPackage from "../../../packages/tokens-css/package.json";
+import reactPackage from "../../../node_modules/@digitaltableteur/react/package.json";
+import tokensPackage from "../../../node_modules/@digitaltableteur/tokens/package.json";
+import tokensCssPackage from "../../../node_modules/@digitaltableteur/tokens-css/package.json";
 
 export const DESIGN_SYSTEM_PACKAGE_VERSIONS = {
   react: reactPackage.version,


### PR DESCRIPTION
## Summary
- pair the cookie-consent provider and modal on the local app implementation to avoid mixed React contexts
- force Finnish Transport Agency KPI label/detail text to the white token on blue cards
- read About page design-system package versions from installed npm packages instead of local workspace package metadata

## Verification
- npm run typecheck
- npm run lint:css
- npm run check:contrast
- npm test -- nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.test.tsx
- Playwright runtime probe for /work/finnish-transport-agency and /about on localhost:3011
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie consent handling in the app layout, helping the consent prompt load more reliably.
  * Updated a key results section to use consistent white text, improving readability in that area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->