### PR TITLE
Fix language preference persistence

### DIFF
--- a/providers/I18nProvider.test.tsx
+++ b/providers/I18nProvider.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import i18n from "../i18n/config";
+import { useLocalization } from "../nextjs-app/shared/lib/translation";
+import { I18nProvider } from "./I18nProvider";
+
+function clearLanguageCookie() {
+  document.cookie = "i18next=; max-age=0; path=/";
+}
+
+function setLanguageCookie(language: string) {
+  document.cookie = `i18next=${language}; path=/; max-age=31536000`;
+}
+
+function getLanguageCookie() {
+  return document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("i18next="));
+}
+
+function LanguageProbe() {
+  const { resolvedLanguage, changeLanguage } = useLocalization();
+
+  return (
+    <>
+      <output data-testid="language">
+        {resolvedLanguage.split("-")[0] ?? "en"}
+      </output>
+      <button type="button" onClick={() => void changeLanguage("en")}>
+        English
+      </button>
+    </>
+  );
+}
+
+describe("I18nProvider", () => {
+  beforeEach(async () => {
+    clearLanguageCookie();
+    window.localStorage.clear();
+    await i18n.changeLanguage("en");
+  });
+
+  afterEach(async () => {
+    clearLanguageCookie();
+    window.localStorage.clear();
+    await i18n.changeLanguage("en");
+  });
+
+  it("persists a user language switch across provider remounts", async () => {
+    setLanguageCookie("fi");
+    window.localStorage.setItem("i18nextLng", "fi");
+
+    const { unmount } = render(
+      <I18nProvider>
+        <LanguageProbe />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("language")).toHaveTextContent("fi");
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "English" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("language")).toHaveTextContent("en");
+    });
+
+    expect(getLanguageCookie()).toBe("i18next=en");
+    expect(window.localStorage.getItem("i18nextLng")).toBe("en");
+
+    unmount();
+    await i18n.changeLanguage("fi");
+
+    render(
+      <I18nProvider>
+        <LanguageProbe />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("language")).toHaveTextContent("en");
+    });
+  });
+
+  it("uses localStorage before a stale language cookie", async () => {
+    setLanguageCookie("fi");
+    window.localStorage.setItem("i18nextLng", "en");
+    await i18n.changeLanguage("fi");
+
+    render(
+      <I18nProvider>
+        <LanguageProbe />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("language")).toHaveTextContent("en");
+    });
+  });
+});

--- a/providers/I18nProvider.tsx
+++ b/providers/I18nProvider.tsx
@@ -13,14 +13,71 @@ import {
 const supportedLanguages = ["en", "fi", "sv"] as const;
 type SupportedLanguage = (typeof supportedLanguages)[number];
 
-const normalizeLanguage = (
+const LANGUAGE_COOKIE_NAME = "i18next";
+const LANGUAGE_STORAGE_KEY = "i18nextLng";
+const LANGUAGE_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+const getSupportedLanguage = (
   value: string | null | undefined,
-): SupportedLanguage => {
-  if (!value) return "en";
+): SupportedLanguage | null => {
+  if (!value) return null;
   const base = value.split("-")[0];
   return supportedLanguages.includes(base as SupportedLanguage)
     ? (base as SupportedLanguage)
-    : "en";
+    : null;
+};
+
+const normalizeLanguage = (
+  value: string | null | undefined,
+): SupportedLanguage => {
+  return getSupportedLanguage(value) ?? "en";
+};
+
+const getLanguageCookie = (): SupportedLanguage | null => {
+  if (typeof document === "undefined") return null;
+
+  const rawCookie = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${LANGUAGE_COOKIE_NAME}=`))
+    ?.slice(LANGUAGE_COOKIE_NAME.length + 1);
+
+  return getSupportedLanguage(
+    rawCookie ? decodeURIComponent(rawCookie) : null,
+  );
+};
+
+const getStoredLanguage = (): SupportedLanguage | null => {
+  if (typeof window === "undefined") return null;
+
+  try {
+    return getSupportedLanguage(
+      window.localStorage.getItem(LANGUAGE_STORAGE_KEY),
+    );
+  } catch {
+    return null;
+  }
+};
+
+const getPersistedLanguage = (): SupportedLanguage | null =>
+  getStoredLanguage() ?? getLanguageCookie();
+
+const persistLanguagePreference = (language: SupportedLanguage): void => {
+  if (typeof document !== "undefined") {
+    document.cookie = [
+      `${LANGUAGE_COOKIE_NAME}=${encodeURIComponent(language)}`,
+      "path=/",
+      `max-age=${LANGUAGE_COOKIE_MAX_AGE_SECONDS}`,
+      "SameSite=Lax",
+    ].join("; ");
+  }
+
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+    } catch {
+      // Cookies keep the preference when localStorage is unavailable.
+    }
+  }
 };
 
 /**
@@ -66,23 +123,28 @@ export function I18nProvider({ children }: { children: React.ReactNode }) {
     [],
   );
 
+  const changeLanguage = useCallback(async (language: string) => {
+    const targetLanguage = normalizeLanguage(language);
+    persistLanguagePreference(targetLanguage);
+
+    try {
+      return await i18n.changeLanguage(targetLanguage);
+    } catch {
+      persistLanguagePreference("en");
+      return i18n.changeLanguage("en");
+    }
+  }, []);
+
   // Sync language preference client-side after hydration (non-blocking)
   useEffect(() => {
     // Skip if running on server
     if (typeof window === "undefined") return;
 
     const syncLanguage = () => {
-      // Detect language from cookie or localStorage
-      const cookieLang = decodeURIComponent(
-        document.cookie
-          .split("; ")
-          .find((row) => row.startsWith("i18next="))
-          ?.slice(8) ?? "",
-      );
+      const persistedLanguage = getPersistedLanguage();
+      if (!persistedLanguage) return;
 
-      const targetLanguage = normalizeLanguage(
-        cookieLang || localStorage.getItem("i18nextLng"),
-      );
+      const targetLanguage = persistedLanguage;
       const currentLanguage = normalizeLanguage(
         i18n.resolvedLanguage || i18n.language,
       );
@@ -91,6 +153,7 @@ export function I18nProvider({ children }: { children: React.ReactNode }) {
       if (currentLanguage !== targetLanguage) {
         i18n.changeLanguage(targetLanguage).catch(() => {
           // Fallback to English on error
+          persistLanguagePreference("en");
           i18n.changeLanguage("en").catch(console.error);
         });
       }
@@ -133,7 +196,7 @@ export function I18nProvider({ children }: { children: React.ReactNode }) {
         translate={translate}
         language={runtimeLanguage.language}
         resolvedLanguage={runtimeLanguage.resolvedLanguage}
-        changeLanguage={i18n.changeLanguage.bind(i18n)}
+        changeLanguage={changeLanguage}
         getResourceBundle={getResourceBundle}
       >
         {children}


### PR DESCRIPTION
## Summary
- Persist app-level language changes to both `i18next` cookie and `i18nextLng` localStorage from `I18nProvider`.
- Restore localStorage before cookie fallback so stale cookies cannot override the saved user preference.
- Add regression coverage for FI to EN switching across provider remounts and stale-cookie conflicts.

## Verification
- `npx vitest run providers/I18nProvider.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Playwright against `next start -p 3001`: Finnish persisted first load, switch to English, navigate to `/about`, reload, header remains English with `i18next=en` and `i18nextLng=en`.