### PR TITLE
fix(i18n): FI about delivery title 'mittakaavassa' → 'skaalautuvasti'

### DIFF
--- a/nextjs-app/shared/locales/fi/translation.json
+++ b/nextjs-app/shared/locales/fi/translation.json
@@ -466,7 +466,7 @@
   "aboutManifestoPhrase10": "Uteliaisuutta",
   "aboutManifestoPhrase11": "Tuotteiden tekemistä vaivattomiksi käyttää.",
   "aboutHeroSubtitle": "Muotoiluvetoinen tekoälykonsultti tuotejohtajille, jotka rakentavat monimutkaisia SaaS-tuotteita",
-  "aboutDeliveryTitle": "Näin toimitamme mittakaavassa",
+  "aboutDeliveryTitle": "Näin toimitamme skaalautuvasti",
   "aboutDeliverySubtitle": "Seniorivetoista, verkostoitunutta ja rakennettu kestämään toimeksiannon yli.",
   "aboutDeliverySeniorTitle": "Seniorivetoinen toteutus",
   "aboutDeliverySeniorDescription": "Jokaista toimeksiantoa johtavat kokeneet tekijät käytännön tasolla. Työskentelet niiden kanssa, jotka tekevät työn, et asiakaspäälliköiden kerroksen kanssa.",


### PR DESCRIPTION
Finnish copy tweak requested by Petri: "Näin toimitamme mittakaavassa" → "Näin toimitamme skaalautuvasti" (aboutDeliveryTitle). EN/SV unchanged. validate:translations ✓, page tests 79/79 ✓, no other occurrences of the old string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)