### PR TITLE
chore(design-system): deprecate the generic Hero pattern

### DIFF
--- a/docs/design-system/dogfooding-plan.md
+++ b/docs/design-system/dogfooding-plan.md
@@ -43,12 +43,15 @@ edit).
 Result: dogfooding debt can only go down, and AI-generated PRs that hand-roll
 a button fail locally before review.
 
-## Phase 1: Hero fix (a11y defect + promotion unblock)
+## Phase 1: Generic Hero — RESOLVED by deprecation (2026-07-10)
 
-`patterns/Hero/Hero.tsx:126-135, 222-236`: raw `<a>` wrapping `<Button>` is a
-nested-interactive a11y bug in production. Pass `href` to Button directly.
-This also unblocks Hero, the last consumer-backed beta pattern, for promotion
-(2 prod consumers; every other consumer-backed pattern is stable as of #1041).
+The audit flagged `patterns/Hero/Hero.tsx:126-135, 222-236` (raw `<a>`
+wrapping `<Button>`, a nested-interactive defect). Re-verification showed the
+generic Hero has **zero production consumers** (barrel re-exports only; the
+front page uses HomeHero, and HeroSection plus the six specialized heroes
+cover every real page). Owner decision: deprecate instead of fix. The
+contract's `deprecatedReason` documents the successor components and warns
+against the anchor-wrap pattern; any future hero work composes HeroSection.
 
 ## Phase 2: Quick-win sweep
 

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,12 +1,13 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-09T19:56:25.834Z",
+  "generatedAt": "2026-07-09T20:13:58.357Z",
   "summary": {
     "componentCount": 161,
     "statusCounts": {
-      "beta": 50,
+      "beta": 49,
       "stable": 88,
-      "alpha": 23
+      "alpha": 23,
+      "deprecated": 1
     },
     "honestBetaDocDebt": 0,
     "catalogCompletenessPercent": 87.5,
@@ -106,9 +107,10 @@
     },
     "statusMix": {
       "digitaltableteur": {
-        "beta": 50,
+        "beta": 49,
         "stable": 88,
-        "alpha": 23
+        "alpha": 23,
+        "deprecated": 1
       },
       "dsharp": {
         "beta": 110,
@@ -35718,7 +35720,7 @@
         "name": "Hero",
         "tier": "pattern",
         "group": "marketing",
-        "status": "beta",
+        "status": "deprecated",
         "description": "Configurable general-purpose page hero with heading, subtitle, optional image, and an actions slot across layout and background variants.",
         "dense": "General-purpose hero: title/subtitle/description, optional image and actions; layout variant, background, and align knobs.",
         "keywords": [
@@ -35771,7 +35773,7 @@
           "reviewed": true,
           "forcedColorsVerified": true,
           "ariaRequirements": [],
-          "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+          "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-10 — Deprecated: no production consumers (barrel re-exports only, verified via computeConsumersForComponent); compose HeroSection or use a specialized hero instead."
         },
         "tokens": {
           "colors": [],
@@ -35880,7 +35882,8 @@
         },
         "forbiddenUse": [
           "Bypass design tokens or skip forced-colors verification at beta."
-        ]
+        ],
+        "deprecatedReason": "Zero production consumers; superseded by HeroSection (layout primitive) and the specialized heroes (HomeHero, ProjectHero, ContactHero, AboutHero, ArticleHero, BlogHero). Also carries a nested-interactive defect (raw <a> wrapping <Button>) — use <Button href> in any successor."
       },
       "spec": "# Hero\n\n## Intent\nDocuments how **Hero** is used in production layouts and Storybook examples.\n\n## Interaction contract\n- Keyboard: See **Playground** / **Example** stories and component tests.\n- Pointer: Standard click/tap on interactive affordances.\n- Screen readers: Verify labels, roles, and live regions in stories.\n\n## Do / don't\n- Do: Match the **Example** story composition on Hero pages.\n- Don't: Bypass design tokens or skip forced-colors verification at beta.\n\n## Design notes\n- Tokens: Uses semantic colors/spacing from `variables.css`.\n- Figma: Linked from the component contract `figma` URL.\n",
       "documentationDebt": false,

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -17004,7 +17004,7 @@
       "name": "Hero",
       "group": "marketing",
       "tier": 2,
-      "status": "beta",
+      "status": "deprecated",
       "description": "Configurable general-purpose page hero with heading, subtitle, optional image, and an actions slot across layout and background variants.",
       "dense": "General-purpose hero: title/subtitle/description, optional image and actions; layout variant, background, and align knobs.",
       "keywords": [

--- a/nextjs-app/shared/patterns/Hero/Hero.contract.json
+++ b/nextjs-app/shared/patterns/Hero/Hero.contract.json
@@ -3,7 +3,7 @@
     "name": "Hero",
     "tier": "pattern",
     "group": "marketing",
-    "status": "beta",
+    "status": "deprecated",
     "description": "Configurable general-purpose page hero with heading, subtitle, optional image, and an actions slot across layout and background variants.",
     "dense": "General-purpose hero: title/subtitle/description, optional image and actions; layout variant, background, and align knobs.",
     "keywords": [
@@ -56,7 +56,7 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-10 — Deprecated: no production consumers (barrel re-exports only, verified via computeConsumersForComponent); compose HeroSection or use a specialized hero instead."
     },
     "tokens": {
         "colors": [],
@@ -165,5 +165,6 @@
     },
     "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
-    ]
+    ],
+    "deprecatedReason": "Zero production consumers; superseded by HeroSection (layout primitive) and the specialized heroes (HomeHero, ProjectHero, ContactHero, AboutHero, ArticleHero, BlogHero). Also carries a nested-interactive defect (raw <a> wrapping <Button>) — use <Button href> in any successor."
 }

--- a/nextjs-app/shared/patterns/Hero/Hero.stories.tsx
+++ b/nextjs-app/shared/patterns/Hero/Hero.stories.tsx
@@ -8,7 +8,7 @@ import { t } from "i18next";
 const meta: Meta<typeof Hero> = {
   title: "Patterns/Hero",
   component: Hero,
-  tags: ["beta", "autodocs"],
+  tags: ["deprecated", "autodocs"],
   parameters: {
     design: {
       type: "figma",


### PR DESCRIPTION
Owner decision: the generic `Hero` pattern is deprecated rather than fixed. Verified zero production consumers (barrel re-exports only — the front page renders HomeHero; HeroSection and the six specialized heroes cover every real page). Its nested-interactive defect (raw `<a>` wrapping `<Button>`) is documented in `deprecatedReason` with the successor guidance (`<Button href>`, compose HeroSection). Storybook sidebar/badge now show deprecated. Dogfooding plan Phase 1 updated.

Gates ✓ (build:tokens, contract-props, consumers, typecheck, lint, vitest 2200/2200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)