### PR TITLE
feat(design-system): ToastStack (alpha) — concurrent toasts stack instead of replacing

### DIFF
--- a/nextjs-app/shared/components/Toast/Toast.contract.json
+++ b/nextjs-app/shared/components/Toast/Toast.contract.json
@@ -161,10 +161,14 @@
         "onClose": {
             "optional": true,
             "type": "() => void"
+        },
+        "inline": {
+            "optional": true,
+            "type": "boolean"
         }
     },
     "forbiddenUse": [
-        "mount two <Toast /> instances side by side; the shared live region double-announces and the visuals go stale.",
+        "mount two overlapping fixed <Toast /> instances yourself; use ToastStack (or the app ToastProvider) so concurrent messages stack instead of replacing each other.",
         "rely on Toast for compliance acknowledgements (cookie consent, legal notices); it auto-dismisses — use AlertBanner or Modal.",
         "use Toast for validation errors on a field; the message detaches from the input — use the field's error prop."
     ],
@@ -242,10 +246,11 @@
     },
     "composesWith": [
         "Button",
-        "Text",
-        "Modal",
-        "TextInput",
         "CheckboxGroup",
-        "TextArea"
+        "Modal",
+        "Text",
+        "TextArea",
+        "TextInput",
+        "ToastStack"
     ]
 }

--- a/nextjs-app/shared/components/Toast/Toast.module.css
+++ b/nextjs-app/shared/components/Toast/Toast.module.css
@@ -124,6 +124,15 @@
   transform: none;
 }
 
+/* Inline mode: a parent (ToastStack) owns placement */
+
+.toast--inline {
+  position: static;
+  inset: auto;
+  z-index: auto;
+  transform: none;
+}
+
 /* Reduced motion: keep the toast, drop the fade/slide */
 @media (prefers-reduced-motion: reduce) {
   .toast {

--- a/nextjs-app/shared/components/Toast/Toast.spec.md
+++ b/nextjs-app/shared/components/Toast/Toast.spec.md
@@ -22,8 +22,10 @@ anything that should stay until dismissed, AlertBanner.
 - Do: pair `tone="error"` with an actionable next step ("Retry" in
   the message text) so the user knows what to do. Use AlertBanner for
   persistent errors that can't be auto-resolved.
-- Don't: stack toasts. The provider queues them — calling `showToast`
-  three times in a frame shows the last one only, which is intentional.
+- Don't: hand-roll overlapping fixed toasts. Concurrent messages stack via
+  ToastStack — the app provider renders one stack per position, so calling
+  `showToast` repeatedly shows every message (decision 2026-07-09; the old
+  last-one-wins behavior hid the "language changed" confirmation).
 - Don't: rely on Toast for compliance acknowledgements (cookie consent,
   GDPR). Those need persistent acknowledgement; use Modal +
   CookieConsent.

--- a/nextjs-app/shared/components/Toast/Toast.stories.tsx
+++ b/nextjs-app/shared/components/Toast/Toast.stories.tsx
@@ -2,6 +2,7 @@ import contract from "./Toast.contract.json";
 import React, { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import Toast, { type ToastTone, type ToastPosition } from "@dt/Toast";
+import ToastStack from "@dt/ToastStack";
 import Button from "@dt/Button";
 import { ToastProvider, useToast } from "@/providers/ToastProvider";
 import { expect, userEvent, waitFor, within } from "storybook/test";
@@ -110,6 +111,10 @@ export const Placement: Story = {
         story:
           "position anchors the toast to a viewport corner or edge center. The app default is bottom-center; keep one placement per app so toasts are predictable.",
       },
+      // Inline docs previews transform their container, which hijacks
+      // position: fixed; an iframe gives the toast a real viewport so each
+      // placement lands where the trigger says.
+      story: { inline: false, iframeHeight: 360 },
     },
   },
   render: function PlacementStory() {
@@ -175,6 +180,40 @@ export const ProviderDriven: Story = {
       <ToastProvider>
         <SaveButton />
       </ToastProvider>
+    );
+  },
+};
+
+/** Concurrent toasts stack via ToastStack instead of replacing each other. */
+export const Stacked: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story:
+          "Concurrent messages stack (newest nearest the docked edge) via ToastStack — the app ToastProvider renders one stack per position, so firing showToast repeatedly shows every message.",
+      },
+      // Same iframe treatment as Placement: fixed positioning needs a real
+      // viewport in docs.
+      story: { inline: false, iframeHeight: 360 },
+    },
+  },
+  render: function StackedStory() {
+    return (
+      <ToastStack
+        toasts={[
+          { id: "saved", message: "Settings saved.", tone: "success", duration: 600000 },
+          { id: "lang", message: "Language changed to English", duration: 600000 },
+          {
+            id: "notice",
+            message: "This content is only available in English",
+            tone: "info",
+            duration: 600000,
+          },
+        ]}
+        position="bottom-center"
+      />
     );
   },
 };

