### PR TITLE
fix(i18n): FI hero option 'Suunnittelujärjestelmät…' → 'Design Systemit…'

### DIFF
--- a/nextjs-app/shared/locales/fi/translation.json
+++ b/nextjs-app/shared/locales/fi/translation.json
@@ -313,7 +313,7 @@
     "Nopeat brändi-sprintit kunnianhimoisille startupeille.",
     "Maailmanluokan design. Startup-nopeus.",
     "Kaksi viikkoa skaalautuvaan brändiin.",
-    "Suunnittelujärjestelmät, joilla koko organisaatiosi toimittaa yhtenäisen tuotteen nopeammin."
+    "Design Systemit, joilla koko organisaatiosi toimittaa yhtenäisen tuotteen nopeammin."
   ],
   "homeHeroGradientSubtext": "Konseptista koodiin me rakennamme ihmislähtöisiä GenAI-kokemuksia.",
   "homeHeroSubtext": "Konseptista koodiin me rakennamme ihmislähtöisiä GenAI-kokemuksia.",


### PR DESCRIPTION
Changes the last entry of `homeHeroGradientTitleOptions` (FI) to "Design Systemit, joilla koko organisaatiosi toimittaa yhtenäisen tuotteen nopeammin." — aligning the randomized hero titles with the `homeHeroTitle` terminology from #1034.

Left as-is (out of scope, say the word if wanted): the "designjärjestelmiä" hero option and `homeHighlightTitle` ("GenAI-suunnittelujärjestelmille", highlight section not hero).

validate:translations ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)