### PR TITLE
fix: retry GitHub OIDC token fetch on transient proxy errors

### DIFF
--- a/scripts/design-system/check-npm-oidc-publish-auth.mjs
+++ b/scripts/design-system/check-npm-oidc-publish-auth.mjs
@@ -110,17 +110,33 @@ async function getGitHubIdToken() {
   const audience = `npm:${new URL(registry).hostname}`;
   const url = new URL(process.env.ACTIONS_ID_TOKEN_REQUEST_URL);
   url.searchParams.append("audience", audience);
-  const response = await fetch(url.href, {
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN}`,
-    },
-  });
-  const json = await response.json();
-  if (!response.ok || !json.value) {
-    throw new Error(`GitHub OIDC token request failed with status ${response.status}`);
+  // The runner-local token endpoint intermittently answers through a proxy
+  // with plain-text errors ("upstream connect error ... reset reason: overflow"),
+  // so parse defensively and retry instead of crashing on non-JSON bodies.
+  let lastFailure = "";
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    const response = await fetch(url.href, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN}`,
+      },
+    });
+    const text = await response.text();
+    let json;
+    try {
+      json = JSON.parse(text);
+    } catch {
+      json = null;
+    }
+    if (response.ok && json?.value) return json.value;
+    lastFailure = `status ${response.status}: ${redact(text).slice(0, 200)}`;
+    if (attempt < 3) {
+      await new Promise((resolve) => setTimeout(resolve, attempt * 2000));
+    }
   }
-  return json.value;
+  throw new Error(
+    `GitHub OIDC token request failed after 3 attempts (${lastFailure})`,
+  );
 }
 
 async function verifyExchangeEndpoint(idToken, exchangePath) {


### PR DESCRIPTION
## Summary
- Publish run 29018566954 failed at the OIDC auth probe because the GitHub token endpoint answered with a plain-text Envoy error (`upstream connect error ... reset reason: overflow`) and the script crashed on `response.json()` with a raw SyntaxError.
- Parse the token response defensively (text -> JSON) and retry up to 3 times with backoff before failing with a redacted, readable error.
- Mirrors the defensive parsing already used for the npm exchange response in the same file.

## Verification
- `node --check` passes; file is eslint-ignored by config.
- Full local gate (typecheck, lint, vitest, build) run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of sign-in/auth token retrieval by retrying failed responses automatically.
  * Added safer handling for unexpected or non-JSON responses, reducing abrupt failures.
  * Enhanced error messages to include useful status details while keeping response content redacted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->