--- a/nextjs-app/shared/components/Toast/Toast.tsx
+++ b/nextjs-app/shared/components/Toast/Toast.tsx
@@ -35,6 +35,11 @@ export interface ToastProps {
   duration?: number;
   /** Called when the auto-dismiss timer fires. */
   onClose?: () => void;
+  /**
+   * Render in normal document flow instead of fixed-positioning itself; a
+   * parent (ToastStack) owns placement. `position` is ignored when set.
+   */
+  inline?: boolean;
 }
 
 /**
@@ -44,7 +49,7 @@ export interface ToastProps {
  * AnimatePresence mount/unmount, which would defeat the live region.
  */
 const Toast = forwardRef<HTMLDivElement, ToastProps>(function Toast(
-  { open, tone, position = "bottom-center", size = "md", message, duration = 3000, onClose },
+  { open, tone, position = "bottom-center", size = "md", message, duration = 3000, onClose, inline },
   ref,
 ) {
   useEffect(() => {
@@ -70,7 +75,7 @@ const Toast = forwardRef<HTMLDivElement, ToastProps>(function Toast(
         styles.toast,
         styles[`toast--${size}`],
         tone ? styles[`toast--${tone}`] : "",
-        styles[`toast--${position}`],
+        inline ? styles["toast--inline"] : styles[`toast--${position}`],
         !isVisible ? styles["toast--hidden"] : "",
       ]
         .filter(Boolean)

--- a/nextjs-app/shared/components/ToastStack/ToastStack.contract.json
+++ b/nextjs-app/shared/components/ToastStack/ToastStack.contract.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+  "name": "ToastStack",
+  "tier": "molecule",
+  "group": "feedback",
+  "status": "alpha",
+  "description": "Docked stack of transient toasts: renders Toast children inline and owns the fixed placement, newest toast nearest the docked edge, so concurrent messages stay visible instead of replacing each other.",
+  "figma": null,
+  "radixPrimitive": null,
+  "element": "div",
+  "variants": {
+    "position": {
+      "values": [
+        "top-left",
+        "top-center",
+        "top-right",
+        "bottom-left",
+        "bottom-center",
+        "bottom-right"
+      ],
+      "default": "bottom-center",
+      "forwarded": false
+    }
+  },
+  "slots": [],
+  "asChild": false,
+  "subParts": [],
+  "requiredStories": [
+    "Default",
+    "Playground",
+    "Example",
+    "ForcedColors"
+  ],
+  "a11y": {
+    "keyboard": [],
+    "ariaRequirements": [
+      "each stacked Toast keeps its own live region (role=status or role=alert per tone) so concurrent messages announce independently",
+      "the stack wrapper is presentational: no role, pointer-events none with interactive children restored"
+    ],
+    "reviewed": false,
+    "forcedColorsVerified": false,
+    "reducedMotion": true
+  },
+  "tokens": {
+    "colors": [],
+    "spacing": [
+      "--space-internal-8",
+      "--space-layout-24"
+    ]
+  },
+  "lightDarkVerified": false,
+  "consumers": [],
+  "schemaVersion": 2,
+  "props": {
+    "toasts": {
+      "optional": false,
+      "type": "ToastStackItem[]"
+    },
+    "position": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "top-left",
+        "top-center",
+        "top-right",
+        "bottom-left",
+        "bottom-center",
+        "bottom-right"
+      ]
+    },
+    "onDismiss": {
+      "optional": true,
+      "type": "(id: string) => void"
+    },
+    "max": {
+      "optional": true,
+      "type": "number"
+    },
+    "className": {
+      "optional": true,
+      "type": "string"
+    }
+  },
+  "forbiddenUse": [
+    "mounting more than one ToastStack per position; group toasts by position and render one stack per active position instead",
+    "persistent or compliance-critical messaging; toasts auto-dismiss (use AlertBanner)"
+  ],
+  "prefersOver": [
+    "multiple sibling <Toast /> mounts, whose fixed positions overlap and whose messages replace each other"
+  ],
+  "displayName": "ToastStack",
+  "keywords": [
+    "toast stack",
+    "notification stack",
+    "snackbar queue",
+    "stacked toasts",
+    "concurrent notifications"
+  ],
+  "dense": "docked flex stack of Toast (inline mode); toasts: {id,message,tone?,duration?,size?}[], 6 dock positions, max visible (default 5, oldest wait), onDismiss(id) on per-toast auto-dismiss",
+  "usage": {
+    "description": "ToastStack is the multi-toast surface behind the app ToastProvider: showToast calls append items and each renders as an inline Toast laid out by the stack, newest nearest the docked edge. Use it (or the provider) whenever more than one transient message can be alive at once; a bare Toast stays correct for single, fully controlled cases."
+  },
+  "playground": {
+    "defaults": {
+      "position": "bottom-center"
+    }
+  },
+  "composesWith": [
+    "Toast"
+  ]
+}

--- a/nextjs-app/shared/components/ToastStack/ToastStack.module.css
+++ b/nextjs-app/shared/components/ToastStack/ToastStack.module.css
@@ -15,13 +15,14 @@
 }
 
 /*
- * Bottom positions grow upward: newest toast is appended last and
- * column-reverse keeps it nearest the docked edge.
+ * Newest toast stays nearest the docked edge. Bottom docks grow upward from
+ * their anchor, so plain column order already puts the appended-last toast at
+ * the edge; top docks need column-reverse for the same effect.
  */
 
-.stack--bottom-left,
-.stack--bottom-center,
-.stack--bottom-right {
+.stack--top-left,
+.stack--top-center,
+.stack--top-right {
   flex-direction: column-reverse;
 }
 

--- a/nextjs-app/shared/components/ToastStack/ToastStack.module.css
+++ b/nextjs-app/shared/components/ToastStack/ToastStack.module.css
@@ -1,0 +1,64 @@
+.stack {
+  display: flex;
+  position: fixed;
+  z-index: 1000;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-internal-8);
+  pointer-events: none;
+}
+
+/* Children stay interactive even though the wrapper ignores events */
+
+.stack > * {
+  pointer-events: auto;
+}
+
+/*
+ * Bottom positions grow upward: newest toast is appended last and
+ * column-reverse keeps it nearest the docked edge.
+ */
+
+.stack--bottom-left,
+.stack--bottom-center,
+.stack--bottom-right {
+  flex-direction: column-reverse;
+}
+
+.stack--top-left {
+  top: var(--space-layout-24);
+  left: var(--space-layout-24);
+  align-items: flex-start;
+}
+
+.stack--top-center {
+  inset-inline: 0;
+  top: var(--space-layout-24);
+  margin-inline: auto;
+  width: fit-content;
+}
+
+.stack--top-right {
+  top: var(--space-layout-24);
+  right: var(--space-layout-24);
+  align-items: flex-end;
+}
+
+.stack--bottom-left {
+  bottom: var(--space-layout-24);
+  left: var(--space-layout-24);
+  align-items: flex-start;
+}
+
+.stack--bottom-center {
+  inset-inline: 0;
+  bottom: var(--space-layout-24);
+  margin-inline: auto;
+  width: fit-content;
+}
+
+.stack--bottom-right {
+  right: var(--space-layout-24);
+  bottom: var(--space-layout-24);
+  align-items: flex-end;
+}

--- a/nextjs-app/shared/components/ToastStack/ToastStack.spec.md
+++ b/nextjs-app/shared/components/ToastStack/ToastStack.spec.md
@@ -1,0 +1,45 @@
+# ToastStack
+
+## Intent
+Keep concurrent transient messages visible together instead of letting the
+newest replace the rest. The motivating case: switching UI language on an
+English-only article fires both "language changed" and the content-language
+notice — with a single Toast slot the confirmation was never seen. ToastStack
+owns the fixed docking that a lone Toast handles itself and lays the toasts
+out with the newest nearest the docked edge.
+
+## Interaction contract
+- Keyboard: the stack never captures focus; individual toasts follow the
+  Toast contract (no dismiss button, timer-driven).
+- Pointer: the wrapper is `pointer-events: none` so it never blocks the page;
+  children restore `pointer-events: auto`.
+- Screen readers: each toast keeps its own live region (`status` or `alert`
+  per tone), so concurrent messages announce independently — the reason the
+  stack renders multiple Toast instances rather than swapping one message.
+- Overflow: at most `max` (default 5) toasts render; older ones wait
+  unrendered, and because a Toast's timer only runs while rendered, bursts
+  drain oldest-first instead of being dropped.
+
+## Do / don't
+- Do: drive it from the app `ToastProvider` — `showToast` appends and the
+  provider renders one stack per active position.
+- Do: give every toast a stable `id`; dismissal and list identity depend on it.
+- Don't: mount more than one ToastStack at the same position; their fixed
+  wrappers would overlap. Group by position instead.
+- Don't: use it for persistent or compliance-critical messaging — toasts
+  auto-dismiss (AlertBanner or Modal own those cases).
+
+## Design notes
+- The stack owns fixed placement; toasts render with the `inline` prop so
+  their own position classes never fight the wrapper. Bottom docks use
+  `column-reverse` so appending keeps the newest toast nearest the edge.
+- Spacing uses `--space-internal-8` between toasts and the same
+  `--space-layout-24` screen-edge offset a lone Toast uses, so a single-item
+  stack is visually identical to a bare Toast.
+- No entry/exit animation beyond Toast's own opacity/translate transition;
+  reduced-motion inherits Toast's handling.
+
+## Status
+Alpha. Not yet a `@digitaltableteur/react` export; the app imports it via
+`@dt/ToastStack` (allowlisted in the registry-resolution guard) until it is
+promoted onto the published surface.

--- a/nextjs-app/shared/components/ToastStack/ToastStack.stories.tsx
+++ b/nextjs-app/shared/components/ToastStack/ToastStack.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import React, { useCallback, useRef, useState } from "react";
+import ToastStack, {
+  type ToastStackItem,
+  type ToastStackProps,
+} from "./ToastStack";
+import contract from "./ToastStack.contract.json";
+
+const seedToasts: ToastStackItem[] = [
+  { id: "changed", message: "Language changed", tone: "success", duration: 60000 },
+  {
+    id: "notice",
+    message: "This content is only available in English",
+    tone: "info",
+    duration: 60000,
+  },
+];
+
+const meta = {
+  title: "Feedback/ToastStack",
+  component: ToastStack,
+  tags: ["alpha", "!autodocs"],
+  parameters: {
+    layout: "fullscreen",
+    a11y: { test: "error" },
+    contractStatus: contract.status,
+  },
+  args: { toasts: seedToasts, position: "bottom-center" },
+} satisfies Meta<typeof ToastStack>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+const PlaygroundHarness = (args: ToastStackProps) => {
+  const [toasts, setToasts] = useState<ToastStackItem[]>(args.toasts);
+  const counter = useRef(0);
+  const tones = ["info", "success", "warning", "error"] as const;
+
+  const push = useCallback(() => {
+    counter.current += 1;
+    const tone = tones[counter.current % tones.length];
+    setToasts((current) => [
+      ...current,
+      {
+        id: `toast-${counter.current}`,
+        message: `Stacked toast #${counter.current}`,
+        tone,
+        duration: 4000,
+      },
+    ]);
+  }, []);
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  return (
+    <div style={{ minHeight: "60vh", padding: "1rem" }}>
+      <button type="button" onClick={push}>
+        Push toast
+      </button>
+      <ToastStack {...args} toasts={toasts} onDismiss={dismiss} />
+    </div>
+  );
+};
+
+export const Playground: Story = {
+  render: (args) => <PlaygroundHarness {...args} toasts={[]} />,
+};
+
+export const Example: Story = {
+  name: "Example",
+  args: {
+    toasts: seedToasts,
+    position: "bottom-center",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The language-switch case that motivated the component: the change confirmation and the content-language notice stay visible together instead of replacing each other.",
+      },
+    },
+  },
+};
+
+export const ForcedColors: Story = {
+  name: "ForcedColors",
+  args: { toasts: seedToasts },
+  parameters: {
+    chromatic: { forcedColors: "active" },
+  },
+};

