### PR TITLE
Prove React package OIDC publish path

### DIFF
--- a/.github/scripts/write-npm-read-config.sh
+++ b/.github/scripts/write-npm-read-config.sh
@@ -17,3 +17,7 @@ cat > "$RUNNER_TEMP/npm-read.npmrc" <<EOF
 registry=https://registry.npmjs.org/
 //registry.npmjs.org/:_authToken=${NPM_READ_TOKEN}
 EOF
+
+cat > "$RUNNER_TEMP/npm-publish.npmrc" <<EOF
+registry=https://registry.npmjs.org/
+EOF

--- a/.github/workflows/ds-publish.yml
+++ b/.github/workflows/ds-publish.yml
@@ -34,11 +34,21 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
-      - name: Use npm with Trusted Publisher support
-        run: npm install -g npm@latest
+      - name: Verify npm Trusted Publisher CLI support
+        run: |
+          node <<'NODE'
+          const { execFileSync } = require("node:child_process");
+          const version = execFileSync("npm", ["--version"], { encoding: "utf8" }).trim();
+          const [major, minor, patch] = version.split(".").map(Number);
+          const supported =
+            major > 11 || (major === 11 && (minor > 5 || (minor === 5 && patch >= 1)));
+          if (!supported) {
+            throw new Error(`npm ${version} is too old for Trusted Publisher OIDC; need >=11.5.1`);
+          }
+          console.log(`npm ${version} supports Trusted Publisher OIDC`);
+          NODE
 
       - name: Prepare private npm read config
         env:
@@ -67,7 +77,7 @@ jobs:
         run: npm run check:package-tarballs
 
       - name: Verify publish dry run
-        run: npm run check:package-publish-dry-run
+        run: NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/npm-publish.npmrc" npm run check:package-publish-dry-run
 
       - name: Verify local npm consumer install
         run: npm run check:npm-consumer-install
@@ -86,14 +96,18 @@ jobs:
         if: ${{ inputs.package == 'react' || inputs.package == 'all' }}
         run: npm run check:react-public-surface -- --require-publishable
 
+      - name: Verify @digitaltableteur/react OIDC publish auth
+        if: ${{ (inputs.package == 'react' || inputs.package == 'all') && inputs.dry_run == false }}
+        run: NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/npm-publish.npmrc" node scripts/design-system/check-npm-oidc-publish-auth.mjs @digitaltableteur/react
+
       - name: Publish @digitaltableteur/tokens
         if: ${{ inputs.package == 'tokens' || inputs.package == 'all' }}
         working-directory: packages/tokens
         run: |
           if [ "${{ inputs.dry_run }}" = "true" ]; then
-            npm publish --dry-run --access restricted
+            NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/npm-publish.npmrc" npm publish --dry-run --access restricted
           else
-            npm publish --access restricted
+            NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/npm-publish.npmrc" npm publish --access restricted
           fi
 
       - name: Publish @digitaltableteur/tokens-css
@@ -101,9 +115,9 @@ jobs:
         working-directory: packages/tokens-css
         run: |
           if [ "${{ inputs.dry_run }}" = "true" ]; then
-            npm publish --dry-run --access restricted
+            NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/npm-publish.npmrc" npm publish --dry-run --access restricted
           else
-            npm publish --access restricted
+            NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/npm-publish.npmrc" npm publish --access restricted
           fi
 
       - name: Publish @digitaltableteur/react
@@ -111,9 +125,9 @@ jobs:
         working-directory: packages/react
         run: |
           if [ "${{ inputs.dry_run }}" = "true" ]; then
-            npm publish --dry-run --access restricted
+            NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/npm-publish.npmrc" npm publish --dry-run --access restricted
           else
-            npm publish --access restricted
+            NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/npm-publish.npmrc" npm publish --access restricted
           fi
 
       - name: Verify @digitaltableteur/react registry install

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.2 - 2026-07-09
+
+- Prepares the React package for publication through the GitHub Actions Trusted Publisher path.
+- Keeps the public runtime API unchanged from 0.1.1.
+- Adds workflow diagnostics for npm OIDC token exchange failures before the real publish step.
+- Hardens npm pack parsing for current npm JSON output shapes.
+- Verified by `check:trusted-publisher`, `check:package-release-notes`, `check:package-tarballs`, `check:react-package`, `check:react-public-api`, `check:react-public-surface`, and `check:react-publish-preflight -- --strict`.
+
 ## 0.1.1 - 2026-07-08
 
 - Adds the package README used by the private npm package page.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/react",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": false,
   "description": "React components and host adapters for the Digitaltableteur design system.",
   "type": "module",

