### PR TITLE
chore: consume @digitaltableteur/react@0.1.2 from npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ai-sdk/openai": "^3.0.71",
         "@ai-sdk/react": "^3.0.207",
         "@calcom/embed-react": "^1.5.3",
-        "@digitaltableteur/react": "^0.1.1",
+        "@digitaltableteur/react": "^0.1.2",
         "@digitaltableteur/tokens": "^0.1.0",
         "@digitaltableteur/tokens-css": "^0.1.0",
         "@emailjs/browser": "^4.4.1",
@@ -3404,9 +3404,9 @@
       "license": "MIT"
     },
     "node_modules/@digitaltableteur/react": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.1.tgz",
-      "integrity": "sha512-AEms+abxSwSV6fbS2StUMtku5eMwegdeq9DYykIor+kms+WXMwbQ9KVCduBW/QIdoS9lbBpP/V3+fdHUZsfv4g==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.2.tgz",
+      "integrity": "sha512-Nr0tMC9rRCJX+eOAu92lYhh11+qyFE17pD+5kmRt0BLcF6CuTgL5rC04aD2zY+hv5S1R9+8rd2sUTnS5XcDeXg==",
       "license": "UNLICENSED",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "@ai-sdk/openai": "^3.0.71",
     "@ai-sdk/react": "^3.0.207",
     "@calcom/embed-react": "^1.5.3",
-    "@digitaltableteur/react": "^0.1.1",
+    "@digitaltableteur/react": "^0.1.2",
     "@digitaltableteur/tokens": "^0.1.0",
     "@digitaltableteur/tokens-css": "^0.1.0",
     "@emailjs/browser": "^4.4.1",


### PR DESCRIPTION
## Summary
- Bumps the app to `@digitaltableteur/react@^0.1.2`, the first version published through the GitHub Actions Trusted Publisher OIDC path (run 29020300633).
- Lockfile resolves the registry tarball; no other changes.

## Verification (local, all exit 0)
- `check:package-registry-resolution` — resolves react@0.1.2 + tokens@0.1.0 + tokens-css@0.1.0 from registry node_modules
- `check:storybook-registry-package`
- `check:react-registry-install` — clean consumer install of the published 0.1.2 (105 exports, runtime + types)
- `typecheck`, `lint`, `vitest` (2135 passed), `build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)