--- a/nextjs-app/shared/components/ToastStack/ToastStack.stories.tsx
+++ b/nextjs-app/shared/components/ToastStack/ToastStack.stories.tsx
@@ -7,7 +7,8 @@ import ToastStack, {
 import contract from "./ToastStack.contract.json";
 
 const seedToasts: ToastStackItem[] = [
-  { id: "changed", message: "Language changed", tone: "success", duration: 60000 },
+  { id: "saved", message: "Settings saved.", tone: "success", duration: 60000 },
+  { id: "changed", message: "Language changed to English", duration: 60000 },
   {
     id: "notice",
     message: "This content is only available in English",

--- a/nextjs-app/shared/components/ToastStack/ToastStack.test.tsx
+++ b/nextjs-app/shared/components/ToastStack/ToastStack.test.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import ToastStack, { type ToastStackItem } from "@dt/ToastStack";
+import styles from "./ToastStack.module.css";
+
+expect.extend(toHaveNoViolations);
+
+const items: ToastStackItem[] = [
+  { id: "a", message: "Language changed" },
+  { id: "b", message: "This content is only available in English", tone: "info" },
+];
+
+describe("ToastStack", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    if (vi.isFakeTimers()) {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("renders every toast message at once", () => {
+    render(<ToastStack toasts={items} />);
+    expect(screen.getByText("Language changed")).toBeInTheDocument();
+    expect(
+      screen.getByText("This content is only available in English"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders toasts inline so the stack owns placement", () => {
+    const { container } = render(<ToastStack toasts={items} />);
+    const stack = container.firstElementChild as HTMLElement;
+    expect(stack.className).toContain(styles.stack);
+    expect(stack.className).toContain(styles["stack--bottom-center"]);
+    for (const toast of stack.children) {
+      expect(toast.className).toMatch(/toast--inline/);
+    }
+  });
+
+  it("reports each dismissal with the toast id", () => {
+    const onDismiss = vi.fn();
+    render(
+      <ToastStack
+        toasts={[
+          { id: "fast", message: "Fast", duration: 1000 },
+          { id: "slow", message: "Slow", duration: 5000 },
+        ]}
+        onDismiss={onDismiss}
+      />,
+    );
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(onDismiss).toHaveBeenCalledWith("fast");
+    expect(onDismiss).not.toHaveBeenCalledWith("slow");
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(onDismiss).toHaveBeenCalledWith("slow");
+  });
+
+  it("caps rendered toasts at max, dropping the oldest", () => {
+    const many = Array.from({ length: 7 }, (_, index) => ({
+      id: String(index),
+      message: `Toast ${index}`,
+    }));
+    render(<ToastStack toasts={many} max={3} />);
+    expect(screen.queryByText("Toast 3")).not.toBeInTheDocument();
+    expect(screen.getByText("Toast 4")).toBeInTheDocument();
+    expect(screen.getByText("Toast 6")).toBeInTheDocument();
+  });
+
+  it("positions the stack per the position prop", () => {
+    const { container } = render(
+      <ToastStack toasts={items} position="top-right" />,
+    );
+    const stack = container.firstElementChild as HTMLElement;
+    expect(stack.className).toContain(styles["stack--top-right"]);
+  });
+
+  it("has no axe violations", async () => {
+    vi.useRealTimers();
+    const { container } = render(<ToastStack toasts={items} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/ToastStack/ToastStack.tsx
+++ b/nextjs-app/shared/components/ToastStack/ToastStack.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { forwardRef } from "react";
+import Toast, {
+  type ToastPosition,
+  type ToastTone,
+} from "../Toast/Toast";
+import { cn } from "../../lib/cn";
+import styles from "./ToastStack.module.css";
+
+export interface ToastStackItem {
+  /** Stable identity for dismissal and list rendering. */
+  id: string;
+  /** Message text displayed in the toast. */
+  message: string;
+  /** Semantic colour. */
+  tone?: ToastTone;
+  /** Auto-dismiss delay in ms. @default 3000 */
+  duration?: number;
+  /** Size. @default "md" */
+  size?: "sm" | "md" | "lg";
+}
+
+export interface ToastStackProps {
+  /** Toasts to display, oldest first; new toasts are appended by the caller. */
+  toasts: ToastStackItem[];
+  /** Screen corner/edge the stack docks to. @default "bottom-center" */
+  position?: ToastPosition;
+  /** Called with the toast id when its auto-dismiss timer fires. */
+  onDismiss?: (id: string) => void;
+  /**
+   * Maximum toasts rendered at once; older ones wait (their timers only run
+   * while rendered), so bursts drain in order. @default 5
+   */
+  max?: number;
+  /** Optional classes on the stack wrapper. */
+  className?: string;
+}
+
+/**
+ * Docked stack of transient toasts. Owns the fixed placement that a lone
+ * `Toast` handles itself: children render inline and the stack lays them out
+ * with the newest toast nearest the docked screen edge. Each toast keeps its
+ * own live region and auto-dismiss timer, so messages announce independently
+ * instead of replacing each other.
+ */
+const ToastStack = forwardRef<HTMLDivElement, ToastStackProps>(
+  function ToastStack(
+    { toasts, position = "bottom-center", onDismiss, max = 5, className },
+    ref,
+  ) {
+    const visible = toasts.slice(-Math.max(1, max));
+
+    return (
+      <div
+        ref={ref}
+        className={cn(styles.stack, styles[`stack--${position}`], className)}
+      >
+        {visible.map((toast) => (
+          <Toast
+            key={toast.id}
+            inline
+            open
+            message={toast.message}
+            tone={toast.tone}
+            duration={toast.duration}
+            size={toast.size}
+            onClose={onDismiss ? () => onDismiss(toast.id) : undefined}
+          />
+        ))}
+      </div>
+    );
+  },
+);
+
+export default ToastStack;

--- a/nextjs-app/shared/components/ToastStack/index.ts
+++ b/nextjs-app/shared/components/ToastStack/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./ToastStack";
+export type { ToastStackProps, ToastStackItem } from "./ToastStack";

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,18 +1,18 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-08T23:37:19.274Z",
+  "generatedAt": "2026-07-09T16:24:37.980Z",
   "summary": {
-    "componentCount": 160,
+    "componentCount": 161,
     "statusCounts": {
       "beta": 75,
       "stable": 63,
-      "alpha": 22
+      "alpha": 23
     },
     "honestBetaDocDebt": 0,
-    "catalogCompletenessPercent": 87.4,
-    "codebaseComponentCount": 183,
-    "usageCoveragePercent": 93.1,
-    "componentsWithProductionUsage": 45,
+    "catalogCompletenessPercent": 87.5,
+    "codebaseComponentCount": 184,
+    "usageCoveragePercent": 92.5,
+    "componentsWithProductionUsage": 46,
     "notReadyForStablePromotion": false
   },
   "exportPolicy": {
@@ -56,15 +56,15 @@
   },
   "catalogCoverage": {
     "description": "Catalog completeness across the codebase. componentCount above is the catalog count; this block reveals how much of the codebase that catalog actually represents.",
-    "totalComponentsInCodebase": 183,
-    "inCatalog": 160,
+    "totalComponentsInCodebase": 184,
+    "inCatalog": 161,
     "outOfCatalog": 23,
-    "catalogCompletenessPercent": 87.4,
+    "catalogCompletenessPercent": 87.5,
     "artifactCoverage": {
-      "stories": 144,
-      "tests": 132,
+      "stories": 145,
+      "tests": 133,
       "mdx": 3,
-      "spec": 160
+      "spec": 161
     },
     "outOfCatalogByBucket": {
       "catalog-gap": 0,
@@ -76,21 +76,21 @@
   },
   "usageCoverage": {
     "description": "Auto-detected import evidence from app/** and nextjs-app/**. Separate from contract.consumers[], which remains the stable-promotion gate for shipping-product proof.",
-    "catalogedComponents": 160,
+    "catalogedComponents": 161,
     "withAnyUsage": 149,
-    "withProductionUsage": 45,
+    "withProductionUsage": 46,
     "uniqueImportedComponents": 149,
-    "totalEvidenceRows": 839,
-    "aliasImportFiles": 464,
-    "relativeImportFiles": 383,
+    "totalEvidenceRows": 845,
+    "aliasImportFiles": 469,
+    "relativeImportFiles": 384,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
   },
   "relationshipGraph": {
     "description": "Merged static composesWith policy + co-import evidence (see generate-relationship-graph.mjs).",
-    "generatedAt": "2026-07-08T23:37:14.681Z",
+    "generatedAt": "2026-07-09T16:24:34.507Z",
     "coImportMinFiles": 3,
-    "nodesWithComposesWith": 85,
+    "nodesWithComposesWith": 86,
     "regenerate": "npm run build:relationship-graph or npm run build:tokens",
     "path": "nextjs-app/shared/foundations/dist/relationship-graph.json"
   },
@@ -101,14 +101,14 @@
   "dsharpParity": {
     "description": "Comparison against DSharp as of 2026-05-26. Breadth is close, maturity is not. This block walks back the earlier parity overclaim.",
     "contractCount": {
-      "digitaltableteur": 160,
+      "digitaltableteur": 161,
       "dsharp": 112
     },
     "statusMix": {
       "digitaltableteur": {
         "beta": 75,
         "stable": 63,
-        "alpha": 22
+        "alpha": 23
       },
       "dsharp": {
         "beta": 110,
@@ -4292,11 +4292,17 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Breadcrumb",
-        "importCount": 1,
-        "productionImportCount": 0,
+        "importCount": 2,
+        "productionImportCount": 1,
         "patternImportCount": 0,
         "componentImportCount": 1,
         "evidence": [
+          {
+            "path": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Breadcrumb",
+            "context": "production"
+          },
           {
             "path": "nextjs-app/shared/components/index.ts",
             "importKind": "relative",
@@ -4372,7 +4378,14 @@
           "skip levels to make the trail shorter. If the user is at",
           "render the breadcrumb above a hero — it gets lost. Place it"
         ],
-        "composesWith": [],
+        "composesWith": [
+          "Button",
+          "Card",
+          "Text",
+          "Title",
+          "MarkdownMessage",
+          "PageLayout"
+        ],
         "prefersOver": [],
         "declaredPropCount": 6
       }
@@ -4753,8 +4766,8 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Button",
-        "importCount": 66,
-        "productionImportCount": 7,
+        "importCount": 67,
+        "productionImportCount": 8,
         "patternImportCount": 6,
         "componentImportCount": 32,
         "evidence": [
@@ -4801,6 +4814,12 @@
             "context": "production"
           },
           {
+            "path": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Button",
+            "context": "production"
+          },
+          {
             "path": "nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx",
             "importKind": "alias",
             "importPath": "@dt/Button",
@@ -4820,12 +4839,6 @@
           },
           {
             "path": "nextjs-app/shared/patterns/HighlightSection/HighlightSection.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/Button",
-            "context": "pattern"
-          },
-          {
-            "path": "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
             "importKind": "alias",
             "importPath": "@dt/Button",
             "context": "pattern"
@@ -5510,13 +5523,19 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Card",
-        "importCount": 7,
-        "productionImportCount": 2,
+        "importCount": 8,
+        "productionImportCount": 3,
         "patternImportCount": 0,
         "componentImportCount": 4,
         "evidence": [
           {
             "path": "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Card",
+            "context": "production"
+          },
+          {
+            "path": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
             "importKind": "alias",
             "importPath": "@dt/Card",
             "context": "production"
@@ -5703,8 +5722,8 @@
           "Text",
           "Button",
           "PageLayout",
-          "Icon",
-          "Badge"
+          "Breadcrumb",
+          "MarkdownMessage"
         ],
         "prefersOver": [],
         "declaredPropCount": 16
@@ -9818,8 +9837,8 @@
           "animations",
           "Stack",
           "Link",
-          "ScrollIndicator",
-          "Badge"
+          "Badge",
+          "Checkbox"
         ],
         "prefersOver": [],
         "declaredPropCount": 5
@@ -17956,10 +17975,12 @@
           "Bypass design tokens or skip forced-colors verification at beta."
         ],
         "composesWith": [
-          "OpenHours",
-          "ServicesGrid",
-          "StudioMap",
-          "DonnyBookingEmbed"
+          "Breadcrumb",
+          "Button",
+          "Card",
+          "Text",
+          "Title",
+          "PageLayout"
         ],
         "prefersOver": [],
         "declaredPropCount": 6
@@ -28966,8 +28987,8 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Text",
-        "importCount": 79,
-        "productionImportCount": 18,
+        "importCount": 80,
+        "productionImportCount": 19,
         "patternImportCount": 10,
         "componentImportCount": 27,
         "evidence": [
@@ -28979,6 +29000,12 @@
           },
           {
             "path": "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Text",
+            "context": "production"
+          },
+          {
+            "path": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
             "importKind": "alias",
             "importPath": "@dt/Text",
             "context": "production"
@@ -29033,12 +29060,6 @@
           },
           {
             "path": "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/Text",
-            "context": "production"
-          },
-          {
-            "path": "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx",
             "importKind": "alias",
             "importPath": "@dt/Text",
             "context": "production"
@@ -30290,8 +30311,8 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Title",
-        "importCount": 56,
-        "productionImportCount": 23,
+        "importCount": 57,
+        "productionImportCount": 24,
         "patternImportCount": 9,
         "componentImportCount": 15,
         "evidence": [
@@ -30362,7 +30383,7 @@
             "context": "production"
           },
           {
-            "path": "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx",
+            "path": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
             "importKind": "alias",
             "importPath": "@dt/Title",
             "context": "production"
@@ -30653,10 +30674,14 @@
           "onClose": {
             "optional": true,
             "type": "() => void"
+          },
+          "inline": {
+            "optional": true,
+            "type": "boolean"
           }
         },
         "forbiddenUse": [
-          "mount two <Toast /> instances side by side; the shared live region double-announces and the visuals go stale.",
+          "mount two overlapping fixed <Toast /> instances yourself; use ToastStack (or the app ToastProvider) so concurrent messages stack instead of replacing each other.",
           "rely on Toast for compliance acknowledgements (cookie consent, legal notices); it auto-dismisses — use AlertBanner or Modal.",
           "use Toast for validation errors on a field; the message detaches from the input — use the field's error prop."
         ],
@@ -30734,21 +30759,22 @@
         },
         "composesWith": [
           "Button",
-          "Text",
-          "Modal",
-          "TextInput",
           "CheckboxGroup",
-          "TextArea"
+          "Modal",
+          "Text",
+          "TextArea",
+          "TextInput",
+          "ToastStack"
         ]
       },
-      "spec": "# Toast\n\n## Intent\nAcknowledge a user-initiated action without blocking the flow. Toast is\ndeliberately transient — the user is not expected to read it twice.\nFor anything that demands a response, the right primitive is Modal; for\nanything that should stay until dismissed, AlertBanner.\n\n## Interaction contract\n- Keyboard: Toast does not capture focus. There is no dismiss button\n  by default — the toast disappears on its own timer.\n- Pointer: the surface does not respond to clicks. (Click-to-dismiss is\n  a future affordance; tabling until a consumer needs it.)\n- Screen readers: announced via `aria-live`. `polite` for info and\n  success; `assertive` for warning and error so the announcement\n  interrupts. `aria-atomic=\"true\"` makes the full message announce on\n  every update, not just the changed words.\n\n## Do / don't\n- Do: keep the message ≤ 60 characters so it fits on a single line.\n  Two-line toasts get cropped at the bottom of mobile viewports.\n- Do: pair `tone=\"error\"` with an actionable next step (\"Retry\" in\n  the message text) so the user knows what to do. Use AlertBanner for\n  persistent errors that can't be auto-resolved.\n- Don't: stack toasts. The provider queues them — calling `showToast`\n  three times in a frame shows the last one only, which is intentional.\n- Don't: rely on Toast for compliance acknowledgements (cookie consent,\n  GDPR). Those need persistent acknowledgement; use Modal +\n  CookieConsent.\n- Don't: use Toast for validation errors on a field. The visual is far\n  from the error source; use HelperText.\n\n## Design notes\n- Tokens: tone surfaces use the same `--color-<tone>-surface`\n  tokens as AlertBanner so the visual language is consistent. Radius is\n  `--radius-md`; elevation is `--shadow-lg` since Toast floats above\n  content.\n- Figma: https://www.figma.com/design/digitaltableteur/toast — six\n  positions × four severities; size prop maps `sm` / `md` / `lg`.\n- Icons are direct Phosphor `weight=\"fill\"` imports (not via the\n  `<Icon />` component) to keep visual alignment tight with the\n  `ToastProvider` library used in the chat widget. The shared icon set is the\n  one nailed-down constraint between the two.\n- The `<ToastProvider>` at the app root owns the live region; this\n  component is the visual + ARIA implementation rendered on demand.\n  Direct `<Toast />` mounting is supported but discouraged.\n",
+      "spec": "# Toast\n\n## Intent\nAcknowledge a user-initiated action without blocking the flow. Toast is\ndeliberately transient — the user is not expected to read it twice.\nFor anything that demands a response, the right primitive is Modal; for\nanything that should stay until dismissed, AlertBanner.\n\n## Interaction contract\n- Keyboard: Toast does not capture focus. There is no dismiss button\n  by default — the toast disappears on its own timer.\n- Pointer: the surface does not respond to clicks. (Click-to-dismiss is\n  a future affordance; tabling until a consumer needs it.)\n- Screen readers: announced via `aria-live`. `polite` for info and\n  success; `assertive` for warning and error so the announcement\n  interrupts. `aria-atomic=\"true\"` makes the full message announce on\n  every update, not just the changed words.\n\n## Do / don't\n- Do: keep the message ≤ 60 characters so it fits on a single line.\n  Two-line toasts get cropped at the bottom of mobile viewports.\n- Do: pair `tone=\"error\"` with an actionable next step (\"Retry\" in\n  the message text) so the user knows what to do. Use AlertBanner for\n  persistent errors that can't be auto-resolved.\n- Don't: hand-roll overlapping fixed toasts. Concurrent messages stack via\n  ToastStack — the app provider renders one stack per position, so calling\n  `showToast` repeatedly shows every message (decision 2026-07-09; the old\n  last-one-wins behavior hid the \"language changed\" confirmation).\n- Don't: rely on Toast for compliance acknowledgements (cookie consent,\n  GDPR). Those need persistent acknowledgement; use Modal +\n  CookieConsent.\n- Don't: use Toast for validation errors on a field. The visual is far\n  from the error source; use HelperText.\n\n## Design notes\n- Tokens: tone surfaces use the same `--color-<tone>-surface`\n  tokens as AlertBanner so the visual language is consistent. Radius is\n  `--radius-md`; elevation is `--shadow-lg` since Toast floats above\n  content.\n- Figma: https://www.figma.com/design/digitaltableteur/toast — six\n  positions × four severities; size prop maps `sm` / `md` / `lg`.\n- Icons are direct Phosphor `weight=\"fill\"` imports (not via the\n  `<Icon />` component) to keep visual alignment tight with the\n  `ToastProvider` library used in the chat widget. The shared icon set is the\n  one nailed-down constraint between the two.\n- The `<ToastProvider>` at the app root owns the live region; this\n  component is the visual + ARIA implementation rendered on demand.\n  Direct `<Toast />` mounting is supported but discouraged.\n",
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Toast",
-        "importCount": 7,
+        "importCount": 8,
         "productionImportCount": 0,
         "patternImportCount": 0,
-        "componentImportCount": 5,
+        "componentImportCount": 6,
         "evidence": [
           {
             "path": "nextjs-app/shared/components/CodeSnippet/CodeSnippet.tsx",
@@ -30778,6 +30804,12 @@
             "path": "nextjs-app/shared/components/SocialShare/SocialShare.tsx",
             "importKind": "alias",
             "importPath": "@dt/Toast/Toast",
+            "context": "component"
+          },
+          {
+            "path": "nextjs-app/shared/components/ToastStack/ToastStack.tsx",
+            "importKind": "relative",
+            "importPath": "../Toast/Toast",
             "context": "component"
           },
           {
@@ -30844,6 +30876,10 @@
           "onClose": {
             "optional": true,
             "type": "() => void"
+          },
+          "inline": {
+            "optional": true,
+            "type": "boolean"
           }
         },
         "variants": {
@@ -30872,7 +30908,7 @@
           "pair `tone=\"error\"` with an actionable next step (\"Retry\" in"
         ],
         "avoidWhen": [
-          "stack toasts. The provider queues them — calling `showToast`",
+          "hand-roll overlapping fixed toasts. Concurrent messages stack via",
           "rely on Toast for compliance acknowledgements (cookie consent,",
           "use Toast for validation errors on a field. The visual is far"
         ],
@@ -30884,7 +30920,7 @@
         ],
         "keyboard": [],
         "compositionRules": [
-          "stack toasts. The provider queues them — calling `showToast`"
+          "hand-roll overlapping fixed toasts. Concurrent messages stack via"
         ],
         "canonicalExamples": [
           "Default",
@@ -30897,7 +30933,7 @@
           "window.alert"
         ],
         "forbiddenUse": [
-          "stack toasts. The provider queues them — calling `showToast`",
+          "hand-roll overlapping fixed toasts. Concurrent messages stack via",
           "rely on Toast for compliance acknowledgements (cookie consent,",
           "use Toast for validation errors on a field. The visual is far"
         ],
@@ -30912,7 +30948,198 @@
         "prefersOver": [
           "AlertBanner for page-level persistent status"
         ],
-        "declaredPropCount": 7
+        "declaredPropCount": 8
+      }
+    },
+    {
+      "name": "ToastStack",
+      "contract": {
+        "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+        "name": "ToastStack",
+        "tier": "molecule",
+        "group": "feedback",
+        "status": "alpha",
+        "description": "Docked stack of transient toasts: renders Toast children inline and owns the fixed placement, newest toast nearest the docked edge, so concurrent messages stay visible instead of replacing each other.",
+        "figma": null,
+        "radixPrimitive": null,
+        "element": "div",
+        "variants": {
+          "position": {
+            "values": [
+              "top-left",
+              "top-center",
+              "top-right",
+              "bottom-left",
+              "bottom-center",
+              "bottom-right"
+            ],
+            "default": "bottom-center",
+            "forwarded": false
+          }
+        },
+        "slots": [],
+        "asChild": false,
+        "subParts": [],
+        "requiredStories": [
+          "Default",
+          "Playground",
+          "Example",
+          "ForcedColors"
+        ],
+        "a11y": {
+          "keyboard": [],
+          "ariaRequirements": [
+            "each stacked Toast keeps its own live region (role=status or role=alert per tone) so concurrent messages announce independently",
+            "the stack wrapper is presentational: no role, pointer-events none with interactive children restored"
+          ],
+          "reviewed": false,
+          "forcedColorsVerified": false,
+          "reducedMotion": true
+        },
+        "tokens": {
+          "colors": [],
+          "spacing": [
+            "--space-internal-8",
+            "--space-layout-24"
+          ]
+        },
+        "lightDarkVerified": false,
+        "consumers": [],
+        "schemaVersion": 2,
+        "props": {
+          "toasts": {
+            "optional": false,
+            "type": "ToastStackItem[]"
+          },
+          "position": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "top-left",
+              "top-center",
+              "top-right",
+              "bottom-left",
+              "bottom-center",
+              "bottom-right"
+            ]
+          },
+          "onDismiss": {
+            "optional": true,
+            "type": "(id: string) => void"
+          },
+          "max": {
+            "optional": true,
+            "type": "number"
+          },
+          "className": {
+            "optional": true,
+            "type": "string"
+          }
+        },
+        "forbiddenUse": [
+          "mounting more than one ToastStack per position; group toasts by position and render one stack per active position instead",
+          "persistent or compliance-critical messaging; toasts auto-dismiss (use AlertBanner)"
+        ],
+        "prefersOver": [
+          "multiple sibling <Toast /> mounts, whose fixed positions overlap and whose messages replace each other"
+        ],
+        "displayName": "ToastStack",
+        "keywords": [
+          "toast stack",
+          "notification stack",
+          "snackbar queue",
+          "stacked toasts",
+          "concurrent notifications"
+        ],
+        "dense": "docked flex stack of Toast (inline mode); toasts: {id,message,tone?,duration?,size?}[], 6 dock positions, max visible (default 5, oldest wait), onDismiss(id) on per-toast auto-dismiss",
+        "usage": {
+          "description": "ToastStack is the multi-toast surface behind the app ToastProvider: showToast calls append items and each renders as an inline Toast laid out by the stack, newest nearest the docked edge. Use it (or the provider) whenever more than one transient message can be alive at once; a bare Toast stays correct for single, fully controlled cases."
+        },
+        "playground": {
+          "defaults": {
+            "position": "bottom-center"
+          }
+        },
+        "composesWith": [
+          "Toast"
+        ]
+      },
+      "spec": "# ToastStack\n\n## Intent\nKeep concurrent transient messages visible together instead of letting the\nnewest replace the rest. The motivating case: switching UI language on an\nEnglish-only article fires both \"language changed\" and the content-language\nnotice — with a single Toast slot the confirmation was never seen. ToastStack\nowns the fixed docking that a lone Toast handles itself and lays the toasts\nout with the newest nearest the docked edge.\n\n## Interaction contract\n- Keyboard: the stack never captures focus; individual toasts follow the\n  Toast contract (no dismiss button, timer-driven).\n- Pointer: the wrapper is `pointer-events: none` so it never blocks the page;\n  children restore `pointer-events: auto`.\n- Screen readers: each toast keeps its own live region (`status` or `alert`\n  per tone), so concurrent messages announce independently — the reason the\n  stack renders multiple Toast instances rather than swapping one message.\n- Overflow: at most `max` (default 5) toasts render; older ones wait\n  unrendered, and because a Toast's timer only runs while rendered, bursts\n  drain oldest-first instead of being dropped.\n\n## Do / don't\n- Do: drive it from the app `ToastProvider` — `showToast` appends and the\n  provider renders one stack per active position.\n- Do: give every toast a stable `id`; dismissal and list identity depend on it.\n- Don't: mount more than one ToastStack at the same position; their fixed\n  wrappers would overlap. Group by position instead.\n- Don't: use it for persistent or compliance-critical messaging — toasts\n  auto-dismiss (AlertBanner or Modal own those cases).\n\n## Design notes\n- The stack owns fixed placement; toasts render with the `inline` prop so\n  their own position classes never fight the wrapper. Bottom docks use\n  `column-reverse` so appending keeps the newest toast nearest the edge.\n- Spacing uses `--space-internal-8` between toasts and the same\n  `--space-layout-24` screen-edge offset a lone Toast uses, so a single-item\n  stack is visually identical to a bare Toast.\n- No entry/exit animation beyond Toast's own opacity/translate transition;\n  reduced-motion inherits Toast's handling.\n\n## Status\nAlpha. Not yet a `@digitaltableteur/react` export; the app imports it via\n`@dt/ToastStack` (allowlisted in the registry-resolution guard) until it is\npromoted onto the published surface.\n",
+      "documentationDebt": false,
+      "usage": {
+        "publicImport": "@dt/ToastStack",
+        "importCount": 0,
+        "productionImportCount": 0,
+        "patternImportCount": 0,
+        "componentImportCount": 0,
+        "evidence": []
+      },
+      "agent": {
+        "preferredImport": "@dt/ToastStack",
+        "intent": "Keep concurrent transient messages visible together instead of letting the newest replace the rest. The motivating case: switching UI language on an English-only article fires both \"language changed\" and the content-lan…",
+        "props": {
+          "toasts": {
+            "optional": false,
+            "type": "ToastStackItem[]"
+          },
+          "position": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "top-left",
+              "top-center",
+              "top-right",
+              "bottom-left",
+              "bottom-center",
+              "bottom-right"
+            ]
+          },
+          "onDismiss": {
+            "optional": true,
+            "type": "(id: string) => void"
+          },
+          "max": {
+            "optional": true,
+            "type": "number"
+          },
+          "className": {
+            "optional": true,
+            "type": "string"
+          }
+        },
+        "variants": {},
+        "cvaVariants": {},
+        "variantsFnName": null,
+        "useWhen": [
+          "drive it from the app `ToastProvider` — `showToast` appends and the",
+          "give every toast a stable `id`; dismissal and list identity depend on it."
+        ],
+        "avoidWhen": [
+          "mount more than one ToastStack at the same position; their fixed",
+          "use it for persistent or compliance-critical messaging — toasts"
+        ],
+        "requiredA11y": [
+          "each stacked Toast keeps its own live region (role=status or role=alert per tone) so concurrent messages announce independently",
+          "the stack wrapper is presentational: no role, pointer-events none with interactive children restored"
+        ],
+        "keyboard": [],
+        "compositionRules": [
+          "mount more than one ToastStack at the same position; their fixed"
+        ],
+        "canonicalExamples": [
+          "Default",
+          "Playground",
+          "Example",
+          "ForcedColors"
+        ],
+        "replacementFor": [],
+        "forbiddenUse": [
+          "mount more than one ToastStack at the same position; their fixed",
+          "use it for persistent or compliance-critical messaging — toasts"
+        ],
+        "composesWith": [],
+        "prefersOver": [],
+        "declaredPropCount": 5
       }
     },
     {
@@ -37023,8 +37250,9 @@
           "Title",
           "Card",
           "Text",
-          "AuthorBio",
-          "Button"
+          "Button",
+          "Breadcrumb",
+          "MarkdownMessage"
         ],
         "prefersOver": [],
         "declaredPropCount": 11

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-08T23:37:18.867Z",
+  "generatedAt": "2026-07-09T16:16:15.779Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -1306,7 +1306,14 @@
         "skip levels to make the trail shorter. If the user is at",
         "render the breadcrumb above a hero — it gets lost. Place it"
       ],
-      "composesWith": [],
+      "composesWith": [
+        "Button",
+        "Card",
+        "Text",
+        "Title",
+        "MarkdownMessage",
+        "PageLayout"
+      ],
       "prefersOver": [],
       "declaredPropCount": 6
     },
@@ -1694,8 +1701,8 @@
         "Text",
         "Button",
         "PageLayout",
-        "Icon",
-        "Badge"
+        "Breadcrumb",
+        "MarkdownMessage"
       ],
       "prefersOver": [],
       "declaredPropCount": 16
@@ -3046,8 +3053,8 @@
         "animations",
         "Stack",
         "Link",
-        "ScrollIndicator",
-        "Badge"
+        "Badge",
+        "Checkbox"
       ],
       "prefersOver": [],
       "declaredPropCount": 5
@@ -5507,10 +5514,12 @@
         "Bypass design tokens or skip forced-colors verification at beta."
       ],
       "composesWith": [
-        "OpenHours",
-        "ServicesGrid",
-        "StudioMap",
-        "DonnyBookingEmbed"
+        "Breadcrumb",
+        "Button",
+        "Card",
+        "Text",
+        "Title",
+        "PageLayout"
       ],
       "prefersOver": [],
       "declaredPropCount": 6
@@ -9492,6 +9501,10 @@
         "onClose": {
           "optional": true,
           "type": "() => void"
+        },
+        "inline": {
+          "optional": true,
+          "type": "boolean"
         }
       },
       "variants": {
@@ -9520,7 +9533,7 @@
         "pair `tone=\"error\"` with an actionable next step (\"Retry\" in"
       ],
       "avoidWhen": [
-        "stack toasts. The provider queues them — calling `showToast`",
+        "hand-roll overlapping fixed toasts. Concurrent messages stack via",
         "rely on Toast for compliance acknowledgements (cookie consent,",
         "use Toast for validation errors on a field. The visual is far"
       ],
@@ -9532,7 +9545,7 @@
       ],
       "keyboard": [],
       "compositionRules": [
-        "stack toasts. The provider queues them — calling `showToast`"
+        "hand-roll overlapping fixed toasts. Concurrent messages stack via"
       ],
       "canonicalExamples": [
         "Default",
@@ -9545,7 +9558,7 @@
         "window.alert"
       ],
       "forbiddenUse": [
-        "stack toasts. The provider queues them — calling `showToast`",
+        "hand-roll overlapping fixed toasts. Concurrent messages stack via",
         "rely on Toast for compliance acknowledgements (cookie consent,",
         "use Toast for validation errors on a field. The visual is far"
       ],
