### PR TITLE
Restore provider runtime updates across package boundaries

### DIFF
--- a/app/components/LanguageNotice/LanguageNotice.test.tsx
+++ b/app/components/LanguageNotice/LanguageNotice.test.tsx
@@ -1,0 +1,67 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import enTranslations from "@/nextjs-app/shared/locales/en/translation.json";
+import fiTranslations from "@/nextjs-app/shared/locales/fi/translation.json";
+import svTranslations from "@/nextjs-app/shared/locales/sv/translation.json";
+import { ToastRuntimeProvider } from "@/nextjs-app/shared/lib/toast";
+import { TranslationProvider } from "@/nextjs-app/shared/lib/translation";
+import { LanguageNotice } from "./LanguageNotice";
+
+const bundles = {
+  en: enTranslations,
+  fi: fiTranslations,
+  sv: svTranslations,
+} as const;
+
+function renderNotice({
+  contentLanguage = "en",
+  resolvedLanguage,
+  showToast = vi.fn(),
+}: {
+  contentLanguage?: string;
+  resolvedLanguage: keyof typeof bundles;
+  showToast?: ReturnType<typeof vi.fn>;
+}) {
+  render(
+    <TranslationProvider
+      language={resolvedLanguage}
+      resolvedLanguage={resolvedLanguage}
+      getResourceBundle={(language) =>
+        bundles[language as keyof typeof bundles]
+      }
+    >
+      <ToastRuntimeProvider value={{ showToast }}>
+        <LanguageNotice contentLanguage={contentLanguage} />
+      </ToastRuntimeProvider>
+    </TranslationProvider>,
+  );
+
+  return { showToast };
+}
+
+describe("LanguageNotice", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("announces direct English-only article visits in the current UI language", async () => {
+    const { showToast } = renderNotice({ resolvedLanguage: "fi" });
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(
+        "Tämä sisältö on saatavilla vain englanniksi.",
+        { duration: 5000 },
+      );
+    });
+  });
+
+  it("does not announce when content and UI language match", async () => {
+    const { showToast } = renderNotice({ resolvedLanguage: "en" });
+
+    await waitFor(() => {
+      expect(showToast).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/components/LanguageNotice/LanguageNotice.tsx
+++ b/app/components/LanguageNotice/LanguageNotice.tsx
@@ -1,7 +1,12 @@
 "use client";
 
-import { useEffect, useId } from "react";
-import { registerContentLanguageNotice } from "@/nextjs-app/shared/lib/contentLanguageNotice";
+import { useEffect, useId, useRef } from "react";
+import {
+  getContentLanguageNoticeMessage,
+  registerContentLanguageNotice,
+} from "@/nextjs-app/shared/lib/contentLanguageNotice";
+import { useToast } from "@/nextjs-app/shared/lib/toast";
+import { useLocalization } from "@/nextjs-app/shared/lib/translation";
 
 interface LanguageNoticeProps {
   /** The language code of the content (e.g., "en") */
@@ -18,11 +23,30 @@ export function LanguageNotice({
   contentLanguage,
 }: LanguageNoticeProps) {
   const id = useId();
+  const announcedKeyRef = useRef<string | null>(null);
+  const { resolvedLanguage, getResourceBundle } = useLocalization();
+  const { showToast } = useToast();
 
   useEffect(
     () => registerContentLanguageNotice({ id, contentLanguage }),
     [contentLanguage, id],
   );
+
+  useEffect(() => {
+    const targetLanguage = resolvedLanguage.split("-")[0] || "en";
+    const message = getContentLanguageNoticeMessage({
+      targetLanguage,
+      getResourceBundle,
+    });
+
+    if (!message) return;
+
+    const announcementKey = `${contentLanguage}:${targetLanguage}`;
+    if (announcedKeyRef.current === announcementKey) return;
+
+    announcedKeyRef.current = announcementKey;
+    showToast(message, { duration: 5000 });
+  }, [contentLanguage, getResourceBundle, resolvedLanguage, showToast]);
 
   return null;
 }

--- a/nextjs-app/shared/components/ThemeProvider/ThemeProvider.test.tsx
+++ b/nextjs-app/shared/components/ThemeProvider/ThemeProvider.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { ThemeProvider, useTheme } from "@dt/ThemeProvider";
 
@@ -44,6 +44,11 @@ const TestComponent = () => {
       </button>
     </div>
   );
+};
+
+const ExternalBridgeThemeProbe = () => {
+  const { theme } = useTheme();
+  return <span data-testid="bridge-theme">{theme}</span>;
 };
 
 describe("ThemeProvider", () => {
@@ -201,5 +206,29 @@ describe("ThemeProvider", () => {
     const invalidButton = screen.getByTestId("set-invalid");
     act(() => invalidButton.click());
     expect(screen.getByTestId("current-theme")).toHaveTextContent("light");
+  });
+
+  it("bridges theme updates to consumers outside the provider tree", async () => {
+    const provider = render(
+      <ThemeProvider forcedTheme="dark">
+        <span />
+      </ThemeProvider>,
+    );
+
+    render(<ExternalBridgeThemeProbe />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bridge-theme")).toHaveTextContent("dark");
+    });
+
+    provider.rerender(
+      <ThemeProvider forcedTheme="hcb">
+        <span />
+      </ThemeProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bridge-theme")).toHaveTextContent("hcb");
+    });
   });
 });

--- a/nextjs-app/shared/components/ThemeProvider/ThemeProvider.tsx
+++ b/nextjs-app/shared/components/ThemeProvider/ThemeProvider.tsx
@@ -5,7 +5,9 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 
 export type Theme = "light" | "dark" | "hcb" | "hcw";
@@ -175,16 +177,70 @@ interface ThemeContextProps {
   resetToSystemPreference: () => void;
 }
 
-const ThemeContext = createContext<ThemeContextProps>({
+const defaultThemeContext: ThemeContextProps = {
   theme: "light",
   toggleTheme: () => {},
   setTheme: () => {},
   systemPreference: "light",
   isExplicitChoice: false,
   resetToSystemPreference: () => {},
-});
+};
 
-export const useTheme = () => useContext(ThemeContext);
+const ThemeContext = createContext<ThemeContextProps | null>(null);
+
+const BRIDGE_KEY = "__digitaltableteurThemeRuntime";
+
+type ThemeBridge = {
+  runtime: ThemeContextProps | null;
+  version: number;
+  listeners: Set<() => void>;
+};
+
+function getThemeBridge(): ThemeBridge | null {
+  if (typeof globalThis === "undefined") return null;
+
+  const globalStore = globalThis as typeof globalThis & {
+    [BRIDGE_KEY]?: Partial<ThemeBridge>;
+  };
+
+  globalStore[BRIDGE_KEY] ??= {};
+  const bridge = globalStore[BRIDGE_KEY];
+  bridge.runtime ??= null;
+  bridge.version ??= 0;
+  bridge.listeners ??= new Set<() => void>();
+
+  return bridge as ThemeBridge;
+}
+
+function getBridgedThemeRuntime(): ThemeContextProps {
+  return getThemeBridge()?.runtime ?? defaultThemeContext;
+}
+
+function notifyThemeBridge(bridge: ThemeBridge): void {
+  bridge.version += 1;
+  bridge.listeners.forEach((listener) => listener());
+}
+
+function subscribeThemeBridge(listener: () => void): () => void {
+  const bridge = getThemeBridge();
+  if (!bridge) return () => undefined;
+
+  bridge.listeners.add(listener);
+  return () => {
+    bridge.listeners.delete(listener);
+  };
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  const bridgedRuntime = useSyncExternalStore(
+    subscribeThemeBridge,
+    getBridgedThemeRuntime,
+    getBridgedThemeRuntime,
+  );
+
+  return context ?? bridgedRuntime;
+};
 
 /**
  * ThemeProvider component.
@@ -298,6 +354,32 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
       resetToSystemPreference,
     ]
   );
+  const previousBridgeRuntimeRef = useRef<
+    ThemeContextProps | null | undefined
+  >(undefined);
+
+  const bridge = getThemeBridge();
+  if (bridge) {
+    if (previousBridgeRuntimeRef.current === undefined) {
+      previousBridgeRuntimeRef.current = bridge.runtime;
+    }
+    bridge.runtime = contextValue;
+  }
+
+  useEffect(() => {
+    const activeBridge = getThemeBridge();
+    if (activeBridge) {
+      activeBridge.runtime = contextValue;
+      notifyThemeBridge(activeBridge);
+    }
+
+    return () => {
+      if (activeBridge?.runtime === contextValue) {
+        activeBridge.runtime = previousBridgeRuntimeRef.current ?? null;
+        notifyThemeBridge(activeBridge);
+      }
+    };
+  }, [contextValue]);
 
   return (
     <ThemeContext.Provider value={contextValue}>

--- a/nextjs-app/shared/lib/translation.test.tsx
+++ b/nextjs-app/shared/lib/translation.test.tsx
@@ -126,4 +126,36 @@ describe("translation", () => {
       );
     });
   });
+
+  it("re-renders translate consumers when only the language changes", async () => {
+    let label = "English label";
+    const translate: Translate = () => label;
+
+    const view = render(
+      <TranslationProvider
+        translate={translate}
+        language="en"
+        resolvedLanguage="en"
+      >
+        <TranslationProbe />
+      </TranslationProvider>,
+    );
+
+    expect(screen.getByText("English label")).toBeInTheDocument();
+
+    label = "Suomi label";
+    view.rerender(
+      <TranslationProvider
+        translate={translate}
+        language="fi"
+        resolvedLanguage="fi"
+      >
+        <TranslationProbe />
+      </TranslationProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Suomi label")).toBeInTheDocument();
+    });
+  });
 });

--- a/nextjs-app/shared/lib/translation.tsx
+++ b/nextjs-app/shared/lib/translation.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  useCallback,
   createContext,
   useEffect,
   useContext,
@@ -156,15 +157,26 @@ export function TranslationProvider({
   changeLanguage?: TranslationRuntime["changeLanguage"];
   getResourceBundle?: TranslationRuntime["getResourceBundle"];
 }) {
+  const runtimeTranslate = useCallback<Translate>(
+    (key, fallbackOrOptions, options) =>
+      translate(key, fallbackOrOptions, options),
+    [language, resolvedLanguage, translate],
+  );
   const runtime = useMemo<TranslationRuntime>(
     () => ({
-      translate,
+      translate: runtimeTranslate,
       language,
       resolvedLanguage,
       changeLanguage: changeLanguage ?? (() => undefined),
       getResourceBundle: getResourceBundle ?? (() => undefined),
     }),
-    [changeLanguage, getResourceBundle, language, resolvedLanguage, translate],
+    [
+      changeLanguage,
+      getResourceBundle,
+      language,
+      resolvedLanguage,
+      runtimeTranslate,
+    ],
   );
   const previousBridgeRuntimeRef = useRef<TranslationRuntime | null | undefined>(
     undefined,
@@ -195,7 +207,7 @@ export function TranslationProvider({
 
   return (
     <TranslationRuntimeContext.Provider value={runtime}>
-      <TranslationContext.Provider value={translate}>
+      <TranslationContext.Provider value={runtimeTranslate}>
         {children}
       </TranslationContext.Provider>
     </TranslationRuntimeContext.Provider>
@@ -203,14 +215,7 @@ export function TranslationProvider({
 }
 
 export function useTranslate(): Translate {
-  const translate = useContext(TranslationContext);
-  const bridgedRuntime = useSyncExternalStore(
-    subscribeTranslationBridge,
-    getTranslationBridgeSnapshot,
-    getTranslationBridgeSnapshot,
-  );
-
-  return translate ?? bridgedRuntime.translate;
+  return useLocalization().translate;
 }
 
 export function useLocalization(): TranslationRuntime {

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.module.css
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.module.css
@@ -15,13 +15,14 @@
 
 .modeTabs {
   width: 100%;
-  border-radius: var(--radius-full);
-  background: var(--color-surface-muted);
 }
 
 .modeTabs > button {
   min-block-size: 2.75rem;
   flex: 1 1 0;
+  font-family: var(--font-sans);
+  font-size: var(--font-size-button-s);
+  font-weight: var(--font-weight-medium);
 }
 
 .newBadge {

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.test.tsx
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.test.tsx
@@ -1,8 +1,8 @@
+import { useMemo, useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { I18nextProvider } from "react-i18next";
-import i18n from "../../i18n";
+import { TranslationProvider, type Translate } from "../../lib/translation";
 import { ContactInquiryPanel } from "./ContactInquiryPanel";
 
 vi.mock("../../lib/donny-booking", () => ({
@@ -16,14 +16,75 @@ vi.mock("../../lib/donny-booking", () => ({
   })),
 }));
 
-function renderPanel(initialMode: "message" | "book" = "message") {
-  return render(
-    <I18nextProvider i18n={i18n}>
+const translations = {
+  en: {
+    contactInquiryModeLabel: "Contact options",
+    contactInquiryMessageTab: "Send a message",
+    contactInquiryBookTab: "Book a call",
+    contactInquiryBookTabNew: "NEW!",
+    contactBookingComingSoon:
+      "Online scheduling is not live yet. Send a message and we will reply with times — usually within one business day.",
+    contactBookingUseForm: "Use the contact form",
+    contactBookingEmail: "Email us instead",
+    donnyBookingLoading: "Loading booking calendar",
+  },
+  fi: {
+    contactInquiryModeLabel: "Yhteydenottotavat",
+    contactInquiryMessageTab: "Lähetä viesti",
+    contactInquiryBookTab: "Varaa puhelu",
+    contactInquiryBookTabNew: "UUSI!",
+    contactBookingComingSoon:
+      "Ajanvaraus ei ole vielä käytössä. Lähetä viesti, niin ehdotamme aikoja yleensä yhden arkipäivän kuluessa.",
+    contactBookingUseForm: "Käytä yhteydenottolomaketta",
+    contactBookingEmail: "Lähetä sähköpostia",
+    donnyBookingLoading: "Ladataan varauskalenteria",
+  },
+} as const;
+
+type TestLanguage = keyof typeof translations;
+
+function createTranslate(language: TestLanguage): Translate {
+  return (key, fallbackOrOptions) => {
+    const fallback =
+      typeof fallbackOrOptions === "string"
+        ? fallbackOrOptions
+        : fallbackOrOptions?.defaultValue;
+    return (
+      translations[language][key as keyof (typeof translations)[TestLanguage]] ??
+      fallback ??
+      key
+    ).toString();
+  };
+}
+
+function ContactPanelHarness({
+  initialMode = "message",
+}: {
+  initialMode?: "message" | "book";
+}) {
+  const [language, setLanguage] = useState<TestLanguage>("en");
+  const translate = useMemo(() => createTranslate(language), [language]);
+
+  return (
+    <TranslationProvider
+      translate={translate}
+      language={language}
+      resolvedLanguage={language}
+    >
+      <button type="button" onClick={() => setLanguage("fi")}>
+        Finnish
+      </button>
       <ContactInquiryPanel
         initialMode={initialMode}
         messagePanel={<div>Contact form body</div>}
       />
-    </I18nextProvider>,
+    </TranslationProvider>
+  );
+}
+
+function renderPanel(initialMode: "message" | "book" = "message") {
+  return render(
+    <ContactPanelHarness initialMode={initialMode} />,
   );
 }
 
@@ -70,5 +131,23 @@ describe("ContactInquiryPanel", () => {
     await user.click(screen.getByRole("button", { name: /Use the contact form/i }));
 
     expect(screen.getByText("Contact form body")).toBeInTheDocument();
+  });
+
+  it("updates tab labels without a page reload when language changes", async () => {
+    renderPanel("message");
+
+    expect(
+      screen.getByRole("tab", { name: /Send a message/i }),
+    ).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Finnish" }));
+
+    expect(
+      screen.getByRole("tab", { name: /Lähetä viesti/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("tab", { name: /Send a message/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx
@@ -10,7 +10,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { useTranslate } from "../../lib/translation";
+import { useLocalization } from "../../lib/translation";
 import Button from "@dt/Button";
 import DonnyBookingEmbed from "@dt/DonnyBookingEmbed";
 import Progress from "@dt/Progress";
@@ -47,7 +47,12 @@ export const ContactInquiryPanel = forwardRef<
   { initialMode = "message", packageId, messagePanel, bookingConfig },
   ref,
 ) {
-  const t = useTranslate();
+  const {
+    translate: t,
+    language,
+    resolvedLanguage,
+  } = useLocalization();
+  const activeLanguage = resolvedLanguage || language;
   const [mode, setMode] = useState<ContactInquiryMode>(initialMode);
 
   useEffect(() => {
@@ -73,7 +78,7 @@ export const ContactInquiryPanel = forwardRef<
         />
       </div>
     ),
-    [t],
+    [activeLanguage, t],
   );
 
   const tabs = useMemo<TabItem[]>(
@@ -87,7 +92,7 @@ export const ContactInquiryPanel = forwardRef<
         label: t("contactInquiryBookTab", "Book a call"),
       },
     ],
-    [t],
+    [activeLanguage, t],
   );
 
   const handleSelectMessage = useCallback(() => {
@@ -129,8 +134,8 @@ export const ContactInquiryPanel = forwardRef<
           activeTab={mode}
           onTabChange={handleModeChange}
           ariaLabel={t("contactInquiryModeLabel", "Contact options")}
-          variant="pills"
-          size="lg"
+          variant="underline"
+          size="sm"
           className={styles.modeTabs}
         />
         <span className={styles.newBadge} aria-hidden="true">

--- a/providers/ThemeProvider.tsx
+++ b/providers/ThemeProvider.tsx
@@ -4,15 +4,15 @@ import {
   ThemeProvider,
   useTheme,
   type Theme,
-} from "@digitaltableteur/react";
+} from "../nextjs-app/shared/components/ThemeProvider/ThemeProvider";
 
 /**
- * App compatibility wrapper around the package theme runtime.
+ * App compatibility wrapper around the shared theme runtime.
  *
- * The previous next-themes wrapper rendered a client-side script tag and split
- * the app theme context from the package context. The design-system provider
- * already handles stored/system theme state and applies the expected html/body
- * classes, so the app should inject that package runtime directly.
+ * This mounts the source provider until the next @digitaltableteur/react patch
+ * containing the theme bridge is published. Local app components still import
+ * the source hook, so using the currently published package provider here would
+ * split the context and make the site header theme toggle inert.
  */
 export function NextThemeProvider({
   children,

--- a/providers/ToastProvider.tsx
+++ b/providers/ToastProvider.tsx
@@ -1,11 +1,18 @@
 "use client";
 
-import React, { createContext, useContext, useState, useCallback } from "react";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
 import {
   Toast,
   type ToastTone,
   type ToastPosition,
 } from "@digitaltableteur/react";
+import { ToastRuntimeProvider } from "../nextjs-app/shared/lib/toast";
 
 export interface ShowToastOptions {
   duration?: number;
@@ -56,17 +63,21 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({
     setIsOpen(false);
   }, []);
 
+  const toastRuntime = useMemo(() => ({ showToast }), [showToast]);
+
   return (
-    <ToastContext.Provider value={{ showToast }}>
-      {children}
-      <Toast
-        message={message}
-        open={isOpen}
-        duration={duration}
-        tone={tone}
-        position={position}
-        onClose={handleClose}
-      />
+    <ToastContext.Provider value={toastRuntime}>
+      <ToastRuntimeProvider value={toastRuntime}>
+        {children}
+        <Toast
+          message={message}
+          open={isOpen}
+          duration={duration}
+          tone={tone}
+          position={position}
+          onClose={handleClose}
+        />
+      </ToastRuntimeProvider>
     </ToastContext.Provider>
   );
 };


### PR DESCRIPTION
## Summary
- Restore live language updates for useTranslate consumers across package/local boundaries.
- Restore theme switching by bridging theme runtime and mounting the source provider until the patched React package is published.
- Bridge app toast provider into the shared toast runtime for English-only content notices.
- Switch contact page Send a message / Book a call selector to the shared Tabs underline variant.

## Verification
- npx vitest run nextjs-app/shared/lib/translation.test.tsx nextjs-app/shared/components/ThemeProvider/ThemeProvider.test.tsx nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.test.tsx providers/I18nProvider.test.tsx app/components/LanguageNotice/LanguageNotice.test.tsx
- npm run typecheck
- npm run lint
- npm run lint:css
- npm run audit:rhythm:check
- npm test (268 files, 2135 tests)
- npm run build
- npm run check:site-package-dogfood (27/27 EN/FI/SV)
- Playwright Chromium: FI contact first paint -> switch EN -> hero/tabs update immediately -> /about navigation + reload stay EN -> theme toggle applies themeDark to html/body
- Playwright screenshot confirmed contact selector uses underline Tabs variant

CI note: Local CI pipeline is the project gate; GitHub Actions is not relied on for merge readiness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Language notices now appear as in-app toasts when content and UI languages differ.

* **Bug Fixes**
  * Language changes now update translated content and tab labels immediately without reloading.
  * Theme changes now stay in sync across all parts of the app, including content outside the main theme area.
  * Toast notifications now stay consistent across the app.

* **Style**
  * Updated contact inquiry tab styling for a more polished look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->