### PR TITLE
fix: provide adapter runtimes to both package and local context instances

### DIFF
--- a/providers/AnimationProvider.tsx
+++ b/providers/AnimationProvider.tsx
@@ -11,6 +11,7 @@ import {
   getMotionPreference,
 } from "@/nextjs-app/shared/lib/gsap/motion-safe";
 import { AnimationRuntimeProvider } from "@digitaltableteur/react";
+import { AnimationRuntimeProvider as LocalAnimationRuntimeProvider } from "@/nextjs-app/shared/lib/animation";
 
 // Import GSAP to ensure plugins are registered
 import "@/nextjs-app/shared/lib/gsap";
@@ -41,9 +42,15 @@ export function AnimationProvider({ children }: AnimationProviderProps) {
     };
   }, []);
 
+  // Two module instances (npm package + local shared source) hold separate
+  // AnimationContexts; provide into both so local animation components
+  // (Parallax, PageTransition, ScrollIndicator, marquees) honor
+  // prefers-reduced-motion instead of reading the "full" default.
   return (
     <AnimationRuntimeProvider value={{ motionPreference, isReady }}>
-      {children}
+      <LocalAnimationRuntimeProvider value={{ motionPreference, isReady }}>
+        {children}
+      </LocalAnimationRuntimeProvider>
     </AnimationRuntimeProvider>
   );
 }

--- a/providers/NextImageProvider.tsx
+++ b/providers/NextImageProvider.tsx
@@ -6,6 +6,7 @@ import {
   ImageProvider,
   type ImageComponentProps,
 } from "@digitaltableteur/react";
+import { ImageProvider as LocalImageProvider } from "@/nextjs-app/shared/lib/imageComponent";
 
 /** Adapts next/image to the design-system ImageComponent contract. */
 function NextImageAdapter({ src, alt, ...rest }: ImageComponentProps) {
@@ -18,5 +19,15 @@ function NextImageAdapter({ src, alt, ...rest }: ImageComponentProps) {
  * the framework-agnostic DS `Image`.
  */
 export function NextImageProvider({ children }: { children: ReactNode }) {
-  return <ImageProvider component={NextImageAdapter}>{children}</ImageProvider>;
+  // Two module instances (npm package + local shared source) hold separate
+  // ImageComponentContexts; provide into both so local components (Avatar,
+  // ProjectGallery, cards) keep next/image optimization instead of falling
+  // back to plain <img>.
+  return (
+    <ImageProvider component={NextImageAdapter}>
+      <LocalImageProvider component={NextImageAdapter}>
+        {children}
+      </LocalImageProvider>
+    </ImageProvider>
+  );
 }

--- a/providers/NextLinkProvider.tsx
+++ b/providers/NextLinkProvider.tsx
@@ -6,6 +6,7 @@ import {
   LinkProvider,
   type LinkComponentProps,
 } from "@digitaltableteur/react";
+import { LinkProvider as LocalLinkProvider } from "@/nextjs-app/shared/lib/linkComponent";
 
 /** Adapts next/link to the design-system LinkComponent contract. */
 function NextLinkAdapter({ href, children, ...rest }: LinkComponentProps) {
@@ -22,5 +23,16 @@ function NextLinkAdapter({ href, children, ...rest }: LinkComponentProps) {
  * framework-agnostic DS `Link`.
  */
 export function NextLinkProvider({ children }: { children: ReactNode }) {
-  return <LinkProvider component={NextLinkAdapter}>{children}</LinkProvider>;
+  // The npm package and the locally compiled shared source are two module
+  // instances with two distinct LinkComponentContexts; provide the adapter
+  // into BOTH, or the side left out silently degrades to plain <a> full-page
+  // navigation (package side: catalog components; local side: NextLayout ->
+  // SiteHeader/SiteFooter/cards).
+  return (
+    <LinkProvider component={NextLinkAdapter}>
+      <LocalLinkProvider component={NextLinkAdapter}>
+        {children}
+      </LocalLinkProvider>
+    </LinkProvider>
+  );
 }

--- a/providers/NextNavigationProvider.tsx
+++ b/providers/NextNavigationProvider.tsx
@@ -7,6 +7,7 @@ import {
   NavigationProvider,
   type NavigationRuntime,
 } from "@digitaltableteur/react";
+import { NavigationProvider as LocalNavigationProvider } from "@/nextjs-app/shared/lib/navigation";
 
 type NavigationOptions = Parameters<NavigationRuntime["push"]>[1];
 
@@ -46,5 +47,15 @@ export function NextNavigationProvider({ children }: { children: ReactNode }) {
     [pathname, push, replace, searchParams],
   );
 
-  return <NavigationProvider runtime={runtime}>{children}</NavigationProvider>;
+  // Two module instances (npm package + local shared source) hold separate
+  // NavigationContexts; provide the runtime into both so local consumers
+  // (PageTransition, useNavigation, Donny chat navigation, blog filters) get
+  // real client-side routing instead of the window.location fallback.
+  return (
+    <NavigationProvider runtime={runtime}>
+      <LocalNavigationProvider runtime={runtime}>
+        {children}
+      </LocalNavigationProvider>
+    </NavigationProvider>
+  );
 }


### PR DESCRIPTION
## Summary
The npm package and the locally compiled shared source are two module graphs, each holding its own copy of the link/image/navigation/animation contexts. Since the migration, the app-side providers mounted only the package instance, so every local consumer fell back to context defaults:

- **Link**: SiteHeader/SiteFooter/cards rendered plain `<a>` — every navigation was a full document reload (no client routing, no prefetch, all client state lost per click)
- **Image**: Avatar/ProjectGallery/cards rendered plain `<img>` — next/image optimization silently lost (srcset, priority, blur placeholders)
- **Navigation**: PageTransition/Donny chat/blog filters degraded to `window.location` hard navigation; mobile menu close-on-route-change never fired
- **Animation**: Parallax/PageTransition/marquees read `motionPreference: "full"` regardless of prefers-reduced-motion (a11y regression)

Fix: provide each adapter runtime into BOTH context instances (package + local).

Found by the post-migration regression review (two independent review agents converged on this; confirmed empirically in the browser before fixing).

## Verification
- Browser (dev server, before → after): footer/header link click killed `window` state → now survives (client routing restored); /work images 0/11 → **11/11** served via `/_next/image` with srcset; mobile drawer closes on route change again
- Full local gate: typecheck, lint, vitest, build — all exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)