@@ -9560,7 +9573,74 @@
       "prefersOver": [
         "AlertBanner for page-level persistent status"
       ],
-      "declaredPropCount": 7
+      "declaredPropCount": 8
+    },
+    "ToastStack": {
+      "preferredImport": "@dt/ToastStack",
+      "intent": "Keep concurrent transient messages visible together instead of letting the newest replace the rest. The motivating case: switching UI language on an English-only article fires both \"language changed\" and the content-lan…",
+      "props": {
+        "toasts": {
+          "optional": false,
+          "type": "ToastStackItem[]"
+        },
+        "position": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "top-left",
+            "top-center",
+            "top-right",
+            "bottom-left",
+            "bottom-center",
+            "bottom-right"
+          ]
+        },
+        "onDismiss": {
+          "optional": true,
+          "type": "(id: string) => void"
+        },
+        "max": {
+          "optional": true,
+          "type": "number"
+        },
+        "className": {
+          "optional": true,
+          "type": "string"
+        }
+      },
+      "variants": {},
+      "cvaVariants": {},
+      "variantsFnName": null,
+      "useWhen": [
+        "drive it from the app `ToastProvider` — `showToast` appends and the",
+        "give every toast a stable `id`; dismissal and list identity depend on it."
+      ],
+      "avoidWhen": [
+        "mount more than one ToastStack at the same position; their fixed",
+        "use it for persistent or compliance-critical messaging — toasts"
+      ],
+      "requiredA11y": [
+        "each stacked Toast keeps its own live region (role=status or role=alert per tone) so concurrent messages announce independently",
+        "the stack wrapper is presentational: no role, pointer-events none with interactive children restored"
+      ],
+      "keyboard": [],
+      "compositionRules": [
+        "mount more than one ToastStack at the same position; their fixed"
+      ],
+      "canonicalExamples": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+      ],
+      "replacementFor": [],
+      "forbiddenUse": [
+        "mount more than one ToastStack at the same position; their fixed",
+        "use it for persistent or compliance-critical messaging — toasts"
+      ],
+      "composesWith": [],
+      "prefersOver": [],
+      "declaredPropCount": 5
     },
     "Tooltip": {
       "preferredImport": "@dt/Tooltip",
@@ -11831,8 +11911,9 @@
         "Title",
         "Card",
         "Text",
-        "AuthorBio",
-        "Button"
+        "Button",
+        "Breadcrumb",
+        "MarkdownMessage"
       ],
       "prefersOver": [],
       "declaredPropCount": 11

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -14768,21 +14768,26 @@
         "onClose": {
           "optional": true,
           "type": "() => void"
+        },
+        "inline": {
+          "optional": true,
+          "type": "boolean"
         }
       },
       "composesWith": [
         "Button",
-        "Text",
-        "Modal",
-        "TextInput",
         "CheckboxGroup",
-        "TextArea"
+        "Modal",
+        "Text",
+        "TextArea",
+        "TextInput",
+        "ToastStack"
       ],
       "prefersOver": [
         "AlertBanner for page-level persistent status"
       ],
       "forbiddenUse": [
-        "mount two <Toast /> instances side by side; the shared live region double-announces and the visuals go stale.",
+        "mount two overlapping fixed <Toast /> instances yourself; use ToastStack (or the app ToastProvider) so concurrent messages stack instead of replacing each other.",
         "rely on Toast for compliance acknowledgements (cookie consent, legal notices); it auto-dismisses — use AlertBanner or Modal.",
         "use Toast for validation errors on a field; the message detaches from the input — use the field's error prop."
       ],
