### PR TITLE
feat(design-system): SocialIconLink atom (alpha) — dogfooding Phase 3a

### DIFF
--- a/nextjs-app/shared/components/SocialIconLink/SocialIconLink.contract.json
+++ b/nextjs-app/shared/components/SocialIconLink/SocialIconLink.contract.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "name": "SocialIconLink",
+    "tier": "atom",
+    "group": "navigation",
+    "status": "alpha",
+    "description": "Icon-only social or profile link with enforced accessible name and external-safety (target=_blank + rel) by default.",
+    "dense": "Icon-only anchor: required label, external-safe, token hover/focus, sm/md/lg hit targets.",
+    "keywords": [
+        "social",
+        "icon",
+        "link",
+        "external",
+        "profile",
+        "share"
+    ],
+    "figma": null,
+    "radixPrimitive": null,
+    "element": "a",
+    "variants": {
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "default": "md"
+        }
+    },
+    "slots": [
+        "children"
+    ],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [
+            "Tab",
+            "Enter"
+        ],
+        "ariaRequirements": [
+            "label prop is the accessible name (aria-label); the icon child is aria-hidden",
+            "external links carry rel=noopener noreferrer"
+        ],
+        "reducedMotion": true,
+        "reviewed": false,
+        "forcedColorsVerified": false
+    },
+    "tokens": {
+        "colors": [
+            "--color-muted",
+            "--color-text",
+            "--focus-ring-color"
+        ],
+        "spacing": [
+            "--space-internal-4",
+            "--space-internal-8",
+            "--space-internal-12"
+        ]
+    },
+    "lightDarkVerified": false,
+    "schemaVersion": 2,
+    "displayName": "SocialIconLink",
+    "consumers": []
+}

--- a/nextjs-app/shared/components/SocialIconLink/SocialIconLink.mdx
+++ b/nextjs-app/shared/components/SocialIconLink/SocialIconLink.mdx
@@ -1,0 +1,41 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './SocialIconLink.stories.tsx';
+
+<Meta of={Stories} />
+
+# SocialIconLink
+
+**Status:** alpha · **Tier:** atom · **Group:** navigation
+
+## In use
+See the **Example (footer social row)** story for the canonical production composition.
+
+## How to use
+
+```tsx
+import { SocialIconLink } from '@dt/SocialIconLink';
+import { LinkedinLogo } from '@phosphor-icons/react';
+
+<SocialIconLink
+  href="https://www.linkedin.com/company/digitaltableteur/"
+  label="Digitaltableteur on LinkedIn"
+>
+  <LinkedinLogo aria-hidden="true" />
+</SocialIconLink>
+```
+
+## When to use
+- Icon-only links to social profiles or share targets (footers, article share rows).
+- Any icon-only anchor that must be external-safe and named for assistive tech.
+
+## When not to use
+- Labeled text links: use `Link`.
+- Icon-only *actions* (no navigation): use `IconButton`.
+
+## Accessibility
+- `label` is required and becomes the accessible name; the icon child is wrapped `aria-hidden`.
+- External by default: `target="_blank"` always pairs with `rel="noopener noreferrer"`.
+- Token focus ring on `:focus-visible`; `LinkText`/`Highlight` in forced colors; hover transition disabled under reduced motion.
+
+## Promotion notes
+- Promote to beta after the Figma atom exists (DT-Site-stuff Atoms); consumers land with the swap PR.

