### PR TITLE
chore: consume @digitaltableteur/react@0.1.4 from npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ai-sdk/openai": "^3.0.71",
         "@ai-sdk/react": "^3.0.207",
         "@calcom/embed-react": "^1.5.3",
-        "@digitaltableteur/react": "^0.1.3",
+        "@digitaltableteur/react": "^0.1.4",
         "@digitaltableteur/tokens": "^0.1.0",
         "@digitaltableteur/tokens-css": "^0.1.0",
         "@emailjs/browser": "^4.4.1",
@@ -3404,9 +3404,9 @@
       "license": "MIT"
     },
     "node_modules/@digitaltableteur/react": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.3.tgz",
-      "integrity": "sha512-ZMt44DdDVOqZTtZFxtooQhtEjOiQn5DdNjv24NdBf+KzUOUZyAJEkFbaygvhfuFmgCxrMmHq875gV71GrOAxKQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.4.tgz",
+      "integrity": "sha512-QDGwZxVLLTJiGdQm91/fckv8NIFtYAy7RdI376q22cSZWYTQ4APvlLnxkXCKDl72RtNU1zyMk6eE68v+Zcnaag==",
       "license": "UNLICENSED",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "@ai-sdk/openai": "^3.0.71",
     "@ai-sdk/react": "^3.0.207",
     "@calcom/embed-react": "^1.5.3",
-    "@digitaltableteur/react": "^0.1.3",
+    "@digitaltableteur/react": "^0.1.4",
     "@digitaltableteur/tokens": "^0.1.0",
     "@digitaltableteur/tokens-css": "^0.1.0",
     "@emailjs/browser": "^4.4.1",


### PR DESCRIPTION
Consumes the 0.1.4 publish (token-CSS double-ship fix from #1031, run 29039808967). Installed style.css verified snapshot-free; tokens ship once via the app's variables.css (and tokens-css for external consumers).

Post-publish checks ✓ (registry resolution, react-registry-install 105 exports, storybook-registry-package) + full local gate ✓ (typecheck, lint, lint:css, vitest 2150/2150, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)