### PR TITLE
refactor(design-system): dogfooding quick wins — first ratchet decrease

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-07-07T21:33:00.010Z",
+  "createdAt": "2026-07-09T22:06:32.727Z",
   "directory": "nextjs-app/shared",
   "findings": [
     {
@@ -3225,8 +3225,8 @@
     {
       "column": 13,
       "file": "nextjs-app/shared/components/Modal/Modal.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Modal/Modal.module.css\u001f188\u001f13\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 188,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Modal/Modal.module.css\u001f168\u001f13\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 168,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -3235,8 +3235,8 @@
     {
       "column": 14,
       "file": "nextjs-app/shared/components/Modal/Modal.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Modal/Modal.module.css\u001f194\u001f14\u001f1.5rem\u001fUnexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 194,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Modal/Modal.module.css\u001f174\u001f14\u001f1.5rem\u001fUnexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 174,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -3245,8 +3245,8 @@
     {
       "column": 21,
       "file": "nextjs-app/shared/components/Modal/Modal.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Modal/Modal.module.css\u001f194\u001f21\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 194,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Modal/Modal.module.css\u001f174\u001f21\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 174,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -3255,8 +3255,8 @@
     {
       "column": 26,
       "file": "nextjs-app/shared/components/Modal/Modal.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Modal/Modal.module.css\u001f194\u001f26\u001f0.75rem\u001fUnexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 194,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Modal/Modal.module.css\u001f174\u001f26\u001f0.75rem\u001fUnexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 174,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -3265,8 +3265,8 @@
     {
       "column": 16,
       "file": "nextjs-app/shared/components/Modal/Modal.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Modal/Modal.module.css\u001f198\u001f16\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 198,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Modal/Modal.module.css\u001f178\u001f16\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 178,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -3275,8 +3275,8 @@
     {
       "column": 21,
       "file": "nextjs-app/shared/components/Modal/Modal.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Modal/Modal.module.css\u001f198\u001f21\u001f0.75rem\u001fUnexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 198,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Modal/Modal.module.css\u001f178\u001f21\u001f0.75rem\u001fUnexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 178,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -3285,8 +3285,8 @@
     {
       "column": 14,
       "file": "nextjs-app/shared/components/Modal/Modal.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Modal/Modal.module.css\u001f202\u001f14\u001f0.75rem\u001fUnexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 202,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Modal/Modal.module.css\u001f182\u001f14\u001f0.75rem\u001fUnexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 182,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -3295,8 +3295,8 @@
     {
       "column": 22,
       "file": "nextjs-app/shared/components/Modal/Modal.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Modal/Modal.module.css\u001f202\u001f22\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 202,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Modal/Modal.module.css\u001f182\u001f22\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 182,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -3305,8 +3305,8 @@
     {
       "column": 27,
       "file": "nextjs-app/shared/components/Modal/Modal.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Modal/Modal.module.css\u001f202\u001f27\u001f1.5rem\u001fUnexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 202,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Modal/Modal.module.css\u001f182\u001f27\u001f1.5rem\u001fUnexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 182,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -5603,286 +5603,6 @@
       "value": "1.25rem"
     },
     {
-      "column": 18,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f16\u001f18\u001f1.25rem\u001fUnexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
-      "line": 16,
-      "rule": "rhythmguard/use-scale",
-      "text": "Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
-      "type": "off-scale",
-      "value": "1.25rem"
-    },
-    {
-      "column": 12,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f36\u001f12\u001f1.25rem\u001fUnexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
-      "line": 36,
-      "rule": "rhythmguard/use-scale",
-      "text": "Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
-      "type": "off-scale",
-      "value": "1.25rem"
-    },
-    {
-      "column": 17,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f45\u001f17\u001f1.25rem\u001fUnexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
-      "line": 45,
-      "rule": "rhythmguard/use-scale",
-      "text": "Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
-      "type": "off-scale",
-      "value": "1.25rem"
-    },
-    {
-      "column": 15,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f49\u001f15\u001f2.5rem\u001fUnexpected off-scale value \"2.5rem\". Use scale values (nearest: 32px or 32px). (rhythmguard/use-scale)",
-      "line": 49,
-      "rule": "rhythmguard/use-scale",
-      "text": "Unexpected off-scale value \"2.5rem\". Use scale values (nearest: 32px or 32px). (rhythmguard/use-scale)",
-      "type": "off-scale",
-      "value": "2.5rem"
-    },
-    {
-      "column": 15,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f73\u001f15\u001f2.5rem\u001fUnexpected off-scale value \"2.5rem\". Use scale values (nearest: 32px or 32px). (rhythmguard/use-scale)",
-      "line": 73,
-      "rule": "rhythmguard/use-scale",
-      "text": "Unexpected off-scale value \"2.5rem\". Use scale values (nearest: 32px or 32px). (rhythmguard/use-scale)",
-      "type": "off-scale",
-      "value": "2.5rem"
-    },
-    {
-      "column": 15,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f119\u001f15\u001f2.5rem\u001fUnexpected off-scale value \"2.5rem\". Use scale values (nearest: 32px or 32px). (rhythmguard/use-scale)",
-      "line": 119,
-      "rule": "rhythmguard/use-scale",
-      "text": "Unexpected off-scale value \"2.5rem\". Use scale values (nearest: 32px or 32px). (rhythmguard/use-scale)",
-      "type": "off-scale",
-      "value": "2.5rem"
-    },
-    {
-      "column": 8,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f14\u001f8\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 14,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "0.5rem"
-    },
-    {
-      "column": 18,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f16\u001f18\u001f1.25rem\u001fUnexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 16,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "1.25rem"
-    },
-    {
-      "column": 8,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f26\u001f8\u001f0.75rem\u001fUnexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 26,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "0.75rem"
-    },
-    {
-      "column": 15,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f27\u001f15\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 27,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "1rem"
-    },
-    {
-      "column": 12,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f36\u001f12\u001f1.25rem\u001fUnexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 36,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "1.25rem"
-    },
-    {
-      "column": 15,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f40\u001f15\u001f2rem\u001fUnexpected raw scale value \"2rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 40,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"2rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "2rem"
-    },
-    {
-      "column": 11,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f44\u001f11\u001f0.75rem\u001fUnexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 44,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "0.75rem"
-    },
-    {
-      "column": 17,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f45\u001f17\u001f1.25rem\u001fUnexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 45,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "1.25rem"
-    },
-    {
-      "column": 15,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f49\u001f15\u001f2.5rem\u001fUnexpected raw scale value \"2.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 49,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"2.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "2.5rem"
-    },
-    {
-      "column": 8,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f55\u001f8\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 55,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "1rem"
-    },
-    {
-      "column": 15,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f56\u001f15\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 56,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "1rem"
-    },
-    {
-      "column": 12,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f69\u001f12\u001f1.5rem\u001fUnexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 69,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "1.5rem"
-    },
-    {
-      "column": 15,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f73\u001f15\u001f2.5rem\u001fUnexpected raw scale value \"2.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 73,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"2.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "2.5rem"
-    },
-    {
-      "column": 8,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f79\u001f8\u001f1.5rem\u001fUnexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 79,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "1.5rem"
-    },
-    {
-      "column": 15,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f80\u001f15\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 80,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "1rem"
-    },
-    {
-      "column": 19,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f84\u001f19\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 84,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "1rem"
-    },
-    {
-      "column": 8,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f91\u001f8\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 91,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "1rem"
-    },
-    {
-      "column": 15,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f92\u001f15\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 92,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "1rem"
-    },
-    {
-      "column": 12,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f115\u001f12\u001f1.5rem\u001fUnexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 115,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "1.5rem"
-    },
-    {
-      "column": 15,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f119\u001f15\u001f2.5rem\u001fUnexpected raw scale value \"2.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 119,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"2.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "2.5rem"
-    },
-    {
-      "column": 8,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f125\u001f8\u001f0.75rem\u001fUnexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 125,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "0.75rem"
-    },
-    {
-      "column": 15,
-      "file": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoLeafPage.module.css\u001f126\u001f15\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 126,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "1rem"
-    },
-    {
       "column": 8,
       "file": "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.module.css",
       "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/pages/Pseo/PseoPillarPage.module.css\u001f14\u001f8\u001f0.75rem\u001fUnexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
@@ -5983,16 +5703,6 @@
       "value": "6rem"
     },
     {
-      "column": 18,
-      "file": "nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.module.css\u001f72\u001f18\u001f1px\u001fUnexpected off-scale value \"1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "line": 72,
-      "rule": "rhythmguard/use-scale",
-      "text": "Unexpected off-scale value \"1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "type": "off-scale",
-      "value": "1px"
-    },
-    {
       "column": 22,
       "file": "nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.module.css",
       "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.module.css\u001f9\u001f22\u001f6rem\u001fUnexpected raw scale value \"6rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
@@ -6001,36 +5711,6 @@
       "text": "Unexpected raw scale value \"6rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
       "value": "6rem"
-    },
-    {
-      "column": 24,
-      "file": "nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.module.css\u001f71\u001f24\u001f45%\u001fUnexpected raw scale value \"45%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 71,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"45%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "45%"
-    },
-    {
-      "column": 29,
-      "file": "nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.module.css\u001f71\u001f29\u001f-55%\u001fUnexpected raw scale value \"-55%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 71,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"-55%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "-55%"
-    },
-    {
-      "column": 18,
-      "file": "nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.module.css\u001f72\u001f18\u001f1px\u001fUnexpected raw scale value \"1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 72,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "1px"
     },
     {
       "column": 25,
@@ -6451,36 +6131,6 @@
       "text": "Unexpected raw scale value \"0.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
       "value": "0.25rem"
-    },
-    {
-      "column": 22,
-      "file": "nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.module.css\u001f95\u001f22\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 95,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "1rem"
-    },
-    {
-      "column": 19,
-      "file": "nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.module.css\u001f96\u001f19\u001f0.75rem\u001fUnexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 96,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"0.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "0.75rem"
-    },
-    {
-      "column": 8,
-      "file": "nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.module.css\u001f138\u001f8\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 138,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "0.5rem"
     },
     {
       "column": 12,
@@ -7745,7 +7395,7 @@
   ],
   "formatVersion": 1,
   "summary": {
-    "scaleCleanliness": 91,
-    "totalFindings": 774
+    "scaleCleanliness": 92,
+    "totalFindings": 739
   }
 }

--- a/nextjs-app/shared/components/Modal/Modal.module.css
+++ b/nextjs-app/shared/components/Modal/Modal.module.css
@@ -152,26 +152,6 @@
   text-align: center;
 }
 
-.spinner {
-  width: 24px;
-  height: 24px;
-  flex-shrink: 0;
-  border: 4px solid transparent;
-  border-radius: 50%;
-  background-color: var(--main-body-background-color, var(--color-white));
-  animation: spin 1s linear infinite;
-  border-top-color: var(--color-info);
-}
-
-@keyframes spin {
-  from {
-    transform: rotate(0deg);
-  }
-
-  to {
-    transform: rotate(360deg);
-  }
-}
 
 /* Mobile responsive styles */
 @media (width <= 768px) {

--- a/nextjs-app/shared/components/Modal/Modal.tsx
+++ b/nextjs-app/shared/components/Modal/Modal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import { gsap } from "gsap";
 import styles from "./Modal.module.css";
 import Button from "@dt/Button";
+import Spinner from "@dt/Spinner";
 import Title from "@dt/Title";
 import { getSemanticIcon } from "../../utils/semanticIcons";
 import Icon, { type IconProps } from "@dt/Icon";
@@ -253,9 +254,7 @@ const Modal: React.FC<ModalProps> = ({
           </div>
         )}
         <div className={styles.content}>
-          {isLoading && (
-            <div className={styles.spinner} aria-hidden="true" />
-          )}
+          {isLoading && <Spinner size="lg" />}
           {description && (
             <p id={descriptionId} className={styles.description}>
               {description}

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--loading.dark.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--loading.dark.yaml
@@ -1,4 +1,5 @@
 - button "Open modal"
 - dialog "Saving changes":
   - heading "Saving changes" [level=2]
+  - status "Loading"
   - paragraph: Please wait while we save your edits.

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--loading.forced-colors.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--loading.forced-colors.yaml
@@ -1,4 +1,5 @@
 - button "Open modal"
 - dialog "Saving changes":
   - heading "Saving changes" [level=2]
+  - status "Loading"
   - paragraph: Please wait while we save your edits.

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--loading.light.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--loading.light.yaml
@@ -1,4 +1,5 @@
 - button "Open modal"
 - dialog "Saving changes":
   - heading "Saving changes" [level=2]
+  - status "Loading"
   - paragraph: Please wait while we save your edits.

--- a/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--loading.yaml
+++ b/nextjs-app/shared/components/Modal/__a11y-snapshots__/feedback-modal--loading.yaml
@@ -1,4 +1,5 @@
 - button "Open modal"
 - dialog "Saving changes":
   - heading "Saving changes" [level=2]
+  - status "Loading"
   - paragraph: Please wait while we save your edits.

--- a/nextjs-app/shared/components/Spinner/Spinner.contract.json
+++ b/nextjs-app/shared/components/Spinner/Spinner.contract.json
@@ -53,6 +53,21 @@
     "consumers": [
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/layout.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/EmailSignatureContent.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx",
             "since": "2026-06-04"
         },

--- a/nextjs-app/shared/components/Title/Title.contract.json
+++ b/nextjs-app/shared/components/Title/Title.contract.json
@@ -98,17 +98,17 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AboutPage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/AccessibilityPage/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
             "since": "2026-06-04"
         }
     ],

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-09T20:13:58.357Z",
+  "generatedAt": "2026-07-09T22:05:35.935Z",
   "summary": {
     "componentCount": 161,
     "statusCounts": {
@@ -81,9 +81,9 @@
     "withAnyUsage": 150,
     "withProductionUsage": 46,
     "uniqueImportedComponents": 150,
-    "totalEvidenceRows": 846,
-    "aliasImportFiles": 470,
-    "relativeImportFiles": 384,
+    "totalEvidenceRows": 850,
+    "aliasImportFiles": 471,
+    "relativeImportFiles": 387,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
   },
@@ -26593,10 +26593,10 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Spinner",
-        "importCount": 3,
+        "importCount": 4,
         "productionImportCount": 0,
         "patternImportCount": 0,
-        "componentImportCount": 3,
+        "componentImportCount": 4,
         "evidence": [
           {
             "path": "nextjs-app/shared/components/AppLoading/AppLoading.tsx",
@@ -26608,6 +26608,12 @@
             "path": "nextjs-app/shared/components/index.ts",
             "importKind": "relative",
             "importPath": "./Spinner",
+            "context": "component"
+          },
+          {
+            "path": "nextjs-app/shared/components/Modal/Modal.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Spinner",
             "context": "component"
           },
           {
@@ -26678,11 +26684,11 @@
           "bypass design tokens or skip forced-colors verification at beta."
         ],
         "composesWith": [
-          "Modal",
           "Button",
+          "Icon",
+          "Modal",
           "Text",
-          "TextInput",
-          "Icon"
+          "TextInput"
         ],
         "prefersOver": [],
         "declaredPropCount": 3
@@ -30485,9 +30491,9 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Title",
-        "importCount": 57,
+        "importCount": 60,
         "productionImportCount": 24,
-        "patternImportCount": 9,
+        "patternImportCount": 12,
         "componentImportCount": 15,
         "evidence": [
           {

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-09T16:16:15.779Z",
+  "generatedAt": "2026-07-09T22:05:35.555Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -8231,11 +8231,11 @@
         "bypass design tokens or skip forced-colors verification at beta."
       ],
       "composesWith": [
-        "Modal",
         "Button",
+        "Icon",
+        "Modal",
         "Text",
-        "TextInput",
-        "Icon"
+        "TextInput"
       ],
       "prefersOver": [],
       "declaredPropCount": 3

--- a/nextjs-app/shared/patterns/ContentSection/ContentSection.tsx
+++ b/nextjs-app/shared/patterns/ContentSection/ContentSection.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { cn } from "@/lib/utils";
 import { Container } from "../../components/Container";
 import { Section } from "../../components/Section";
+import Title from "../../components/Title";
 import { FadeIn } from "../../components/animations/FadeIn";
 
 export interface ContentImage {
@@ -88,9 +89,13 @@ export function ContentSection({
 
           {/* Title */}
           <FadeIn direction="up" delay={0.1} distance={20}>
-            <h2 className="font-display font-bold text-2xl tablet:text-3xl desktop:text-4xl text-foreground leading-tight">
+            <Title
+              level={2}
+              unstyled
+              className="font-display font-bold text-2xl tablet:text-3xl desktop:text-4xl text-foreground leading-tight"
+            >
               {title}
-            </h2>
+            </Title>
           </FadeIn>
 
           {/* Content */}

--- a/nextjs-app/shared/patterns/RelatedProjects/RelatedProjects.tsx
+++ b/nextjs-app/shared/patterns/RelatedProjects/RelatedProjects.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import Link from "next/link";
 import { useTranslate } from "../../lib/translation";
 import { cn } from "../../lib/cn";
+import Title from "../../components/Title";
 import { Container } from "../../components/Container";
 import { Section } from "../../components/Section";
 import { FadeIn } from "../../components/animations/FadeIn";
@@ -33,15 +35,19 @@ export function RelatedProjects({
     return (
       <Section spacing="lg" background="default" className={className}>
         <Container size="lg" className="text-center">
-          <h2 className="font-display font-bold text-2xl tablet:text-3xl text-foreground mb-4">
+          <Title
+            level={2}
+            unstyled
+            className="font-display font-bold text-2xl tablet:text-3xl text-foreground mb-4"
+          >
             {t("projectRelatedTitle", "Related Projects")}
-          </h2>
-          <a
+          </Title>
+          <Link
             href="/work"
             className="inline-flex items-center gap-2 text-foreground/70 hover:text-foreground transition-colors font-medium"
           >
             {t("projectBrowseAll", "Browse all projects")} &rarr;
-          </a>
+          </Link>
         </Container>
       </Section>
     );
@@ -57,9 +63,13 @@ export function RelatedProjects({
     >
       <Container size="lg">
         <FadeIn direction="up" delay={0} distance={20}>
-          <h2 className="font-display font-bold text-2xl tablet:text-3xl text-foreground mb-8">
+          <Title
+            level={2}
+            unstyled
+            className="font-display font-bold text-2xl tablet:text-3xl text-foreground mb-8"
+          >
             {displayTitle}
-          </h2>
+          </Title>
         </FadeIn>
 
         <div

--- a/nextjs-app/shared/patterns/StatsSection/StatsSection.tsx
+++ b/nextjs-app/shared/patterns/StatsSection/StatsSection.tsx
@@ -8,6 +8,7 @@ import {
   type AnimatedCounterProps,
 } from "../../components/animations/AnimatedCounter";
 import { FadeIn } from "../../components/animations/FadeIn";
+import Title from "../../components/Title";
 import { cn } from "../../lib/cn";
 
 export interface StatItem extends Omit<AnimatedCounterProps, "className"> {}
@@ -62,9 +63,13 @@ export function StatsSection({
         </noscript>
         {title && (
           <FadeIn direction="up" distance={20}>
-            <h2 className="font-display font-bold text-xl tablet:text-2xl mb-12 text-center">
+            <Title
+              level={2}
+              unstyled
+              className="font-display font-bold text-xl tablet:text-2xl mb-12 text-center"
+            >
               {title}
-            </h2>
+            </Title>
           </FadeIn>
         )}
         <div

--- a/scripts/design-system/dogfood-ratchet.baseline.json
+++ b/scripts/design-system/dogfood-ratchet.baseline.json
@@ -530,7 +530,7 @@
       "utilityLines": 0
     },
     "nextjs-app/shared/patterns/ContentSection/ContentSection.tsx": {
-      "rawElements": 1,
+      "rawElements": 0,
       "utilityLines": 14
     },
     "nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.tsx": {
@@ -586,7 +586,7 @@
       "utilityLines": 5
     },
     "nextjs-app/shared/patterns/RelatedProjects/RelatedProjects.tsx": {
-      "rawElements": 3,
+      "rawElements": 0,
       "utilityLines": 4
     },
     "nextjs-app/shared/patterns/ServicesSection/ServicesSection.tsx": {
@@ -606,7 +606,7 @@
       "utilityLines": 14
     },
     "nextjs-app/shared/patterns/StatsSection/StatsSection.tsx": {
-      "rawElements": 2,
+      "rawElements": 1,
       "utilityLines": 4
     },
     "nextjs-app/shared/patterns/ValuesSection/ValuesSection.tsx": {

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -1416,9 +1416,9 @@
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/components/Modal/Modal.module.css::232::1::rule-empty-line-before::Expected empty line before rule (rule-empty-line-before)",
+      "id": "nextjs-app/shared/components/Modal/Modal.module.css::212::1::rule-empty-line-before::Expected empty line before rule (rule-empty-line-before)",
       "file": "nextjs-app/shared/components/Modal/Modal.module.css",
-      "line": 232,
+      "line": 212,
       "column": 1,
       "rule": "rule-empty-line-before",
       "severity": "warning",


### PR DESCRIPTION
Phase 2 of the [dogfooding plan](https://github.com/PetriLahdelma/digitaltableteur/blob/main/docs/design-system/dogfooding-plan.md) — the first PR to shrink the baseline (**332 → 327 raw elements**), with the ratchet enforcing the lock-in.

## Migrated

- **RelatedProjects**: 2 raw `<h2>` → `Title level={2} unstyled` (exact same classes — verified pixel-identical in the running app on /work/helsinki-design-system) + `<a href="/work">` → `next/link` (gains client-side nav)
- **StatsSection / ContentSection**: raw `<h2>` → `Title unstyled`
- **Modal**: hand-rolled spinner div → DS `Spinner` — the AT delta IS the improvement: the Loading story now announces `status "Loading"` where the old `aria-hidden` div was silent. Dead `.spinner` CSS + keyframes deleted; 4 yamls recaptured, compare green.

## Deliberately kept (reasons)

DesignSprints animated pill (designed interaction, Phase 5), NewsBulletin marquee nav (bespoke chrome, already accessible), Pricing NEW! chip (no matching Badge tone), EnhancedProjectCard tag (audit assumed a Tag component that doesn't exist — Phase 3), CookieConsent h3 (override-class trap), Footer/AskAI (zero consumers → deprecation candidates), global-error (owner decision #4).

## Baselines touched

dogfood ratchet tightened (−5 raw); stylelint baseline updated for the deleted CSS; rhythmguard rebaselined (line-keyed renumbering + prunes long-resolved findings); Spinner/Title consumers[] refreshed (the pre-push gate caught the new edges — working as intended).

## Gate

typecheck ✓ lint ✓ lint:css ✓ vitest 2200/2200 ✓ build ✓ Modal AT compare ✓ + full pre-push DS gate on push ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)