--- a/scripts/design-system/check-npm-consumer-install.mjs
+++ b/scripts/design-system/check-npm-consumer-install.mjs
@@ -52,13 +52,26 @@ function packageDir(packageName) {
   return join(ROOT, dir);
 }
 
+function parsePackJson(stdout, packageName) {
+  const parsed = JSON.parse(stdout);
+  const rows = Array.isArray(parsed)
+    ? parsed
+    : parsed?.[packageName]
+      ? [parsed[packageName]]
+      : [parsed];
+  if (rows.length !== 1) {
+    throw new Error(`npm pack for ${packageName} returned ${rows.length} package rows.`);
+  }
+  return rows[0];
+}
+
 function pack(packageName, destination) {
   const result = run(
     "npm",
     ["pack", "--pack-destination", destination, "--json"],
     { cwd: packageDir(packageName), capture: true },
   );
-  const [packed] = JSON.parse(result);
+  const packed = parsePackJson(result, packageName);
   if (!packed?.filename) {
     throw new Error(`npm pack did not return a filename for ${packageName}`);
   }
@@ -76,7 +89,7 @@ function inspectPack(packageName) {
     cwd: packageDir(packageName),
     capture: true,
   });
-  return JSON.parse(result)[0];
+  return parsePackJson(result, packageName);
 }
 
 const rootPackage = readJson(join(ROOT, "package.json"));

