### PR TITLE
feat(design-system): close registry-guard blind spots + stop token-CSS double-ship (0.1.4)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -38,6 +38,7 @@ jobs:
       - run: npm run check:contrast
       - run: npm run check:token-descriptions
       - run: npm run validate:components
+      - run: npm run check:package-registry-resolution
       - run: npm run check:consumers
       - run: npm run validate:agent-docs
       - run: npm run validate:translations

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,11 @@
 #!/usr/bin/env sh
 . "$(dirname "$0")/_/husky.sh"
 changed=$(git diff --name-only HEAD @{push} 2>/dev/null || git diff --name-only --cached)
+# Registry dogfood gate: app-side imports of package territory must resolve
+# from the npm registry (two-module-instance context splits, #1019).
+if echo "$changed" | grep -qE '^(app|providers|lib|components|i18n)/|^package(-lock)?\.json$|^packages/|check-package-registry-resolution'; then
+  npm run check:package-registry-resolution
+fi
 echo "$changed" | grep -qE 'nextjs-app/shared/(components|patterns|foundations)|scripts/design-system' || exit 0
 # Contract gate: keep the local gate a superset of the farm's validate job for
 # contract-touching changes (2026-07-03 incident: ten red farm runs because

--- a/lib/media/imageSrc.ts
+++ b/lib/media/imageSrc.ts
@@ -1,1 +1,0 @@
-export { isSvgSrc } from "@/nextjs-app/shared/lib/imageSrc";

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,5 @@
-/* cn now lives in the design-system boundary at nextjs-app/shared/lib/cn so it
- * travels with the catalog when it becomes a package. This re-export keeps the
- * `@/lib/utils` specifier working for app-level (non-catalog) call sites. */
-export { cn } from "../nextjs-app/shared/lib/cn";
+/* cn ships in @digitaltableteur/react; this re-export keeps the `@/lib/utils`
+ * specifier working for app-level (non-catalog) call sites. Shared catalog
+ * source must keep importing nextjs-app/shared/lib/cn directly — never this
+ * file — so the package build cannot resolve into the published package. */
+export { cn } from "@digitaltableteur/react";

--- a/nextjs-app/shared/components/Link/Link.tsx
+++ b/nextjs-app/shared/components/Link/Link.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import styles from "./Link.module.css";
-import "../../styles/variables.css";
 import Icon from "@dt/Icon";
 
 export interface LinkProps

--- a/nextjs-app/shared/components/List/List.tsx
+++ b/nextjs-app/shared/components/List/List.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import styles from "./List.module.css";
-import "../../styles/variables.css";
 
 type TextSize = "xxs" | "xs" | "s" | "m" | "l" | "xl" | "xxl";
 type LineHeight = "tight" | "snug" | "normal" | "relaxed" | "loose";

--- a/nextjs-app/shared/components/Text/Text.tsx
+++ b/nextjs-app/shared/components/Text/Text.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import styles from "./Text.module.css";
-import "../../styles/variables.css";
 
 type TextSize = "xxs" | "xs" | "s" | "m" | "l" | "xl" | "xxl";
 type LineHeight = "tight" | "snug" | "normal" | "relaxed" | "loose";

--- a/nextjs-app/shared/components/Title/Title.tsx
+++ b/nextjs-app/shared/components/Title/Title.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import styles from "./Title.module.css";
-import "../../styles/variables.css";
 
 type TitleSize = "xxs" | "xs" | "s" | "m" | "l" | "xl" | "xxl";
 type LineHeight = "tight" | "snug" | "normal" | "relaxed" | "loose";

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.4 - 2026-07-09
+
+- Stops shipping a publish-time snapshot of the design-token sheet inside `dist/style.css`: Title, Text, Link, and List no longer side-effect-import `variables.css`, so tokens ship once, via `@digitaltableteur/tokens-css/tokens.css` as the install docs already instruct. Consumers who skipped `tokens-css` and relied on the embedded snapshot must add it now.
+- Adds a `check:react-package` tripwire: any non-vendor `:root` custom-property definitions in `dist/style.css` fail the package check, so the snapshot cannot creep back.
+- style.css 108.9 kB → 94.3 kB; public runtime API unchanged from 0.1.3.
+- Verified by `check:react-package`, `check:react-public-api`, and the full local gate.
+
 ## 0.1.3 - 2026-07-09
 
 - Stops the package from bundling a stale copy of itself: shared source no longer imports `@digitaltableteur/react` internally (NavLink, NavMenuList, PseoLeafPage now use local modules), which had compounded tarball growth each publish and tripped the 3.5 MB ceiling.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/react",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": false,
   "description": "React components and host adapters for the Digitaltableteur design system.",
   "type": "module",

