### PR TITLE
chore: consume @digitaltableteur/react@0.1.3 from npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ai-sdk/openai": "^3.0.71",
         "@ai-sdk/react": "^3.0.207",
         "@calcom/embed-react": "^1.5.3",
-        "@digitaltableteur/react": "^0.1.2",
+        "@digitaltableteur/react": "^0.1.3",
         "@digitaltableteur/tokens": "^0.1.0",
         "@digitaltableteur/tokens-css": "^0.1.0",
         "@emailjs/browser": "^4.4.1",
@@ -3404,18 +3404,18 @@
       "license": "MIT"
     },
     "node_modules/@digitaltableteur/react": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.2.tgz",
-      "integrity": "sha512-Nr0tMC9rRCJX+eOAu92lYhh11+qyFE17pD+5kmRt0BLcF6CuTgL5rC04aD2zY+hv5S1R9+8rd2sUTnS5XcDeXg==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.3.tgz",
+      "integrity": "sha512-ZMt44DdDVOqZTtZFxtooQhtEjOiQn5DdNjv24NdBf+KzUOUZyAJEkFbaygvhfuFmgCxrMmHq875gV71GrOAxKQ==",
       "license": "UNLICENSED",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "react-phone-number-input": "^3.4.17",
-        "zod": "^4.4.3"
+        "react-phone-number-input": "^3.4.17"
       },
       "peerDependencies": {
+        "framer-motion": ">=12.0.0",
         "react": ">=19.0.0",
         "react-dom": ">=19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "@ai-sdk/openai": "^3.0.71",
     "@ai-sdk/react": "^3.0.207",
     "@calcom/embed-react": "^1.5.3",
-    "@digitaltableteur/react": "^0.1.2",
+    "@digitaltableteur/react": "^0.1.3",
     "@digitaltableteur/tokens": "^0.1.0",
     "@digitaltableteur/tokens-css": "^0.1.0",
     "@emailjs/browser": "^4.4.1",


### PR DESCRIPTION
## Summary
Bumps the app to `@digitaltableteur/react@^0.1.3` — the de-bloated release from #1024/#1025: no self-inlined previous version, framer-motion + runtime deps externalized, 3.58 MB → 1.03 MiB unpacked.

## Verification
- `npm ls`: framer-motion and @phosphor-icons/react **deduped** to the app's single instances (the externalization goal)
- Guards: `check:package-registry-resolution`, `check:storybook-registry-package`, `check:react-registry-install` (105 exports, runtime + types), `check:package-registry-status` (0.1.3 published) — all pass
- Full local gate: typecheck, lint, vitest, build — exit 0
- Browser regression pass on the dev server running 0.1.3: client routing (window state survives nav), 11/11 /work images via /_next/image, EN↔FI switching with persistence, 4-theme cycle with persistence, zero console warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)