--- a/scripts/design-system/check-npm-oidc-publish-auth.mjs
+++ b/scripts/design-system/check-npm-oidc-publish-auth.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * Verify that npm can exchange the current CI OIDC identity for a publish token.
+ *
+ * npm treats OIDC as an optional auth path and otherwise falls through to the
+ * normal "need auth" publish error. This workflow-only guard makes that failure
+ * explicit before the real publish step.
+ */
+import { spawnSync } from "node:child_process";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const PACKAGE_DIRS = new Map([
+  ["@digitaltableteur/tokens", "packages/tokens"],
+  ["@digitaltableteur/tokens-css", "packages/tokens-css"],
+  ["@digitaltableteur/react", "packages/react"],
+]);
+
+const packageName = process.argv[2] ?? "@digitaltableteur/react";
+const packageDir = PACKAGE_DIRS.get(packageName);
+const registry =
+  process.env.npm_config_registry ??
+  process.env.NPM_CONFIG_REGISTRY ??
+  "https://registry.npmjs.org/";
+
+function redact(line) {
+  return line
+    .replace(/Bearer\s+[-._~+/=A-Za-z0-9]+/g, "Bearer [redacted]")
+    .replace(/[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/g, "[jwt-redacted]");
+}
+
+function decodeJwtPayload(token) {
+  const [, payloadB64] = token.split(".");
+  if (!payloadB64) return {};
+  const padded = payloadB64.padEnd(
+    payloadB64.length + ((4 - (payloadB64.length % 4)) % 4),
+    "=",
+  );
+  return JSON.parse(Buffer.from(padded, "base64url").toString("utf8"));
+}
+
+function formatClaimValue(value) {
+  if (value === undefined || value === null || value === "") return "(missing)";
+  if (Array.isArray(value)) return value.join(", ");
+  return String(value);
+}
+
+function npmOidcEscapedPackageName(name) {
+  // Match npm-package-arg's escapedName shape used by npm CLI OIDC publish.
+  return name.startsWith("@") ? name.replace("/", "%2f") : encodeURIComponent(name);
+}
+
+function printTrustedPublisherChecklist() {
+  console.error("Expected npm Trusted Publisher fields for this workflow:");
+  console.error(`  Package access page: https://www.npmjs.com/package/${packageName}/access`);
+  console.error("  Publisher: GitHub Actions");
+  console.error("  Organization or user: PetriLahdelma");
+  console.error("  Repository: digitaltableteur");
+  console.error("  Workflow filename: ds-publish.yml");
+  console.error("  Environment name: leave blank");
+  console.error("  Allowed action: Allow npm publish");
+  console.error(
+    "These values are case-sensitive and must match the GitHub OIDC claims exactly; do not use the npm org name as the GitHub owner.",
+  );
+}
+
+async function getGitHubIdToken() {
+  const audience = `npm:${new URL(registry).hostname}`;
+  const url = new URL(process.env.ACTIONS_ID_TOKEN_REQUEST_URL);
+  url.searchParams.append("audience", audience);
+  const response = await fetch(url.href, {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN}`,
+    },
+  });
+  const json = await response.json();
+  if (!response.ok || !json.value) {
+    throw new Error(`GitHub OIDC token request failed with status ${response.status}`);
+  }
+  return json.value;
+}
+
+async function verifyExchangeEndpoint(idToken) {
+  const exchangeUrl = new URL(
+    `/-/npm/v1/oidc/token/exchange/package/${npmOidcEscapedPackageName(packageName)}`,
+    registry,
+  );
+  const response = await fetch(exchangeUrl.href, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${idToken}`,
+    },
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = { message: text };
+  }
+  return { ok: response.ok, status: response.status, body };
+}
+
+if (!packageDir) {
+  console.error(
+    `Unknown package ${packageName}. Expected one of: ${[...PACKAGE_DIRS.keys()].join(", ")}`,
+  );
+  process.exit(1);
+}
+
+if (process.env.GITHUB_ACTIONS !== "true") {
+  console.error("npm OIDC publish auth guard must run inside GitHub Actions.");
+  process.exit(1);
+}
+
+const missingGitHubOidcEnv = [
+  "ACTIONS_ID_TOKEN_REQUEST_URL",
+  "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+].filter((key) => !process.env[key]);
+
+if (missingGitHubOidcEnv.length) {
+  console.error(
+    `GitHub OIDC environment is unavailable; missing ${missingGitHubOidcEnv.join(", ")}.`,
+  );
+  console.error("Ensure the workflow has permissions: id-token: write.");
+  process.exit(1);
+}
+
+const idToken = await getGitHubIdToken();
+const claims = decodeJwtPayload(idToken);
+const claimKeys = [
+  "iss",
+  "aud",
+  "sub",
+  "repository",
+  "repository_owner",
+  "repository_visibility",
+  "workflow",
+  "workflow_ref",
+  "job_workflow_ref",
+  "ref",
+  "event_name",
+  "environment",
+];
+const claimSummary = claimKeys.map((key) => `${key}: ${formatClaimValue(claims[key])}`);
+
+const exchange = await verifyExchangeEndpoint(idToken);
+
+if (!exchange.ok || !exchange.body?.token) {
+  console.error(
+    `npm OIDC token exchange endpoint rejected ${packageName} with HTTP ${exchange.status}.`,
+  );
+  console.error(
+    `Registry response: ${redact(exchange.body?.message ?? JSON.stringify(exchange.body))}`,
+  );
+  console.error("GitHub OIDC claim summary:");
+  for (const line of claimSummary) console.error(`  ${line}`);
+  printTrustedPublisherChecklist();
+  process.exit(1);
+}
+
+const result = spawnSync(
+  "npm",
+  ["publish", "--dry-run", "--access", "restricted", "--loglevel", "silly"],
+  {
+    cwd: join(ROOT, packageDir),
+    encoding: "utf8",
+    env: { ...process.env, NPM_ID_TOKEN: idToken },
+  },
+);
+
+const combinedOutput = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+const diagnosticLines = combinedOutput
+  .split(/\r?\n/)
+  .filter((line) => /oidc|id_token|need auth|ENEEDAUTH|auth/i.test(line))
+  .map(redact);
+
+const hasOidcSuccess = diagnosticLines.some((line) =>
+  /oidc.*Successfully retrieved and set token/i.test(line),
+);
+
+if (!hasOidcSuccess) {
+  console.error(`npm did not exchange GitHub OIDC for a publish token for ${packageName}.`);
+  if (diagnosticLines.length) {
+    console.error("Relevant npm diagnostics:");
+    for (const line of diagnosticLines) console.error(`  ${line}`);
+  } else {
+    console.error("No npm OIDC diagnostics were emitted.");
+  }
+  printTrustedPublisherChecklist();
+  process.exit(1);
+}
+
+if (result.status !== 0) {
+  console.error(
+    `npm OIDC token exchange succeeded for ${packageName}, but publish dry-run exited ${result.status}.`,
+  );
+  for (const line of diagnosticLines) console.error(`  ${line}`);
+  process.exit(result.status ?? 1);
+}
+
+console.log(
+  `✓ npm OIDC publish auth verified for ${packageName} (${relative(ROOT, join(ROOT, packageDir))})`,
+);

--- a/scripts/design-system/check-package-tarball-contents.mjs
+++ b/scripts/design-system/check-package-tarball-contents.mjs
@@ -86,16 +86,31 @@ function relativePath(path) {
 }
 
 function parsePackJson(stdout, packageName) {
-  const start = stdout.indexOf("[");
-  const end = stdout.lastIndexOf("]");
-  if (start === -1 || end === -1 || end < start) {
-    throw new Error(`npm pack for ${packageName} did not return JSON.`);
+  const trimmed = stdout.trim();
+  const candidates = [
+    trimmed,
+    stdout.slice(stdout.indexOf("["), stdout.lastIndexOf("]") + 1),
+    stdout.slice(stdout.indexOf("{"), stdout.lastIndexOf("}") + 1),
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate);
+      const rows = Array.isArray(parsed)
+        ? parsed
+        : parsed?.[packageName]
+          ? [parsed[packageName]]
+          : [parsed];
+      if (rows.length !== 1) {
+        throw new Error(`npm pack for ${packageName} returned ${rows.length} package rows.`);
+      }
+      return rows[0];
+    } catch {
+      // Try the next candidate. npm may wrap JSON in notice output.
+    }
   }
-  const parsed = JSON.parse(stdout.slice(start, end + 1));
-  if (!Array.isArray(parsed) || parsed.length !== 1) {
-    throw new Error(`npm pack for ${packageName} returned ${parsed.length} package rows.`);
-  }
-  return parsed[0];
+
+  throw new Error(`npm pack for ${packageName} did not return parseable JSON.`);
 }
 
 function packPackage(definition) {

--- a/scripts/design-system/check-react-package.mjs
+++ b/scripts/design-system/check-react-package.mjs
@@ -26,6 +26,19 @@ function assertFile(path, label) {
   }
 }
 
