### PR TITLE
feat: component usage analytics with Storybook docs page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ nextjs-app/shared/foundations/dist/*
 !nextjs-app/shared/foundations/dist/component-catalog.zod.ts
 !nextjs-app/shared/foundations/dist/docs-registry.json
 !nextjs-app/shared/foundations/dist/tokens-manifest.json
+!nextjs-app/shared/foundations/dist/component-usage.json
 packages/*/dist/
 
 # misc

--- a/nextjs-app/shared/foundations/dist/component-usage.json
+++ b/nextjs-app/shared/foundations/dist/component-usage.json
@@ -1,0 +1,3750 @@
+{
+  "generatedAt": "2026-07-09T15:55:12.629Z",
+  "components": [
+    {
+      "name": "__templates__",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 0,
+      "directImporters": [],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "AboutHero",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 6,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/index.ts",
+        "nextjs-app/shared/patterns/AboutHero/index.ts",
+        "nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx",
+        "nextjs-app/shared/patterns/AboutPageContent/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "AboutPageContent",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 4,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/index.ts",
+        "nextjs-app/shared/patterns/AboutPageContent/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "Accordion",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 0,
+      "directImporters": [],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "AlertBanner",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/Mermaid/Mermaid.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 4,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/index.ts",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx",
+        "nextjs-app/shared/components/pages/Work/VertaaUX/index.ts",
+        "nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx"
+      ]
+    },
+    {
+      "name": "animations",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 27,
+      "directImporters": [
+        "nextjs-app/shared/components/BlogGrid/BlogGrid.tsx",
+        "nextjs-app/shared/components/ContactFormSuccess/ContactFormSuccess.tsx",
+        "nextjs-app/shared/components/LocationCard/LocationCard.tsx",
+        "nextjs-app/shared/components/NextLayout/NextLayout.tsx",
+        "nextjs-app/shared/components/SkillsGrid/SkillsGrid.tsx",
+        "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx",
+        "nextjs-app/shared/components/WorkGrid/WorkGrid.tsx",
+        "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
+        "nextjs-app/shared/patterns/AboutHero/AboutHero.tsx",
+        "nextjs-app/shared/patterns/ArticleHero/ArticleHero.tsx",
+        "nextjs-app/shared/patterns/BlogHero/BlogHero.tsx",
+        "nextjs-app/shared/patterns/CTASection/CTASection.tsx",
+        "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx",
+        "nextjs-app/shared/patterns/ContactHero/ContactHero.tsx",
+        "nextjs-app/shared/patterns/ContentSection/ContentSection.tsx",
+        "nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.tsx",
+        "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
+        "nextjs-app/shared/patterns/ManifestoSection/ManifestoSection.tsx",
+        "nextjs-app/shared/patterns/ProjectHero/ProjectHero.tsx",
+        "nextjs-app/shared/patterns/ProjectMetaSection/ProjectMetaSection.tsx",
+        "nextjs-app/shared/patterns/RelatedPosts/RelatedPosts.tsx",
+        "nextjs-app/shared/patterns/RelatedProjects/RelatedProjects.tsx",
+        "nextjs-app/shared/patterns/ServicesSection/ServicesSection.tsx",
+        "nextjs-app/shared/patterns/StatsSection/StatsSection.tsx",
+        "nextjs-app/shared/patterns/ValuesSection/ValuesSection.tsx",
+        "nextjs-app/shared/patterns/WorkHero/WorkHero.tsx",
+        "nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "AppLoading",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "ArticleCard",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "ArticleContent",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 4,
+      "directImporters": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/ClientArticleShell.tsx",
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx"
+      ],
+      "prodPageCount": 10,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/ClientArticleShell.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "ArticleHero",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 10,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/patterns/ArticleHero/index.ts",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "ArticleLayout",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 3,
+      "directImporters": [
+        "app/blog/[slug]/ClientArticleShell.tsx",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 11,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/ClientArticleShell.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/patterns/ArticleLayout/index.ts",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "ArticlePageTemplate",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 3,
+      "directImporters": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 8,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "ArticleShareSection",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx"
+      ],
+      "prodPageCount": 9,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "AskAI",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx",
+        "nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "AspectRatio",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx"
+      ],
+      "prodPageCount": 1,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx"
+      ]
+    },
+    {
+      "name": "Author",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "AuthorBio",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx"
+      ],
+      "prodPageCount": 10,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "Avatar",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/components/Author/Author.tsx",
+        "nextjs-app/shared/components/AuthorBio/AuthorBio.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 10,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "AvatarGroup",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Badge",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 8,
+      "directImporters": [
+        "nextjs-app/shared/components/CookieConsent/CookieConsent.tsx",
+        "nextjs-app/shared/components/MultiCombobox/MultiCombobox.tsx",
+        "nextjs-app/shared/components/OpenHours/OpenHours.tsx",
+        "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx",
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/components/pages/Pseo/PseoClusterBadges.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoPillarMetaBadgeLinks.tsx",
+        "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/components/pages/Pseo/PseoClusterBadges.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoPillarMetaBadgeLinks.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Illustrations/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
+      ]
+    },
+    {
+      "name": "BlogCategoryFilter",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx"
+      ],
+      "prodPageCount": 5,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx",
+        "nextjs-app/shared/patterns/BlogIndexContent/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "BlogGrid",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx"
+      ],
+      "prodPageCount": 5,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx",
+        "nextjs-app/shared/patterns/BlogIndexContent/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "BlogHero",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 6,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/patterns/BlogHero/index.ts",
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx",
+        "nextjs-app/shared/patterns/BlogIndexContent/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "BlogIndexContent",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 4,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/patterns/BlogIndexContent/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "BlogMediaImage",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/components/EnhancedArticleCard/EnhancedArticleCard.tsx",
+        "nextjs-app/shared/components/MdxImage/MdxImage.tsx",
+        "nextjs-app/shared/patterns/ArticleHero/ArticleHero.tsx"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/patterns/ArticleHero/ArticleHero.tsx",
+        "nextjs-app/shared/patterns/ArticleHero/index.ts",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts",
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx"
+      ]
+    },
+    {
+      "name": "BlogNav",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 0,
+      "directImporters": [],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Breadcrumb",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx"
+      ],
+      "prodPageCount": 1,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx"
+      ]
+    },
+    {
+      "name": "Button",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 50,
+      "directImporters": [
+        "app/blog/NextBlogNav.tsx",
+        "app/error.tsx",
+        "app/not-found.tsx",
+        "app/work/NextWorkNav.tsx",
+        "nextjs-app/shared/components/AlertBanner/AlertBanner.tsx",
+        "nextjs-app/shared/components/BlogNav/BlogNav.tsx",
+        "nextjs-app/shared/components/ChatWidget/ChatComposer.tsx",
+        "nextjs-app/shared/components/ChatWidget/ChatHeader.tsx",
+        "nextjs-app/shared/components/ChatWidget/ChatToggle.tsx",
+        "nextjs-app/shared/components/ChatWidget/emailWorkflow/ComposePrompt.tsx",
+        "nextjs-app/shared/components/ChatWidget/emailWorkflow/FieldPrompt.tsx",
+        "nextjs-app/shared/components/ChatWidget/emailWorkflow/ReviewSummary.tsx",
+        "nextjs-app/shared/components/ChatWidget/emailWorkflow/SendStatus.tsx",
+        "nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.tsx",
+        "nextjs-app/shared/components/CodeSnippet/CodeSnippet.tsx",
+        "nextjs-app/shared/components/ContactForm/ContactForm.tsx",
+        "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx",
+        "nextjs-app/shared/components/ContactFormSuccess/ContactFormSuccess.tsx",
+        "nextjs-app/shared/components/ContactFormSuccessEditorial/ContactFormSuccessEditorial.tsx",
+        "nextjs-app/shared/components/CookieConsent/CookieConsent.tsx",
+        "nextjs-app/shared/components/CookieConsent/CookieConsentBanner.tsx",
+        "nextjs-app/shared/components/DonnyBookingEmbed/DonnyBookingEmbed.tsx",
+        "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.tsx",
+        "nextjs-app/shared/components/FileUpload/FileUpload.tsx",
+        "nextjs-app/shared/components/IconButton/IconButton.tsx",
+        "nextjs-app/shared/components/MCPActionButton/MCPActionButton.tsx",
+        "nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.tsx",
+        "nextjs-app/shared/components/Modal/Modal.tsx",
+        "nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.tsx",
+        "nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.tsx",
+        "nextjs-app/shared/components/SocialShare/SocialShare.tsx",
+        "nextjs-app/shared/components/SplitButton/SplitButton.tsx",
+        "nextjs-app/shared/components/StudioMap/StudioMap.tsx",
+        "nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.tsx",
+        "nextjs-app/shared/components/WorkNav/WorkNav.tsx",
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
+        "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullEnPage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullFiPage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullSvPage.tsx",
+        "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+        "nextjs-app/shared/patterns/CTASection/CTASection.tsx",
+        "nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx",
+        "nextjs-app/shared/patterns/Hero/Hero.tsx",
+        "nextjs-app/shared/patterns/HighlightSection/HighlightSection.tsx",
+        "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
+        "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/BlogArticleShare.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "app/dev/code-window/page.tsx",
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "app/tools/email-signature/EmailSignatureContent.tsx",
+        "app/tools/email-signature/page.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/index.ts"
+      ]
+    },
+    {
+      "name": "ButtonGroup",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Card",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 7,
+      "directImporters": [
+        "nextjs-app/shared/components/ComplianceCard/ComplianceCard.tsx",
+        "nextjs-app/shared/components/SelectableCard/SelectableCard.tsx",
+        "nextjs-app/shared/components/SentrySummaryCard/SentrySummaryCard.tsx",
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx"
+      ],
+      "prodPageCount": 3,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx"
+      ]
+    },
+    {
+      "name": "CategoryFilter",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
+        "nextjs-app/shared/components/ui/index.ts"
+      ],
+      "prodPageCount": 3,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "nextjs-app/shared/components/pages/Work/WorkIndex/index.ts",
+        "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx"
+      ]
+    },
+    {
+      "name": "Center",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx"
+      ],
+      "prodPageCount": 1,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx"
+      ]
+    },
+    {
+      "name": "ChatWidget",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/NextLayout/NextLayout.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 1,
+      "prodPages": [
+        "app/layout.tsx"
+      ]
+    },
+    {
+      "name": "Checkbox",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 4,
+      "directImporters": [
+        "nextjs-app/shared/components/AskAI/AskAI.tsx",
+        "nextjs-app/shared/components/CheckboxGroup/CheckboxGroup.tsx",
+        "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 8,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/index.ts",
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
+      ]
+    },
+    {
+      "name": "CheckboxGroup",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 4,
+      "directImporters": [
+        "nextjs-app/shared/components/ChatWidget/emailWorkflow/FieldPrompt.tsx",
+        "nextjs-app/shared/components/ContactForm/ContactForm.tsx",
+        "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 5,
+      "prodPages": [
+        "app/layout.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
+      ]
+    },
+    {
+      "name": "ChunkErrorBoundary",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "ClientLogoMarquee",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx"
+      ],
+      "prodPageCount": 1,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx"
+      ]
+    },
+    {
+      "name": "CodeBlockWindow",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 3,
+      "directImporters": [
+        "app/dev/code-window/page.tsx",
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx"
+      ],
+      "prodPageCount": 10,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "app/dev/code-window/page.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "CodeSnippet",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx"
+      ],
+      "prodPageCount": 2,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/index.ts",
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx"
+      ]
+    },
+    {
+      "name": "Combobox",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/components/FileUpload/FileUpload.tsx",
+        "nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.tsx",
+        "nextjs-app/shared/components/MultiCombobox/MultiCombobox.tsx"
+      ],
+      "prodPageCount": 4,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
+      ]
+    },
+    {
+      "name": "CommandPalette",
+      "kind": "component",
+      "status": "alpha",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "ComplianceCard",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "ContactForm",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/ChatWidget/emailWorkflow/FieldPrompt.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 1,
+      "prodPages": [
+        "app/layout.tsx"
+      ]
+    },
+    {
+      "name": "ContactFormEditorial",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx"
+      ],
+      "prodPageCount": 4,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
+      ]
+    },
+    {
+      "name": "ContactFormSuccess",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/ui/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "ContactFormSuccessEditorial",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "ContactHero",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 2,
+      "prodPages": [
+        "nextjs-app/shared/patterns/ContactHero/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "ContactInquiryPanel",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx"
+      ],
+      "prodPageCount": 5,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactInquiryPanel/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
+      ]
+    },
+    {
+      "name": "ContactPage",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "app/contact/ContactContent.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "ContactPageContentEditorial",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx"
+      ],
+      "prodPageCount": 3,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
+      ]
+    },
+    {
+      "name": "Container",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 31,
+      "directImporters": [
+        "app/blog/[slug]/ServerArticleHero.tsx",
+        "app/blog/[slug]/ServerRelatedPosts.tsx",
+        "app/dev/code-window/page.tsx",
+        "nextjs-app/shared/components/ArticleContent/ArticleContent.tsx",
+        "nextjs-app/shared/components/ProjectNav/ProjectNav.tsx",
+        "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx",
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
+        "nextjs-app/shared/patterns/AboutHero/AboutHero.tsx",
+        "nextjs-app/shared/patterns/ArticleHero/ArticleHero.tsx",
+        "nextjs-app/shared/patterns/BlogHero/BlogHero.tsx",
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx",
+        "nextjs-app/shared/patterns/CTASection/CTASection.tsx",
+        "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx",
+        "nextjs-app/shared/patterns/ContactHero/ContactHero.tsx",
+        "nextjs-app/shared/patterns/ContentSection/ContentSection.tsx",
+        "nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.tsx",
+        "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
+        "nextjs-app/shared/patterns/ManifestoSection/ManifestoSection.tsx",
+        "nextjs-app/shared/patterns/ProjectDetailTemplate/ProjectDetailTemplate.tsx",
+        "nextjs-app/shared/patterns/ProjectHero/ProjectHero.tsx",
+        "nextjs-app/shared/patterns/RelatedPosts/RelatedPosts.tsx",
+        "nextjs-app/shared/patterns/RelatedProjects/RelatedProjects.tsx",
+        "nextjs-app/shared/patterns/ServicesSection/ServicesSection.tsx",
+        "nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx",
+        "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx",
+        "nextjs-app/shared/patterns/StatsSection/StatsSection.tsx",
+        "nextjs-app/shared/patterns/ValuesSection/ValuesSection.tsx",
+        "nextjs-app/shared/patterns/WorkHero/WorkHero.tsx",
+        "nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.tsx",
+        "nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.tsx"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/ClientArticleShell.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleHero.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "app/blog/[slug]/ServerRelatedPosts.tsx",
+        "app/dev/code-window/page.tsx",
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/index.ts"
+      ]
+    },
+    {
+      "name": "ContentSection",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/patterns/ProjectDetailTemplate/ProjectDetailTemplate.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 4,
+      "prodPages": [
+        "nextjs-app/shared/patterns/ContentSection/index.ts",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/ProjectDetailTemplate/index.ts",
+        "nextjs-app/shared/patterns/ProjectDetailTemplate/ProjectDetailTemplate.tsx"
+      ]
+    },
+    {
+      "name": "CookieConsent",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/NextLayout/NextLayout.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 1,
+      "prodPages": [
+        "app/layout.tsx"
+      ]
+    },
+    {
+      "name": "CTASection",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 4,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx",
+        "nextjs-app/shared/patterns/WorkCTA/WorkCTA.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/index.ts",
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/index.ts",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/index.ts",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx"
+      ]
+    },
+    {
+      "name": "CVDownloadSection",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 2,
+      "prodPages": [
+        "nextjs-app/shared/patterns/CVDownloadSection/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "DashLeadList",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx"
+      ],
+      "prodPageCount": 9,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "Designerman",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 0,
+      "directImporters": [],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "DesignSprintsSection",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 3,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/patterns/DesignSprintsSection/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "Display",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 0,
+      "directImporters": [],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Divider",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/components/ui/index.ts",
+        "nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx"
+      ],
+      "prodPageCount": 6,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/navigation/index.ts",
+        "nextjs-app/shared/patterns/SiteFooter/index.ts",
+        "nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx"
+      ]
+    },
+    {
+      "name": "DonnyActionProvider",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 6,
+      "directImporters": [
+        "nextjs-app/shared/components/ChatWidget/chatToolLead.ts",
+        "nextjs-app/shared/components/ChatWidget/chatToolNavigation.ts",
+        "nextjs-app/shared/components/ChatWidget/useDonnyChatNavigation.ts",
+        "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx",
+        "nextjs-app/shared/components/NextLayout/NextLayout.tsx",
+        "nextjs-app/shared/lib/donny-lead/donny-lead-routing.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "DonnyAvatar",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 7,
+      "directImporters": [
+        "nextjs-app/shared/components/ChatWidget/ChatHeader.tsx",
+        "nextjs-app/shared/components/ChatWidget/ChatToggle.tsx",
+        "nextjs-app/shared/components/ChatWidget/chatAvatarState.ts",
+        "nextjs-app/shared/components/ChatWidget/chatToolExpression.ts",
+        "nextjs-app/shared/components/ChatWidget/useDonnyChatExpression.ts",
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/data/donny-expressions.ts"
+      ],
+      "prodPageCount": 1,
+      "prodPages": [
+        "app/layout.tsx"
+      ]
+    },
+    {
+      "name": "DonnyBookingEmbed",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/ChatWidget/ChatMessageBubble.tsx",
+        "nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx"
+      ],
+      "prodPageCount": 7,
+      "prodPages": [
+        "app/layout.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx",
+        "nextjs-app/shared/patterns/ContactInquiryPanel/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
+      ]
+    },
+    {
+      "name": "EmailSignatureGenerator",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "app/tools/email-signature/EmailSignatureContent.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 2,
+      "prodPages": [
+        "app/tools/email-signature/EmailSignatureContent.tsx",
+        "app/tools/email-signature/page.tsx"
+      ]
+    },
+    {
+      "name": "EmptyState",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/WorkGrid/WorkGrid.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 3,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "nextjs-app/shared/components/pages/Work/WorkIndex/index.ts",
+        "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx"
+      ]
+    },
+    {
+      "name": "EnhancedArticleCard",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 4,
+      "directImporters": [
+        "nextjs-app/shared/components/BlogGrid/BlogGrid.tsx",
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx",
+        "nextjs-app/shared/patterns/RelatedPosts/RelatedPosts.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "EnhancedAuthorCard",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "EnhancedProjectCard",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 5,
+      "directImporters": [
+        "nextjs-app/shared/components/WorkGrid/WorkGrid.tsx",
+        "nextjs-app/shared/components/ui/index.ts",
+        "nextjs-app/shared/patterns/RelatedProjects/RelatedProjects.tsx",
+        "nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.tsx",
+        "nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.tsx"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/index.ts",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/index.ts",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/Intrum/index.ts",
+        "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx"
+      ]
+    },
+    {
+      "name": "ExpandableSection",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx"
+      ],
+      "prodPageCount": 4,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
+      ]
+    },
+    {
+      "name": "FileUpload",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/components/ContactForm/ContactForm.tsx",
+        "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 5,
+      "prodPages": [
+        "app/layout.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
+      ]
+    },
+    {
+      "name": "FinnishTransportAgency",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "app/work/finnish-transport-agency/page.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "FlexBox",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx"
+      ],
+      "prodPageCount": 2,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Illustrations/index.ts"
+      ]
+    },
+    {
+      "name": "Footer",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 0,
+      "directImporters": [],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "FormField",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/ui/index.ts"
+      ],
+      "prodPageCount": 1,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx"
+      ]
+    },
+    {
+      "name": "FormFieldEditorial",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx"
+      ],
+      "prodPageCount": 4,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
+      ]
+    },
+    {
+      "name": "Gallery",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx"
+      ],
+      "prodPageCount": 2,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/index.ts",
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx"
+      ]
+    },
+    {
+      "name": "GarageJunction",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "app/work/garage-junction/page.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "GradientDots",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 0,
+      "directImporters": [],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Grid",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/patterns/Footer/Footer.tsx"
+      ],
+      "prodPageCount": 1,
+      "prodPages": [
+        "nextjs-app/shared/patterns/Footer/Footer.tsx"
+      ]
+    },
+    {
+      "name": "GridBlock",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 12,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx",
+        "nextjs-app/shared/components/pages/Work/ProjectSpine/ProjectSpinePage.tsx",
+        "nextjs-app/shared/components/pages/Work/RawView/RawViewPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx",
+        "nextjs-app/shared/components/pages/Work/SapBuildApps/SapBuildAppsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Tulli/TulliPage.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/index.ts",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/Intrum/index.ts",
+        "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/index.ts",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/index.ts",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx"
+      ]
+    },
+    {
+      "name": "GroupLabel",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/CheckboxGroup/CheckboxGroup.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 5,
+      "prodPages": [
+        "app/layout.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
+      ]
+    },
+    {
+      "name": "HelperText",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 12,
+      "directImporters": [
+        "nextjs-app/shared/components/ChatWidget/ChatComposer.tsx",
+        "nextjs-app/shared/components/Checkbox/Checkbox.tsx",
+        "nextjs-app/shared/components/Combobox/Combobox.tsx",
+        "nextjs-app/shared/components/FileUpload/FileUpload.tsx",
+        "nextjs-app/shared/components/MultiCombobox/MultiCombobox.tsx",
+        "nextjs-app/shared/components/PhoneInput/PhoneInput.tsx",
+        "nextjs-app/shared/components/RadioGroup/RadioGroup.tsx",
+        "nextjs-app/shared/components/Select/Select.tsx",
+        "nextjs-app/shared/components/SelectableCard/SelectableCard.tsx",
+        "nextjs-app/shared/components/Switch/Switch.tsx",
+        "nextjs-app/shared/components/TextArea/TextArea.tsx",
+        "nextjs-app/shared/components/TextInput/TextInput.tsx"
+      ],
+      "prodPageCount": 11,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/index.ts",
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts",
+        "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx",
+        "nextjs-app/shared/patterns/CVDownloadSection/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "HelsinkiClock",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Hero",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 2,
+      "prodPages": [
+        "nextjs-app/shared/patterns/Hero/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "HeroBackground",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "HeroSection",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 5,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/patterns/HeroSection/index.ts",
+        "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
+        "nextjs-app/shared/patterns/HomeHero/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "HighlightSection",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 3,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/patterns/HighlightSection/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "HomeHero",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 3,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/patterns/HomeHero/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "Icon",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 48,
+      "directImporters": [
+        "app/blog/NextBlogNav.tsx",
+        "app/error.tsx",
+        "app/not-found.tsx",
+        "app/work/NextWorkNav.tsx",
+        "nextjs-app/shared/components/Accordion/Accordion.tsx",
+        "nextjs-app/shared/components/AlertBanner/AlertBanner.tsx",
+        "nextjs-app/shared/components/Badge/Badge.tsx",
+        "nextjs-app/shared/components/BlogNav/BlogNav.tsx",
+        "nextjs-app/shared/components/Breadcrumb/Breadcrumb.tsx",
+        "nextjs-app/shared/components/Button/Button.tsx",
+        "nextjs-app/shared/components/ChatWidget/ChatComposer.tsx",
+        "nextjs-app/shared/components/ChatWidget/ChatHeader.tsx",
+        "nextjs-app/shared/components/ChatWidget/ChatToggle.tsx",
+        "nextjs-app/shared/components/ChatWidget/ChatToolResultSection.tsx",
+        "nextjs-app/shared/components/Combobox/Combobox.tsx",
+        "nextjs-app/shared/components/ComplianceCard/ComplianceCard.tsx",
+        "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.tsx",
+        "nextjs-app/shared/components/EmptyState/EmptyState.tsx",
+        "nextjs-app/shared/components/Lightbox/Lightbox.tsx",
+        "nextjs-app/shared/components/Link/Link.tsx",
+        "nextjs-app/shared/components/LinkedInQuoteCard/LinkedInQuoteCard.tsx",
+        "nextjs-app/shared/components/Menu/Menu.tsx",
+        "nextjs-app/shared/components/Modal/Modal.tsx",
+        "nextjs-app/shared/components/MultiCombobox/MultiCombobox.tsx",
+        "nextjs-app/shared/components/OpenHours/OpenHours.tsx",
+        "nextjs-app/shared/components/PersonCard/PersonCard.tsx",
+        "nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.tsx",
+        "nextjs-app/shared/components/Select/Select.tsx",
+        "nextjs-app/shared/components/ServicesGrid/ServicesGrid.tsx",
+        "nextjs-app/shared/components/SiteTree/SiteTree.tsx",
+        "nextjs-app/shared/components/SocialShare/SocialShare.tsx",
+        "nextjs-app/shared/components/SplitButton/SplitButton.tsx",
+        "nextjs-app/shared/components/Tabs/Tabs.tsx",
+        "nextjs-app/shared/components/Testimonial/Testimonial.tsx",
+        "nextjs-app/shared/components/WorkNav/WorkNav.tsx",
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
+        "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullEnPage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullFiPage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullSvPage.tsx",
+        "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.tsx",
+        "nextjs-app/shared/patterns/Footer/Footer.tsx",
+        "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.tsx",
+        "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx",
+        "nextjs-app/shared/utils/semanticIcons.tsx"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/BlogArticleShare.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "app/dev/code-window/page.tsx",
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "app/lib/siteStructure.ts",
+        "app/tools/email-signature/EmailSignatureContent.tsx",
+        "app/tools/email-signature/page.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx"
+      ]
+    },
+    {
+      "name": "IconButton",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/components/ui/index.ts",
+        "nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx",
+        "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx"
+      ],
+      "prodPageCount": 7,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/navigation/index.ts",
+        "nextjs-app/shared/patterns/SiteHeader/index.ts",
+        "nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx",
+        "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx"
+      ]
+    },
+    {
+      "name": "icons",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Illustrations",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "app/work/illustrations/page.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "ImagePlaceholder",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 0,
+      "directImporters": [],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "interactive",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 0,
+      "directImporters": [],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Intrum",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "app/work/intrum/page.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Kbd",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "KnobSmithAudio",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "app/work/knobsmith-audio/page.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Label",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 10,
+      "directImporters": [
+        "nextjs-app/shared/components/ChatWidget/ChatComposer.tsx",
+        "nextjs-app/shared/components/Checkbox/Checkbox.tsx",
+        "nextjs-app/shared/components/PhoneInput/PhoneInput.tsx",
+        "nextjs-app/shared/components/Radio/Radio.tsx",
+        "nextjs-app/shared/components/Select/Select.tsx",
+        "nextjs-app/shared/components/Switch/Switch.tsx",
+        "nextjs-app/shared/components/TextArea/TextArea.tsx",
+        "nextjs-app/shared/components/TextInput/TextInput.tsx",
+        "nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 11,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/index.ts",
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts",
+        "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx",
+        "nextjs-app/shared/patterns/CVDownloadSection/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "LanguageSwitcher",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx"
+      ],
+      "prodPageCount": 7,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/navigation/index.ts",
+        "nextjs-app/shared/patterns/SiteHeader/index.ts",
+        "nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx",
+        "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx"
+      ]
+    },
+    {
+      "name": "Lightbox",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/components/ProjectGallery/ProjectGallery.tsx",
+        "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx",
+        "nextjs-app/shared/components/interactive/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Link",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 13,
+      "directImporters": [
+        "nextjs-app/shared/components/AuthorBio/AuthorBio.tsx",
+        "nextjs-app/shared/components/Breadcrumb/Breadcrumb.tsx",
+        "nextjs-app/shared/components/CookieConsent/CookieConsent.tsx",
+        "nextjs-app/shared/components/CookieConsent/CookieConsentBanner.tsx",
+        "nextjs-app/shared/components/LinkedInQuoteCard/LinkedInQuoteCard.tsx",
+        "nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.tsx",
+        "nextjs-app/shared/components/PersonCard/PersonCard.tsx",
+        "nextjs-app/shared/components/SiteTree/SiteTree.tsx",
+        "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx",
+        "nextjs-app/shared/components/Testimonial/Testimonial.tsx",
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/patterns/Footer/Footer.tsx",
+        "nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "app/lib/siteStructure.ts",
+        "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+        "nextjs-app/shared/components/pages/SitemapPage/index.ts"
+      ]
+    },
+    {
+      "name": "LinkedInQuoteCard",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 0,
+      "directImporters": [],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "List",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx",
+        "nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.tsx"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/index.ts",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/index.ts",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/index.ts",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx",
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/index.ts",
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx"
+      ]
+    },
+    {
+      "name": "LocationCard",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/ui/index.ts"
+      ],
+      "prodPageCount": 1,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx"
+      ]
+    },
+    {
+      "name": "Logo",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 0,
+      "directImporters": [],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "LogoConstruction",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "LogoReveal",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "MacWindowFrame",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "ManifestoSection",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 6,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/index.ts",
+        "nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx",
+        "nextjs-app/shared/patterns/AboutPageContent/index.ts",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/ManifestoSection/index.ts"
+      ]
+    },
+    {
+      "name": "MarkdownMessage",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/components/ChatWidget/ChatMessageBubble.tsx",
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx"
+      ],
+      "prodPageCount": 2,
+      "prodPages": [
+        "app/layout.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx"
+      ]
+    },
+    {
+      "name": "MCPActionButton",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "MdxImage",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Menu",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 4,
+      "directImporters": [
+        "nextjs-app/shared/components/Avatar/Avatar.tsx",
+        "nextjs-app/shared/components/Breadcrumb/Breadcrumb.tsx",
+        "nextjs-app/shared/components/SplitButton/SplitButton.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/index.ts",
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts"
+      ]
+    },
+    {
+      "name": "Mermaid",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx",
+        "nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Modal",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 6,
+      "directImporters": [
+        "nextjs-app/shared/components/ContactForm/ContactForm.tsx",
+        "nextjs-app/shared/components/CookieConsent/CookieConsent.tsx",
+        "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.tsx",
+        "nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.tsx",
+        "nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 6,
+      "prodPages": [
+        "app/layout.tsx",
+        "app/tools/email-signature/EmailSignatureContent.tsx",
+        "app/tools/email-signature/page.tsx",
+        "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx",
+        "nextjs-app/shared/patterns/CVDownloadSection/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "MultiCombobox",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx"
+      ],
+      "prodPageCount": 4,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
+      ]
+    },
+    {
+      "name": "navigation",
+      "kind": "pattern",
+      "status": null,
+      "directImportCount": 25,
+      "directImporters": [
+        "app/ai-use/AiUsageContent.tsx",
+        "app/blog/NextBlogNav.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/authors/[slug]/page.tsx",
+        "app/pseo/[slug]/page.tsx",
+        "app/pseo/audiences/[slug]/page.tsx",
+        "app/pseo/services/[slug]/page.tsx",
+        "app/pseo/stacks/[slug]/page.tsx",
+        "app/work/NextWorkNav.tsx",
+        "nextjs-app/shared/components/BlogNav/BlogNav.tsx",
+        "nextjs-app/shared/components/ChatWidget/useDonnyChatNavigation.ts",
+        "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx",
+        "nextjs-app/shared/components/DonnyActionProvider/useDonnyActions.ts",
+        "nextjs-app/shared/components/NavLink/NavLink.tsx",
+        "nextjs-app/shared/components/NavMenuList/NavMenuList.tsx",
+        "nextjs-app/shared/components/NextLayout/NextLayout.tsx",
+        "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx",
+        "nextjs-app/shared/components/WorkNav/WorkNav.tsx",
+        "nextjs-app/shared/components/animations/PageTransition/PageTransition.tsx",
+        "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/hooks/useBlogFilter.ts",
+        "nextjs-app/shared/hooks/useNavigation/useNavigation.ts",
+        "nextjs-app/shared/patterns/index.ts",
+        "providers/NextNavigationProvider.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "NavLink",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx",
+        "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx",
+        "nextjs-app/shared/patterns/navigation/index.ts"
+      ],
+      "prodPageCount": 7,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/navigation/index.ts",
+        "nextjs-app/shared/patterns/SiteHeader/index.ts",
+        "nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx",
+        "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx"
+      ]
+    },
+    {
+      "name": "NavMenuList",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "NewsBulletin",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx"
+      ],
+      "prodPageCount": 3,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/patterns/NewsBulletin/index.ts",
+        "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.tsx"
+      ]
+    },
+    {
+      "name": "NewsletterWaitlist",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 0,
+      "directImporters": [],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "NewThingsCo",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "app/work/new-things-co/page.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "NextLayout",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "app/layout.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 1,
+      "prodPages": [
+        "app/layout.tsx"
+      ]
+    },
+    {
+      "name": "OpenHours",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/ChatWidget/ChatMessageBubble.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 1,
+      "prodPages": [
+        "app/layout.tsx"
+      ]
+    },
+    {
+      "name": "PageLayout",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 13,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx",
+        "nextjs-app/shared/patterns/GridBlock/GridBlock.tsx",
+        "nextjs-app/shared/patterns/Hero/Hero.tsx",
+        "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx",
+        "nextjs-app/shared/patterns/ProjectMetaSection/ProjectMetaSection.tsx",
+        "nextjs-app/shared/patterns/ProofBlock/ProofBlock.tsx",
+        "nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.tsx",
+        "nextjs-app/shared/patterns/StoryBlock/StoryBlock.tsx",
+        "nextjs-app/shared/patterns/TeamBlock/TeamBlock.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/index.ts",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/index.ts",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx"
+      ]
+    },
+    {
+      "name": "pages",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 20,
+      "directImporters": [
+        "nextjs-app/shared/components/ContactPage/index.ts",
+        "nextjs-app/shared/components/FinnishTransportAgency/FinnishTransportAgencyPage.ts",
+        "nextjs-app/shared/components/FinnishTransportAgency/index.ts",
+        "nextjs-app/shared/components/GarageJunction/GarageJunctionPage.ts",
+        "nextjs-app/shared/components/GarageJunction/index.ts",
+        "nextjs-app/shared/components/Illustrations/IllustrationsPage.ts",
+        "nextjs-app/shared/components/Intrum/IntrumPage.ts",
+        "nextjs-app/shared/components/Intrum/index.ts",
+        "nextjs-app/shared/components/KnobSmithAudio/KnobSmithAudioPage.ts",
+        "nextjs-app/shared/components/KnobSmithAudio/index.ts",
+        "nextjs-app/shared/components/NewThingsCo/NewThingsCoPage.ts",
+        "nextjs-app/shared/components/NewThingsCo/index.ts",
+        "nextjs-app/shared/components/RawView/RawViewPage.ts",
+        "nextjs-app/shared/components/RawView/index.ts",
+        "nextjs-app/shared/components/Tulli/TulliPage.ts",
+        "nextjs-app/shared/components/Tulli/index.ts",
+        "nextjs-app/shared/components/VertaaUX/VertaaUXPage.ts",
+        "nextjs-app/shared/components/VertaaUX/index.ts",
+        "nextjs-app/shared/components/WorkIndex/WorkIndexPage.ts",
+        "nextjs-app/shared/components/WorkIndex/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Pagination",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx"
+      ],
+      "prodPageCount": 5,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx",
+        "nextjs-app/shared/patterns/BlogIndexContent/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "PersonCard",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "PhoneInput",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/components/ContactForm/ContactForm.tsx",
+        "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 5,
+      "prodPages": [
+        "app/layout.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
+      ]
+    },
+    {
+      "name": "PricingPageContent",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/PricingPage/PricingPage.tsx"
+      ],
+      "prodPageCount": 3,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/PricingPage/index.ts",
+        "nextjs-app/shared/components/pages/PricingPage/PricingPage.tsx",
+        "nextjs-app/shared/patterns/PricingPageContent/index.ts"
+      ]
+    },
+    {
+      "name": "ProcessBlock",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 12,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx",
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx",
+        "nextjs-app/shared/components/pages/Work/ProjectSpine/ProjectSpinePage.tsx",
+        "nextjs-app/shared/components/pages/Work/RawView/RawViewPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx",
+        "nextjs-app/shared/components/pages/Work/SapBuildApps/SapBuildAppsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/index.ts",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/index.ts",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/index.ts",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx",
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/index.ts",
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx"
+      ]
+    },
+    {
+      "name": "Progress",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/components/DonnyBookingEmbed/DonnyBookingEmbed.tsx",
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx"
+      ],
+      "prodPageCount": 6,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx",
+        "nextjs-app/shared/patterns/ContactInquiryPanel/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
+      ]
+    },
+    {
+      "name": "ProjectCard",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.tsx"
+      ],
+      "prodPageCount": 6,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/WorkMagneticField/index.ts",
+        "nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.tsx",
+        "nextjs-app/shared/patterns/WorkPreviewSection/index.ts",
+        "nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.tsx"
+      ]
+    },
+    {
+      "name": "ProjectDetailLayout",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 17,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx",
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx",
+        "nextjs-app/shared/components/pages/Work/ProjectSpine/ProjectSpinePage.tsx",
+        "nextjs-app/shared/components/pages/Work/RawView/RawViewPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx",
+        "nextjs-app/shared/components/pages/Work/SapBuildApps/SapBuildAppsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Tulli/TulliPage.tsx",
+        "nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx",
+        "nextjs-app/shared/patterns/ProjectDetailTemplate/ProjectDetailTemplate.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/index.ts",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/index.ts",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Illustrations/index.ts",
+        "nextjs-app/shared/components/pages/Work/Intrum/index.ts",
+        "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx"
+      ]
+    },
+    {
+      "name": "ProjectDetailTemplate",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 2,
+      "prodPages": [
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/ProjectDetailTemplate/index.ts"
+      ]
+    },
+    {
+      "name": "ProjectGallery",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/ui/index.ts",
+        "nextjs-app/shared/patterns/ProjectDetailTemplate/ProjectDetailTemplate.tsx"
+      ],
+      "prodPageCount": 4,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/ProjectDetailTemplate/index.ts",
+        "nextjs-app/shared/patterns/ProjectDetailTemplate/ProjectDetailTemplate.tsx"
+      ]
+    },
+    {
+      "name": "ProjectHero",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 16,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx",
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx",
+        "nextjs-app/shared/components/pages/Work/ProjectSpine/ProjectSpinePage.tsx",
+        "nextjs-app/shared/components/pages/Work/RawView/RawViewPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx",
+        "nextjs-app/shared/components/pages/Work/SapBuildApps/SapBuildAppsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Tulli/TulliPage.tsx",
+        "nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx",
+        "nextjs-app/shared/patterns/ProjectDetailTemplate/ProjectDetailTemplate.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/index.ts",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/index.ts",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/Intrum/index.ts",
+        "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/index.ts",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx"
+      ]
+    },
+    {
+      "name": "ProjectMetaSection",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 7,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx",
+        "nextjs-app/shared/components/pages/Work/RawView/RawViewPage.tsx",
+        "nextjs-app/shared/components/pages/Work/SapBuildApps/SapBuildAppsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Tulli/TulliPage.tsx",
+        "nextjs-app/shared/patterns/ProjectDetailTemplate/ProjectDetailTemplate.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/Intrum/index.ts",
+        "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx",
+        "nextjs-app/shared/components/pages/Work/RawView/index.ts",
+        "nextjs-app/shared/components/pages/Work/RawView/RawViewPage.tsx",
+        "nextjs-app/shared/components/pages/Work/SapBuildApps/index.ts",
+        "nextjs-app/shared/components/pages/Work/SapBuildApps/SapBuildAppsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Tulli/index.ts",
+        "nextjs-app/shared/components/pages/Work/Tulli/TulliPage.tsx",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/ProjectDetailTemplate/index.ts"
+      ]
+    },
+    {
+      "name": "ProjectNav",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 16,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx",
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx",
+        "nextjs-app/shared/components/pages/Work/ProjectSpine/ProjectSpinePage.tsx",
+        "nextjs-app/shared/components/pages/Work/RawView/RawViewPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx",
+        "nextjs-app/shared/components/pages/Work/SapBuildApps/SapBuildAppsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Tulli/TulliPage.tsx",
+        "nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx",
+        "nextjs-app/shared/components/ui/index.ts",
+        "nextjs-app/shared/patterns/ProjectDetailTemplate/ProjectDetailTemplate.tsx"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/index.ts",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/index.ts",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/Intrum/index.ts",
+        "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/index.ts"
+      ]
+    },
+    {
+      "name": "ProofBlock",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 2,
+      "prodPages": [
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/ProofBlock/index.ts"
+      ]
+    },
+    {
+      "name": "Prose",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/ui/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Radio",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/RadioGroup/RadioGroup.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "RadioGroup",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "RawView",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "app/work/raw-view/page.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "ReadingProgress",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/patterns/ArticleLayout/ArticleLayout.tsx"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/ClientArticleShell.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/patterns/ArticleLayout/ArticleLayout.tsx",
+        "nextjs-app/shared/patterns/ArticleLayout/index.ts",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "RelatedPosts",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 3,
+      "directImporters": [
+        "app/blog/[slug]/page.tsx",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 10,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/RelatedPosts/index.ts"
+      ]
+    },
+    {
+      "name": "RelatedProjects",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 16,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx",
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx",
+        "nextjs-app/shared/components/pages/Work/ProjectSpine/ProjectSpinePage.tsx",
+        "nextjs-app/shared/components/pages/Work/RawView/RawViewPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx",
+        "nextjs-app/shared/components/pages/Work/SapBuildApps/SapBuildAppsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Tulli/TulliPage.tsx",
+        "nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx",
+        "nextjs-app/shared/patterns/ProjectDetailTemplate/ProjectDetailTemplate.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/index.ts",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/index.ts",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/Intrum/index.ts",
+        "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/index.ts",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx"
+      ]
+    },
+    {
+      "name": "ScrollIndicator",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 4,
+      "directImporters": [
+        "nextjs-app/shared/patterns/AboutHero/AboutHero.tsx",
+        "nextjs-app/shared/patterns/BlogHero/BlogHero.tsx",
+        "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
+        "nextjs-app/shared/patterns/ProjectHero/ProjectHero.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Section",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 21,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
+        "nextjs-app/shared/patterns/AboutHero/AboutHero.tsx",
+        "nextjs-app/shared/patterns/ArticleHero/ArticleHero.tsx",
+        "nextjs-app/shared/patterns/BlogHero/BlogHero.tsx",
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx",
+        "nextjs-app/shared/patterns/CTASection/CTASection.tsx",
+        "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx",
+        "nextjs-app/shared/patterns/ContactHero/ContactHero.tsx",
+        "nextjs-app/shared/patterns/ContentSection/ContentSection.tsx",
+        "nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.tsx",
+        "nextjs-app/shared/patterns/ManifestoSection/ManifestoSection.tsx",
+        "nextjs-app/shared/patterns/ProjectDetailTemplate/ProjectDetailTemplate.tsx",
+        "nextjs-app/shared/patterns/ProjectHero/ProjectHero.tsx",
+        "nextjs-app/shared/patterns/RelatedPosts/RelatedPosts.tsx",
+        "nextjs-app/shared/patterns/RelatedProjects/RelatedProjects.tsx",
+        "nextjs-app/shared/patterns/ServicesSection/ServicesSection.tsx",
+        "nextjs-app/shared/patterns/StatsSection/StatsSection.tsx",
+        "nextjs-app/shared/patterns/ValuesSection/ValuesSection.tsx",
+        "nextjs-app/shared/patterns/WorkHero/WorkHero.tsx",
+        "nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.tsx",
+        "nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.tsx"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/index.ts",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts"
+      ]
+    },
+    {
+      "name": "SecureCVDownload",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx"
+      ],
+      "prodPageCount": 3,
+      "prodPages": [
+        "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx",
+        "nextjs-app/shared/patterns/CVDownloadSection/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "SegmentedControl",
+      "kind": "component",
+      "status": "alpha",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Select",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/components/ContactForm/ContactForm.tsx",
+        "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 5,
+      "prodPages": [
+        "app/layout.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
+      ]
+    },
+    {
+      "name": "SelectableCard",
+      "kind": "component",
+      "status": "alpha",
+      "directImportCount": 0,
+      "directImporters": [],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "SentrySummaryCard",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 0,
+      "directImporters": [],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "ServiceCard",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/patterns/ServicesSection/ServicesSection.tsx"
+      ],
+      "prodPageCount": 4,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/ServicesSection/index.ts",
+        "nextjs-app/shared/patterns/ServicesSection/ServicesSection.tsx"
+      ]
+    },
+    {
+      "name": "ServicesBlock",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 2,
+      "prodPages": [
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/ServicesBlock/index.ts"
+      ]
+    },
+    {
+      "name": "ServicesGrid",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/ChatWidget/ChatMessageBubble.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 1,
+      "prodPages": [
+        "app/layout.tsx"
+      ]
+    },
+    {
+      "name": "ServicesSection",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 3,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/ServicesSection/index.ts"
+      ]
+    },
+    {
+      "name": "Sitefooter",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 0,
+      "directImporters": [],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "SiteFooter",
+      "kind": "pattern",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/navigation/index.ts"
+      ],
+      "prodPageCount": 5,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/navigation/index.ts",
+        "nextjs-app/shared/patterns/SiteFooter/index.ts"
+      ]
+    },
+    {
+      "name": "Siteheader",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 0,
+      "directImporters": [],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "SiteHeader",
+      "kind": "pattern",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/navigation/index.ts"
+      ],
+      "prodPageCount": 7,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/navigation/index.ts",
+        "nextjs-app/shared/patterns/SiteHeader/index.ts",
+        "nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx",
+        "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx"
+      ]
+    },
+    {
+      "name": "SiteTree",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 3,
+      "directImporters": [
+        "app/lib/siteStructure.ts",
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/components/pages/SitemapPage/SitemapPage.tsx"
+      ],
+      "prodPageCount": 3,
+      "prodPages": [
+        "app/lib/siteStructure.ts",
+        "nextjs-app/shared/components/pages/SitemapPage/index.ts",
+        "nextjs-app/shared/components/pages/SitemapPage/SitemapPage.tsx"
+      ]
+    },
+    {
+      "name": "Skeleton",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 4,
+      "directImporters": [
+        "nextjs-app/shared/components/ArticleCard/ArticleCard.tsx",
+        "nextjs-app/shared/components/Card/Card.tsx",
+        "nextjs-app/shared/components/PersonCard/PersonCard.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 3,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx"
+      ]
+    },
+    {
+      "name": "SkillsGrid",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "SkipLink",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/patterns/navigation/index.ts"
+      ],
+      "prodPageCount": 4,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/navigation/index.ts"
+      ]
+    },
+    {
+      "name": "SocialShare",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "app/blog/[slug]/BlogArticleShare.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 4,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleShare.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx"
+      ]
+    },
+    {
+      "name": "Spacer",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 0,
+      "directImporters": [],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Spinner",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/components/AppLoading/AppLoading.tsx",
+        "nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 3,
+      "prodPages": [
+        "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx",
+        "nextjs-app/shared/patterns/CVDownloadSection/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "SplitButton",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/CodeSnippet/CodeSnippet.tsx"
+      ],
+      "prodPageCount": 2,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/index.ts",
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx"
+      ]
+    },
+    {
+      "name": "Stack",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx",
+        "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
+        "nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx"
+      ],
+      "prodPageCount": 9,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
+        "nextjs-app/shared/patterns/HomeHero/index.ts",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/navigation/index.ts",
+        "nextjs-app/shared/patterns/SiteFooter/index.ts",
+        "nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx"
+      ]
+    },
+    {
+      "name": "StatsSection",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx"
+      ],
+      "prodPageCount": 5,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/index.ts",
+        "nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx",
+        "nextjs-app/shared/patterns/AboutPageContent/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "StatusDot",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/Badge/Badge.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/components/pages/Pseo/PseoClusterBadges.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoPillarMetaBadgeLinks.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Illustrations/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
+      ]
+    },
+    {
+      "name": "StoryBlock",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 15,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx",
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx",
+        "nextjs-app/shared/components/pages/Work/ProjectSpine/ProjectSpinePage.tsx",
+        "nextjs-app/shared/components/pages/Work/RawView/RawViewPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx",
+        "nextjs-app/shared/components/pages/Work/SapBuildApps/SapBuildAppsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Tulli/TulliPage.tsx",
+        "nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/index.ts",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/index.ts",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/Intrum/index.ts",
+        "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/index.ts",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx"
+      ]
+    },
+    {
+      "name": "StudioMap",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/ChatWidget/ChatMessageBubble.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 1,
+      "prodPages": [
+        "app/layout.tsx"
+      ]
+    },
+    {
+      "name": "Switch",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "TableOfContents",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/hooks/useTableOfContents.ts",
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Tabs",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx"
+      ],
+      "prodPageCount": 6,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx",
+        "nextjs-app/shared/patterns/ContactInquiryPanel/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
+      ]
+    },
+    {
+      "name": "TailwindTest",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "app/dev/tailwind-test/page.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "TeamBlock",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 4,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/index.ts",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/TeamBlock/index.ts"
+      ]
+    },
+    {
+      "name": "Testimonial",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Text",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 57,
+      "directImporters": [
+        "app/dev/code-window/page.tsx",
+        "nextjs-app/shared/components/AlertBanner/AlertBanner.tsx",
+        "nextjs-app/shared/components/ArticleCard/ArticleCard.tsx",
+        "nextjs-app/shared/components/AuthorBio/AuthorBio.tsx",
+        "nextjs-app/shared/components/Card/Card.tsx",
+        "nextjs-app/shared/components/ChatWidget/ChatHeader.tsx",
+        "nextjs-app/shared/components/ChatWidget/ChatMessages.tsx",
+        "nextjs-app/shared/components/ChatWidget/emailWorkflow/ComposePrompt.tsx",
+        "nextjs-app/shared/components/ChatWidget/emailWorkflow/FieldPrompt.tsx",
+        "nextjs-app/shared/components/ChatWidget/emailWorkflow/SendStatus.tsx",
+        "nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.tsx",
+        "nextjs-app/shared/components/CodeSnippet/CodeSnippet.tsx",
+        "nextjs-app/shared/components/ComplianceCard/ComplianceCard.tsx",
+        "nextjs-app/shared/components/ContactForm/ContactForm.tsx",
+        "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.tsx",
+        "nextjs-app/shared/components/EmptyState/EmptyState.tsx",
+        "nextjs-app/shared/components/FinnishTransportAgency/ColorPalette.tsx",
+        "nextjs-app/shared/components/MCPActionButton/MCPActionButton.tsx",
+        "nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.tsx",
+        "nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.tsx",
+        "nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.tsx",
+        "nextjs-app/shared/components/PersonCard/PersonCard.tsx",
+        "nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.tsx",
+        "nextjs-app/shared/components/SentrySummaryCard/SentrySummaryCard.tsx",
+        "nextjs-app/shared/components/SocialShare/SocialShare.tsx",
+        "nextjs-app/shared/components/Testimonial/Testimonial.tsx",
+        "nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.tsx",
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/components/pages/Colophon/ColophonPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx",
+        "nextjs-app/shared/components/pages/SitemapPage/SitemapPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx",
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx",
+        "nextjs-app/shared/components/pages/Work/ProjectSpine/ProjectSpinePage.tsx",
+        "nextjs-app/shared/components/pages/Work/RawView/RawViewPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx",
+        "nextjs-app/shared/components/pages/Work/SapBuildApps/SapBuildAppsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Tulli/TulliPage.tsx",
+        "nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/GridBlock/GridBlock.tsx",
+        "nextjs-app/shared/patterns/Hero/Hero.tsx",
+        "nextjs-app/shared/patterns/HighlightSection/HighlightSection.tsx",
+        "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx",
+        "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx",
+        "nextjs-app/shared/patterns/ProofBlock/ProofBlock.tsx",
+        "nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.tsx",
+        "nextjs-app/shared/patterns/StoryBlock/StoryBlock.tsx",
+        "nextjs-app/shared/patterns/TeamBlock/TeamBlock.tsx"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/BlogArticleShare.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "app/dev/code-window/page.tsx",
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "app/tools/email-signature/EmailSignatureContent.tsx",
+        "app/tools/email-signature/page.tsx",
+        "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx"
+      ]
+    },
+    {
+      "name": "TextArea",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/components/ChatWidget/emailWorkflow/FieldPrompt.tsx",
+        "nextjs-app/shared/components/ContactForm/ContactForm.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 2,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx"
+      ]
+    },
+    {
+      "name": "TextInput",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 6,
+      "directImporters": [
+        "nextjs-app/shared/components/ChatWidget/emailWorkflow/FieldPrompt.tsx",
+        "nextjs-app/shared/components/ContactForm/ContactForm.tsx",
+        "nextjs-app/shared/components/FileUpload/FileUpload.tsx",
+        "nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.tsx",
+        "nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.tsx",
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 9,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
+        "nextjs-app/shared/components/pages/ContactPage/index.ts",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts",
+        "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx",
+        "nextjs-app/shared/patterns/CVDownloadSection/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ]
+    },
+    {
+      "name": "ThemeProvider",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 7,
+      "directImporters": [
+        "app/layout.tsx",
+        "nextjs-app/shared/components/icons/Logo.tsx",
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/hooks/usePersistentTheme.ts",
+        "nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx",
+        "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx",
+        "providers/ThemeProvider.tsx"
+      ],
+      "prodPageCount": 7,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/navigation/index.ts",
+        "nextjs-app/shared/patterns/SiteHeader/index.ts",
+        "nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx",
+        "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx"
+      ]
+    },
+    {
+      "name": "Title",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 49,
+      "directImporters": [
+        "app/dev/code-window/page.tsx",
+        "nextjs-app/shared/components/ArticleCard/ArticleCard.tsx",
+        "nextjs-app/shared/components/AuthorBio/AuthorBio.tsx",
+        "nextjs-app/shared/components/Card/Card.tsx",
+        "nextjs-app/shared/components/ChatWidget/ChatHeader.tsx",
+        "nextjs-app/shared/components/ChatWidget/emailWorkflow/ReviewSummary.tsx",
+        "nextjs-app/shared/components/ChatWidget/emailWorkflow/SendStatus.tsx",
+        "nextjs-app/shared/components/ChunkErrorBoundary/ChunkErrorBoundary.tsx",
+        "nextjs-app/shared/components/ComplianceCard/ComplianceCard.tsx",
+        "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.tsx",
+        "nextjs-app/shared/components/EmptyState/EmptyState.tsx",
+        "nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.tsx",
+        "nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.tsx",
+        "nextjs-app/shared/components/Modal/Modal.tsx",
+        "nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.tsx",
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
+        "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+        "nextjs-app/shared/components/pages/Colophon/ColophonPage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullEnPage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullFiPage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullSvPage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyPage.tsx",
+        "nextjs-app/shared/components/pages/ImprintPage/ImprintPage.tsx",
+        "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx",
+        "nextjs-app/shared/components/pages/SitemapPage/SitemapPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx",
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx",
+        "nextjs-app/shared/components/pages/Work/ProjectSpine/ProjectSpinePage.tsx",
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx",
+        "nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/Hero/Hero.tsx",
+        "nextjs-app/shared/patterns/HighlightSection/HighlightSection.tsx",
+        "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx",
+        "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx",
+        "nextjs-app/shared/patterns/ProofBlock/ProofBlock.tsx",
+        "nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.tsx",
+        "nextjs-app/shared/patterns/StoryBlock/StoryBlock.tsx",
+        "nextjs-app/shared/patterns/TeamBlock/TeamBlock.tsx"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleMdxBody.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "app/dev/code-window/page.tsx",
+        "app/dev/tailwind-test/page.tsx",
+        "app/layout.tsx",
+        "app/tools/email-signature/EmailSignatureContent.tsx",
+        "app/tools/email-signature/page.tsx",
+        "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
+        "nextjs-app/shared/components/pages/AccessibilityPage/index.ts",
+        "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx"
+      ]
+    },
+    {
+      "name": "Toast",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 7,
+      "directImporters": [
+        "nextjs-app/shared/components/CodeSnippet/CodeSnippet.tsx",
+        "nextjs-app/shared/components/ContactForm/ContactForm.tsx",
+        "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.tsx",
+        "nextjs-app/shared/components/SocialShare/SocialShare.tsx",
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/lib/toast.tsx",
+        "providers/ToastProvider.tsx"
+      ],
+      "prodPageCount": 9,
+      "prodPages": [
+        "app/blog/[slug]/BlogArticleShare.tsx",
+        "app/blog/[slug]/page.tsx",
+        "app/blog/[slug]/ServerArticleContent.tsx",
+        "app/blog/[slug]/ServerArticleMain.tsx",
+        "app/layout.tsx",
+        "app/tools/email-signature/EmailSignatureContent.tsx",
+        "app/tools/email-signature/page.tsx",
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/index.ts",
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx"
+      ]
+    },
+    {
+      "name": "Tooltip",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/SkillsGrid/SkillsGrid.tsx",
+        "nextjs-app/shared/components/interactive/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "TransformingActionInput",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "Tulli",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "app/work/tulli/page.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "ui",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx",
+        "nextjs-app/shared/components/interactive/index.ts"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "ValueCard",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/patterns/ValuesSection/ValuesSection.tsx"
+      ],
+      "prodPageCount": 7,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/index.ts",
+        "nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx",
+        "nextjs-app/shared/patterns/AboutPageContent/index.ts",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/ValuesSection/index.ts",
+        "nextjs-app/shared/patterns/ValuesSection/ValuesSection.tsx"
+      ]
+    },
+    {
+      "name": "ValuesSection",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 6,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+        "nextjs-app/shared/components/pages/AboutPage/index.ts",
+        "nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx",
+        "nextjs-app/shared/patterns/AboutPageContent/index.ts",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/ValuesSection/index.ts"
+      ]
+    },
+    {
+      "name": "VertaaUX",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "app/work/vertaaux/page.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "VisuallyHidden",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/components/ui/index.ts"
+      ],
+      "prodPageCount": 1,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx"
+      ]
+    },
+    {
+      "name": "WipBadge",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 0,
+      "directImporters": [],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "WorkCTA",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/patterns/ProjectDetailLayout/ProjectDetailLayout.tsx"
+      ],
+      "prodPageCount": 12,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/index.ts",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/index.ts",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Illustrations/index.ts",
+        "nextjs-app/shared/components/pages/Work/Intrum/index.ts",
+        "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx"
+      ]
+    },
+    {
+      "name": "WorkGrid",
+      "kind": "component",
+      "status": "stable",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
+        "nextjs-app/shared/components/ui/index.ts"
+      ],
+      "prodPageCount": 3,
+      "prodPages": [
+        "app/dev/tailwind-test/page.tsx",
+        "nextjs-app/shared/components/pages/Work/WorkIndex/index.ts",
+        "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx"
+      ]
+    },
+    {
+      "name": "WorkHero",
+      "kind": "pattern",
+      "status": "alpha",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 4,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Work/WorkIndex/index.ts",
+        "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/WorkHero/index.ts"
+      ]
+    },
+    {
+      "name": "WorkIndex",
+      "kind": "component",
+      "status": null,
+      "directImportCount": 1,
+      "directImporters": [
+        "app/work/page.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
+    },
+    {
+      "name": "WorkMagneticField",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 1,
+      "directImporters": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx"
+      ],
+      "prodPageCount": 2,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/patterns/WorkMagneticField/index.ts"
+      ]
+    },
+    {
+      "name": "WorkNav",
+      "kind": "component",
+      "status": "beta",
+      "directImportCount": 2,
+      "directImporters": [
+        "nextjs-app/shared/components/index.ts",
+        "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx"
+      ],
+      "prodPageCount": 2,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Illustrations/index.ts"
+      ]
+    },
+    {
+      "name": "WorkPreviewSection",
+      "kind": "pattern",
+      "status": "beta",
+      "directImportCount": 3,
+      "directImporters": [
+        "nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.tsx",
+        "nextjs-app/shared/patterns/WorkMagneticField/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
+      ],
+      "prodPageCount": 5,
+      "prodPages": [
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/patterns/index.ts",
+        "nextjs-app/shared/patterns/WorkMagneticField/index.ts",
+        "nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.tsx",
+        "nextjs-app/shared/patterns/WorkPreviewSection/index.ts"
+      ]
+    }
+  ]
+}