@@ -14849,7 +14854,7 @@
         {
           "story": "Placement",
           "description": "position anchors the toast to a viewport corner or edge center. The app default is bottom-center; keep one placement per app so toasts are predictable.",
-          "source": "export const Placement: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: {\n      description: {\n        story:\n          \"position anchors the toast to a viewport corner or edge center. The app default is bottom-center; keep one placement per app so toasts are predictable.\",\n      },\n    },\n  },\n  render: function PlacementStory() {\n    const positions: ToastPosition[] = [\n      \"top-left\",\n      \"top-center\",\n      \"top-right\",\n      \"bottom-left\",\n      \"bottom-center\",\n      \"bottom-right\",\n    ];\n    const [position, setPosition] = useState<ToastPosition | null>(null);\n    return (\n      <>\n        {positions.map((p) => (\n          <Button\n            key={p}\n            variant=\"secondary\"\n            size=\"sm\"\n            onClick={() => setPosition(p)}\n          >\n            {p}\n          </Button>\n        ))}\n        <Toast\n          message={position ? `Anchored ${position}.` : \"\"}\n          open={position !== null}\n          tone=\"info\"\n          position={position ?? undefined}\n          onClose={() => setPosition(null)}\n        />\n      </>\n    );\n  },\n};\n\n/** The recommended integration: fire toasts through the app-root provider. */"
+          "source": "export const Placement: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: {\n      description: {\n        story:\n          \"position anchors the toast to a viewport corner or edge center. The app default is bottom-center; keep one placement per app so toasts are predictable.\",\n      },\n      // Inline docs previews transform their container, which hijacks\n      // position: fixed; an iframe gives the toast a real viewport so each\n      // placement lands where the trigger says.\n      story: { inline: false, iframeHeight: 360 },\n    },\n  },\n  render: function PlacementStory() {\n    const positions: ToastPosition[] = [\n      \"top-left\",\n      \"top-center\",\n      \"top-right\",\n      \"bottom-left\",\n      \"bottom-center\",\n      \"bottom-right\",\n    ];\n    const [position, setPosition] = useState<ToastPosition | null>(null);\n    return (\n      <>\n        {positions.map((p) => (\n          <Button\n            key={p}\n            variant=\"secondary\"\n            size=\"sm\"\n            onClick={() => setPosition(p)}\n          >\n            {p}\n          </Button>\n        ))}\n        <Toast\n          message={position ? `Anchored ${position}.` : \"\"}\n          open={position !== null}\n          tone=\"info\"\n          position={position ?? undefined}\n          onClose={() => setPosition(null)}\n        />\n      </>\n    );\n  },\n};\n\n/** The recommended integration: fire toasts through the app-root provider. */"
         },
         {
           "story": "ProviderDriven",
@@ -14862,6 +14867,95 @@
           "source": "export const Example: Story = {\n  globals: { forcedColors: \"none\" },\n  tags: [\"beta-matrix\", \"example\"],\n  parameters: {\n    a11y: { disable: true },\n    controls: { disable: true },\n    docs: {\n      description: {\n        story:\n          \"The canonical post-action confirmation: success tone, default bottom-center placement, auto-dismiss after 3 seconds.\",\n      },\n    },\n  },\n  render: function ExampleStory() {\n    const [open, setOpen] = React.useState(true);\n    return (\n      <Toast\n        message=\"Saved successfully.\"\n        open={open}\n        tone=\"success\"\n        onClose={() => setOpen(false)}\n      />\n    );\n  },\n};"
         }
       ]