+function parsePackJson(stdout, packageName) {
+  const parsed = JSON.parse(stdout);
+  const rows = Array.isArray(parsed)
+    ? parsed
+    : parsed?.[packageName]
+      ? [parsed[packageName]]
+      : [parsed];
+  if (rows.length !== 1) {
+    throw new Error(`npm pack for ${packageName} returned ${rows.length} package rows.`);
+  }
+  return rows[0];
+}
+
 run("npm", ["--prefix", "packages/react", "run", "build"]);
 
 assertFile(join(dist, "index.js"), "React package JS entry");
@@ -59,7 +72,7 @@ const packJson = run(
   ["pack", "./packages/react", "--dry-run", "--json"],
   { capture: true },
 );
-const [pack] = JSON.parse(packJson);
+const pack = parsePackJson(packJson, "@digitaltableteur/react");
 const files = new Set(pack.files.map((file) => file.path));
 for (const required of ["dist/index.js", "dist/index.d.ts", "dist/style.css"]) {
   if (!files.has(required)) {

--- a/scripts/design-system/check-trusted-publisher-config.mjs
+++ b/scripts/design-system/check-trusted-publisher-config.mjs
@@ -253,6 +253,7 @@ const REQUIRED_REPOSITORY_PATHS = [
   "scripts/design-system/astryx-roadmap.state.json",
   "scripts/design-system/build-token-css.mjs",
   "scripts/design-system/build-tokens.mjs",
+  "scripts/design-system/check-npm-oidc-publish-auth.mjs",
   "scripts/design-system/check-npm-consumer-install.mjs",
   "scripts/design-system/check-package-publish-dry-run.mjs",
   "scripts/design-system/check-package-registry-resolution.mjs",
@@ -341,6 +342,13 @@ non-secret npm Trusted Publisher setup values for the private
 - Environment name: ${report.npmEnvironmentName ?? "leave blank"}
 - Allowed action: ${report.allowedActions.join(", ")}
 
+These values are case-sensitive and must match the GitHub OIDC claims exactly:
+\`repository: ${report.githubOwner}/${report.githubRepository}\`,
+\`workflow_ref: ${report.githubOwner}/${report.githubRepository}/${report.workflowPath}\`.
+Configure them on each package access page, for example
+\`https://www.npmjs.com/package/@digitaltableteur/react/access\`. Do not use the
+npm organization name as the GitHub owner.
+
 ## GitHub workflow state
 
 - Workflow path: \`${report.workflowPath}\`
@@ -400,6 +408,9 @@ ${formatPackageRows(report.packages)}
   OIDC-only and must not receive \`NPM_TOKEN\`, \`NODE_AUTH_TOKEN\`, or
   \`NPM_READ_TOKEN\`.
 - Keep npm publish commands restricted: \`npm publish --access restricted\`.
+- Keep the workflow-only OIDC auth guard immediately before real React publishes
+  so failed trust exchanges report npm's redacted OIDC diagnostic instead of
+  falling through to \`ENEEDAUTH\`.
 - Keep \`@digitaltableteur/react\` behind \`check:react-publish-clearance\` and \`check:react-public-surface -- --require-publishable\`.
 - Local machines remain the CI-quality authority; GitHub Actions is only the npm OIDC transport.
 
@@ -536,9 +547,10 @@ if (!existsSync(WORKFLOW)) {
     "contents: read",
     "runs-on: ubuntu-latest",
     "node-version: 24",
-    "registry-url: https://registry.npmjs.org",
     "package-manager-cache: false",
-    "npm install -g npm@latest",
+    "Verify npm Trusted Publisher CLI support",
+    "npm ${version} supports Trusted Publisher OIDC",
+    ">=11.5.1",
     "NPM_READ_TOKEN: ${{ secrets.NPM_READ_TOKEN }}",
     "bash .github/scripts/write-npm-read-config.sh",
     "NPM_CONFIG_USERCONFIG=\"$RUNNER_TEMP/npm-read.npmrc\" npm ci",
@@ -548,14 +560,16 @@ if (!existsSync(WORKFLOW)) {
     "npm run check:package-release-notes",
     "npm run check:package-registry-resolution",
     "npm run check:package-tarballs",
-    "npm run check:package-publish-dry-run",
+    "NPM_CONFIG_USERCONFIG=\"$RUNNER_TEMP/npm-publish.npmrc\" npm run check:package-publish-dry-run",
     "npm run check:npm-consumer-install",
     "npm run check:react-public-surface",
     "npm run check:react-public-api",
     "npm run check:react-publish-clearance",
     "npm run check:react-public-surface -- --require-publishable",
-    "npm publish --dry-run --access restricted",
-    "npm publish --access restricted",
+    "Verify @digitaltableteur/react OIDC publish auth",
+    "NPM_CONFIG_USERCONFIG=\"$RUNNER_TEMP/npm-publish.npmrc\" node scripts/design-system/check-npm-oidc-publish-auth.mjs @digitaltableteur/react",
+    "NPM_CONFIG_USERCONFIG=\"$RUNNER_TEMP/npm-publish.npmrc\" npm publish --dry-run --access restricted",
+    "NPM_CONFIG_USERCONFIG=\"$RUNNER_TEMP/npm-publish.npmrc\" npm publish --access restricted",
     "NPM_CONFIG_USERCONFIG=\"$RUNNER_TEMP/npm-read.npmrc\" npm run check:react-registry-install",
     "packages/tokens",
     "packages/tokens-css",


### PR DESCRIPTION
## Summary

- replaces the stale/conflicted OIDC draft with a narrow branch from current main
- isolates npm read auth from publish auth so publish steps use a token-free config and GitHub OIDC
- adds a workflow-only npm OIDC exchange diagnostic before real React publishes
- bumps @digitaltableteur/react to 0.1.2 so the Trusted Publisher path has an unpublished patch to publish
- hardens npm pack JSON parsing for current npm output shapes

## Verification

- npm run check:package-release-notes
- npm run check:package-tarballs
- npm run check:react-package
- npm run check:react-public-api
- npm run check:react-public-surface
- npm run check:package-publish-dry-run
- npm run check:npm-consumer-install
- npm run check:trusted-publisher
- npm run check:react-publish-preflight -- --strict reached package-registry-status and stopped because @digitaltableteur/react@0.1.2 is not yet published (expected before OIDC publish)

GitHub Actions is used here only as the npm Trusted Publisher transport, not as the local CI quality gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger publishing checks for the React package, including support for Trusted Publisher verification during release workflows.
  * Improved handling of package tarball data so publish and install checks are more reliable across npm output formats.

* **Bug Fixes**
  * Added clearer diagnostics when publish authorization or npm token exchange fails.
  * Made publish-related checks more consistent by using a dedicated npm config for release steps.

* **Chores**
  * Bumped the React package version to **0.1.2**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->