### PR TITLE
feat: prepare @digitaltableteur/react@0.1.3 with honest externals

### DIFF
--- a/nextjs-app/shared/components/NavLink/NavLink.test.tsx
+++ b/nextjs-app/shared/components/NavLink/NavLink.test.tsx
@@ -5,7 +5,7 @@ import { NavLink } from "./NavLink";
 import {
   NavigationProvider,
   type NavigationRuntime,
-} from "@digitaltableteur/react";
+} from "../../lib/navigation";
 
 expect.extend(toHaveNoViolations);
 

--- a/nextjs-app/shared/components/NavMenuList/NavMenuList.test.tsx
+++ b/nextjs-app/shared/components/NavMenuList/NavMenuList.test.tsx
@@ -5,7 +5,7 @@ import NavMenuList, { NavMenuItem } from "@dt/NavMenuList";
 import {
   NavigationProvider,
   type NavigationRuntime,
-} from "@digitaltableteur/react";
+} from "../../lib/navigation";
 
 const items: NavMenuItem[] = [
   { to: "/", label: "Home", exact: true },

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.3 - 2026-07-09
+
+- Stops the package from bundling a stale copy of itself: shared source no longer imports `@digitaltableteur/react` internally (NavLink, NavMenuList, PseoLeafPage now use local modules), which had compounded tarball growth each publish and tripped the 3.5 MB ceiling.
+- Externalizes `framer-motion` (new peer dependency, `>=12.0.0`) and the declared runtime dependencies (`@phosphor-icons/react`, `class-variance-authority`, `clsx`, `react-phone-number-input`) instead of inlining them, so consumers get single module instances and the dependency map is honest.
+- Removes the unused `zod` dependency.
+- Keeps the public runtime API unchanged from 0.1.1/0.1.2.
+- Verified by `check:react-package`, `check:package-tarballs`, `check:react-public-api`, `check:react-public-surface`, `check:npm-consumer-install`, and the full local gate.
+
 ## 0.1.2 - 2026-07-09
 
 - Prepares the React package for publication through the GitHub Actions Trusted Publisher path.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/react",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": false,
   "description": "React components and host adapters for the Digitaltableteur design system.",
   "type": "module",
@@ -28,6 +28,7 @@
     "**/*.css"
   ],
   "peerDependencies": {
+    "framer-motion": ">=12.0.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"
   },
@@ -35,8 +36,7 @@
     "@phosphor-icons/react": "^2.1.10",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "react-phone-number-input": "^3.4.17",