--- a/nextjs-app/shared/components/SocialIconLink/SocialIconLink.module.css
+++ b/nextjs-app/shared/components/SocialIconLink/SocialIconLink.module.css
@@ -1,0 +1,70 @@
+.root {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: var(--radius-sm, 4px);
+  text-decoration: none;
+  color: var(--color-muted);
+  transition: color 0.2s ease;
+}
+
+.root:hover {
+  color: var(--color-text);
+}
+
+.root:focus-visible {
+  outline: var(--focus-ring-width, 2px) solid
+    var(--focus-ring-color, var(--color-primary));
+  outline-offset: 2px;
+}
+
+.icon {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* Hit targets: padding grows the interactive area beyond the glyph. */
+
+.sm {
+  padding: var(--space-internal-4);
+}
+
+.sm .icon > * {
+  block-size: 1rem;
+  inline-size: 1rem;
+}
+
+.md {
+  padding: var(--space-internal-8);
+}
+
+.md .icon > * {
+  block-size: 1.25rem;
+  inline-size: 1.25rem;
+}
+
+.lg {
+  padding: var(--space-internal-12);
+}
+
+.lg .icon > * {
+  block-size: 1.5rem;
+  inline-size: 1.5rem;
+}
+
+@media (forced-colors: active) {
+  .root {
+    color: LinkText;
+  }
+
+  .root:focus-visible {
+    outline-color: Highlight;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .root {
+    transition: none;
+  }
+}

--- a/nextjs-app/shared/components/SocialIconLink/SocialIconLink.spec.md
+++ b/nextjs-app/shared/components/SocialIconLink/SocialIconLink.spec.md
@@ -1,0 +1,20 @@
+# SocialIconLink
+
+## Intent
+Give icon-only social/profile links one accessible, external-safe implementation. Every hand-rolled `<a aria-label><Icon/></a>` in SiteFooter, ArticleShareSection, and SocialShare repeats the same four obligations (accessible name, aria-hidden icon, target=_blank, rel=noopener); this atom makes them impossible to forget.
+
+## Interaction contract
+- Keyboard: Tab focuses the link (token focus ring), Enter activates it.
+- Pointer: whole padded hit target is clickable; hover shifts color muted → text.
+- Screen readers: announced as a link named by `label`; the icon child is aria-hidden so the glyph never leaks into the name.
+
+## Do / don't
+- Do: pass a human label ("Digitaltableteur on LinkedIn"), not the platform name alone when context needs it.
+- Do: size the hit target with `size` (sm/md/lg paddings), not custom CSS.
+- Don't: put text children inside — this is icon-only; use Link for labeled links.
+- Don't: disable `external` for social profiles; same-tab is for internal routes only.
+
+## Design notes
+- Tokens: --color-muted (rest), --color-text (hover), --focus-ring-color, --space-internal-{4,8,12} hit paddings.
+- Forced colors: LinkText color, Highlight focus outline.
+- Figma: pending (alpha); create in DT-Site-stuff Atoms before beta.

--- a/nextjs-app/shared/components/SocialIconLink/SocialIconLink.stories.tsx
+++ b/nextjs-app/shared/components/SocialIconLink/SocialIconLink.stories.tsx
@@ -1,0 +1,118 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  InstagramLogo,
+  FacebookLogo,
+  LinkedinLogo,
+  GithubLogo,
+} from "@phosphor-icons/react";
+import { SocialIconLink } from "./SocialIconLink";
+import contract from "./SocialIconLink.contract.json";
+
+const meta = {
+  title: "Atoms/SocialIconLink",
+  component: SocialIconLink,
+  parameters: {
+    layout: "centered",
+    a11y: { test: "error" },
+    contractStatus: contract.status,
+    docs: {
+      description: {
+        component: contract.description,
+      },
+    },
+  },
+  // Custom MDX docs pages exist for all catalog entries; do not also enable autodocs
+  // or Storybook will treat it as conflicting sources of truth for the docs page.
+  tags: ["!autodocs"],
+  argTypes: {
+    size: {
+      control: "radio",
+      options: ["sm", "md", "lg"],
+      description: "Hit-target size token.",
+      table: { defaultValue: { summary: "md" }, category: "Appearance" },
+    },
+    external: {
+      control: "boolean",
+      description: "Open in a new tab with rel=noopener noreferrer.",
+      table: { defaultValue: { summary: "true" }, category: "Behavior" },
+    },
+    href: {
+      control: "text",
+      description: "Destination URL.",
+      table: { category: "Content" },
+    },
+    label: {
+      control: "text",
+      description: "Accessible name (the control is icon-only).",
+      table: { category: "Accessibility" },
+    },
+    children: { table: { disable: true } },
+  },
+  args: {
+    href: "https://www.linkedin.com/company/digitaltableteur/",
+    label: "Digitaltableteur on LinkedIn",
+    size: "md" as const,
+    external: true,
+    children: <LinkedinLogo aria-hidden="true" />,
+  },
+} satisfies Meta<typeof SocialIconLink>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "none" },
+};
+
+export const Playground: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "none" },
+};
+
+export const Example: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "none" },
+  name: "Example (footer social row)",
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div style={{ display: "flex", gap: "var(--space-internal-8)" }}>
+      <SocialIconLink
+        href="https://www.instagram.com/digitaltableteur/"
+        label="Digitaltableteur on Instagram"
+      >
+        <InstagramLogo aria-hidden="true" />
+      </SocialIconLink>
+      <SocialIconLink
+        href="https://www.facebook.com/digitaltableteur"
+        label="Digitaltableteur on Facebook"
+      >
+        <FacebookLogo aria-hidden="true" />
+      </SocialIconLink>
+      <SocialIconLink
+        href="https://www.linkedin.com/company/digitaltableteur/"
+        label="Digitaltableteur on LinkedIn"
+      >
+        <LinkedinLogo aria-hidden="true" />
+      </SocialIconLink>
+      <SocialIconLink
+        href="https://github.com/PetriLahdelma"
+        label="Petri Lahdelma on GitHub"
+      >
+        <GithubLogo aria-hidden="true" />
+      </SocialIconLink>
+    </div>
+  ),
+};
+
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "active" },
+  parameters: {
+    docs: {
+      description: {
+        story: "Forced-colors verification story.",
+      },
+    },
+  },
+};

