### PR TITLE
Keep valid residual fixes from dirty main

### DIFF
--- a/app/components/LanguageNotice/LanguageNotice.tsx
+++ b/app/components/LanguageNotice/LanguageNotice.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { useTranslation } from "react-i18next";
-import { useToast } from "@/providers/ToastProvider";
+import { useEffect, useId } from "react";
+import { registerContentLanguageNotice } from "@/nextjs-app/shared/lib/contentLanguageNotice";
 
 interface LanguageNoticeProps {
   /** The language code of the content (e.g., "en") */
@@ -18,30 +17,12 @@ interface LanguageNoticeProps {
 export function LanguageNotice({
   contentLanguage,
 }: LanguageNoticeProps) {
-  const { i18n, t } = useTranslation();
-  const { showToast } = useToast();
-  const lastNoticeRef = useRef<string | null>(null);
+  const id = useId();
 
-  // Normalize to 2-letter code
-  const currentLang = (i18n.language?.split("-")[0] || "en").toLowerCase();
-  const contentLang = contentLanguage.toLowerCase();
-
-  const languageName = t(`languageName.${contentLang}`, {
-    defaultValue: "English",
-  });
-  const notice = t("contentLanguageNotice", { language: languageName });
-
-  useEffect(() => {
-    if (currentLang === contentLang) return;
-    const noticeKey = `${currentLang}:${contentLang}:${notice}`;
-    if (lastNoticeRef.current === noticeKey) return;
-    lastNoticeRef.current = noticeKey;
-    showToast(notice, {
-      duration: 5000,
-      tone: "info",
-      position: "bottom-center",
-    });
-  }, [contentLang, currentLang, notice, showToast]);
+  useEffect(
+    () => registerContentLanguageNotice({ id, contentLanguage }),
+    [contentLanguage, id],
+  );
 
   return null;
 }

--- a/nextjs-app/shared/components/pages/Work/FinnishTransportAgency/finnishTransportAgency.module.css
+++ b/nextjs-app/shared/components/pages/Work/FinnishTransportAgency/finnishTransportAgency.module.css
@@ -399,7 +399,7 @@
 
 .resultsContent h3 {
   margin-block-end: var(--space-layout-8);
-  color: white;
+  color: var(--color-white);
 }
 
 .resultsGrid {
@@ -419,6 +419,7 @@
   background: #00649b;
   backdrop-filter: blur(10px);
   text-align: left;
+  color: var(--color-white);
   transition: transform 0.3s ease, background 0.3s ease;
 }
 
@@ -433,7 +434,7 @@
   font-weight: 800;
   line-height: 1;
   letter-spacing: -0.02em;
-  color: white;
+  color: var(--color-white);
 }
 
 .resultLabel {

--- a/scripts/design-system/generate-agent-manifest.mjs
+++ b/scripts/design-system/generate-agent-manifest.mjs
@@ -61,6 +61,33 @@ const RELATIONSHIP_GRAPH_PATH = join(
   ROOT,
   "nextjs-app/shared/foundations/dist/relationship-graph.json",
 );
+
+function withoutGeneratedAtField(payload) {
+  if (!payload || typeof payload !== "object") return payload;
+  const { generatedAt: _generatedAt, ...rest } = payload;
+  return rest;
+}
+
+function preserveManifestSectionGeneratedAt(sectionName, nextSection) {
+  if (!existsSync(OUT) || !nextSection) return nextSection?.generatedAt ?? null;
+
+  try {
+    const previousManifest = JSON.parse(readFileSync(OUT, "utf8"));
+    const previousSection = previousManifest?.[sectionName];
+    if (
+      previousSection?.generatedAt &&
+      JSON.stringify(withoutGeneratedAtField(previousSection)) ===
+        JSON.stringify(withoutGeneratedAtField(nextSection))
+    ) {
+      return previousSection.generatedAt;
+    }
+  } catch {
+    // Fall through to the generated section timestamp.
+  }
+
+  return nextSection.generatedAt ?? null;
+}
+
 let relationshipGraph = null;
 if (existsSync(RELATIONSHIP_GRAPH_PATH)) {
   try {
@@ -77,6 +104,10 @@ if (existsSync(RELATIONSHIP_GRAPH_PATH)) {
       regenerate: "npm run build:relationship-graph or npm run build:tokens",
       path: "nextjs-app/shared/foundations/dist/relationship-graph.json",
     };
+    relationshipGraph.generatedAt = preserveManifestSectionGeneratedAt(
+      "relationshipGraph",
+      relationshipGraph,
+    );
   } catch (err) {
     console.warn("⚠  Could not parse relationship-graph.json:", err.message);
   }

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -1,6 +1,6 @@
 {
   "generatedBy": "npm run lint:css:update",
-  "warningCount": 448,
+  "warningCount": 446,
   "warnings": [
     {
       "id": "app/blog/NextBlogNav.module.css::7::3::order/properties-order::Expected \"margin-inline\" to come before \"max-width\" (order/properties-order)",
@@ -1608,24 +1608,6 @@
       "id": "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/finnishTransportAgency.module.css::392::3::scale-unlimited/declaration-strict-value::Work case studies may use deliberate per-project palettes; tokens still preferred. (scale-unlimited/declaration-strict-value)",
       "file": "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/finnishTransportAgency.module.css",
       "line": 392,
-      "column": 3,
-      "rule": "scale-unlimited/declaration-strict-value",
-      "severity": "warning",
-      "text": "Work case studies may use deliberate per-project palettes; tokens still preferred. (scale-unlimited/declaration-strict-value)"
-    },
-    {
-      "id": "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/finnishTransportAgency.module.css::402::3::scale-unlimited/declaration-strict-value::Work case studies may use deliberate per-project palettes; tokens still preferred. (scale-unlimited/declaration-strict-value)",
-      "file": "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/finnishTransportAgency.module.css",
-      "line": 402,
-      "column": 3,
-      "rule": "scale-unlimited/declaration-strict-value",
-      "severity": "warning",
-      "text": "Work case studies may use deliberate per-project palettes; tokens still preferred. (scale-unlimited/declaration-strict-value)"
-    },
-    {
-      "id": "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/finnishTransportAgency.module.css::436::3::scale-unlimited/declaration-strict-value::Work case studies may use deliberate per-project palettes; tokens still preferred. (scale-unlimited/declaration-strict-value)",
-      "file": "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/finnishTransportAgency.module.css",
-      "line": 436,
       "column": 3,
       "rule": "scale-unlimited/declaration-strict-value",
       "severity": "warning",


### PR DESCRIPTION
## What changed

This PR keeps the safe residue from the remaining dirty-main set after PR #1004 landed:

- registers content-language notices through the existing content-language notice bridge so the SiteHeader language-change toast can include the notice
- sets Finnish Transport KPI card text to `var(--color-white)` and records the improved stylelint baseline
- makes the generated agent manifest preserve the nested relationship-graph timestamp when graph content is unchanged, so `check:generated` stays repeatable

## What was explicitly rejected from the dirty set

The broader 74-path residue was not merged wholesale because it contained stale/regressive package work, including a downgrade of `@digitaltableteur/react` from `0.1.1` to `0.1.0`, app/product dependencies being added to the React package, roadmap status rollbacks, i18n copy regressions, and a layout change that made static routes dynamic.

## Local CI-pipeline

- npm run typecheck
- npm run lint:css
- npm run audit:rhythm:check
- npm run check:generated
- npm test
- npm run build
- git diff --check