--- a/scripts/design-system/check-package-registry-resolution.mjs
+++ b/scripts/design-system/check-package-registry-resolution.mjs
@@ -43,7 +43,7 @@ const PACKAGE_CHECKS = [
   },
 ];
 
-const APP_LOCAL_IMPORT_ROOTS = ["app", "providers"];
+const APP_LOCAL_IMPORT_ROOTS = ["app", "providers", "lib", "components", "i18n"];
 const ALLOWED_APP_LOCAL_IMPORTS = new Map([
   [
     "@dt/EmailSignatureGenerator",
@@ -57,6 +57,94 @@ const ALLOWED_APP_LOCAL_IMPORTS = new Map([
     "alpha component, not yet a package export; migrate this import to @digitaltableteur/react when ToastStack reaches the published surface",
   ],
 ]);
+
+// Local shared-source imports of package-exported symbols. Each entry must
+// explain why the LOCAL module instance is required instead of the registry
+// package (the #1019 context split came from exactly this pattern going
+// unclassified). Keyed `file :: importPath`, both exact.
+const ALLOWED_LOCAL_SHARED_IMPORTS = new Map([
+  [
+    "providers/NextLinkProvider.tsx :: @/nextjs-app/shared/lib/linkComponent",
+    "dual-provides the LOCAL LinkProvider instance alongside the package one (#1019)",
+  ],
+  [
+    "providers/NextImageProvider.tsx :: @/nextjs-app/shared/lib/imageComponent",
+    "dual-provides the LOCAL ImageProvider instance alongside the package one (#1019)",
+  ],
+  [
+    "providers/NextNavigationProvider.tsx :: @/nextjs-app/shared/lib/navigation",
+    "dual-provides the LOCAL NavigationProvider instance alongside the package one (#1019)",
+  ],
+  [
+    "providers/AnimationProvider.tsx :: @/nextjs-app/shared/lib/animation",
+    "dual-provides the LOCAL AnimationRuntimeProvider instance alongside the package one (#1019)",
+  ],
+  [
+    "app/layout.tsx :: @/nextjs-app/shared/lib/cookieConsent",
+    "local shell (NextLayout -> CookieConsent) provides and consumes the LOCAL consent context end-to-end; the package instance is unused",
+  ],
+  [
+    "providers/ToastProvider.tsx :: ../nextjs-app/shared/lib/toast",
+    "toast runtime is LOCAL end-to-end (ToastStack + LanguageNotice read this instance); dual-provide if a package component ever calls useToast",
+  ],
+  [
+    "app/components/LanguageNotice/LanguageNotice.tsx :: @/nextjs-app/shared/lib/toast",
+    "reads the LOCAL toast instance mounted by providers/ToastProvider",
+  ],
+  [
+    "app/components/LanguageNotice/LanguageNotice.tsx :: @/nextjs-app/shared/lib/translation",
+    "translation runtime is globalThis-bridged; kept local to match the toast import in the same file",
+  ],
+  [
+    "providers/ThemeProvider.tsx :: ../nextjs-app/shared/components/ThemeProvider/ThemeProvider",
+    "theme runtime is globalThis-bridged; the local wrapper is the canonical mount",
+  ],
+  [
+    "providers/I18nProvider.tsx :: ../nextjs-app/shared/lib/translation",
+    "translation runtime is globalThis-bridged; the local provider is the canonical mount",
+  ],
+  [
+    "app/blog/[slug]/ServerArticleHero.tsx :: @/nextjs-app/shared/components/Container",
+    "React Server Component; the package dist is 'use client' so the local import keeps this subtree server-rendered",
+  ],
+  [
+    "app/blog/[slug]/ServerRelatedPosts.tsx :: @/nextjs-app/shared/components/Container",
+    "React Server Component; the package dist is 'use client' so the local import keeps this subtree server-rendered",
+  ],
+]);
+
+function installedReactExports() {
+  const distPath = join(
+    ROOT,
+    "node_modules/@digitaltableteur/react/dist/index.js",
+  );
+  const source = readFileSync(distPath, "utf8");
+  const blocks = [...source.matchAll(/export\s*\{([^}]*)\}/g)];
+  if (blocks.length === 0) {
+    throw new Error(
+      `no export block found in ${relativePath(distPath)}; cannot derive the installed export surface`,
+    );
+  }
+  const names = new Set();
+  for (const block of blocks) {
+    for (const entry of block[1].split(",")) {
+      const parts = entry.trim().split(/\s+as\s+/);
+      const publicName = (parts[1] ?? parts[0]).trim();
+      if (/^[A-Za-z_$][\w$]*$/.test(publicName)) names.add(publicName);
+    }
+  }
+  return names;
+}
+
+function namedSpecifiers(clause) {
+  if (!clause) return [];
+  const braced = clause.match(/\{([^}]*)\}/);
+  if (!braced) return [];
+  return braced[1]
+    .split(",")
+    .map((entry) => entry.trim().replace(/^type\s+/, "").split(/\s+as\s+/)[0].trim())
+    .filter((name) => /^[A-Za-z_$][\w$]*$/.test(name));
+}
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
@@ -97,7 +185,12 @@ function sourceFiles(root) {
       }
       return;
     }
