### PR TITLE
fix: accept least-privilege install tokens in registry install guards

### DIFF
--- a/scripts/design-system/check-react-registry-install.mjs
+++ b/scripts/design-system/check-react-registry-install.mjs
@@ -92,6 +92,20 @@ function accessValue(accessReport, packageName) {
   return typeof value === "string" ? value : null;
 }
 
+/**
+ * npm `access` APIs need org-level permission that a least-privilege
+ * install token (read-only, package-scoped) intentionally lacks and 403s
+ * on. Readability is proven by `npm view` + the scratch install, so the
+ * access metadata is best-effort: null when the token cannot list it.
+ */
+function readCommandJsonOptional(command, args) {
+  try {
+    return readCommandJson(command, args);
+  } catch {
+    return null;
+  }
+}
+
 const rootPackage = readJson(join(ROOT, "package.json"));
 const roadmapState = readJson(join(ROOT, "scripts/design-system/astryx-roadmap.state.json"));
 const reactPackage = readJson(join(ROOT, "packages/react/package.json"));
@@ -155,7 +169,7 @@ function readReactViewWithRetry() {
 }
 
 const reactView = readReactViewWithRetry();
-const accessPackages = readCommandJson(
+const accessPackages = readCommandJsonOptional(
   "npm",
   npmArgs([...userconfigArgs, "access", "list", "packages", "digitaltableteur", "--json"]),
 );
@@ -218,9 +232,13 @@ try {
       `Registry @digitaltableteur/react version mismatch: expected ${reactVersion}, got ${reactView.ok ? reactView.json : "unpublished"}`,
     );
   }
-  if (report.packages[2].orgAccess !== "read-write") {
+  if (
+    report.packages[2].orgAccess !== null &&
+    report.packages[2].orgAccess !== "read-only" &&
+    report.packages[2].orgAccess !== "read-write"
+  ) {
     throw new Error(
-      `Registry @digitaltableteur/react org access mismatch: expected read-write, got ${report.packages[2].orgAccess ?? "missing"}`,
+      `Registry @digitaltableteur/react org access mismatch: expected read-only or read-write, got ${report.packages[2].orgAccess}`,
     );
   }
 

--- a/scripts/design-system/check-registry-token-install.mjs
+++ b/scripts/design-system/check-registry-token-install.mjs
@@ -48,6 +48,20 @@ function readCommandJson(command, args) {
   return output ? JSON.parse(output) : {};
 }
 
+/**
+ * npm `access` APIs need org-level permission that a least-privilege
+ * install token (read-only, package-scoped) intentionally lacks and 403s
+ * on. Readability is proven by `npm view` + the scratch install, so the
+ * access metadata is best-effort: null when the token cannot list it.
+ */
+function readCommandJsonOptional(command, args) {
+  try {
+    return readCommandJson(command, args);
+  } catch {
+    return null;
+  }
+}
+
 function accessValue(accessReport, packageName) {
   const value = accessReport?.[packageName];
   return typeof value === "string" ? value : null;
@@ -74,15 +88,15 @@ const registryTokensCssVersion = run(
   ]),
   { capture: true },
 ).trim();
-const accessPackages = readCommandJson(
+const accessPackages = readCommandJsonOptional(
   "npm",
   npmArgs([...userconfigArgs, "access", "list", "packages", "digitaltableteur", "--json"]),
 );
-const tokensAccessStatus = readCommandJson(
+const tokensAccessStatus = readCommandJsonOptional(
   "npm",
   npmArgs([...userconfigArgs, "access", "get", "status", "@digitaltableteur/tokens", "--json"]),
 );
-const tokensCssAccessStatus = readCommandJson(
+const tokensCssAccessStatus = readCommandJsonOptional(
   "npm",
   npmArgs([
     ...userconfigArgs,
@@ -132,14 +146,18 @@ try {
     );
   }
   for (const pkg of report.packages) {
-    if (pkg.orgAccess !== "read-write") {
+    if (
+      pkg.orgAccess !== null &&
+      pkg.orgAccess !== "read-only" &&
+      pkg.orgAccess !== "read-write"
+    ) {
       throw new Error(
-        `Registry ${pkg.name} org access mismatch: expected read-write, got ${pkg.orgAccess ?? "missing"}`,
+        `Registry ${pkg.name} org access mismatch: expected read-only or read-write, got ${pkg.orgAccess}`,
       );
     }
-    if (pkg.accessStatus !== "private") {
+    if (pkg.accessStatus !== null && pkg.accessStatus !== "private") {
       throw new Error(
-        `Registry ${pkg.name} access status mismatch: expected private, got ${pkg.accessStatus ?? "missing"}`,
+        `Registry ${pkg.name} access status mismatch: expected private, got ${pkg.accessStatus}`,
       );
     }
   }


### PR DESCRIPTION
## Summary
The registry install guards called org-level npm access APIs and asserted org **read-write** — satisfiable only by the old over-privileged token that was rotated out today. The new token is read-only and scoped to `@digitaltableteur` packages (least privilege), so `npm access list packages` 403s and both guards crashed before testing anything real.

- Access metadata is now best-effort (null when the token cannot list it)
- Assertion relaxed to read-only-or-better when the metadata is available
- Actual readability remains hard-proven by `npm view` + the scratch install

## Verification
- Both checks pass with the rotated read-only token: react@0.1.2 clean install (105 exports, runtime + types), tokens + tokens-css (184 tokens)
- Full local gate: typecheck, lint, vitest, build — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry checks so missing access metadata no longer causes the verification run to fail.
  * Relaxed permission validation to accept both read-only and read-write access where applicable.
  * Updated report checks to only flag mismatches when access details are actually available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->