--- a/nextjs-app/shared/stories/Docs/ComponentUsage.stories.tsx
+++ b/nextjs-app/shared/stories/Docs/ComponentUsage.stories.tsx
@@ -1,0 +1,140 @@
+import React, { useMemo, useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import usageReport from "../../foundations/dist/component-usage.json";
+import styles from "./Documentation.module.css";
+
+type UsageRow = {
+  name: string;
+  kind: string;
+  status: string | null;
+  directImportCount: number;
+  directImporters: string[];
+  prodPageCount: number;
+  prodPages: string[];
+};
+
+type SortKey = "name" | "directImportCount" | "prodPageCount";
+
+const rows = (usageReport as { generatedAt: string; components: UsageRow[] })
+  .components;
+const generatedAt = (usageReport as { generatedAt: string }).generatedAt;
+
+const ComponentUsageContent = () => {
+  const [sortKey, setSortKey] = useState<SortKey>("directImportCount");
+  const [onlyUnused, setOnlyUnused] = useState(false);
+
+  const sorted = useMemo(() => {
+    const filtered = onlyUnused
+      ? rows.filter((row) => row.directImportCount === 0)
+      : rows;
+    return [...filtered].sort((a, b) =>
+      sortKey === "name"
+        ? a.name.localeCompare(b.name)
+        : b[sortKey] - a[sortKey] || a.name.localeCompare(b.name),
+    );
+  }, [sortKey, onlyUnused]);
+
+  const unusedCount = rows.filter((row) => row.directImportCount === 0).length;
+
+  return (
+    <article className={styles.wrapper}>
+      <header className={styles.header}>
+        <h1>Component Usage</h1>
+        <p className={styles.lead}>
+          Real adoption data from the production codebase: how many source
+          files import each component (statically or via dynamic import), and
+          how many production pages transitively render it. Regenerate with{" "}
+          <code>npm run report:component-usage</code>. Generated{" "}
+          {new Date(generatedAt).toLocaleString("en-GB")}. {rows.length}{" "}
+          components, {unusedCount} without any importer.
+        </p>
+      </header>
+
+      <section className={styles.section}>
+        <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
+          <label>
+            Sort by{" "}
+            <select
+              value={sortKey}
+              onChange={(event) => setSortKey(event.target.value as SortKey)}
+            >
+              <option value="directImportCount">direct imports</option>
+              <option value="prodPageCount">prod pages</option>
+              <option value="name">name</option>
+            </select>
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={onlyUnused}
+              onChange={(event) => setOnlyUnused(event.target.checked)}
+            />{" "}
+            only zero-import components
+          </label>
+        </div>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Component</th>
+              <th>Kind</th>
+              <th>Status</th>
+              <th>Direct imports</th>
+              <th>Prod pages</th>
+              <th>Importers</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((row) => (
+              <tr key={`${row.kind}-${row.name}`}>
+                <td>
+                  <code>{row.name}</code>
+                </td>
+                <td>{row.kind}</td>
+                <td>{row.status ?? "—"}</td>
+                <td>{row.directImportCount}</td>
+                <td>{row.prodPageCount}</td>
+                <td>
+                  {row.directImporters.length > 0 ? (
+                    <details>
+                      <summary>
+                        {row.directImporters.length} file
+                        {row.directImporters.length === 1 ? "" : "s"}
+                      </summary>
+                      <ul>
+                        {row.directImporters.map((path) => (
+                          <li key={path}>
+                            <code>{path}</code>
+                          </li>
+                        ))}
+                      </ul>
+                    </details>
+                  ) : (
+                    "—"
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </article>
+  );
+};
+
+const meta: Meta = {
+  title: "Docs/ComponentUsage",
+  parameters: {
+    layout: "fullscreen",
+    vitest: {
+      skip: true, // Documentation showcase; data-driven, no behavior to test.
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ComponentUsageContent>;
+
+export const Usage: Story = {
+  render: () => <ComponentUsageContent />,
+};

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "validate:components": "tsx scripts/design-system/validate-components.ts",
     "validate:agent-docs": "node scripts/validate-agent-docs.mjs",
     "report:doc-coverage": "node scripts/design-system/report-doc-coverage.mjs",
+    "report:component-usage": "node scripts/design-system/report-component-usage.mjs",
     "audit:catalog": "node scripts/design-system/audit-catalog-coverage.mjs",
     "audit:controls": "node scripts/design-system/audit-controls.mjs",
     "audit:snapshot-debt": "node scripts/design-system/audit-snapshot-debt.mjs",

--- a/scripts/design-system/report-component-usage.mjs
+++ b/scripts/design-system/report-component-usage.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * Component usage report: for every catalog component, count direct imports
+ * across app + shared source and the production entry files that transitively
+ * render it (via consumers-lib's module graph). Writes
+ * nextjs-app/shared/foundations/dist/component-usage.json for the Storybook
+ * usage docs page and prints a summary table.
+ *
+ * Direct-import matching is word-boundary exact on the path segment
+ * (`@dt/Button`, `components/Button`, `patterns/Button`) plus named imports
+ * from the "@digitaltableteur/react" barrel, so `EnhancedArticleCard` never
+ * counts as `ArticleCard` (the raw-grep substring trap).
+ */
+import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { join, relative, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { computeConsumersForComponent } from "./consumers-lib.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const OUT_PATH = join(ROOT, "nextjs-app/shared/foundations/dist/component-usage.json");
+const COMPONENT_ROOTS = [
+  { base: "nextjs-app/shared/components", kind: "component" },
+  { base: "nextjs-app/shared/patterns", kind: "pattern" },
+];
+const SCAN_ROOTS = ["app", "providers", "nextjs-app/shared", "lib", "components"];
+const SCAN_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".mjs"]);
+const EXCLUDED_DIR_NAMES = new Set(["node_modules", "dist", ".next", "__a11y-snapshots__"]);
+
+function listComponents() {
+  const items = [];
+  for (const { base, kind } of COMPONENT_ROOTS) {
+    const abs = join(ROOT, base);
+    if (!existsSync(abs)) continue;
+    for (const entry of readdirSync(abs, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const contractPath = join(abs, entry.name, `${entry.name}.contract.json`);
+      let status = null;
+      if (existsSync(contractPath)) {
+        try {
+          status = JSON.parse(readFileSync(contractPath, "utf8")).status ?? null;
+        } catch {
+          status = "unreadable-contract";
+        }
+      }
+      items.push({ name: entry.name, kind, status });
+    }
+  }
+  return items.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function* walkFiles(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIR_NAMES.has(entry.name)) continue;
+      yield* walkFiles(join(dir, entry.name));
+      continue;
+    }
+    const ext = entry.name.slice(entry.name.lastIndexOf("."));
+    if (!SCAN_EXTENSIONS.has(ext)) continue;
+    if (/\.(test|stories)\.(ts|tsx)$/.test(entry.name)) continue;
+    yield join(dir, entry.name);
+  }
+}
+
+function collectSourceFiles() {
+  const files = [];
+  for (const rootDir of SCAN_ROOTS) {
+    const abs = join(ROOT, rootDir);
+    if (!existsSync(abs)) continue;
+    files.push(...walkFiles(abs));
+  }
+  return files;
+}
+
+function importPatternsFor(name) {
+  return [
+    // Any import specifier where a path segment equals the component name
+    // exactly: "@dt/Name", ".../components/Name", "../Name/Name", "./Name".
+    // Component dirs are PascalCase, so lowercase packages (next/link) and
+    // css-module files (./Name.module.css) never match a segment.
+    new RegExp(`from\\s+["'](?:[^"']*/)?${name}(?:/[^"']*)?["']`),
+    // Dynamic imports (next/dynamic lazy chunks): import("../Name/Name")
+    new RegExp(`import\\(\\s*["'](?:[^"']*/)?${name}(?:/[^"']*)?["']\\s*\\)`),
+  ];
+}
+
+function barrelImportedNames(source) {
+  const names = new Set();
+  const barrelImportRe = /import\s+(?:type\s+)?\{([^}]+)\}\s+from\s+["']@digitaltableteur\/react["']/g;
+  for (const match of source.matchAll(barrelImportRe)) {
+    for (const raw of match[1].split(",")) {
+      const cleaned = raw.replace(/\btype\b/, "").trim().split(/\s+as\s+/)[0].trim();
+      if (cleaned) names.add(cleaned);
+    }
+  }
+  return names;
+}
+
+const components = listComponents();
+const files = collectSourceFiles();
+const fileEntries = files.map((path) => {
+  const source = readFileSync(path, "utf8");
+  return {
+    path: relative(ROOT, path),
+    source,
+    barrelNames: source.includes("@digitaltableteur/react") ? barrelImportedNames(source) : new Set(),
+  };
+});
+
+const rows = components.map(({ name, kind, status }) => {
+  const patterns = importPatternsFor(name);
+  const importers = [];
+  for (const entry of fileEntries) {
+    // A component's own directory does not count as an importer of itself.
+    if (entry.path.includes(`/${name}/`)) continue;
+    const direct = patterns.some((re) => re.test(entry.source));
+    const viaBarrel = entry.barrelNames.has(name);
+    if (direct || viaBarrel) importers.push(entry.path);
+  }
+  const consumers = computeConsumersForComponent(name);
+  return {
+    name,
+    kind,
+    status,
+    directImportCount: importers.length,
+    directImporters: importers.sort(),
+    prodPageCount: consumers.length,
+    prodPages: consumers.map((c) => c.path),
+  };
+});
+
+mkdirSync(dirname(OUT_PATH), { recursive: true });
+writeFileSync(
+  OUT_PATH,
+  `${JSON.stringify({ generatedAt: new Date().toISOString(), components: rows }, null, 2)}\n`,
+);
+
+const sorted = [...rows].sort(
+  (a, b) => b.directImportCount - a.directImportCount || a.name.localeCompare(b.name),
+);
+const pad = (value, width) => String(value).padEnd(width);
+console.log(pad("component", 30), pad("kind", 10), pad("status", 8), pad("imports", 8), "prod pages");
+for (const row of sorted) {
+  console.log(
+    pad(row.name, 30),
+    pad(row.kind, 10),
+    pad(row.status ?? "-", 8),
+    pad(row.directImportCount, 8),
+    row.prodPageCount,
+  );
+}
+const unused = sorted.filter((row) => row.directImportCount === 0);
+console.log(`\n${rows.length} components; ${unused.length} with zero direct imports.`);
+console.log(`Report: ${relative(ROOT, OUT_PATH)}`);


### PR DESCRIPTION
## Summary
- `npm run report:component-usage` counts, per catalog component/pattern: direct importers (path-segment-exact static imports, `@digitaltableteur/react` barrel imports, dynamic `import()`) and production pages that transitively render it (consumers-lib module graph). Writes `foundations/dist/component-usage.json`.
- New Storybook page **Docs/ComponentUsage**: sortable table (imports / prod pages / name), zero-import filter, expandable importer lists.
- Snapshot: 203 components, 18 with zero importers. Leaders: Text 57, Button 50, Title 49, Icon 48.

## Verification
- Story registered and rendering in the running Storybook (checked via index.json + browser)
- Full local gate: typecheck, lint, vitest, build — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new usage report and Storybook documentation view that show how components are used, with sorting and filtering options.
  * Added a command to generate the latest usage report data.

* **Chores**
  * Updated ignore rules so the generated usage report can be tracked in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->