### PR TITLE
docs(design-system): deprecation policy + enforcement

### DIFF
--- a/docs/design-system/deprecation-policy.md
+++ b/docs/design-system/deprecation-policy.md
@@ -1,0 +1,101 @@
+# Component Deprecation Policy
+
+> Status: ACTIVE since 2026-07-10. First application: the generic `Hero`
+> pattern (#1043). Sized for a one-person team whose main "other consumers"
+> are AI agents and the published `@digitaltableteur/react` package.
+
+## What the big systems do (sources)
+
+- **Carbon**: assets deprecated in one major version remain through the next
+  and are removed the one after (deprecated in v9→v10, removed in v11), with
+  a public deprecations index page.
+- **Primer**: a deprecated component requires deprecation documentation
+  naming the alternatives, and a warning shown to consumers using it.
+- **Polaris**: legacy components are deprecated and replaced at the next
+  major; migration paths are documented at least a month before deprecation.
+- **Spectrum Web Components**: JSDoc `@deprecated since x.y.z` + runtime
+  dev-mode warnings, deprecation notices in release notes/docs/package.json
+  with a migration link; removal at the next major or "2 releases or six
+  months, whichever is smaller".
+
+Common thread: mark loudly in every surface a consumer touches, name the
+successor, hold a predictable window, remove only at a version boundary,
+keep a public record.
+
+## The solo-team adaptation
+
+Multi-team grace periods exist to protect strangers on unknown timelines. We
+have no strangers: consumers are this repo (verified mechanically), AI agents
+(reading the catalog registries), and hypothetically npm consumers of
+`@digitaltableteur/react`. So the policy optimizes for two things instead:
+**agents must never be steered toward a deprecated component**, and **the
+"why" must survive deletion** — the solo failure mode is future-you (or
+future-agent) rebuilding the same thing and re-hitting the same trap.
+
+## Rules
+
+### R1. Eligibility
+
+A component or pattern may be deprecated only when **both** hold:
+
+1. Zero production consumers, verified with
+   `computeConsumersForComponent(name)` (barrel re-exports do not count), or
+   all consumers are migrated to the successor **in the same or an earlier
+   PR**. Never deprecate something still shipped.
+2. A successor exists or the capability is intentionally dropped, and
+   `deprecatedReason` says which.
+
+### R2. Marking (one PR)
+
+- `contract.status = "deprecated"` and a **required** `deprecatedReason`
+  naming successor(s) and any defect/anti-pattern the component carried
+  (this is the tombstone text; write it for a reader who can no longer see
+  the code).
+- Story meta tag flips to `"deprecated"` (sidebar dot + WipBadge render the
+  deprecated treatment).
+- If the symbol is exported by `@digitaltableteur/react`: add JSDoc
+  `/** @deprecated <reason + successor> */` on the export (IDE
+  strikethrough) and a CHANGELOG entry in the next publish.
+- Enforced by `validate:components`: deprecated status without a
+  `deprecatedReason` fails.
+
+### R3. Freeze
+
+From the deprecation PR onward: no feature work, no promotion sweeps, no
+snapshot/controls investment. Only fixes that keep the build green. The
+component is excluded from `find-component` results by default (agents pass
+`--include-deprecated` only when investigating history).
+
+### R4. Removal window
+
+- **Catalog-only (not package-exported)**: removable after **30 days**, or
+  immediately if it was zero-consumer at deprecation time and the month has
+  no publish planned — whichever comes first in a natural cleanup PR. The
+  window is a regret buffer, not a migration period; nobody external is
+  waiting.
+- **Package-exported**: the export survives at least **one published
+  version** carrying the JSDoc `@deprecated` + CHANGELOG notice, and is
+  removed in the next version after that (pre-1.0 semver: a minor bump with
+  a BREAKING note; post-1.0: a major bump). Carbon's two-major window shrinks
+  to one published version because the package has no known external
+  consumers yet; revisit if that changes.
+
+### R5. Removal PR checklist
+
+1. Delete the component directory (source, stories, tests, snapshots,
+   contract, spec/MDX) and its barrel exports.
+2. Sweep translations/assets only it referenced.
+3. Move its row in the Deprecation log below from "deprecated" to "removed",
+   with the PR link. The `deprecatedReason` text is preserved in the log.
+4. Full local gate + `validate:agent-docs`; CHANGELOG entry if packaged.
+
+### R6. Record
+
+Every deprecation and removal is a row in the log below. The log is the
+institutional memory that outlives the code.
+
+## Deprecation log
+
+| Component | Tier | Deprecated | Reason (tombstone) | Removable after | Removed |
+|---|---|---|---|---|---|
+| Hero | pattern | 2026-07-10 (#1043) | Zero production consumers; superseded by HeroSection + the six specialized heroes (HomeHero, ProjectHero, ContactHero, AboutHero, ArticleHero, BlogHero). Carried a nested-interactive defect (raw `<a>` wrapping `<Button>`); successors must use `<Button href>`. | 2026-08-09 | — |

--- a/nextjs-app/shared/components/AGENTS.md
+++ b/nextjs-app/shared/components/AGENTS.md
@@ -106,8 +106,9 @@ Coverage target: >80%. Include axe-core in component tests.
 - **WIP** → Storybook badge; not production-ready
 - **beta** → contract + spec required, plus docs: a Carbon-style MDX page or contract doc-field adoption (`usage`/`keywords`/`dense` + autodocs frame; colocated MDX must then be deleted); honest doc debt tracked in `agent-manifest.json`
 - **stable** → a11y snapshots, production consumer, review evidence in contract
+- **deprecated** → zero consumers (or migrated first) + required `deprecatedReason` naming successors; hidden from `find-component` by default; removal rules + log in [`docs/design-system/deprecation-policy.md`](../../../docs/design-system/deprecation-policy.md)
 
-Do not promote to stable without running validation gates in skill `dt-design-system`.
+Do not promote to stable without running validation gates in skill `dt-design-system`. Never build on a deprecated component; its `deprecatedReason` names the successor.
 
 ---
 

--- a/scripts/design-system/find-component.mjs
+++ b/scripts/design-system/find-component.mjs
@@ -4,6 +4,10 @@
  *
  *   npm run find-component -- "dismissible warning banner"
  *   npm run find-component -- --json "primary action button"
+ *   npm run find-component -- --include-deprecated "legacy hero"
+ *
+ * Deprecated components are excluded by default so agents are never steered
+ * toward them (docs/design-system/deprecation-policy.md R3).
  */
 import { readFileSync, existsSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
@@ -17,7 +21,12 @@ import {
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const MANIFEST = join(ROOT, "nextjs-app/shared/foundations/dist/agent-manifest.json");
 const jsonMode = process.argv.includes("--json");
-const query = process.argv.slice(2).filter((arg) => arg !== "--json").join(" ").trim();
+const includeDeprecated = process.argv.includes("--include-deprecated");
+const query = process.argv
+  .slice(2)
+  .filter((arg) => arg !== "--json" && arg !== "--include-deprecated")
+  .join(" ")
+  .trim();
 
 if (!query) {
   console.error("Usage: npm run find-component -- [--json] \"your intent\"");
@@ -43,6 +52,15 @@ if (existsSync(MANIFEST)) {
       : { name, description: "", status: "alpha" };
     return { name, contract, usage: byComponent.get(name) };
   });
+}
+
+const deprecatedCount = components.filter(
+  (component) => component.contract?.status === "deprecated",
+).length;
+if (!includeDeprecated) {
+  components = components.filter(
+    (component) => component.contract?.status !== "deprecated",
+  );
 }
 
 const ranked = rankComponentsForIntent(query, components, 8);
@@ -97,4 +115,9 @@ for (const { name, score, entry } of ranked) {
       `    production usage: ${usage.productionImportCount} file(s); e.g. ${usage.evidence.find((e) => e.context === "production")?.path ?? usage.evidence[0]?.path}`,
     );
   }
+}
+if (!includeDeprecated && deprecatedCount > 0) {
+  console.log(
+    `  (${deprecatedCount} deprecated component(s) hidden — pass --include-deprecated to see them)`,
+  );
 }

--- a/scripts/design-system/validate-components.ts
+++ b/scripts/design-system/validate-components.ts
@@ -561,6 +561,17 @@ export function validateComponentsDir(root: string): ValidationResult {
             errors.push(`${name}.contract.json: stable requires a11y.reviewed to be true`)
         }
 
+        // Deprecation gate (docs/design-system/deprecation-policy.md R2): the
+        // tombstone text is mandatory — it outlives the code in the policy log.
+        if (manifest.status === 'deprecated') {
+            const reason = (manifest as { deprecatedReason?: unknown }).deprecatedReason
+            if (typeof reason !== 'string' || reason.trim().length < 20) {
+                errors.push(
+                    `${name}.contract.json: deprecated requires a substantive deprecatedReason naming the successor component(s) (see docs/design-system/deprecation-policy.md)`,
+                )
+            }
+        }
+
         // Stable promotion gate: accessibility-tree snapshot evidence
         // (replaced the manual screenReaderVerified gate on 2026-05-03 —
         // automating real SR audio is infeasible without paid SaaS, but


### PR DESCRIPTION
Defines the component deprecation rules (docs/design-system/deprecation-policy.md), distilled from how Carbon, Primer, Polaris, and Spectrum Web Components do it, then right-sized for a one-person team whose actual consumers are this repo (mechanically verifiable), AI agents (catalog registries), and the npm package.

**Rules:** zero-consumer or migrate-first eligibility; mandatory substantive `deprecatedReason` tombstone; freeze + hidden from `find-component` by default; 30-day removal window for catalog-only components, one published `@deprecated` version for package exports; removal checklist; permanent deprecation log (Hero seeded as the first row, removable 2026-08-09).

**Enforcement shipped with the policy:**
- `validate:components` fails a deprecated contract without a substantive `deprecatedReason` (negative-tested)
- `find-component` excludes deprecated components unless `--include-deprecated`, printing the hidden count — agents are never steered toward them
- Status-lifecycle section in components AGENTS.md documents the stage

Gates ✓ (validate:agent-docs, validate:components, typecheck, lint, vitest 2200/2200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added formal support for deprecated components, including clearer status guidance and successor recommendations.
  * The component search tool can now optionally include deprecated items, and otherwise hides them by default with a notice.

* **Documentation**
  * Added a new deprecation policy page and lifecycle guidance for component status management.

* **Bug Fixes**
  * Strengthened validation so deprecated components must include a meaningful deprecation reason before passing checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->