-    "zod": "^4.4.3"
+    "react-phone-number-input": "^3.4.17"
   },
   "scripts": {
     "build": "vite build --config vite.config.ts && tsc -p tsconfig.types.json && node ../../scripts/design-system/assemble-react-package-types.mjs"

--- a/packages/react/public-api.manifest.json
+++ b/packages/react/public-api.manifest.json
@@ -1,6 +1,6 @@
 {
   "packageName": "@digitaltableteur/react",
-  "packageVersion": "0.1.0",
+  "packageVersion": "0.1.3",
   "packageExports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -7,14 +7,26 @@ const packageRoot = fileURLToPath(new URL(".", import.meta.url));
 const repoRoot = resolve(packageRoot, "../..");
 const sharedRoot = resolve(repoRoot, "nextjs-app/shared");
 const componentsRoot = resolve(sharedRoot, "components");
+// Everything here must be a peerDependency or dependency in package.json:
+// inlining a declared dependency ships two copies (bundle + registry install)
+// with independent module state (framer AnimatePresence, phosphor registry).
 const externalPackages = [
   "react",
   "react-dom",
   "react/jsx-runtime",
   "react/jsx-dev-runtime",
+  "framer-motion",
+  "@phosphor-icons/react",
+  "class-variance-authority",
+  "clsx",
+  "react-phone-number-input",
 ];
 
 function isExternal(id: string): boolean {
+  // Stylesheets stay bundled into dist/style.css even when their package is
+  // external (react-phone-number-input/style.css) — a bare CSS import in the
+  // emitted JS would break non-bundler consumers.
+  if (id.endsWith(".css")) return false;
   return externalPackages.some(
     (pkg) => id === pkg || id.startsWith(`${pkg}/`),
   );

--- a/scripts/design-system/check-npm-consumer-install.mjs
+++ b/scripts/design-system/check-npm-consumer-install.mjs
@@ -104,10 +104,21 @@ const reactTypesVersion =
   rootPackage.dependencies?.["@types/react"] ?? rootPackage.devDependencies?.["@types/react"];
 const reactDomTypesVersion =
   rootPackage.dependencies?.["@types/react-dom"] ?? rootPackage.devDependencies?.["@types/react-dom"];
+// framer-motion is a package peerDependency; the repo installs with
+// legacy-peer-deps so the consumer must install it explicitly like react.
+const framerMotionVersion =
+  rootPackage.dependencies?.["framer-motion"] ?? rootPackage.devDependencies?.["framer-motion"];
 
-if (!reactVersion || !reactDomVersion || !typescriptVersion || !reactTypesVersion || !reactDomTypesVersion) {
+if (
+  !reactVersion ||
+  !reactDomVersion ||
+  !typescriptVersion ||
+  !reactTypesVersion ||
+  !reactDomTypesVersion ||
+  !framerMotionVersion
+) {
   throw new Error(
-    "Root package.json must declare react, react-dom, typescript, @types/react, and @types/react-dom for the consumer smoke.",
+    "Root package.json must declare react, react-dom, framer-motion, typescript, @types/react, and @types/react-dom for the consumer smoke.",
   );
 }
 
@@ -445,6 +456,7 @@ void tree;
       "--prefer-offline",
       `react@${reactVersion}`,
       `react-dom@${reactDomVersion}`,
+      `framer-motion@${framerMotionVersion}`,
       `typescript@${typescriptVersion}`,
       `@types/react@${reactTypesVersion}`,
       `@types/react-dom@${reactDomTypesVersion}`,

--- a/scripts/design-system/check-package-registry-status.mjs
+++ b/scripts/design-system/check-package-registry-status.mjs
@@ -117,11 +117,11 @@ function checkPublishedPackage(row, exactView, orgAccess, errors) {
   if (exactView.json !== row.expectedVersion) {
     errors.push(`${row.name} registry version ${exactView.json} does not match expected ${row.expectedVersion}.`);
   }
-  if (row.accessStatus !== "private") {
-    errors.push(`${row.name} access status ${row.accessStatus ?? "missing"} does not match expected private.`);
+  if (row.accessStatus !== null && row.accessStatus !== "private") {
+    errors.push(`${row.name} access status ${row.accessStatus} does not match expected private.`);
   }
-  if (row.orgAccess !== "read-write") {
-    errors.push(`${row.name} org access ${row.orgAccess ?? "missing"} does not match expected read-write.`);
+  if (row.orgAccess !== null && row.orgAccess !== "read-only" && row.orgAccess !== "read-write") {
+    errors.push(`${row.name} org access ${row.orgAccess} does not match expected read-only or read-write.`);
   }
 }
 
@@ -136,11 +136,11 @@ function checkUnpublishedPackage(row, exactView, errors) {
 }
 
 const errors = [];
+// npm `access list` needs org-level permission that a least-privilege install
+// token (read-only, package-scoped) intentionally lacks and 403s on. Org
+// access metadata is best-effort; version/readability checks below still run.
 const accessPackagesResult = runNpm(["access", "list", "packages", "digitaltableteur", "--json"]);
-const accessPackages = accessPackagesResult.ok ? accessPackagesResult.json : {};
-if (!accessPackagesResult.ok) {
-  errors.push("npm access list packages digitaltableteur failed; cannot verify org access.");
-}
+const accessPackages = accessPackagesResult.ok ? accessPackagesResult.json : null;
 
 const rows = PACKAGE_DEFS.map((definition) => {
   const pkg = readJson(join(ROOT, definition.dir, "package.json"));

--- a/scripts/design-system/check-react-publish-review-packet.mjs
+++ b/scripts/design-system/check-react-publish-review-packet.mjs
@@ -95,6 +95,20 @@ function relativePath(path) {
   return relative(ROOT, path);
 }
 
+/**
+ * Org access metadata is best-effort: npm `access` org APIs 403 for
+ * least-privilege install tokens (read-only, package-scoped), which the
+ * upstream reports record as null. Readability is proven by npm view and
+ * the scratch installs, so null is acceptable here.
+ */
+function isAcceptableOrgAccess(value) {
+  return value == null || value === "read-only" || value === "read-write";
+}
+
+function isAcceptableAccessStatus(value) {
+  return value == null || value === "private";
+}
+
 function resolveRootPath(path) {
   return isAbsolute(path) ? path : join(ROOT, path);
 }
@@ -529,11 +543,11 @@ function validateRegistryTokenInstallReport(report, errors) {
     if (row.expectedVersion !== row.registryVersion) {
       errors.push(`${row.name} registry version ${row.registryVersion} does not match expected ${row.expectedVersion}.`);
     }
-    if (row.orgAccess !== "read-write") {
-      errors.push(`${row.name} org access ${row.orgAccess ?? "missing"} does not match expected read-write.`);
+    if (!isAcceptableOrgAccess(row.orgAccess)) {
+      errors.push(`${row.name} org access ${row.orgAccess} does not match expected read-only or read-write.`);
     }
-    if (row.accessStatus !== "private") {
-      errors.push(`${row.name} access status ${row.accessStatus ?? "missing"} does not match expected private.`);
+    if (!isAcceptableAccessStatus(row.accessStatus)) {
+      errors.push(`${row.name} access status ${row.accessStatus} does not match expected private.`);
     }
   }
   if ((report.consumer?.tokenCount ?? 0) < 180) {
@@ -606,9 +620,9 @@ function validateReactRegistryInstallReport(report, errors) {
         `@digitaltableteur/react registry smoke saw ${reactRow.actualState}@${reactRow.registryVersion}; expected published@${reactRow.expectedVersion}.`,
       );
     }
-    if (reactRow.orgAccess !== "read-write") {
+    if (!isAcceptableOrgAccess(reactRow.orgAccess)) {
       errors.push(
-        `@digitaltableteur/react registry access is ${reactRow.orgAccess ?? "missing"}; expected read-write.`,
+        `@digitaltableteur/react registry access is ${reactRow.orgAccess}; expected read-only or read-write.`,
       );
     }
     if ((report.consumer?.reactExports ?? 0) < MIN_REACT_RUNTIME_EXPORTS) {
@@ -680,8 +694,8 @@ function validatePackageRegistryStatusReport(report, errors) {
     if (row.actualState !== "published" || row.registryVersion !== row.expectedVersion) {
       errors.push(`${packageName} registry state is ${row.actualState}@${row.registryVersion}; expected published@${row.expectedVersion}.`);
     }
-    if (row.accessStatus !== "private" || row.orgAccess !== "read-write") {
-      errors.push(`${packageName} registry access is ${row.accessStatus ?? "missing"}/${row.orgAccess ?? "missing"}; expected private/read-write.`);
+    if (!isAcceptableAccessStatus(row.accessStatus) || !isAcceptableOrgAccess(row.orgAccess)) {
+      errors.push(`${packageName} registry access is ${row.accessStatus}/${row.orgAccess}; expected private/read-only-or-better.`);
     }
   }
   if (!reactRow) {
@@ -698,9 +712,9 @@ function validatePackageRegistryStatusReport(report, errors) {
         `@digitaltableteur/react@${reactRow.expectedVersion} registry state is ${reactRow.actualState}@${reactRow.registryVersion}; expected published@${reactRow.expectedVersion}.`,
       );
     }
-    if (reactRow.accessStatus !== "private" || reactRow.orgAccess !== "read-write") {
+    if (!isAcceptableAccessStatus(reactRow.accessStatus) || !isAcceptableOrgAccess(reactRow.orgAccess)) {
       errors.push(
-        `@digitaltableteur/react registry access is ${reactRow.accessStatus ?? "missing"}/${reactRow.orgAccess ?? "missing"}; expected private/read-write.`,
+        `@digitaltableteur/react registry access is ${reactRow.accessStatus}/${reactRow.orgAccess}; expected private/read-only-or-better.`,
       );
     }
   }

--- a/scripts/design-system/check-react-registry-install.mjs
+++ b/scripts/design-system/check-react-registry-install.mjs
@@ -122,6 +122,10 @@ const reactTypesVersion =
   rootPackage.dependencies?.["@types/react"] ?? rootPackage.devDependencies?.["@types/react"];
 const reactDomTypesVersion =
   rootPackage.dependencies?.["@types/react-dom"] ?? rootPackage.devDependencies?.["@types/react-dom"];
+// framer-motion is a package peerDependency; the repo installs with
+// legacy-peer-deps so the scratch consumer must install it explicitly.
+const framerMotionVersion =
+  rootPackage.dependencies?.["framer-motion"] ?? rootPackage.devDependencies?.["framer-motion"];
 const forbiddenReactExports = roadmapState.reactPublicSurface?.forbiddenExports ?? [];
 
 if (
@@ -129,10 +133,11 @@ if (
   !reactDomDependencyVersion ||
   !typescriptVersion ||
   !reactTypesVersion ||
-  !reactDomTypesVersion
+  !reactDomTypesVersion ||
+  !framerMotionVersion
 ) {
   throw new Error(
-    "Root package.json must declare react, react-dom, typescript, @types/react, and @types/react-dom for the registry smoke.",
+    "Root package.json must declare react, react-dom, framer-motion, typescript, @types/react, and @types/react-dom for the registry smoke.",
   );
 }
 
@@ -490,6 +495,7 @@ void tree;
       "--package-lock=false",
       `react@${reactDependencyVersion}`,
       `react-dom@${reactDomDependencyVersion}`,
+      `framer-motion@${framerMotionVersion}`,
       `typescript@${typescriptVersion}`,
       `@types/react@${reactTypesVersion}`,
       `@types/react-dom@${reactDomTypesVersion}`,


### PR DESCRIPTION
## Summary
- **Externalizes framer-motion** (new peer, `>=12.0.0`) and the declared runtime dependencies (phosphor, cva, clsx, react-phone-number-input) instead of inlining them: single module instances for consumers, honest dependency map. CSS ids stay bundled so phone-input styles remain in `style.css`.
- Drops the unused `zod` dependency.
- Combined with #1024, the package shrinks **3.58 MB → 1.03 MiB unpacked**; public API unchanged (105 exports, manifest restamped to 0.1.3).
- Consumer smokes install framer-motion explicitly (repo uses legacy-peer-deps which skips peer auto-install); NavLink/NavMenuList tests provide the local navigation module.
- Completes the least-privilege token sweep: registry-status and publish-review-packet guards now tolerate the rotated read-only token (same treatment as #1022).

## Verification
- `check:react-publish-preflight -- --strict --require-clearance`: **22/22 checks pass** (includes lint, typecheck, full vitest, build, all package/tarball/consumer checks, clearance record)
- Clean-consumer smoke: 105 exports, runtime + types, with externalized peers

🤖 Generated with [Claude Code](https://claude.com/claude-code)