+    },
+    "ToastStack": {
+      "name": "ToastStack",
+      "group": "feedback",
+      "tier": 2,
+      "status": "alpha",
+      "description": "Docked stack of transient toasts: renders Toast children inline and owns the fixed placement, newest toast nearest the docked edge, so concurrent messages stay visible instead of replacing each other.",
+      "dense": "docked flex stack of Toast (inline mode); toasts: {id,message,tone?,duration?,size?}[], 6 dock positions, max visible (default 5, oldest wait), onDismiss(id) on per-toast auto-dismiss",
+      "keywords": [
+        "toast stack",
+        "notification stack",
+        "snackbar queue",
+        "stacked toasts",
+        "concurrent notifications"
+      ],
+      "importLine": "import ToastStack from \"@dt/ToastStack\";",
+      "keyProps": [
+        {
+          "name": "toasts",
+          "type": "ToastStackItem[]",
+          "required": true
+        },
+        {
+          "name": "position",
+          "type": "top-left | top-center | top-right | bottom-left | bottom-center | bottom-right",
+          "required": false
+        },
+        {
+          "name": "max",
+          "type": "number",
+          "required": false
+        },
+        {
+          "name": "className",
+          "type": "string",
+          "required": false
+        }
+      ],
+      "props": {
+        "toasts": {
+          "optional": false,
+          "type": "ToastStackItem[]"
+        },
+        "position": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "top-left",
+            "top-center",
+            "top-right",
+            "bottom-left",
+            "bottom-center",
+            "bottom-right"
+          ]
+        },
+        "onDismiss": {
+          "optional": true,
+          "type": "(id: string) => void"
+        },
+        "max": {
+          "optional": true,
+          "type": "number"
+        },
+        "className": {
+          "optional": true,
+          "type": "string"
+        }
+      },
+      "composesWith": [
+        "Toast"
+      ],
+      "prefersOver": [
+        "multiple sibling <Toast /> mounts, whose fixed positions overlap and whose messages replace each other"
+      ],
+      "forbiddenUse": [
+        "mounting more than one ToastStack per position; group toasts by position and render one stack per active position instead",
+        "persistent or compliance-critical messaging; toasts auto-dismiss (use AlertBanner)"
+      ],
+      "usage": {
+        "description": "ToastStack is the multi-toast surface behind the app ToastProvider: showToast calls append items and each renders as an inline Toast laid out by the stack, newest nearest the docked edge. Use it (or the provider) whenever more than one transient message can be alive at once; a bare Toast stays correct for single, fully controlled cases."
+      },
+      "tokens": {
+        "colors": [],
+        "spacing": [
+          "--space-internal-8",
+          "--space-layout-24"
+        ]
+      },
+      "examples": []
     },
     "Tooltip": {
       "name": "Tooltip",

--- a/nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx
+++ b/nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useRef } from "react";
 import { cn } from "../../lib/cn";
