### PR TITLE
Refine contact inquiry badge sizing

### DIFF
--- a/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.module.css
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.module.css
@@ -28,12 +28,12 @@
 .newBadge {
   position: absolute;
   z-index: 2;
-  padding-block: var(--space-internal-2);
-  padding-inline: var(--space-internal-4);
+  padding-block: var(--space-internal-4);
+  padding-inline: var(--space-internal-8);
   border-radius: var(--radius-full);
   background-color: var(--logo-background);
   font-family: var(--font-sans);
-  font-size: var(--font-size-text-xxs);
+  font-size: var(--space-internal-12);
   font-weight: 700;
   line-height: 1;
   letter-spacing: 0.04em;


### PR DESCRIPTION
## Summary
- Set the contact inquiry NEW badge to a computed 12px font size.
- Increase badge padding to 4px block / 8px inline.
- Keep the contact selector on the shared Tabs underline variant.

## Verification
- npm run lint:css
- npm run audit:rhythm:check
- npx vitest run nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.test.tsx
- Commit hooks: check:contrast, lint:css, audit:rhythm:check, typecheck, lint
- Playwright screenshot /tmp/dt-contact-tabs-badge-12px.png confirmed computed font-size 12px and padding 4px/8px

CI note: Local CI pipeline is the project gate; GitHub Actions is not relied on for merge readiness.