### PR TITLE
fix: stop shared source from importing its own published package

### DIFF
--- a/nextjs-app/shared/components/NavLink/NavLink.tsx
+++ b/nextjs-app/shared/components/NavLink/NavLink.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { Link } from "../../lib/linkComponent";
-import { useNavigationPathname } from "@digitaltableteur/react";
+// Same-module-instance rule: shared source must not import its own published
+// package name — the package build would inline the PREVIOUS npm version of
+// itself (compounding tarball growth) and read a context no host provides.
+import { useNavigationPathname } from "../../lib/navigation";
 import { type ReactNode } from "react";
 import { cn } from "../../lib/cn";
 

--- a/nextjs-app/shared/components/NavMenuList/NavMenuList.tsx
+++ b/nextjs-app/shared/components/NavMenuList/NavMenuList.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { Link } from "../../lib/linkComponent";
-import { useNavigationPathname } from "@digitaltableteur/react";
+import { useNavigationPathname } from "../../lib/navigation";
 import styles from "./NavMenuList.module.css";
 
 export type NavMenuItem = {

--- a/nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx
+++ b/nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx
@@ -5,7 +5,11 @@ import type {
   PseoRelatedLinkCopy,
 } from "@/lib/pseo/types";
 
-import { Breadcrumb, Button, Card, Text, Title } from "@digitaltableteur/react";
+import Breadcrumb from "@dt/Breadcrumb";
+import Button from "@dt/Button";
+import Card from "@dt/Card";
+import Text from "@dt/Text";
+import Title from "@dt/Title";
 import MarkdownMessage from "@dt/MarkdownMessage";
 import PageLayout from "../../../patterns/PageLayout/PageLayout";
 import { PseoClusterBadges } from "./PseoClusterBadges";


### PR DESCRIPTION
## Summary
NavLink, NavMenuList, and PseoLeafPage imported `@digitaltableteur/react` from inside the package's own source graph, so every package build inlined the **previous npm version of itself** — 0.1.2 carries an inlined 0.1.1, and the next build (inlining 0.1.2) blew the tarball ceiling in [run 29026147512](https://github.com/PetriLahdelma/digitaltableteur/actions/runs/29026147512) (3.58 MB > 3.5 MB). The compounding self-inlining was flagged by the post-migration package-boundary review; the size guard caught it becoming real. The inlined copy also carried navigation contexts no host mounts.

Point the three files at local modules (`lib/navigation`, `@dt/*`).

## Verification
- Package rebuild: **3.58 MB → 1.55 MiB unpacked**; `check:react-package` (105 exports) and `check:package-tarballs` pass
- Browser: NavLink active state correct on /work, client routing preserved (window state survives nav)
- Full local gate: typecheck, lint, vitest, build — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)