### PR TITLE
fix(i18n): restore hero title/subtext per-visit randomization

### DIFF
--- a/providers/I18nProvider.test.tsx
+++ b/providers/I18nProvider.test.tsx
@@ -3,7 +3,10 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import i18n from "../i18n/config";
-import { useLocalization } from "../nextjs-app/shared/lib/translation";
+import {
+  useLocalization,
+  useTranslate,
+} from "../nextjs-app/shared/lib/translation";
 import { I18nProvider } from "./I18nProvider";
 
 function clearLanguageCookie() {
@@ -46,6 +49,35 @@ describe("I18nProvider", () => {
     clearLanguageCookie();
     window.localStorage.clear();
     await i18n.changeLanguage("en");
+  });
+
+  it("returns arrays structurally for returnObjects lookups (hero randomization)", async () => {
+    // Regression: the translate wrapper String()-coerced non-string i18next
+    // results, so HomeHero's homeHeroGradientTitleOptions array arrived as
+    // joined text and per-visit title randomization silently died.
+    let captured: unknown;
+    function ReturnObjectsProbe() {
+      const t = useTranslate();
+      captured = t("homeHeroGradientTitleOptions", {
+        returnObjects: true,
+        defaultValue: [],
+      }) as unknown;
+      return null;
+    }
+
+    render(
+      <I18nProvider>
+        <ReturnObjectsProbe />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => {
+      expect(Array.isArray(captured)).toBe(true);
+    });
+    expect((captured as string[]).length).toBeGreaterThan(1);
+    for (const entry of captured as unknown[]) {
+      expect(typeof entry).toBe("string");
+    }
   });
 
   it("persists a user language switch across provider remounts", async () => {

--- a/providers/I18nProvider.tsx
+++ b/providers/I18nProvider.tsx
@@ -106,7 +106,15 @@ export function I18nProvider({ children }: { children: React.ReactNode }) {
           ? { ...options, defaultValue: fallbackOrOptions }
           : fallbackOrOptions;
       const translated = i18n.t(key, translationOptions);
-      return typeof translated === "string" ? translated : String(translated);
+      if (typeof translated === "string") return translated;
+      // `returnObjects: true` lookups (e.g. HomeHero's title/subtext option
+      // arrays) must pass through structurally, matching the shared lib's
+      // fallbackTranslate; String() here turned arrays into joined text and
+      // silently killed the per-visit hero randomization.
+      if (translated !== null && typeof translated === "object") {
+        return translated as unknown as string;
+      }
+      return String(translated);
     },
     [],
   );


### PR DESCRIPTION
## Root cause

The npm-migration translate wrapper in `providers/I18nProvider.tsx` (`fda848f6d`, 2026-07-08) coerced every non-string i18next result with `String()`. HomeHero fetches its title/subtext option arrays with `returnObjects: true`; the arrays arrived as comma-joined strings, failed HomeHero's `Array.isArray` check, and the hero permanently fell back to the static `homeHeroTitle` — the regression Petri noticed (no random swap on refresh).

## Fix

The wrapper passes structured values through unchanged, matching the shared lib's `fallbackTranslate` semantics; only primitives get `String()`.

## Verification

- New regression test: `returnObjects` lookups return real arrays through `I18nProvider`. Verified it FAILS against the old wrapper and passes with the fix.
- Live check in the running app: three refreshes produced three different hero titles.
- typecheck ✓ lint ✓ vitest 2151/2151 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)