### PR TITLE
fix(security): untrack npm userconfig and harden token handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,7 @@ public/visual-diff/report.json
 
 # Personal / tax documents — never commit
 **/Verokortti*.pdf
+
+# Project-local npm userconfig (.npmrc redirects userconfig here) — may hold a
+# live read token for private @digitaltableteur installs; never track it.
+.npm-userconfig

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,6 +5,16 @@
 # contract gate (build:tokens + check:contract-props + check:consumers) and
 # validate:components for design-system paths.
 # Bypass in a genuine emergency with: git commit --no-verify
+
+# Secret tripwire (2026-07-04 purge incident): block staged npm auth token
+# VALUES before anything else. Matches added lines only (+++ headers excluded);
+# env interpolations like _authToken=${token} and doc placeholders stay legal —
+# only literal npm_ granular tokens and UUID-shaped classic tokens trip it.
+if git diff --cached -U0 | grep -qE '^\+[^+].*_authToken[^=]*=.*(npm_[A-Za-z0-9]{20,}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})'; then
+  echo "pre-commit: staged content contains a literal npm auth token — unstage it (tokens belong in the gitignored .npm-userconfig, never in git)." >&2
+  exit 1
+fi
+
 npm run check:contrast &&
 npm run lint:css &&
 npm run audit:rhythm:check &&

--- a/.npm-userconfig
+++ b/.npm-userconfig
@@ -1,3 +1,0 @@
-; Intentionally empty. digitaltableteur installs only from the public npm registry
-; unless a caller provides a private read userconfig through NPM_CONFIG_USERCONFIG.
-; Do not add token values here.

--- a/.npm-userconfig.example
+++ b/.npm-userconfig.example
@@ -1,0 +1,5 @@
+; Template for the project-local npm userconfig (.npmrc sets userconfig=.npm-userconfig).
+; Copy to .npm-userconfig (gitignored) and add a granular READ token only when
+; installing private @digitaltableteur packages locally:
+;   //registry.npmjs.org/:_authToken=<npm read token>
+; Never commit token values; .npm-userconfig is untracked on purpose.

--- a/scripts/design-system/check-trusted-publisher-config.mjs
+++ b/scripts/design-system/check-trusted-publisher-config.mjs
@@ -416,8 +416,9 @@ git add --pathspec-from-file=${report.publishPathspecPath}
 ~~~
 
 Do not stage token-bearing \`.npm-userconfig\` values, generated \`.omx/state\`
-files, or unrelated local work as part of the publish transport commit. The
-tracked \`.npm-userconfig\` must remain non-secret.
+files, or unrelated local work as part of the publish transport commit.
+\`.npm-userconfig\` is untracked and gitignored on purpose (it may hold a live
+read token); copy \`.npm-userconfig.example\` to recreate it locally.
 
 ## Dirty paths outside publish scope
 

--- a/scripts/vercel-install.sh
+++ b/scripts/vercel-install.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Read token only: the publish path is OIDC-only and must never share auth
-# with installs, so NPM_TOKEN is intentionally NOT accepted here.
+# Installs must use a READ token: the publish path is OIDC-only and install
+# auth must never share a publish-capable token. The Vercel project currently
+# provides NPM_TOKEN (2026-07-09); accept it as a DEPRECATED fallback until the
+# rotated token lands as NPM_READ_TOKEN, then delete this fallback.
 token="${NPM_READ_TOKEN:-}"
+if [ -z "$token" ] && [ -n "${NPM_TOKEN:-}" ]; then
+  echo "::warning::Using deprecated NPM_TOKEN for installs — rename the Vercel env var to NPM_READ_TOKEN (granular, read-only) and remove NPM_TOKEN."
+  token="$NPM_TOKEN"
+fi
 
 if [ -z "$token" ]; then
   echo "::error::NPM_READ_TOKEN is required to install private @digitaltableteur packages."

--- a/scripts/vercel-install.sh
+++ b/scripts/vercel-install.sh
@@ -1,14 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-token="${NPM_READ_TOKEN:-${NPM_TOKEN:-}}"
+# Read token only: the publish path is OIDC-only and must never share auth
+# with installs, so NPM_TOKEN is intentionally NOT accepted here.
+token="${NPM_READ_TOKEN:-}"
 
 if [ -z "$token" ]; then
-  echo "::error::NPM_TOKEN or NPM_READ_TOKEN is required to install private @digitaltableteur packages."
+  echo "::error::NPM_READ_TOKEN is required to install private @digitaltableteur packages."
   exit 1
 fi
 
-npm_userconfig="${VERCEL_NPM_USERCONFIG:-${TMPDIR:-/tmp}/digitaltableteur-vercel-npmrc}"
+umask 077
+if [ -n "${VERCEL_NPM_USERCONFIG:-}" ]; then
+  npm_userconfig="$VERCEL_NPM_USERCONFIG"
+else
+  npm_userconfig="$(mktemp "${TMPDIR:-/tmp}/digitaltableteur-vercel-npmrc.XXXXXX")"
+  trap 'rm -f "$npm_userconfig"' EXIT
+fi
 
 cat > "$npm_userconfig" <<EOF
 registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Summary
Post-migration security review findings (repo has a prior secret-purge incident):

- **Untrack + gitignore `.npm-userconfig`** — `.npmrc` points `userconfig` at this tracked file, making it a token magnet: the working tree currently carries a live read token in it, one broad `git add` away from being committed. Comment-only `.npm-userconfig.example` added instead. npm resolves a missing userconfig cleanly, so fresh clones work.
- **Pre-commit secret tripwire** — blocks staged literal npm token values (`npm_...` granular and UUID-shaped classic); env interpolations and doc placeholders stay legal. Validated against all four cases.
- **`scripts/vercel-install.sh` hardening** — `umask 077` + `mktemp` + cleanup trap for the generated npmrc (was fixed world-readable path in /tmp, never deleted). NPM_TOKEN kept as a loudly-deprecated fallback because the Vercel project currently only has `NPM_TOKEN`; goes strict once the rotated token lands as `NPM_READ_TOKEN`.
- Guard handoff text updated to describe the untracked reality.

## Follow-up (user)
Rotate the npm read token (treat the one in the working tree as exposed), add it to Vercel as `NPM_READ_TOKEN`, remove `NPM_TOKEN`; then delete the fallback.

## Verification
- Tripwire regex validated: catches granular + classic literals, allows `${token}` and `<placeholder>`
- `check:trusted-publisher`, `check:package-registry-resolution`, `check:package-release-notes` all pass
- Full local gate: typecheck, lint, vitest, build — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)