### PR TITLE
Keep Finnish Transport result cards readable

### DIFF
--- a/nextjs-app/shared/components/pages/Work/FinnishTransportAgency/finnishTransportAgency.module.css
+++ b/nextjs-app/shared/components/pages/Work/FinnishTransportAgency/finnishTransportAgency.module.css
@@ -390,6 +390,10 @@
   padding-block: var(--space-layout-64);
   padding-inline: var(--cs-page-inset);
   background-color: #0088CE;
+
+  --fta-result-card-text-color: var(--color-white);
+
+  color: var(--fta-result-card-text-color);
 }
 
 .resultsContent {
@@ -419,13 +423,7 @@
   background: #00649b;
   backdrop-filter: blur(10px);
   text-align: left;
-  color: var(--color-white);
-  transition: transform 0.3s ease, background 0.3s ease;
-}
-
-.resultItem:hover {
-  background: #005b8c;
-  transform: translateY(-4px);
+  color: var(--fta-result-card-text-color);
 }
 
 .resultValue {
@@ -434,7 +432,7 @@
   font-weight: 800;
   line-height: 1;
   letter-spacing: -0.02em;
-  color: var(--color-white);
+  color: var(--fta-result-card-text-color);
 }
 
 .resultLabel {
@@ -444,7 +442,7 @@
   font-weight: 600;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--color-white);
+  color: var(--fta-result-card-text-color);
 }
 
 .resultDetail {
@@ -452,7 +450,7 @@
   font-family: var(--font-sans);
   font-size: var(--font-size-text-s);
   line-height: 1.5;
-  color: var(--color-white);
+  color: var(--fta-result-card-text-color);
 }
 
 /* Responsive */


### PR DESCRIPTION
## Summary

- makes Finnish Transport Agency KPI/result card copy inherit from a local white token variable
- removes hover background/translate behavior because these cards are static, not interactive controls

## Verification

- npm test -- nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.test.tsx
- npm run lint:css
- pre-commit hook: check:contrast, lint:css, audit:rhythm:check, typecheck, lint

GitHub Actions is not used as the quality gate here; local verification is the gate.