-    if (/\.(?:ts|tsx|js|jsx|mjs|cjs)$/.test(path)) {
+    if (
+      /\.(?:ts|tsx|js|jsx|mjs|cjs)$/.test(path) &&
+      !/\.(?:test|spec|stories)\.|__tests__|__mocks__/.test(path)
+    ) {
+      // Test/story files mount whichever module instance the code under test
+      // reads; they are not part of the app runtime bundle.
       entries.push(path);
     }
   };
@@ -105,24 +198,69 @@ function sourceFiles(root) {
   return entries.sort((a, b) => a.localeCompare(b));
 }
 
+// Matches every module-specifier form that can pull local shared source into
+// the app bundle: static import/export-from (incl. `import type`), dynamic
+// import(), and bare side-effect import. The original guard only matched
+// `from "..."` and missed dynamic import() (the ChatWidget/next-dynamic class)
+// and `export ... from` re-export shims.
+const MODULE_SPECIFIER_RE =
+  /(?:import|export)\s+(?:type\s+)?([\w*$][\w*$]*|[\w*{},\s$]+?)\s+from\s+["']([^"']+)["']|import\s*\(\s*["']([^"']+)["']\s*\)|import\s+["']([^"']+)["']/g;
+
 function findAppLocalImports(publicExports) {
   const imports = [];
-  const importRe = /\bfrom\s+["'](@dt\/([^"']+))["']/g;
   for (const root of APP_LOCAL_IMPORT_ROOTS) {
     for (const file of sourceFiles(root)) {
       const source = readFileSync(file, "utf8");
-      for (const match of source.matchAll(importRe)) {
-        const importPath = match[1];
-        const exportName = match[2].split("/")[0];
-        const publicExport = publicExports.has(exportName);
-        const allowedReason = ALLOWED_APP_LOCAL_IMPORTS.get(importPath) ?? null;
-        imports.push({
-          file: relativePath(file),
-          importPath,
-          exportName,
-          publicExport,
-          allowedReason,
-        });
+      for (const match of source.matchAll(MODULE_SPECIFIER_RE)) {
+        const clause = match[1] ?? null;
+        const importPath = match[2] ?? match[3] ?? match[4];
+        const form = match[2] ? "static" : match[3] ? "dynamic" : "bare";
+        if (importPath.startsWith("@dt/")) {
+          const exportName = importPath.slice("@dt/".length).split("/")[0];
+          imports.push({
+            kind: "dt-alias",
+            form,
+            file: relativePath(file),
+            importPath,
+            exportName,
+            publicExport: publicExports.has(exportName),
+            allowedReason: ALLOWED_APP_LOCAL_IMPORTS.get(importPath) ?? null,
+          });
+          continue;
+        }
+        if (importPath.includes("nextjs-app/shared/")) {
+          // Package-exported symbols reached through local shared source
+          // create a second module instance (the #1019 context split).
+          const specifiers = namedSpecifiers(clause);
+          const pathTail = importPath.split("/").filter(Boolean);
+          const componentCandidate =
+            importPath.includes("/shared/components/") ||
+            importPath.includes("/shared/patterns/")
+              ? pathTail[pathTail.indexOf("shared") + 2]
+              : null;
+          const packageHits = new Set(
+            specifiers.filter((name) => publicExports.has(name)),
+          );
+          if (
+            specifiers.length === 0 &&
+            componentCandidate &&
+            publicExports.has(componentCandidate)
+          ) {
+            // default / dynamic / bare import of an exported component dir
+            packageHits.add(componentCandidate);
+          }
+          if (packageHits.size === 0) continue;
+          const allowKey = `${relativePath(file)} :: ${importPath}`;
+          imports.push({
+            kind: "local-shared",
+            form,
+            file: relativePath(file),
+            importPath,
+            exportName: [...packageHits].join(", "),
+            publicExport: true,
+            allowedReason: ALLOWED_LOCAL_SHARED_IMPORTS.get(allowKey) ?? null,
+          });
+        }
       }
     }
   }
@@ -132,7 +270,17 @@ function findAppLocalImports(publicExports) {
 const packageJson = readJson(join(ROOT, "package.json"));
 const packageLock = readJson(join(ROOT, "package-lock.json"));
 const reactPublicApi = readJson(REACT_PUBLIC_API_MANIFEST);
-const reactPublicExports = new Set(reactPublicApi.runtimeExports ?? []);
+const manifestExports = new Set(reactPublicApi.runtimeExports ?? []);
+// Validate app imports against what the INSTALLED package actually exports,
+// not the source-HEAD manifest: a symbol added to shared source but not yet
+// published must keep resolving locally until it ships.
+const reactPublicExports = installedReactExports();
+const manifestOnlyExports = [...manifestExports].filter(
+  (name) => !reactPublicExports.has(name),
+);
+const installedOnlyExports = [...reactPublicExports].filter(
+  (name) => !manifestExports.has(name),
+);
 const workspaces = packageJson.workspaces ?? [];
 const errors = [];
 const rows = [];
@@ -212,14 +360,22 @@ for (const check of PACKAGE_CHECKS) {
 
 const appLocalImports = findAppLocalImports(reactPublicExports);
 for (const row of appLocalImports) {
-  if (row.publicExport) {
-    errors.push(
-      `${row.file} imports ${row.importPath} locally, but ${row.exportName} is exported from @digitaltableteur/react; use the registry package instead.`,
-    );
+  if (row.kind === "dt-alias") {
+    if (row.publicExport) {
+      errors.push(
+        `${row.file} imports ${row.importPath} locally (${row.form}), but ${row.exportName} is exported from the installed @digitaltableteur/react; use the registry package instead.`,
+      );
+    }
+    if (!row.allowedReason) {
+      errors.push(
+        `${row.file} imports ${row.importPath} (${row.form}); app @dt imports must be explicitly classified as non-package app/product/site surfaces.`,
+      );
+    }
+    continue;
   }
   if (!row.allowedReason) {
     errors.push(
-      `${row.file} imports ${row.importPath}; app/provider @dt imports must be explicitly classified as non-package app/product/site surfaces.`,
+      `${row.file} imports ${row.exportName} from ${row.importPath} (${row.form}); these symbols are exported from the installed @digitaltableteur/react — import from the registry package, or classify the local-instance requirement in ALLOWED_LOCAL_SHARED_IMPORTS.`,
     );
   }
 }
@@ -229,6 +385,10 @@ const report = {
   status: errors.length ? "failed" : "passed",
   rows,
   appLocalImports,
+  exportDrift: {
+    manifestOnly: manifestOnlyExports,
+    installedOnly: installedOnlyExports,
+  },
   errors,
 };
 
@@ -247,7 +407,17 @@ console.log(
 );
 if (appLocalImports.length) {
   console.log(
-    `  App/provider @dt imports classified (${appLocalImports.length} non-package surface${appLocalImports.length === 1 ? "" : "s"})`,
+    `  App-local imports of package territory classified (${appLocalImports.length})`,
+  );
+}
+if (manifestOnlyExports.length) {
+  console.log(
+    `  ⓘ ${manifestOnlyExports.length} manifest export(s) not yet in the installed package (pending publish): ${manifestOnlyExports.join(", ")}`,
+  );
+}
+if (installedOnlyExports.length) {
+  console.log(
+    `  ⓘ ${installedOnlyExports.length} installed export(s) missing from the source manifest: ${installedOnlyExports.join(", ")}`,
   );
 }
 console.log(`  Report: ${relativePath(OUT_JSON)}`);

--- a/scripts/design-system/check-react-package.mjs
+++ b/scripts/design-system/check-react-package.mjs
@@ -52,6 +52,24 @@ if (!jsEntry.startsWith('"use client";')) {
   );
 }
 
+// Design tokens ship ONCE, via @digitaltableteur/tokens-css. A variables.css
+// side-effect import anywhere in the package module graph snapshots the whole
+// token sheet into dist/style.css at publish time — a stale duplicate that
+// fights the app's live variables.css on cascade order (fixed for 0.1.4).
+// The only allowed :root custom-prop definitions are the bundled third-party
+// react-phone-number-input sheet (--PhoneInput* namespace).
+const cssEntry = readFileSync(join(dist, "style.css"), "utf8");
+for (const match of cssEntry.matchAll(/:root\s*{([^}]*)}/g)) {
+  const foreign = [...match[1].matchAll(/--([\w-]+)\s*:/g)]
+    .map((def) => def[1])
+    .filter((name) => !name.startsWith("PhoneInput"));
+  if (foreign.length > 0) {
+    throw new Error(
+      `dist/style.css defines design tokens at :root (${foreign.slice(0, 5).join(", ")}${foreign.length > 5 ? ", …" : ""}); tokens must ship only via @digitaltableteur/tokens-css — remove the variables.css side-effect import from the package module graph.`,
+    );
+  }
+}
+
 const smoke = run(
   "node",
   [


### PR DESCRIPTION
## Summary

Closes both open hardening tasks from the npm-migration follow-ups.

### 1. Registry-guard blind spots (`check:package-registry-resolution`)

- Catches **dynamic `import()`**, **bare side-effect imports**, and **`export … from`** re-exports (was: static `from` only).
- Flags **local shared-source imports of package-exported symbols** in any path form (`@/` alias or relative) — the #1019 context-split class. Every surviving local-instance use is now explicitly classified with a reason: dual-provide providers, globalThis-bridged theme/translation runtimes, RSC-vs-`use client` boundaries, and the local-only toast runtime.
- Scans `lib/`, `components/`, `i18n/` in addition to `app/` + `providers/`; test/story files excluded (not app runtime bundle).
- Validates against the **installed** package export surface (parsed from `dist/index.js`) instead of the source-HEAD manifest, and reports manifest↔installed export drift.
- Wired into **pre-push** and the farm **pr-validation** workflow.
- Negative-tested: planted dynamic/export-from/bare imports are all caught.
- Fallout fixed: dead `lib/media/imageSrc.ts` export-from shim deleted; `lib/utils.ts` cn shim now re-exports from the registry package.

### 2. Token-CSS double-ship (rides publish 0.1.4)

- `Title`/`Text`/`Link`/`List` no longer side-effect-import `variables.css`, so the package build stops snapshotting the whole token sheet into `style.css` (108.9 kB → 94.3 kB). Tokens ship once, via `@digitaltableteur/tokens-css`, per the documented consumer contract.
- New `check:react-package` tripwire: non-vendor `:root` custom-prop definitions in `dist/style.css` fail the check (verified it catches the 0.1.3 sheet; the vendored react-phone-number-input block is exempt).
- `packages/react` bumped to **0.1.4** + CHANGELOG. Publish via `ds-publish.yml` after merge.

## Verification

- Guard negative tests (planted violations caught), tripwire negative test vs published 0.1.3 CSS.
- Tokens verified resolving in the running app after the import removal (computed-style check).
- Full local gate: typecheck ✓ lint ✓ lint:css ✓ vitest 2150/2150 ✓ build ✓ + DS gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger validation in release and pre-push checks to catch package resolution issues earlier.

* **Bug Fixes**
  * Removed unnecessary shared style loading from several UI components, reducing duplicate styling and improving consistency.
  * Updated shared utility exports to use the correct package source.

* **Chores**
  * Bumped the React package to version 0.1.4 and updated the changelog.
  * Tightened package-level checks to better detect unexpected build or export drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->