### PR TITLE
feat(work): Garage Junction also appears under the Branding filter

### DIFF
--- a/nextjs-app/shared/data/projects.test.ts
+++ b/nextjs-app/shared/data/projects.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolveProjectNavigationPath } from "./projects";
+import {
+  filterProjects,
+  projects,
+  resolveProjectNavigationPath,
+} from "./projects";
 
 describe("resolveProjectNavigationPath", () => {
   it("resolves slug aliases", () => {
@@ -40,5 +44,19 @@ describe("resolveProjectNavigationPath", () => {
     expect(resolveProjectNavigationPath("design system")).toBeNull();
     expect(resolveProjectNavigationPath("unknown client")).toBeNull();
     expect(resolveProjectNavigationPath("/contact")).toBeNull();
+  });
+});
+
+describe("filterProjects", () => {
+  it("includes secondary-category projects in the category filter", () => {
+    const branding = filterProjects(projects, "branding").map((p) => p.slug);
+    const uxDesign = filterProjects(projects, "ux-design").map((p) => p.slug);
+    // Garage Junction is primarily ux-design and also branding
+    expect(branding).toContain("garage-junction");
+    expect(uxDesign).toContain("garage-junction");
+  });
+
+  it("returns every project for 'all'", () => {
+    expect(filterProjects(projects, "all")).toHaveLength(projects.length);
   });
 });

--- a/nextjs-app/shared/data/projects.ts
+++ b/nextjs-app/shared/data/projects.ts
@@ -29,6 +29,8 @@ export interface Project {
   autoPlayVideo?: boolean;
   /** Primary category */
   category: Exclude<ProjectCategory, "all">;
+  /** Additional categories the project also appears under when filtering */
+  secondaryCategories?: Exclude<ProjectCategory, "all">[];
   /** Tags for filtering and display */
   tags: string[];
   /** Featured project flag */
@@ -113,6 +115,7 @@ export const projects: Project[] = [
     thumbnailVideo: "/images/portfolio/garage_junction/GJ_loop.mov",
     autoPlayVideo: true,
     category: "ux-design",
+    secondaryCategories: ["branding"],
     tags: ["Web Design", "Animation", "Branding"],
     featured: false,
     order: 8,
@@ -264,8 +267,12 @@ export const categories: CategoryOption[] = [
   { value: "tools", labelKey: "workFilterTools" },
 ];
 
+function projectCategories(project: Project): Exclude<ProjectCategory, "all">[] {
+  return [project.category, ...(project.secondaryCategories ?? [])];
+}
+
 /**
- * Filter projects by category
+ * Filter projects by category (primary or secondary)
  */
 export function filterProjects(
   projectList: Project[],
@@ -275,7 +282,7 @@ export function filterProjects(
     return [...projectList].sort(compareProjects);
   }
   return [...projectList]
-    .filter((project) => project.category === category)
+    .filter((project) => projectCategories(project).includes(category))
     .sort(compareProjects);
 }
 
@@ -296,9 +303,11 @@ export function getRelatedProjects(
   const current = getProjectBySlug(currentSlug);
   if (!current) return [];
 
+  const currentCategories = projectCategories(current);
   const sameCategory = projects.filter(
     (project) =>
-      project.slug !== currentSlug && project.category === current.category,
+      project.slug !== currentSlug &&
+      projectCategories(project).some((cat) => currentCategories.includes(cat)),
   );
 
   if (sameCategory.length >= maxItems) {
@@ -307,7 +316,8 @@ export function getRelatedProjects(
 
   const otherProjects = projects.filter(
     (project) =>
-      project.slug !== currentSlug && project.category !== current.category,
+      project.slug !== currentSlug &&
+      !projectCategories(project).some((cat) => currentCategories.includes(cat)),
   );
 
   return [...sameCategory, ...otherProjects].slice(0, maxItems);


### PR DESCRIPTION
Garage Junction was only findable under UX Design. The Project model now supports an optional `secondaryCategories` list; `filterProjects` and `getRelatedProjects` match primary or secondary categories. Garage Junction keeps ux-design as its primary (card label unchanged) and gains branding.

Verified in the running app: Branding filter → Garage Junction, New Things Co, Finnish Transport Agency; UX Design filter → KnobSmith Audio, VertaaUX, Garage Junction. Regression test added.

Full gate ✓ (typecheck, lint, vitest 2187/2187, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects can now belong to an additional category, improving how items are grouped and discovered.
  * Project filtering now includes items that match either their main or secondary category.
  * Related project suggestions now better reflect overlapping categories.

* **Bug Fixes**
  * A project now appears in both “branding” and “ux-design” filters when applicable.
  * The “all” filter continues to show the full project list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->