--- a/nextjs-app/shared/components/SocialIconLink/SocialIconLink.test.tsx
+++ b/nextjs-app/shared/components/SocialIconLink/SocialIconLink.test.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { describe, it, expect } from "vitest";
+import { SocialIconLink } from "./SocialIconLink";
+
+expect.extend(toHaveNoViolations);
+
+function Glyph() {
+  return <svg viewBox="0 0 16 16" />;
+}
+
+describe("SocialIconLink", () => {
+  it("renders a link named by label with an aria-hidden icon", () => {
+    render(
+      <SocialIconLink href="https://example.com/x" label="Us on X">
+        <Glyph />
+      </SocialIconLink>,
+    );
+    const link = screen.getByRole("link", { name: "Us on X" });
+    expect(link).toHaveAttribute("href", "https://example.com/x");
+    expect(link.querySelector("[aria-hidden='true'] svg")).toBeInTheDocument();
+  });
+
+  it("is external-safe by default", () => {
+    render(
+      <SocialIconLink href="https://example.com" label="Profile">
+        <Glyph />
+      </SocialIconLink>,
+    );
+    const link = screen.getByRole("link", { name: "Profile" });
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("drops target/rel for internal links (external=false)", () => {
+    render(
+      <SocialIconLink href="/contact" label="Contact" external={false}>
+        <Glyph />
+      </SocialIconLink>,
+    );
+    const link = screen.getByRole("link", { name: "Contact" });
+    expect(link).not.toHaveAttribute("target");
+    expect(link).not.toHaveAttribute("rel");
+  });
+
+  it("applies the size class", () => {
+    const { container } = render(
+      <SocialIconLink href="https://example.com" label="P" size="lg">
+        <Glyph />
+      </SocialIconLink>,
+    );
+    expect((container.firstElementChild as HTMLElement).className).toMatch(/lg/);
+  });
+
+  it("appends custom className and forwards anchor attributes", () => {
+    render(
+      <SocialIconLink
+        href="https://example.com"
+        label="P"
+        className="custom-class"
+        data-testid="social"
+      >
+        <Glyph />
+      </SocialIconLink>,
+    );
+    const link = screen.getByTestId("social");
+    expect(link.className).toContain("custom-class");
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(
+      <>
+        <SocialIconLink href="https://example.com/a" label="Instagram profile">
+          <Glyph />
+        </SocialIconLink>
+        <SocialIconLink href="/inner" label="Internal" external={false}>
+          <Glyph />
+        </SocialIconLink>
+      </>,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/SocialIconLink/SocialIconLink.tsx
+++ b/nextjs-app/shared/components/SocialIconLink/SocialIconLink.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import styles from "./SocialIconLink.module.css";
+import { cn } from "../../lib/cn";
+
+type SocialIconLinkSize = "sm" | "md" | "lg";
+
+export interface SocialIconLinkProps
+  extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "children"> {
+  /** Destination URL. */
+  href: string;
+  /** Accessible name — required, the control is icon-only. */
+  label: string;
+  /** The icon. Rendered inside an aria-hidden wrapper so only `label` names the link. */
+  children: React.ReactNode;
+  /** Hit-target size token. @default "md" */
+  size?: SocialIconLinkSize;
+  /** Open in a new tab with rel="noopener noreferrer". @default true */
+  external?: boolean;
+  /** Additional CSS class names. */
+  className?: string;
+}
+
+const sizeClassMap: Record<SocialIconLinkSize, string> = {
+  sm: styles.sm,
+  md: styles.md,
+  lg: styles.lg,
+};
+
+/**
+ * Icon-only social/profile link: anchor semantics, enforced accessible name,
+ * external-safety (target + rel) by default, and token-driven hover/focus
+ * treatment. Replaces the hand-rolled `<a aria-label><Icon/></a>` pattern
+ * repeated across SiteFooter, ArticleShareSection, and SocialShare.
+ */
+export const SocialIconLink = React.forwardRef<
+  HTMLAnchorElement,
+  SocialIconLinkProps
+>(function SocialIconLink(
+  { href, label, children, size = "md", external = true, className, ...rest },
+  ref,
+) {
+  return (
+    <a
+      ref={ref}
+      href={href}
+      aria-label={label}
+      title={label}
+      target={external ? "_blank" : undefined}
+      rel={external ? "noopener noreferrer" : undefined}
+      className={cn(styles.root, sizeClassMap[size], className)}
+      {...rest}
+    >
+      <span className={styles.icon} aria-hidden="true">
+        {children}
+      </span>
+    </a>
+  );
+});
+
+export default SocialIconLink;

--- a/nextjs-app/shared/components/SocialIconLink/index.ts
+++ b/nextjs-app/shared/components/SocialIconLink/index.ts
@@ -1,0 +1,2 @@
+export { SocialIconLink, default } from "./SocialIconLink";
+export type { SocialIconLinkProps } from "./SocialIconLink";

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,18 +1,18 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-09T22:05:35.935Z",
+  "generatedAt": "2026-07-09T22:38:46.231Z",
   "summary": {
-    "componentCount": 161,
+    "componentCount": 162,
     "statusCounts": {
       "beta": 49,
       "stable": 88,
-      "alpha": 23,
+      "alpha": 24,
       "deprecated": 1
     },
     "honestBetaDocDebt": 0,
-    "catalogCompletenessPercent": 87.5,
-    "codebaseComponentCount": 184,
-    "usageCoveragePercent": 93.2,
+    "catalogCompletenessPercent": 87.6,
+    "codebaseComponentCount": 185,
+    "usageCoveragePercent": 92.6,
     "componentsWithProductionUsage": 46,
     "notReadyForStablePromotion": false
   },
@@ -57,15 +57,15 @@
   },
   "catalogCoverage": {
     "description": "Catalog completeness across the codebase. componentCount above is the catalog count; this block reveals how much of the codebase that catalog actually represents.",
-    "totalComponentsInCodebase": 184,
-    "inCatalog": 161,
+    "totalComponentsInCodebase": 185,
+    "inCatalog": 162,
     "outOfCatalog": 23,
-    "catalogCompletenessPercent": 87.5,
+    "catalogCompletenessPercent": 87.6,
     "artifactCoverage": {
-      "stories": 145,
-      "tests": 144,
-      "mdx": 3,
-      "spec": 161
+      "stories": 146,
+      "tests": 145,
+      "mdx": 4,
+      "spec": 162
     },
     "outOfCatalogByBucket": {
       "catalog-gap": 0,
@@ -77,7 +77,7 @@
   },
   "usageCoverage": {
     "description": "Auto-detected import evidence from app/** and nextjs-app/**. Separate from contract.consumers[], which remains the stable-promotion gate for shipping-product proof.",
-    "catalogedComponents": 161,
+    "catalogedComponents": 162,
     "withAnyUsage": 150,
     "withProductionUsage": 46,
     "uniqueImportedComponents": 150,
@@ -102,14 +102,14 @@
   "dsharpParity": {
     "description": "Comparison against DSharp as of 2026-05-26. Breadth is close, maturity is not. This block walks back the earlier parity overclaim.",
     "contractCount": {
-      "digitaltableteur": 161,
+      "digitaltableteur": 162,
       "dsharp": 112
     },
     "statusMix": {
       "digitaltableteur": {
         "beta": 49,
         "stable": 88,
-        "alpha": 23,
+        "alpha": 24,
         "deprecated": 1
       },
       "dsharp": {
@@ -25997,6 +25997,169 @@
       }
     },
     {
+      "name": "SocialIconLink",
+      "contract": {
+        "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+        "name": "SocialIconLink",
+        "tier": "atom",
+        "group": "navigation",
+        "status": "alpha",
+        "description": "Icon-only social or profile link with enforced accessible name and external-safety (target=_blank + rel) by default.",
+        "dense": "Icon-only anchor: required label, external-safe, token hover/focus, sm/md/lg hit targets.",
+        "keywords": [
+          "social",
+          "icon",
+          "link",
+          "external",
+          "profile",
+          "share"
+        ],
+        "figma": null,
+        "radixPrimitive": null,
+        "element": "a",
+        "variants": {
+          "size": {
+            "values": [
+              "sm",
+              "md",
+              "lg"
+            ],
+            "default": "md"
+          }
+        },
+        "slots": [
+          "children"
+        ],
+        "asChild": false,
+        "subParts": [],
+        "requiredStories": [
+          "Default",
+          "Playground",
+          "Example",
+          "ForcedColors"
+        ],
+        "a11y": {
+          "keyboard": [
+            "Tab",
+            "Enter"
+          ],
+          "ariaRequirements": [
+            "label prop is the accessible name (aria-label); the icon child is aria-hidden",
+            "external links carry rel=noopener noreferrer"
+          ],
+          "reducedMotion": true,
+          "reviewed": false,
+          "forcedColorsVerified": false
+        },
+        "tokens": {
+          "colors": [
+            "--color-muted",
+            "--color-text",
+            "--focus-ring-color"
+          ],
+          "spacing": [
+            "--space-internal-4",
+            "--space-internal-8",
+            "--space-internal-12"
+          ]
+        },
+        "lightDarkVerified": false,
+        "schemaVersion": 2,
+        "displayName": "SocialIconLink",
+        "consumers": []
+      },
+      "spec": "# SocialIconLink\n\n## Intent\nGive icon-only social/profile links one accessible, external-safe implementation. Every hand-rolled `<a aria-label><Icon/></a>` in SiteFooter, ArticleShareSection, and SocialShare repeats the same four obligations (accessible name, aria-hidden icon, target=_blank, rel=noopener); this atom makes them impossible to forget.\n\n## Interaction contract\n- Keyboard: Tab focuses the link (token focus ring), Enter activates it.\n- Pointer: whole padded hit target is clickable; hover shifts color muted → text.\n- Screen readers: announced as a link named by `label`; the icon child is aria-hidden so the glyph never leaks into the name.\n\n## Do / don't\n- Do: pass a human label (\"Digitaltableteur on LinkedIn\"), not the platform name alone when context needs it.\n- Do: size the hit target with `size` (sm/md/lg paddings), not custom CSS.\n- Don't: put text children inside — this is icon-only; use Link for labeled links.\n- Don't: disable `external` for social profiles; same-tab is for internal routes only.\n\n## Design notes\n- Tokens: --color-muted (rest), --color-text (hover), --focus-ring-color, --space-internal-{4,8,12} hit paddings.\n- Forced colors: LinkText color, Highlight focus outline.\n- Figma: pending (alpha); create in DT-Site-stuff Atoms before beta.\n",
+      "documentationDebt": false,
+      "usage": {
+        "publicImport": "@dt/SocialIconLink",
+        "importCount": 0,
+        "productionImportCount": 0,
+        "patternImportCount": 0,
+        "componentImportCount": 0,
+        "evidence": []
+      },
+      "agent": {
+        "preferredImport": "@dt/SocialIconLink",
+        "intent": "Give icon-only social/profile links one accessible, external-safe implementation. Every hand-rolled `<a aria-label><Icon/></a>` in SiteFooter, ArticleShareSection, and SocialShare repeats the same four obligations (acce…",
+        "props": {
+          "href": {
+            "optional": false,
+            "type": "string"
+          },
+          "label": {
+            "optional": false,
+            "type": "string"
+          },
+          "children": {
+            "optional": false,
+            "type": "React.ReactNode"
+          },
+          "size": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "sm",
+              "md",
+              "lg"
+            ]
+          },
+          "external": {
+            "optional": true,
+            "type": "boolean"
+          },
+          "className": {
+            "optional": true,
+            "type": "string"
+          }
+        },
+        "variants": {
+          "size": {
+            "values": [
+              "sm",
+              "md",
+              "lg"
+            ],
+            "default": "sm"
+          }
+        },
+        "cvaVariants": {},
+        "variantsFnName": null,
+        "useWhen": [
+          "pass a human label (\"Digitaltableteur on LinkedIn\"), not the platform name alone when context needs it.",
+          "size the hit target with `size` (sm/md/lg paddings), not custom CSS."
+        ],
+        "avoidWhen": [
+          "put text children inside — this is icon-only; use Link for labeled links.",
+          "disable `external` for social profiles; same-tab is for internal routes only."
+        ],
+        "requiredA11y": [
+          "label prop is the accessible name (aria-label); the icon child is aria-hidden",
+          "external links carry rel=noopener noreferrer"
+        ],
+        "keyboard": [
+          "Tab",
+          "Enter"
+        ],
+        "compositionRules": [
+          "put text children inside — this is icon-only; use Link for labeled links."
+        ],
+        "canonicalExamples": [
+          "Default",
+          "Playground",
+          "Example",
+          "ForcedColors"
+        ],
+        "replacementFor": [],
+        "forbiddenUse": [
+          "put text children inside — this is icon-only; use Link for labeled links.",
+          "disable `external` for social profiles; same-tab is for internal routes only."
+        ],
+        "composesWith": [],
+        "prefersOver": [],
+        "declaredPropCount": 6
+      }
+    },
+    {
       "name": "SocialShare",
       "contract": {
         "$schema": "../../../scripts/design-system/contract.schema.v2.json",
@@ -26492,6 +26655,21 @@
         },
         "lightDarkVerified": true,
         "consumers": [
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/layout.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/EmailSignatureContent.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/page.tsx",
+            "since": "2026-06-04"
+          },
           {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx",
@@ -30354,17 +30532,17 @@
           },
           {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AboutPage/index.ts",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
-            "since": "2026-06-04"
-          },
-          {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/AccessibilityPage/index.ts",
-            "since": "2026-06-04"
-          },
-          {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
             "since": "2026-06-04"
           }
         ],

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-09T22:05:35.555Z",
+  "generatedAt": "2026-07-09T22:38:45.950Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -8024,6 +8024,86 @@
       ],
       "prefersOver": [],
       "declaredPropCount": 3
+    },
+    "SocialIconLink": {
+      "preferredImport": "@dt/SocialIconLink",
+      "intent": "Give icon-only social/profile links one accessible, external-safe implementation. Every hand-rolled `<a aria-label><Icon/></a>` in SiteFooter, ArticleShareSection, and SocialShare repeats the same four obligations (acce…",
+      "props": {
+        "href": {
+          "optional": false,
+          "type": "string"
+        },
+        "label": {
+          "optional": false,
+          "type": "string"
+        },
+        "children": {
+          "optional": false,
+          "type": "React.ReactNode"
+        },
+        "size": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "sm",
+            "md",
+            "lg"
+          ]
+        },
+        "external": {
+          "optional": true,
+          "type": "boolean"
+        },
+        "className": {
+          "optional": true,
+          "type": "string"
+        }
+      },
+      "variants": {
+        "size": {
+          "values": [
+            "sm",
+            "md",
+            "lg"
+          ],
+          "default": "sm"
+        }
+      },
+      "cvaVariants": {},
+      "variantsFnName": null,
+      "useWhen": [
+        "pass a human label (\"Digitaltableteur on LinkedIn\"), not the platform name alone when context needs it.",
+        "size the hit target with `size` (sm/md/lg paddings), not custom CSS."
+      ],
+      "avoidWhen": [
+        "put text children inside — this is icon-only; use Link for labeled links.",
+        "disable `external` for social profiles; same-tab is for internal routes only."
+      ],
+      "requiredA11y": [
+        "label prop is the accessible name (aria-label); the icon child is aria-hidden",
+        "external links carry rel=noopener noreferrer"
+      ],
+      "keyboard": [
+        "Tab",
+        "Enter"
+      ],
+      "compositionRules": [
+        "put text children inside — this is icon-only; use Link for labeled links."
+      ],
+      "canonicalExamples": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+      ],
+      "replacementFor": [],
+      "forbiddenUse": [
+        "put text children inside — this is icon-only; use Link for labeled links.",
+        "disable `external` for social profiles; same-tab is for internal routes only."
+      ],
+      "composesWith": [],
+      "prefersOver": [],
+      "declaredPropCount": 6
     },
     "SocialShare": {
       "preferredImport": "@dt/SocialShare",

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -12415,6 +12415,42 @@
         }
       ]
     },
