### PR TITLE
feat(design-system): dogfood ratchet — raw HTML / Tailwind debt can only decrease

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -39,6 +39,7 @@ jobs:
       - run: npm run check:token-descriptions
       - run: npm run validate:components
       - run: npm run check:package-registry-resolution
+      - run: npm run check:dogfood-ratchet
       - run: npm run check:consumers
       - run: npm run validate:agent-docs
       - run: npm run validate:translations

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -6,6 +6,11 @@ changed=$(git diff --name-only HEAD @{push} 2>/dev/null || git diff --name-only 
 if echo "$changed" | grep -qE '^(app|providers|lib|components|i18n)/|^package(-lock)?\.json$|^packages/|check-package-registry-resolution'; then
   npm run check:package-registry-resolution
 fi
+# Dogfood ratchet: raw HTML / Tailwind debt can only decrease
+# (docs/design-system/dogfooding-plan.md Phase 0).
+if echo "$changed" | grep -qE '^app/|^nextjs-app/shared/(patterns|components)/|dogfood-ratchet'; then
+  npm run check:dogfood-ratchet
+fi
 echo "$changed" | grep -qE 'nextjs-app/shared/(components|patterns|foundations)|scripts/design-system' || exit 0
 # Contract gate: keep the local gate a superset of the farm's validate job for
 # contract-touching changes (2026-07-03 incident: ten red farm runs because

--- a/package.json
+++ b/package.json
@@ -181,7 +181,8 @@
     "lint:composition": "node scripts/design-system/lint-composition.mjs --strict",
     "capture:a11y-snapshots": "node scripts/design-system/capture-story-a11y-snapshots.mjs",
     "promote:stable-atoms": "node scripts/design-system/promote-stable-atoms.mjs",
-    "check:bundle-budgets": "node scripts/design-system/check-bundle-budgets.mjs"
+    "check:bundle-budgets": "node scripts/design-system/check-bundle-budgets.mjs",
+    "check:dogfood-ratchet": "node scripts/design-system/check-dogfood-ratchet.mjs"
   },
   "dependencies": {
     "@ai-sdk/mcp": "^1.0.51",

--- a/scripts/design-system/check-dogfood-ratchet.mjs
+++ b/scripts/design-system/check-dogfood-ratchet.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Dogfood ratchet: raw-HTML elements and Tailwind utility lines can only
+ * decrease (docs/design-system/dogfooding-plan.md Phase 0).
+ *
+ *   npm run check:dogfood-ratchet             # compare against baseline
+ *   npm run check:dogfood-ratchet -- --update # tighten/rewrite the baseline
+ *
+ * Counts are keyed PER FILE (not per line) so unrelated edits inside a file
+ * never trip the gate — only adding another raw element or utility line does.
+ * The committed baseline is the debt inventory; intentionally-raw sites
+ * (honeypots, email-template HTML, markdown maps) simply live in it at their
+ * current count and never need exemption bookkeeping.
+ */
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { join, relative, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const BASELINE_PATH = join(ROOT, "scripts/design-system/dogfood-ratchet.baseline.json");
+const update = process.argv.includes("--update");
+
+const SCAN_ROOTS = ["app", "nextjs-app/shared/patterns", "nextjs-app/shared/components"];
+// Not app runtime UI, or deliberately raw-by-design surfaces.
+const SKIP_RE =
+  /(?:\.(?:test|spec|stories)\.|__tests__|__mocks__|__a11y-snapshots__|\/app\/dev\/|TailwindTest|\.figma\.|\.mdx$)/;
+
+// Raw JSX elements with a DS replacement (Button, Link/RouterLink, Image,
+// Title, TextInput/TextArea/Select, Table, List).
+const RAW_ELEMENT_RE = /<(?:button|a|img|h[1-4]|input|select|textarea|table|ul|ol)\b/g;
+
+// A quoted string counts as Tailwind styling when >=2 of its tokens look like
+// utility classes. Line-level: any line containing such a string counts once.
+const UTILITY_TOKEN_RE =
+  /^(?:(?:hover|focus|focus-visible|active|disabled|group-hover|group-focus|peer|motion-reduce|motion-safe|dark|sm|md|lg|xl|2xl|tablet|desktop|max-tablet|max-desktop):)*(?:-?(?:flex|grid|block|inline|inline-block|inline-flex|hidden|relative|absolute|fixed|sticky|static|items|justify|content|place|self|gap|space|divide|p|px|py|pt|pb|pl|pr|m|mx|my|mt|mb|ml|mr|w|h|size|min-w|min-h|max-w|max-h|text|font|leading|tracking|list|bg|from|via|to|border|rounded|shadow|ring|outline|opacity|z|overflow|transition|duration|ease|delay|animate|scale|rotate|translate|skew|origin|cursor|select|resize|pointer-events|touch|whitespace|break|truncate|object|aspect|grow|shrink|basis|order|col|row|auto-cols|auto-rows|inset|top|bottom|left|right|start|end|underline|no-underline|line-through|uppercase|lowercase|capitalize|normal-case|italic|not-italic|antialiased|subpixel-antialiased|backdrop|blur|brightness|contrast|grayscale|invert|saturate|sepia|drop-shadow|mix-blend|fill|stroke|sr-only|not-sr-only|group|peer|container|prose)(?:-[\w./%[\]#]+)?)$/;
+
+function isUtilityString(value) {
+  const tokens = value.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return false;
+  const hits = tokens.filter((token) => UTILITY_TOKEN_RE.test(token)).length;
+  return hits >= 2;
+}
+
+function countFile(source) {
+  let rawElements = 0;
+  for (const _ of source.matchAll(RAW_ELEMENT_RE)) rawElements += 1;
+
+  let utilityLines = 0;
+  for (const line of source.split("\n")) {
+    const strings = line.match(/"[^"]*"|'[^']*'|`[^`]*`/g) ?? [];
+    if (strings.some((quoted) => isUtilityString(quoted.slice(1, -1)))) {
+      utilityLines += 1;
+    }
+  }
+  return { rawElements, utilityLines };
+}
+
+function* sourceFiles(root) {
+  const absolute = join(ROOT, root);
+  if (!existsSync(absolute)) return;
+  const stack = [absolute];
+  while (stack.length) {
+    const dir = stack.pop();
+    for (const entry of readdirSync(dir)) {
+      if (entry === "node_modules" || entry.startsWith(".")) continue;
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        stack.push(full);
+        continue;
+      }
+      if (!/\.(?:tsx|jsx)$/.test(full)) continue;
+      const rel = relative(ROOT, full).replace(/\\/g, "/");
+      if (SKIP_RE.test(rel) || SKIP_RE.test(`/${rel}`)) continue;
+      yield { full, rel };
+    }
+  }
+}
+
+const current = {};
+for (const root of SCAN_ROOTS) {
+  for (const { full, rel } of sourceFiles(root)) {
+    const { rawElements, utilityLines } = countFile(readFileSync(full, "utf8"));
+    if (rawElements > 0 || utilityLines > 0) {
+      current[rel] = { rawElements, utilityLines };
+    }
+  }
+}
+
+const totals = Object.values(current).reduce(
+  (sum, c) => ({
+    rawElements: sum.rawElements + c.rawElements,
+    utilityLines: sum.utilityLines + c.utilityLines,
+  }),
+  { rawElements: 0, utilityLines: 0 },
+);
+
+const sortedCurrent = Object.fromEntries(
+  Object.keys(current)
+    .sort()
+    .map((key) => [key, current[key]]),
+);
+
+if (update || !existsSync(BASELINE_PATH)) {
+  writeFileSync(
+    BASELINE_PATH,
+    `${JSON.stringify({ note: "Per-file dogfood debt. Counts may only decrease; tighten with npm run check:dogfood-ratchet -- --update. See docs/design-system/dogfooding-plan.md.", files: sortedCurrent }, null, 2)}\n`,
+  );
+  console.log(
+    `✓ dogfood ratchet baseline written: ${Object.keys(current).length} files, ${totals.rawElements} raw elements, ${totals.utilityLines} Tailwind utility lines`,
+  );
+  process.exit(0);
+}
+
+const baseline = JSON.parse(readFileSync(BASELINE_PATH, "utf8")).files ?? {};
+const regressions = [];
+const improvements = [];
+
+for (const [file, counts] of Object.entries(current)) {
+  const base = baseline[file];
+  if (!base) {
+    regressions.push(`${file}: NEW file with ${counts.rawElements} raw element(s), ${counts.utilityLines} utility line(s) — use DS components (npm run find-component)`);
+    continue;
+  }
+  for (const key of ["rawElements", "utilityLines"]) {
+    if (counts[key] > base[key]) {
+      regressions.push(`${file}: ${key} ${base[key]} → ${counts[key]} (ratchet only goes down)`);
+    } else if (counts[key] < base[key]) {
+      improvements.push(`${file}: ${key} ${base[key]} → ${counts[key]}`);
+    }
+  }
+}
+for (const file of Object.keys(baseline)) {
+  if (!current[file]) improvements.push(`${file}: cleared (was ${baseline[file].rawElements}/${baseline[file].utilityLines})`);
+}
+
+if (regressions.length) {
+  console.error("✗ dogfood ratchet failed — raw HTML / Tailwind debt increased:");
+  for (const line of regressions) console.error(`  - ${line}`);
+  console.error("  Swap in DS components (npm run find-component -- \"your intent\") or, for a justified exception, tighten scope and discuss in the PR.");
+  process.exit(1);
+}
+
+if (improvements.length) {
+  console.error("✗ dogfood ratchet: debt DECREASED (good!) — lock it in:");
+  for (const line of improvements.slice(0, 20)) console.error(`  - ${line}`);
+  console.error("  Run: npm run check:dogfood-ratchet -- --update  and commit the baseline.");
+  process.exit(1);
+}
+
+console.log(
+  `✓ dogfood ratchet holds (${Object.keys(current).length} files, ${totals.rawElements} raw elements, ${totals.utilityLines} utility lines)`,
+);

--- a/scripts/design-system/dogfood-ratchet.baseline.json
+++ b/scripts/design-system/dogfood-ratchet.baseline.json
@@ -1,0 +1,629 @@
+{
+  "note": "Per-file dogfood debt. Counts may only decrease; tighten with npm run check:dogfood-ratchet -- --update. See docs/design-system/dogfooding-plan.md.",
+  "files": {
+    "app/blog/DraftPreviewBanner.tsx": {
+      "rawElements": 1,
+      "utilityLines": 4
+    },
+    "app/blog/[slug]/ServerArticleContent.tsx": {
+      "rawElements": 0,
+      "utilityLines": 2
+    },
+    "app/blog/[slug]/ServerArticleHero.tsx": {
+      "rawElements": 1,
+      "utilityLines": 11
+    },
+    "app/blog/[slug]/ServerArticleMain.tsx": {
+      "rawElements": 0,
+      "utilityLines": 5
+    },
+    "app/blog/[slug]/ServerRelatedPosts.tsx": {
+      "rawElements": 2,
+      "utilityLines": 6
+    },
+    "app/blog/page.tsx": {
+      "rawElements": 3,
+      "utilityLines": 0
+    },
+    "app/design-system/agent/page.tsx": {
+      "rawElements": 11,
+      "utilityLines": 20
+    },
+    "app/error.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "app/global-error.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "app/pricing/page.tsx": {
+      "rawElements": 0,
+      "utilityLines": 4
+    },
+    "app/work/new-things-co/page.tsx": {
+      "rawElements": 0,
+      "utilityLines": 3
+    },
+    "nextjs-app/shared/components/Accordion/Accordion.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/ArticleCard/ArticleCard.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/ArticleContent/ArticleContent.tsx": {
+      "rawElements": 0,
+      "utilityLines": 1
+    },
+    "nextjs-app/shared/components/ArticleShareSection/ArticleShareSection.tsx": {
+      "rawElements": 5,
+      "utilityLines": 11
+    },
+    "nextjs-app/shared/components/AskAI/AskAI.tsx": {
+      "rawElements": 6,
+      "utilityLines": 2
+    },
+    "nextjs-app/shared/components/AspectRatio/AspectRatio.tsx": {
+      "rawElements": 0,
+      "utilityLines": 2
+    },
+    "nextjs-app/shared/components/Author/Author.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/Avatar/Avatar.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/Badge/Badge.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/BlogCategoryFilter/BlogCategoryFilter.tsx": {
+      "rawElements": 3,
+      "utilityLines": 22
+    },
+    "nextjs-app/shared/components/BlogGrid/BlogGrid.tsx": {
+      "rawElements": 0,
+      "utilityLines": 5
+    },
+    "nextjs-app/shared/components/BlogMediaImage/BlogMediaImage.tsx": {
+      "rawElements": 2,
+      "utilityLines": 2
+    },
+    "nextjs-app/shared/components/Breadcrumb/Breadcrumb.tsx": {
+      "rawElements": 3,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/Button/Button.tsx": {
+      "rawElements": 5,
+      "utilityLines": 1
+    },
+    "nextjs-app/shared/components/Card/Card.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/CategoryFilter/CategoryFilter.tsx": {
+      "rawElements": 3,
+      "utilityLines": 22
+    },
+    "nextjs-app/shared/components/Center/Center.tsx": {
+      "rawElements": 0,
+      "utilityLines": 1
+    },
+    "nextjs-app/shared/components/ChatWidget/ChatComposer.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/ChatWidget/ChatMessageBubble.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/ChatWidget/ChatTextArea.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/ChatWidget/ChatToolResultSection.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/Checkbox/Checkbox.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/ChunkErrorBoundary/ChunkErrorBoundary.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/ClientLogoMarquee/ClientLogoMarquee.tsx": {
+      "rawElements": 2,
+      "utilityLines": 7
+    },
+    "nextjs-app/shared/components/Combobox/Combobox.tsx": {
+      "rawElements": 4,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/CommandPalette/CommandPalette.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/ContactForm/ContactForm.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/ContactFormSuccess/ContactFormSuccess.tsx": {
+      "rawElements": 1,
+      "utilityLines": 11
+    },
+    "nextjs-app/shared/components/ContactFormSuccessEditorial/ContactFormSuccessEditorial.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/CookieConsent/CookieConsent.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/DashLeadList/DashLeadList.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/Designerman/Designerman.tsx": {
+      "rawElements": 1,
+      "utilityLines": 1
+    },
+    "nextjs-app/shared/components/Display/Display.tsx": {
+      "rawElements": 0,
+      "utilityLines": 1
+    },
+    "nextjs-app/shared/components/DonnyBookingEmbed/DonnyBookingEmbed.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.tsx": {
+      "rawElements": 44,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/EnhancedArticleCard/EnhancedArticleCard.tsx": {
+      "rawElements": 2,
+      "utilityLines": 31
+    },
+    "nextjs-app/shared/components/EnhancedAuthorCard/EnhancedAuthorCard.tsx": {
+      "rawElements": 1,
+      "utilityLines": 27
+    },
+    "nextjs-app/shared/components/EnhancedProjectCard/EnhancedProjectCard.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/ExpandableSection/ExpandableSection.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/FileUpload/FileUpload.tsx": {
+      "rawElements": 4,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/FinnishTransportAgency/ColorPalette.tsx": {
+      "rawElements": 4,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/Gallery/Gallery.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/HeroBackground/HeroBackground.tsx": {
+      "rawElements": 0,
+      "utilityLines": 12
+    },
+    "nextjs-app/shared/components/Icon/Icon.tsx": {
+      "rawElements": 0,
+      "utilityLines": 1
+    },
+    "nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.tsx": {
+      "rawElements": 2,
+      "utilityLines": 4
+    },
+    "nextjs-app/shared/components/Lightbox/Lightbox.tsx": {
+      "rawElements": 4,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/Link/Link.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/LinkedInQuoteCard/LinkedInQuoteCard.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/LocationCard/LocationCard.tsx": {
+      "rawElements": 3,
+      "utilityLines": 16
+    },
+    "nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.tsx": {
+      "rawElements": 5,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/MdxImage/MdxImage.tsx": {
+      "rawElements": 1,
+      "utilityLines": 1
+    },
+    "nextjs-app/shared/components/Menu/Menu.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/Modal/Modal.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/MultiCombobox/MultiCombobox.tsx": {
+      "rawElements": 4,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/NavLink/NavLink.tsx": {
+      "rawElements": 0,
+      "utilityLines": 1
+    },
+    "nextjs-app/shared/components/NavMenuList/NavMenuList.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/OpenHours/OpenHours.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/Pagination/Pagination.tsx": {
+      "rawElements": 3,
+      "utilityLines": 24
+    },
+    "nextjs-app/shared/components/PersonCard/PersonCard.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/ProjectCard/ProjectCard.tsx": {
+      "rawElements": 2,
+      "utilityLines": 19
+    },
+    "nextjs-app/shared/components/ProjectGallery/ProjectGallery.tsx": {
+      "rawElements": 1,
+      "utilityLines": 8
+    },
+    "nextjs-app/shared/components/ProjectNav/ProjectNav.tsx": {
+      "rawElements": 0,
+      "utilityLines": 23
+    },
+    "nextjs-app/shared/components/Prose/Prose.tsx": {
+      "rawElements": 0,
+      "utilityLines": 1
+    },
+    "nextjs-app/shared/components/Radio/Radio.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/ScrollIndicator/ScrollIndicator.tsx": {
+      "rawElements": 1,
+      "utilityLines": 6
+    },
+    "nextjs-app/shared/components/Section/Section.tsx": {
+      "rawElements": 0,
+      "utilityLines": 7
+    },
+    "nextjs-app/shared/components/SegmentedControl/SegmentedControl.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/Select/Select.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/SelectableCard/SelectableCard.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/SentrySummaryCard/SentrySummaryCard.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/ServiceCard/ServiceCard.tsx": {
+      "rawElements": 1,
+      "utilityLines": 12
+    },
+    "nextjs-app/shared/components/SiteTree/SiteTree.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/SkillsGrid/SkillsGrid.tsx": {
+      "rawElements": 1,
+      "utilityLines": 13
+    },
+    "nextjs-app/shared/components/SkipLink/SkipLink.tsx": {
+      "rawElements": 1,
+      "utilityLines": 2
+    },
+    "nextjs-app/shared/components/SocialShare/SocialShare.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/StudioMap/StudioMap.tsx": {
+      "rawElements": 1,
+      "utilityLines": 10
+    },
+    "nextjs-app/shared/components/Switch/Switch.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/TableOfContents/TableOfContents.tsx": {
+      "rawElements": 4,
+      "utilityLines": 12
+    },
+    "nextjs-app/shared/components/Tabs/Tabs.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/Testimonial/Testimonial.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/TextArea/TextArea.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/TextInput/TextInput.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/ValueCard/ValueCard.tsx": {
+      "rawElements": 1,
+      "utilityLines": 14
+    },
+    "nextjs-app/shared/components/WorkGrid/WorkGrid.tsx": {
+      "rawElements": 0,
+      "utilityLines": 1
+    },
+    "nextjs-app/shared/components/animations/KineticTitle/KineticTitle.tsx": {
+      "rawElements": 0,
+      "utilityLines": 2
+    },
+    "nextjs-app/shared/components/animations/Parallax/Parallax.tsx": {
+      "rawElements": 0,
+      "utilityLines": 2
+    },
+    "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx": {
+      "rawElements": 8,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx": {
+      "rawElements": 10,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullEnPage.tsx": {
+      "rawElements": 4,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullFiPage.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullSvPage.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyPage.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/pages/Home/HomePage.tsx": {
+      "rawElements": 0,
+      "utilityLines": 4
+    },
+    "nextjs-app/shared/components/pages/ImprintPage/ImprintPage.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx": {
+      "rawElements": 10,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx": {
+      "rawElements": 3,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx": {
+      "rawElements": 1,
+      "utilityLines": 3
+    },
+    "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx": {
+      "rawElements": 0,
+      "utilityLines": 3
+    },
+    "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx": {
+      "rawElements": 1,
+      "utilityLines": 1
+    },
+    "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx": {
+      "rawElements": 3,
+      "utilityLines": 1
+    },
+    "nextjs-app/shared/components/pages/Work/ProjectSpine/ProjectSpinePage.tsx": {
+      "rawElements": 2,
+      "utilityLines": 1
+    },
+    "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx": {
+      "rawElements": 2,
+      "utilityLines": 2
+    },
+    "nextjs-app/shared/components/pages/Work/SapBuildApps/SapBuildAppsPage.tsx": {
+      "rawElements": 0,
+      "utilityLines": 2
+    },
+    "nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx": {
+      "rawElements": 14,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx": {
+      "rawElements": 0,
+      "utilityLines": 1
+    },
+    "nextjs-app/shared/patterns/AboutHero/AboutHero.tsx": {
+      "rawElements": 0,
+      "utilityLines": 11
+    },
+    "nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx": {
+      "rawElements": 2,
+      "utilityLines": 35
+    },
+    "nextjs-app/shared/patterns/ArticleHero/ArticleHero.tsx": {
+      "rawElements": 0,
+      "utilityLines": 23
+    },
+    "nextjs-app/shared/patterns/ArticleLayout/ArticleLayout.tsx": {
+      "rawElements": 0,
+      "utilityLines": 5
+    },
+    "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx": {
+      "rawElements": 2,
+      "utilityLines": 5
+    },
+    "nextjs-app/shared/patterns/BlogHero/BlogHero.tsx": {
+      "rawElements": 0,
+      "utilityLines": 6
+    },
+    "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx": {
+      "rawElements": 0,
+      "utilityLines": 6
+    },
+    "nextjs-app/shared/patterns/CTASection/CTASection.tsx": {
+      "rawElements": 1,
+      "utilityLines": 10
+    },
+    "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx": {
+      "rawElements": 1,
+      "utilityLines": 8
+    },
+    "nextjs-app/shared/patterns/ContactHero/ContactHero.tsx": {
+      "rawElements": 0,
+      "utilityLines": 9
+    },
+    "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/patterns/ContentSection/ContentSection.tsx": {
+      "rawElements": 1,
+      "utilityLines": 14
+    },
+    "nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.tsx": {
+      "rawElements": 2,
+      "utilityLines": 13
+    },
+    "nextjs-app/shared/patterns/Footer/Footer.tsx": {
+      "rawElements": 16,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/patterns/Hero/Hero.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/patterns/HeroSection/HeroSection.tsx": {
+      "rawElements": 0,
+      "utilityLines": 3
+    },
+    "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx": {
+      "rawElements": 0,
+      "utilityLines": 5
+    },
+    "nextjs-app/shared/patterns/ManifestoSection/ManifestoSection.tsx": {
+      "rawElements": 1,
+      "utilityLines": 10
+    },
+    "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.tsx": {
+      "rawElements": 3,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/patterns/PageLayout/PageLayout.tsx": {
+      "rawElements": 1,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx": {
+      "rawElements": 4,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/patterns/ProjectDetailLayout/ProjectDetailLayout.tsx": {
+      "rawElements": 0,
+      "utilityLines": 4
+    },
+    "nextjs-app/shared/patterns/ProjectHero/ProjectHero.tsx": {
+      "rawElements": 2,
+      "utilityLines": 38
+    },
+    "nextjs-app/shared/patterns/ProjectMetaSection/ProjectMetaSection.tsx": {
+      "rawElements": 8,
+      "utilityLines": 23
+    },
+    "nextjs-app/shared/patterns/RelatedPosts/RelatedPosts.tsx": {
+      "rawElements": 1,
+      "utilityLines": 5
+    },
+    "nextjs-app/shared/patterns/RelatedProjects/RelatedProjects.tsx": {
+      "rawElements": 3,
+      "utilityLines": 4
+    },
+    "nextjs-app/shared/patterns/ServicesSection/ServicesSection.tsx": {
+      "rawElements": 1,
+      "utilityLines": 5
+    },
+    "nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx": {
+      "rawElements": 2,
+      "utilityLines": 15
+    },
+    "nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx": {
+      "rawElements": 2,
+      "utilityLines": 17
+    },
+    "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx": {
+      "rawElements": 0,
+      "utilityLines": 14
+    },
+    "nextjs-app/shared/patterns/StatsSection/StatsSection.tsx": {
+      "rawElements": 2,
+      "utilityLines": 4
+    },
+    "nextjs-app/shared/patterns/ValuesSection/ValuesSection.tsx": {
+      "rawElements": 1,
+      "utilityLines": 7
+    },
+    "nextjs-app/shared/patterns/WorkHero/WorkHero.tsx": {
+      "rawElements": 0,
+      "utilityLines": 6
+    },
+    "nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.tsx": {
+      "rawElements": 1,
+      "utilityLines": 1
+    },
+    "nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.tsx": {
+      "rawElements": 1,
+      "utilityLines": 15
+    }
+  }
+}


### PR DESCRIPTION
Phase 0 of the [dogfooding plan](https://github.com/PetriLahdelma/digitaltableteur/blob/main/docs/design-system/dogfooding-plan.md): enforcement before migration.

`check:dogfood-ratchet` counts per file (app/ + shared patterns + components; tests/stories/dev harnesses skipped): **raw JSX elements** with a DS replacement and **Tailwind utility lines** (≥2 utility tokens in one quoted string). The committed baseline is the debt inventory — **156 files, 332 raw elements, 732 utility lines** (top offenders match the audit: ProjectHero 38, AboutPageContent 35, MobileDrawer 17 exactly).

Mechanics: count-keyed per file (not line-keyed — the rhythmguard lesson), fails on any increase or new nonzero file, and **decreases also fail** with instructions to run `--update`, so every migration PR locks its gain into the committed baseline. Intentionally-raw sites just live in the baseline; no exemption bookkeeping. Wired into pre-push + farm pr-validation.

Negative-tested both directions (planted raw button + utility line trips both counters; clean tree passes; improvement path demands the baseline tighten).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new dogfood ratchet check to PR validation and pre-push checks for design-system related changes.
  * Introduced a baseline report to track and prevent regressions in raw HTML usage and utility-style usage.

* **Bug Fixes**
  * Ensures changes in key app and shared UI areas are gated before merging or pushing, helping keep design-system debt from increasing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->