### PR TITLE
fix(security): require NPM_READ_TOKEN for Vercel installs

### DIFF
--- a/scripts/vercel-install.sh
+++ b/scripts/vercel-install.sh
@@ -1,15 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Installs must use a READ token: the publish path is OIDC-only and install
-# auth must never share a publish-capable token. The Vercel project currently
-# provides NPM_TOKEN (2026-07-09); accept it as a DEPRECATED fallback until the
-# rotated token lands as NPM_READ_TOKEN, then delete this fallback.
+# Read token only: the publish path is OIDC-only and install auth must never
+# share a publish-capable token, so NPM_TOKEN is intentionally not accepted.
 token="${NPM_READ_TOKEN:-}"
-if [ -z "$token" ] && [ -n "${NPM_TOKEN:-}" ]; then
-  echo "::warning::Using deprecated NPM_TOKEN for installs — rename the Vercel env var to NPM_READ_TOKEN (granular, read-only) and remove NPM_TOKEN."
-  token="$NPM_TOKEN"
-fi
 
 if [ -z "$token" ]; then
   echo "::error::NPM_READ_TOKEN is required to install private @digitaltableteur packages."


### PR DESCRIPTION
## Summary
Completes the token rotation: Vercel now has `NPM_READ_TOKEN` (verified via `vercel env ls`) and `NPM_TOKEN` is removed, so the deprecated fallback added in #1020 is deleted. Installs now hard-require the read-only token name.

## Verification
- `bash -n` clean; script changes only (no runtime surface)
- Vercel env confirmed: `NPM_READ_TOKEN` present in Production, `NPM_TOKEN` gone
- Local full gate ran on the parent commit; this diff touches only the Vercel install script

🤖 Generated with [Claude Code](https://claude.com/claude-code)