+    "SocialIconLink": {
+      "name": "SocialIconLink",
+      "group": "navigation",
+      "tier": 2,
+      "status": "alpha",
+      "description": "Icon-only social or profile link with enforced accessible name and external-safety (target=_blank + rel) by default.",
+      "dense": "Icon-only anchor: required label, external-safe, token hover/focus, sm/md/lg hit targets.",
+      "keywords": [
+        "social",
+        "icon",
+        "link",
+        "external",
+        "profile",
+        "share"
+      ],
+      "importLine": "import { SocialIconLink } from \"@dt/SocialIconLink\";",
+      "keyProps": [],
+      "props": {},
+      "composesWith": [],
+      "prefersOver": [],
+      "forbiddenUse": [],
+      "usage": null,
+      "tokens": {
+        "colors": [
+          "--color-muted",
+          "--color-text",
+          "--focus-ring-color"
+        ],
+        "spacing": [
+          "--space-internal-4",
+          "--space-internal-8",
+          "--space-internal-12"
+        ]
+      },
+      "examples": []
+    },
     "SocialShare": {
       "name": "SocialShare",
       "group": "structure",

--- a/scripts/design-system/dogfood-ratchet.baseline.json
+++ b/scripts/design-system/dogfood-ratchet.baseline.json
@@ -349,6 +349,10 @@
       "rawElements": 1,
       "utilityLines": 2
     },
