### PR TITLE
Let Vercel install private design-system packages

### DIFF
--- a/scripts/vercel-install.sh
+++ b/scripts/vercel-install.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+token="${NPM_READ_TOKEN:-${NPM_TOKEN:-}}"
+
+if [ -z "$token" ]; then
+  echo "::error::NPM_TOKEN or NPM_READ_TOKEN is required to install private @digitaltableteur packages."
+  exit 1
+fi
+
+npm_userconfig="${VERCEL_NPM_USERCONFIG:-${TMPDIR:-/tmp}/digitaltableteur-vercel-npmrc}"
+
+cat > "$npm_userconfig" <<EOF
+registry=https://registry.npmjs.org/
+//registry.npmjs.org/:_authToken=${token}
+legacy-peer-deps=true
+EOF
+
+NPM_CONFIG_USERCONFIG="$npm_userconfig" npm ci

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "installCommand": "bash scripts/vercel-install.sh",
   "headers": [
     {
       "source": "/api/(.*)",


### PR DESCRIPTION
## Summary

- configures Vercel to use an install script instead of default npm install
- writes a temporary npm userconfig from NPM_TOKEN or NPM_READ_TOKEN during Vercel dependency install
- keeps private npm auth out of committed files and avoids using the dirty local .npm-userconfig

## Why

Production did not receive #1007 because Vercel failed before build while installing private @digitaltableteur packages. The latest production deployment for commit 1adc1b566 failed with npm E404 on @digitaltableteur/tokens-css because install auth was unavailable.

## Verification

- bash -n scripts/vercel-install.sh
- scripts/vercel-install.sh with local npm token source completed npm ci
- pre-commit hook: check:contrast, lint:css, audit:rhythm:check, typecheck, lint

GitHub Actions is not used as the quality gate here; local verification is the gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved deployment installs by adding a dedicated install step for private package access.
  * Supports authenticated installs during deployment when a valid npm token is provided.
* **Bug Fixes**
  * Fails early with a clear error if deployment credentials are missing.
  * Helps prevent install issues by using a consistent npm configuration during dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->