-import { getContentLanguageNoticeMessage } from "../../lib/contentLanguageNotice";
 import { Link as RouterLink } from "../../lib/linkComponent";
 import { useLocalization } from "../../lib/translation";
 import { NavLink } from "../../components/NavLink";
@@ -143,20 +142,16 @@ export function SiteHeader({
     const labelKey = langLabel?.announcementKey ?? `languageName.${code}`;
     const label =
       typeof bundle?.[labelKey] === "string" ? bundle[labelKey] : code;
-    const contentLanguageNotice = getContentLanguageNoticeMessage({
-      targetLanguage: code,
-      getResourceBundle,
-    });
-    const languageChangedMessage = t("languageChanged", {
-      lng: code,
-      language: label,
-    });
 
+    // Only the change confirmation: toasts stack now (ToastStack), so
+    // LanguageNotice's own content-language toast shows alongside instead of
+    // replacing this one — appending it here would read twice.
     showToast(
-      contentLanguageNotice
-        ? `${languageChangedMessage}. ${contentLanguageNotice}`
-        : languageChangedMessage,
-      contentLanguageNotice ? 5000 : 3000,
+      t("languageChanged", {
+        lng: code,
+        language: label,
+      }),
+      3000,
     );
   };
 

--- a/nextjs-app/shared/stories/Docs/ComponentUsage.stories.tsx
+++ b/nextjs-app/shared/stories/Docs/ComponentUsage.stories.tsx
@@ -43,12 +43,38 @@ const ComponentUsageContent = () => {
         <p className={styles.lead}>
           Real adoption data from the production codebase: how many source
           files import each component (statically or via dynamic import), and
-          how many production pages transitively render it. Regenerate with{" "}
-          <code>npm run report:component-usage</code>. Generated{" "}
-          {new Date(generatedAt).toLocaleString("en-GB")}. {rows.length}{" "}
-          components, {unusedCount} without any importer.
+          how many production pages transitively render it.
         </p>
       </header>
+
+      <section className={styles.section}>
+        <div className={styles.principleGrid}>
+          <div className={styles.principle}>
+            <h3>{rows.length}</h3>
+            <p>Components in the catalog</p>
+          </div>
+          <div className={styles.principle}>
+            <h3>{unusedCount}</h3>
+            <p>Without any importer</p>
+          </div>
+          <div className={styles.principle}>
+            <h3>{new Date(generatedAt).toLocaleDateString("en-GB")}</h3>
+            <p>
+              Generated{" "}
+              {new Date(generatedAt).toLocaleTimeString("en-GB", {
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            </p>
+          </div>
+          <div className={styles.principle}>
+            <h3>Regenerate</h3>
+            <p>
+              <code>npm run report:component-usage</code>
+            </p>
+          </div>
+        </div>
+      </section>
 
       <section className={styles.section}>
         <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>

--- a/providers/ToastProvider.tsx
+++ b/providers/ToastProvider.tsx
@@ -5,19 +5,21 @@ import React, {
   useCallback,
   useContext,
   useMemo,
+  useRef,
   useState,
 } from "react";
-import {
-  Toast,
-  type ToastTone,
-  type ToastPosition,
-} from "@digitaltableteur/react";
+import type { ToastTone, ToastPosition } from "@digitaltableteur/react";
+import ToastStack, { type ToastStackItem } from "@dt/ToastStack";
 import { ToastRuntimeProvider } from "../nextjs-app/shared/lib/toast";
 
 export interface ShowToastOptions {
   duration?: number;
   tone?: ToastTone;
   position?: ToastPosition;
+}
+
+interface StackedToast extends ToastStackItem {
+  position: ToastPosition;
 }
 
 interface ToastContextType {
@@ -41,42 +43,51 @@ export const useToast = () => {
 export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const [message, setMessage] = useState("");
-  const [duration, setDuration] = useState(3000);
-  const [tone, setTone] = useState<ToastTone | undefined>(undefined);
-  const [position, setPosition] = useState<ToastPosition>("bottom-center");
+  const [toasts, setToasts] = useState<StackedToast[]>([]);
+  const nextIdRef = useRef(0);
 
   const showToast = useCallback(
-    (msg: string, options?: number | ShowToastOptions) => {
-      const opts = typeof options === "number" ? { duration: options } : (options ?? {});
-      setMessage(msg);
-      setDuration(opts.duration ?? 3000);
-      setTone(opts.tone);
-      setPosition(opts.position ?? "bottom-center");
-      setIsOpen(true);
+    (message: string, options?: number | ShowToastOptions) => {
+      const opts =
+        typeof options === "number" ? { duration: options } : (options ?? {});
+      nextIdRef.current += 1;
+      setToasts((current) => [
+        ...current,
+        {
+          id: `toast-${nextIdRef.current}`,
+          message,
+          duration: opts.duration ?? 3000,
+          tone: opts.tone,
+          position: opts.position ?? "bottom-center",
+        },
+      ]);
     },
     [],
   );
 
-  const handleClose = useCallback(() => {
-    setIsOpen(false);
+  const dismissToast = useCallback((id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
   }, []);
 
   const toastRuntime = useMemo(() => ({ showToast }), [showToast]);
+
+  const positions = useMemo(
+    () => [...new Set(toasts.map((toast) => toast.position))],
+    [toasts],
+  );
 
   return (
     <ToastContext.Provider value={toastRuntime}>
       <ToastRuntimeProvider value={toastRuntime}>
         {children}
-        <Toast
-          message={message}
-          open={isOpen}
-          duration={duration}
-          tone={tone}
-          position={position}
-          onClose={handleClose}
-        />
+        {positions.map((position) => (
+          <ToastStack
+            key={position}
+            position={position}
+            toasts={toasts.filter((toast) => toast.position === position)}
+            onDismiss={dismissToast}
+          />
+        ))}
       </ToastRuntimeProvider>
     </ToastContext.Provider>
   );

--- a/scripts/design-system/check-package-registry-resolution.mjs
+++ b/scripts/design-system/check-package-registry-resolution.mjs
@@ -52,6 +52,10 @@ const ALLOWED_APP_LOCAL_IMPORTS = new Map([
   ["@dt/NextLayout", "site shell surface; intentionally outside @digitaltableteur/react"],
   ["@dt/SiteTree", "site structure type; intentionally outside @digitaltableteur/react"],
   ["@dt/SocialShare", "blog/social sharing surface; intentionally outside @digitaltableteur/react"],
+  [
+    "@dt/ToastStack",
+    "alpha component, not yet a package export; migrate this import to @digitaltableteur/react when ToastStack reaches the published surface",
+  ],
 ]);
 
 function readJson(path) {


### PR DESCRIPTION
## Summary
Design decision (2026-07-09): **toasts stack, don't replace**. Motivating bug: switching language on an English-only article swallowed the "language changed" confirmation (single-slot provider).

- **New `ToastStack` molecule (alpha)** composing Toast: owns fixed docking (6 positions), newest toast nearest the docked edge (top docks column-reverse), per-toast live regions and timers, `max` visible (default 5) with older toasts waiting unrendered so bursts drain in order.
- **Toast** gains an additive `inline` prop (parent owns placement); contract/spec/forbiddenUse updated away from the old last-one-wins blessing.
- **App ToastProvider** manages a toast array, one stack per active position; SiteHeader stops appending the content notice (LanguageNotice's toast now survives alongside — appending read twice).
- **Story fixes** (reported): Placement + Stacked render as docs iframes — inline docs previews transform the container, hijacking `position: fixed`; Toast docs gain a 3-toast Stacked example; ComponentUsage page leads with stat cards.
- Registry guard classifies `@dt/ToastStack` (alpha, not yet a package export).

## Verification
- Browser (dev): EN switch shows the confirmation alone; FI switch on an English article stacks confirmation + notice; no duplication.
- Storybook: Stacked shows 3 toasts newest-at-edge; Placement anchors to real viewport corners (top-right verified); usage stat cards render.
- ToastStack tests 6/6 incl. axe; full gate + contract add-on (build:tokens, check:contract-props, check:consumers) exit 0; stylelint/rhythm/contrast baselines clean (centering via inset-inline/margin-inline, no raw -50%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)