+    "nextjs-app/shared/components/SocialIconLink/SocialIconLink.tsx": {
+      "rawElements": 2,
+      "utilityLines": 0
+    },
     "nextjs-app/shared/components/SocialShare/SocialShare.tsx": {
       "rawElements": 1,
       "utilityLines": 0


### PR DESCRIPTION
First of the three blessed Phase-3 primitives.

**API**: `href` + required `label` (accessible name; icon child is aria-hidden) + `size` sm/md/lg hit targets + `external` (default true → `target=_blank` always paired with `rel=noopener noreferrer`). CSS Modules on tokens; forced-colors LinkText/Highlight; reduced-motion safe.

**Why**: the hand-rolled `<a aria-label><Icon/></a>` pattern repeats ~13× (SiteFooter, ArticleShareSection, SocialShare) — the most repeated raw pattern in the audit. Each repeat re-implements four obligations by hand; this atom makes them unforgettable.

**Evidence**: 6 unit tests incl. jest-axe; Storybook suite 4/4 with axe error gate; `audit:controls --effects` 0 inert; validate:components ✓; full gate (typecheck, lint, lint:css, vitest 2206/2206).

Consumer swaps follow in the next PR (plan sequencing: swaps consume a reviewed API). Figma atom + beta promotion queued after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)