### PR TITLE
fix(i18n): FI hero option 'designjärjestelmiä' → 'design systeemejä'

### DIFF
--- a/nextjs-app/shared/locales/fi/translation.json
+++ b/nextjs-app/shared/locales/fi/translation.json
@@ -306,7 +306,7 @@
     "AI-vetoista designia post template -maailmaan.",
     "Pikseleistä ennustaviin järjestelmiin.",
     "Design, joka oppii, skaalautuu ja voittaa monimutkaisuuden.",
-    "Rakennamme tulevaisuuden kestäviä designjärjestelmiä AI:n avulla.",
+    "Rakennamme tulevaisuuden kestäviä design systeemejä AI:n avulla.",
     "Älykästä designia vakaviin tuotteisiin.",
     "Vähemmän hälinää. Enemmän älykkyyttä.",
     "Strategista designia, vahvistettuna AI:lla.",


### PR DESCRIPTION
Aligns the remaining FI randomized hero option with the Design Systemit terminology (#1034/#1038). validate:translations ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)