### PR TITLE
feat(design-system): FilterChip atom + filter components consume it (Phase 3b)

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-07-09T22:06:32.727Z",
+  "createdAt": "2026-07-09T23:09:42.284Z",
   "directory": "nextjs-app/shared",
   "findings": [
     {
@@ -2571,6 +2571,26 @@
       "text": "Unexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
       "value": "0.5rem"
+    },
+    {
+      "column": 21,
+      "file": "nextjs-app/shared/components/FilterChip/FilterChip.module.css",
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/FilterChip/FilterChip.module.css\u001f66\u001f21\u001f-1px\u001fUnexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 66,
+      "rule": "rhythmguard/use-scale",
+      "text": "Unexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "type": "off-scale",
+      "value": "-1px"
+    },
+    {
+      "column": 21,
+      "file": "nextjs-app/shared/components/FilterChip/FilterChip.module.css",
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/FilterChip/FilterChip.module.css\u001f66\u001f21\u001f-1px\u001fUnexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 66,
+      "rule": "rhythmguard/prefer-token",
+      "text": "Unexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "type": "token-opportunity",
+      "value": "-1px"
     },
     {
       "column": 8,
@@ -7396,6 +7416,6 @@
   "formatVersion": 1,
   "summary": {
     "scaleCleanliness": 92,
-    "totalFindings": 739
+    "totalFindings": 741
   }
 }

--- a/nextjs-app/shared/components/BlogCategoryFilter/BlogCategoryFilter.tsx
+++ b/nextjs-app/shared/components/BlogCategoryFilter/BlogCategoryFilter.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslate } from "../../lib/translation";
 import { cn } from "../../lib/cn";
+import { FilterChip } from "../FilterChip";
 
 export interface BlogCategoryFilterProps {
   /** Array of unique tags */
@@ -22,15 +23,34 @@ export interface BlogCategoryFilterProps {
   className?: string;
 }
 
-const sizeClasses = {
-  sm: "text-xs px-3 py-1.5",
-  md: "text-sm px-4 py-2",
-  lg: "text-base px-5 py-2.5",
+/** BlogCategoryFilter variant names predate FilterChip's; map plural → singular. */
+const chipVariantMap = {
+  pills: "pill",
+  underline: "underline",
+  minimal: "minimal",
+} as const;
+
+const groupClassMap = {
+  pills: cn(
+    "flex flex-wrap gap-2",
+    "overflow-x-auto scrollbar-hide",
+    "-mx-4 px-4 tablet:mx-0 tablet:px-0",
+  ),
+  underline: cn(
+    "flex gap-6 border-b border-border",
+    "overflow-x-auto scrollbar-hide",
+    "-mx-4 px-4 tablet:mx-0 tablet:px-0",
+  ),
+  minimal: cn(
+    "flex flex-wrap gap-4",
+    "overflow-x-auto scrollbar-hide",
+    "-mx-4 px-4 tablet:mx-0 tablet:px-0",
+  ),
 } as const;
 
 /**
  * Single-select tag filter for the blog archive, rendered as a labelled
- * `role="group"` of `aria-pressed` toggle buttons (with an implicit "All").
+ * `role="group"` of FilterChip toggle buttons (with an implicit "All").
  * A filter is a UI control, not a set of tab panels, so it is a group of
  * toggle buttons rather than a tablist. Controlled via `selectedTag` /
  * `onTagChange`; ships pills, underline and minimal treatments and optional
@@ -65,147 +85,29 @@ export function BlogCategoryFilter({
 
   const options = [allOption, ...tagOptions];
 
-  const renderPills = () => (
+  return (
     <div
       role="group"
       aria-label={t("blogFilterByTag", "Filter by topic")}
-      className={cn(
-        "flex flex-wrap gap-2",
-        "overflow-x-auto scrollbar-hide",
-        "-mx-4 px-4 tablet:mx-0 tablet:px-0",
-        className
-      )}
+      className={cn(groupClassMap[variant], className)}
     >
-      {options.map((option) => {
-        const isActive =
-          option.value === selectedTag ||
-          (option.value === null && selectedTag === null);
-
-        return (
-          <button
-            key={option.value ?? "all"}
-            aria-pressed={isActive}
-            onClick={() => onTagChange(option.value)}
-            className={cn(
-              "font-body whitespace-nowrap rounded-full",
-              "border transition-all duration-200",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-              sizeClasses[size],
-              isActive
-                ? "bg-foreground text-background border-foreground"
-                : "bg-transparent text-muted-foreground border-border hover:border-foreground hover:text-foreground"
-            )}
-          >
-            {option.label}
-            {option.count !== undefined && (
-              <span
-                className={cn(
-                  "ml-1.5",
-                  isActive ? "text-background" : "text-muted-foreground"
-                )}
-              >
-                ({option.count})
-              </span>
-            )}
-          </button>
-        );
-      })}
+      {options.map((option) => (
+        <FilterChip
+          key={option.value ?? "all"}
+          pressed={
+            option.value === selectedTag ||
+            (option.value === null && selectedTag === null)
+          }
+          onClick={() => onTagChange(option.value)}
+          variant={chipVariantMap[variant]}
+          size={size}
+          count={option.count}
+        >
+          {option.label}
+        </FilterChip>
+      ))}
     </div>
   );
-
-  const renderUnderline = () => (
-    <div
-      role="group"
-      aria-label={t("blogFilterByTag", "Filter by topic")}
-      className={cn(
-        "flex gap-6 border-b border-border",
-        "overflow-x-auto scrollbar-hide",
-        "-mx-4 px-4 tablet:mx-0 tablet:px-0",
-        className
-      )}
-    >
-      {options.map((option) => {
-        const isActive =
-          option.value === selectedTag ||
-          (option.value === null && selectedTag === null);
-
-        return (
-          <button
-            key={option.value ?? "all"}
-            aria-pressed={isActive}
-            onClick={() => onTagChange(option.value)}
-            className={cn(
-              "font-body whitespace-nowrap pb-3",
-              "border-b-2 -mb-px transition-colors duration-200",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-              sizeClasses[size],
-              isActive
-                ? "border-foreground text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground"
-            )}
-          >
-            {option.label}
-            {option.count !== undefined && (
-              <span className="ml-1.5 text-muted-foreground">
-                ({option.count})
-              </span>
-            )}
-          </button>
-        );
-      })}
-    </div>
-  );
-
-  const renderMinimal = () => (
-    <div
-      role="group"
-      aria-label={t("blogFilterByTag", "Filter by topic")}
-      className={cn(
-        "flex flex-wrap gap-4",
-        "overflow-x-auto scrollbar-hide",
-        "-mx-4 px-4 tablet:mx-0 tablet:px-0",
-        className
-      )}
-    >
-      {options.map((option) => {
-        const isActive =
-          option.value === selectedTag ||
-          (option.value === null && selectedTag === null);
-
-        return (
-          <button
-            key={option.value ?? "all"}
-            aria-pressed={isActive}
-            onClick={() => onTagChange(option.value)}
-            className={cn(
-              "font-body whitespace-nowrap transition-colors duration-200",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded",
-              sizeClasses[size],
-              isActive
-                ? "text-foreground font-medium"
-                : "text-muted-foreground hover:text-foreground"
-            )}
-          >
-            {option.label}
-            {option.count !== undefined && (
-              <span className="ml-1.5 text-muted-foreground">
-                ({option.count})
-              </span>
-            )}
-          </button>
-        );
-      })}
-    </div>
-  );
-
-  switch (variant) {
-    case "underline":
-      return renderUnderline();
-    case "minimal":
-      return renderMinimal();
-    default:
-      return renderPills();
-  }
 }
 
 BlogCategoryFilter.displayName = "BlogCategoryFilter";

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--default.dark.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--default.dark.yaml
@@ -1,6 +1,6 @@
 - group "Filter by topic":
-  - button "All Posts(15)"
-  - button "Design(6)" [pressed]
-  - button "Tooling(3)"
-  - button "Process(4)"
-  - button "Branding(2)"
+  - button "All Posts (15)"
+  - button "Design (6)" [pressed]
+  - button "Tooling (3)"
+  - button "Process (4)"
+  - button "Branding (2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--default.forced-colors.yaml
@@ -1,6 +1,6 @@
 - group "Filter by topic":
-  - button "All Posts(15)"
-  - button "Design(6)" [pressed]
-  - button "Tooling(3)"
-  - button "Process(4)"
-  - button "Branding(2)"
+  - button "All Posts (15)"
+  - button "Design (6)" [pressed]
+  - button "Tooling (3)"
+  - button "Process (4)"
+  - button "Branding (2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--default.light.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--default.light.yaml
@@ -1,6 +1,6 @@
 - group "Filter by topic":
-  - button "All Posts(15)"
-  - button "Design(6)" [pressed]
-  - button "Tooling(3)"
-  - button "Process(4)"
-  - button "Branding(2)"
+  - button "All Posts (15)"
+  - button "Design (6)" [pressed]
+  - button "Tooling (3)"
+  - button "Process (4)"
+  - button "Branding (2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--default.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--default.yaml
@@ -1,6 +1,6 @@
 - group "Filter by topic":
-  - button "All Posts(15)"
-  - button "Design(6)" [pressed]
-  - button "Tooling(3)"
-  - button "Process(4)"
-  - button "Branding(2)"
+  - button "All Posts (15)"
+  - button "Design (6)" [pressed]
+  - button "Tooling (3)"
+  - button "Process (4)"
+  - button "Branding (2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--example.dark.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--example.dark.yaml
@@ -1,6 +1,6 @@
 - group "Filter by topic":
-  - button "All Posts(15)"
-  - button "Design(6)" [pressed]
-  - button "Tooling(3)"
-  - button "Process(4)"
-  - button "Branding(2)"
+  - button "All Posts (15)"
+  - button "Design (6)" [pressed]
+  - button "Tooling (3)"
+  - button "Process (4)"
+  - button "Branding (2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--example.forced-colors.yaml
@@ -1,6 +1,6 @@
 - group "Filter by topic":
-  - button "All Posts(15)"
-  - button "Design(6)" [pressed]
-  - button "Tooling(3)"
-  - button "Process(4)"
-  - button "Branding(2)"
+  - button "All Posts (15)"
+  - button "Design (6)" [pressed]
+  - button "Tooling (3)"
+  - button "Process (4)"
+  - button "Branding (2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--example.light.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--example.light.yaml
@@ -1,6 +1,6 @@
 - group "Filter by topic":
-  - button "All Posts(15)"
-  - button "Design(6)" [pressed]
-  - button "Tooling(3)"
-  - button "Process(4)"
-  - button "Branding(2)"
+  - button "All Posts (15)"
+  - button "Design (6)" [pressed]
+  - button "Tooling (3)"
+  - button "Process (4)"
+  - button "Branding (2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--example.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--example.yaml
@@ -1,6 +1,6 @@
 - group "Filter by topic":
-  - button "All Posts(15)"
-  - button "Design(6)" [pressed]
-  - button "Tooling(3)"
-  - button "Process(4)"
-  - button "Branding(2)"
+  - button "All Posts (15)"
+  - button "Design (6)" [pressed]
+  - button "Tooling (3)"
+  - button "Process (4)"
+  - button "Branding (2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--forced-colors.dark.yaml
@@ -1,6 +1,6 @@
 - group "Filter by topic":
-  - button "All Posts(15)"
-  - button "Design(6)" [pressed]
-  - button "Tooling(3)"
-  - button "Process(4)"
-  - button "Branding(2)"
+  - button "All Posts (15)"
+  - button "Design (6)" [pressed]
+  - button "Tooling (3)"
+  - button "Process (4)"
+  - button "Branding (2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--forced-colors.forced-colors.yaml
@@ -1,6 +1,6 @@
 - group "Filter by topic":
-  - button "All Posts(15)"
-  - button "Design(6)" [pressed]
-  - button "Tooling(3)"
-  - button "Process(4)"
-  - button "Branding(2)"
+  - button "All Posts (15)"
+  - button "Design (6)" [pressed]
+  - button "Tooling (3)"
+  - button "Process (4)"
+  - button "Branding (2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--forced-colors.light.yaml
@@ -1,6 +1,6 @@
 - group "Filter by topic":
-  - button "All Posts(15)"
-  - button "Design(6)" [pressed]
-  - button "Tooling(3)"
-  - button "Process(4)"
-  - button "Branding(2)"
+  - button "All Posts (15)"
+  - button "Design (6)" [pressed]
+  - button "Tooling (3)"
+  - button "Process (4)"
+  - button "Branding (2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--forced-colors.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--forced-colors.yaml
@@ -1,6 +1,6 @@
 - group "Filter by topic":
-  - button "All Posts(15)"
-  - button "Design(6)" [pressed]
-  - button "Tooling(3)"
-  - button "Process(4)"
-  - button "Branding(2)"
+  - button "All Posts (15)"
+  - button "Design (6)" [pressed]
+  - button "Tooling (3)"
+  - button "Process (4)"
+  - button "Branding (2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--minimal.dark.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--minimal.dark.yaml
@@ -1,0 +1,6 @@
+- group "Filter by topic":
+  - button "All Posts"
+  - button "Design"
+  - button "Tooling" [pressed]
+  - button "Process"
+  - button "Branding"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--minimal.forced-colors.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--minimal.forced-colors.yaml
@@ -1,0 +1,6 @@
+- group "Filter by topic":
+  - button "All Posts"
+  - button "Design"
+  - button "Tooling" [pressed]
+  - button "Process"
+  - button "Branding"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--minimal.light.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--minimal.light.yaml
@@ -1,0 +1,6 @@
+- group "Filter by topic":
+  - button "All Posts"
+  - button "Design"
+  - button "Tooling" [pressed]
+  - button "Process"
+  - button "Branding"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--playground.dark.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--playground.dark.yaml
@@ -1,7 +1,6 @@
-- status: Work in progress (beta)
 - group "Filter by topic":
-  - button "All Posts(15)"
-  - button "Design(6)" [pressed]
-  - button "Tooling(3)"
-  - button "Process(4)"
-  - button "Branding(2)"
+  - button "All Posts (15)"
+  - button "Design (6)" [pressed]
+  - button "Tooling (3)"
+  - button "Process (4)"
+  - button "Branding (2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--playground.forced-colors.yaml
@@ -1,7 +1,6 @@
-- status: Work in progress (beta)
 - group "Filter by topic":
-  - button "All Posts(15)"
-  - button "Design(6)" [pressed]
-  - button "Tooling(3)"
-  - button "Process(4)"
-  - button "Branding(2)"
+  - button "All Posts (15)"
+  - button "Design (6)" [pressed]
+  - button "Tooling (3)"
+  - button "Process (4)"
+  - button "Branding (2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--playground.light.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--playground.light.yaml
@@ -1,7 +1,6 @@
-- status: Work in progress (beta)
 - group "Filter by topic":
-  - button "All Posts(15)"
-  - button "Design(6)" [pressed]
-  - button "Tooling(3)"
-  - button "Process(4)"
-  - button "Branding(2)"
+  - button "All Posts (15)"
+  - button "Design (6)" [pressed]
+  - button "Tooling (3)"
+  - button "Process (4)"
+  - button "Branding (2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--playground.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--playground.yaml
@@ -1,6 +1,6 @@
 - group "Filter by topic":
-  - button "All Posts(15)"
-  - button "Design(6)" [pressed]
-  - button "Tooling(3)"
-  - button "Process(4)"
-  - button "Branding(2)"
+  - button "All Posts (15)"
+  - button "Design (6)" [pressed]
+  - button "Tooling (3)"
+  - button "Process (4)"
+  - button "Branding (2)"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--underline.dark.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--underline.dark.yaml
@@ -1,0 +1,6 @@
+- group "Filter by topic":
+  - button "All Posts" [pressed]
+  - button "Design"
+  - button "Tooling"
+  - button "Process"
+  - button "Branding"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--underline.forced-colors.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--underline.forced-colors.yaml
@@ -1,0 +1,6 @@
+- group "Filter by topic":
+  - button "All Posts" [pressed]
+  - button "Design"
+  - button "Tooling"
+  - button "Process"
+  - button "Branding"

--- a/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--underline.light.yaml
+++ b/nextjs-app/shared/components/BlogCategoryFilter/__a11y-snapshots__/site-blogcategoryfilter--underline.light.yaml
@@ -1,0 +1,6 @@
+- group "Filter by topic":
+  - button "All Posts" [pressed]
+  - button "Design"
+  - button "Tooling"
+  - button "Process"
+  - button "Branding"

--- a/nextjs-app/shared/components/CategoryFilter/CategoryFilter.tsx
+++ b/nextjs-app/shared/components/CategoryFilter/CategoryFilter.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "../../lib/cn";
+import { FilterChip } from "../FilterChip";
 
 export interface CategoryOption {
   /** Category value */
@@ -24,10 +25,29 @@ export interface CategoryFilterProps {
   variant?: "pills" | "underline" | "minimal";
 }
 
-const sizeClasses = {
-  sm: "text-xs px-3 py-1.5",
-  md: "text-sm px-4 py-2",
-  lg: "text-base px-5 py-2.5",
+/** CategoryFilter variant names predate FilterChip's; map plural → singular. */
+const chipVariantMap = {
+  pills: "pill",
+  underline: "underline",
+  minimal: "minimal",
+} as const;
+
+const groupClassMap = {
+  pills: cn(
+    "flex flex-wrap gap-2",
+    "overflow-x-auto overflow-y-visible scrollbar-hide",
+    "-mx-4 px-4 py-1 tablet:mx-0 tablet:px-0", // py-1 prevents focus ring clipping
+  ),
+  underline: cn(
+    "flex gap-6 border-b border-border",
+    "overflow-x-auto scrollbar-hide",
+    "-mx-4 px-4 tablet:mx-0 tablet:px-0",
+  ),
+  minimal: cn(
+    "flex flex-wrap gap-4",
+    "overflow-x-auto overflow-y-visible scrollbar-hide",
+    "-mx-4 px-4 py-1 tablet:mx-0 tablet:px-0",
+  ),
 } as const;
 
 export function CategoryFilter({
@@ -38,121 +58,25 @@ export function CategoryFilter({
   size = "md",
   variant = "pills",
 }: CategoryFilterProps) {
-  const renderPills = () => (
+  return (
     <div
       role="group"
       aria-label="Filter projects by category"
-      className={cn(
-        "flex flex-wrap gap-2",
-        "overflow-x-auto overflow-y-visible scrollbar-hide",
-        "-mx-4 px-4 py-1 tablet:mx-0 tablet:px-0", // py-1 prevents focus ring clipping
-        className
-      )}
+      className={cn(groupClassMap[variant], className)}
     >
-      {categories.map((category) => {
-        const isActive = category.value === activeCategory;
-
-        return (
-          <button
-            key={category.value}
-            aria-pressed={isActive}
-            onClick={() => onCategoryChange(category.value)}
-            className={cn(
-              "font-body whitespace-nowrap rounded-full",
-              "border transition-all duration-200",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-              sizeClasses[size],
-              isActive
-                ? "bg-foreground text-background border-foreground"
-                : "bg-transparent text-muted-foreground border-border hover:border-foreground hover:text-foreground"
-            )}
-          >
-            {category.label}
-          </button>
-        );
-      })}
+      {categories.map((category) => (
+        <FilterChip
+          key={category.value}
+          pressed={category.value === activeCategory}
+          onClick={() => onCategoryChange(category.value)}
+          variant={chipVariantMap[variant]}
+          size={size}
+        >
+          {category.label}
+        </FilterChip>
+      ))}
     </div>
   );
-
-  const renderUnderline = () => (
-    <div
-      role="group"
-      aria-label="Filter projects by category"
-      className={cn(
-        "flex gap-6 border-b border-border",
-        "overflow-x-auto scrollbar-hide",
-        "-mx-4 px-4 tablet:mx-0 tablet:px-0",
-        className
-      )}
-    >
-      {categories.map((category) => {
-        const isActive = category.value === activeCategory;
-
-        return (
-          <button
-            key={category.value}
-            aria-pressed={isActive}
-            onClick={() => onCategoryChange(category.value)}
-            className={cn(
-              "font-body whitespace-nowrap pb-3",
-              "border-b-2 -mb-px transition-colors duration-200",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-              sizeClasses[size],
-              isActive
-                ? "border-foreground text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground"
-            )}
-          >
-            {category.label}
-          </button>
-        );
-      })}
-    </div>
-  );
-
-  const renderMinimal = () => (
-    <div
-      role="group"
-      aria-label="Filter projects by category"
-      className={cn(
-        "flex flex-wrap gap-4",
-        "overflow-x-auto overflow-y-visible scrollbar-hide",
-        "-mx-4 px-4 py-1 tablet:mx-0 tablet:px-0",
-        className
-      )}
-    >
-      {categories.map((category) => {
-        const isActive = category.value === activeCategory;
-
-        return (
-          <button
-            key={category.value}
-            aria-pressed={isActive}
-            onClick={() => onCategoryChange(category.value)}
-            className={cn(
-              "font-body whitespace-nowrap transition-colors duration-200",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded",
-              sizeClasses[size],
-              isActive
-                ? "text-foreground font-medium"
-                : "text-muted-foreground hover:text-foreground"
-            )}
-          >
-            {category.label}
-          </button>
-        );
-      })}
-    </div>
-  );
-
-  switch (variant) {
-    case "underline":
-      return renderUnderline();
-    case "minimal":
-      return renderMinimal();
-    default:
-      return renderPills();
-  }
 }
 
 CategoryFilter.displayName = "CategoryFilter";

--- a/nextjs-app/shared/components/FilterChip/FilterChip.contract.json
+++ b/nextjs-app/shared/components/FilterChip/FilterChip.contract.json
@@ -1,0 +1,82 @@
+{
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "name": "FilterChip",
+    "tier": "atom",
+    "group": "controls",
+    "status": "alpha",
+    "description": "Single-select filter toggle chip: a button[aria-pressed] with pill, underline, and minimal treatments.",
+    "figma": null,
+    "radixPrimitive": null,
+    "element": "button",
+    "variants": {
+        "variant": {
+            "values": [
+                "pill",
+                "underline",
+                "minimal"
+            ],
+            "default": "pill"
+        },
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "default": "md"
+        }
+    },
+    "slots": [
+        "children"
+    ],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [
+            "Tab",
+            "Enter",
+            "Space"
+        ],
+        "ariaRequirements": [
+            "aria-pressed reflects the pressed prop (toggle button, not tab)",
+            "parents wrap chips in a labelled role=group"
+        ],
+        "reducedMotion": true,
+        "reviewed": false,
+        "forcedColorsVerified": false
+    },
+    "tokens": {
+        "colors": [
+            "--color-muted",
+            "--color-text",
+            "--color-border",
+            "--focus-ring-color"
+        ],
+        "spacing": [
+            "--space-internal-6",
+            "--space-internal-8",
+            "--space-internal-12",
+            "--space-internal-16",
+            "--space-internal-24"
+        ]
+    },
+    "lightDarkVerified": false,
+    "schemaVersion": 2,
+    "displayName": "FilterChip",
+    "dense": "Filter toggle chip (aria-pressed): pill/underline/minimal, sm/md/lg, optional count.",
+    "keywords": [
+        "filter",
+        "chip",
+        "toggle",
+        "category",
+        "tag",
+        "pressed"
+    ],
+    "consumers": []
+}

--- a/nextjs-app/shared/components/FilterChip/FilterChip.mdx
+++ b/nextjs-app/shared/components/FilterChip/FilterChip.mdx
@@ -1,0 +1,36 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './FilterChip.stories.tsx';
+
+<Meta of={Stories} />
+
+# FilterChip
+
+**Status:** alpha · **Tier:** atom · **Group:** controls
+
+## In use
+See the **Example (filter group)** story: an "All" chip plus tag chips inside a labelled `role="group"`.
+
+## How to use
+
+```tsx
+import { FilterChip } from '@dt/FilterChip';
+
+<div role="group" aria-label="Filter by topic">
+  <FilterChip pressed={active === null} onClick={() => setActive(null)}>All</FilterChip>
+  <FilterChip pressed={active === 'ds'} onClick={() => setActive('ds')} count={3}>Design systems</FilterChip>
+</div>
+```
+
+## When to use
+- Single-select filtering of a visible collection (work grid, blog archive).
+
+## When not to use
+- Switching between content panels: use `Tabs`.
+- Multi-select token input: use `MultiCombobox`.
+
+## Accessibility
+- `aria-pressed` toggle buttons inside a labelled group; counts render inside the accessible name.
+- Token focus ring; Highlight/HighlightText pressed state in forced colors; transitions off under reduced motion.
+
+## Promotion notes
+- Promote to beta after the Figma atom exists; CategoryFilter/BlogCategoryFilter consume it internally.

--- a/nextjs-app/shared/components/FilterChip/FilterChip.module.css
+++ b/nextjs-app/shared/components/FilterChip/FilterChip.module.css
@@ -1,0 +1,112 @@
+.chip {
+  display: inline-flex;
+  align-items: center;
+  border: 0;
+  background: transparent;
+  font-family: var(--font-body);
+  white-space: nowrap;
+  color: var(--color-muted);
+  cursor: pointer;
+  transition:
+    color 0.2s ease,
+    background-color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.chip:hover {
+  color: var(--color-text);
+}
+
+.chip:focus-visible {
+  outline: var(--focus-ring-width, 2px) solid
+    var(--focus-ring-color, var(--color-primary));
+  outline-offset: 2px;
+}
+
+/* Sizes (former Tailwind text-xs/sm/base + px/py steps). */
+
+.sm {
+  padding-block: var(--space-internal-6);
+  padding-inline: var(--space-internal-12);
+  font-size: var(--font-size-text-xs, 0.75rem);
+}
+
+.md {
+  padding-block: var(--space-internal-8);
+  padding-inline: var(--space-internal-16);
+  font-size: var(--font-size-text-s, 0.875rem);
+}
+
+.lg {
+  padding-block: var(--space-internal-8);
+  padding-inline: var(--space-internal-24);
+  font-size: var(--font-size-text-m, 1rem);
+}
+
+/* Pill: bordered rounded toggle; pressed inverts. */
+
+.pill {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full, 9999px);
+}
+
+.pill:hover {
+  border-color: var(--color-text);
+}
+
+.pill[aria-pressed="true"] {
+  border-color: var(--color-text);
+  background-color: var(--color-text);
+  color: var(--main-body-background-color, var(--color-white));
+}
+
+/* Underline: bottom-edge indicator, sits on the group's border. */
+
+.underline {
+  margin-block-end: -1px;
+  padding-inline: 0;
+  border-block-end: 2px solid transparent;
+  border-radius: 0;
+}
+
+.underline[aria-pressed="true"] {
+  color: var(--color-text);
+  border-block-end-color: var(--color-text);
+}
+
+/* Minimal: text-only toggle. */
+
+.minimal {
+  padding-inline: 0;
+  border-radius: var(--radius-sm, 4px);
+}
+
+.minimal[aria-pressed="true"] {
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.count {
+  margin-inline-start: var(--space-internal-2);
+}
+
+@media (forced-colors: active) {
+  .chip {
+    color: ButtonText;
+  }
+
+  .pill {
+    border-color: ButtonText;
+  }
+
+  .chip[aria-pressed="true"] {
+    background-color: Highlight;
+    color: HighlightText;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chip {
+    transition: none;
+  }
+}

--- a/nextjs-app/shared/components/FilterChip/FilterChip.spec.md
+++ b/nextjs-app/shared/components/FilterChip/FilterChip.spec.md
@@ -1,0 +1,20 @@
+# FilterChip
+
+## Intent
+One toggle-chip implementation for single-select filters. CategoryFilter and BlogCategoryFilter each hand-rolled the same aria-pressed button in three visual treatments; FilterChip collapses the six copies into one control.
+
+## Interaction contract
+- Keyboard: Tab focuses each chip; Enter/Space toggles (native button).
+- Pointer: click toggles; hover shifts muted → text ink.
+- Screen readers: announced as a toggle button with pressed state; a filter is a UI control, not a tablist, so parents wrap chips in a labelled role="group".
+
+## Do / don't
+- Do: keep exactly one chip pressed per group (single-select filters).
+- Do: pass counts via the count prop so the "(n)" suffix stays in the accessible name.
+- Don't: use for navigation between panels (that is Tabs).
+- Don't: nest interactive content inside the label.
+
+## Design notes
+- Tokens: --color-muted/-text/-border ink+chrome, --focus-ring-color, --space-internal-{6,8,12,16,24} paddings, --font-size-text-{xs,s,m}.
+- Pressed pill inverts (text bg / canvas ink); underline variant sits on the group border (-1px margin); forced colors use Highlight/HighlightText.
+- Figma: pending (alpha); create in DT-Site-stuff Atoms before beta.

--- a/nextjs-app/shared/components/FilterChip/FilterChip.stories.tsx
+++ b/nextjs-app/shared/components/FilterChip/FilterChip.stories.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FilterChip } from "./FilterChip";
+import contract from "./FilterChip.contract.json";
+
+const meta = {
+  title: "Atoms/FilterChip",
+  component: FilterChip,
+  parameters: {
+    layout: "centered",
+    a11y: { test: "error" },
+    contractStatus: contract.status,
+    docs: {
+      description: {
+        component: contract.description,
+      },
+    },
+  },
+  // Custom MDX docs pages exist for all catalog entries; do not also enable autodocs
+  // or Storybook will treat it as conflicting sources of truth for the docs page.
+  tags: ["!autodocs"],
+  argTypes: {
+    pressed: {
+      control: "boolean",
+      description: "Whether this chip's filter is active (aria-pressed).",
+      table: { category: "Behavior" },
+    },
+    variant: {
+      control: "radio",
+      options: ["pill", "underline", "minimal"],
+      description: "Visual treatment.",
+      table: { defaultValue: { summary: "pill" }, category: "Appearance" },
+    },
+    size: {
+      control: "radio",
+      options: ["sm", "md", "lg"],
+      description: "Size token.",
+      table: { defaultValue: { summary: "md" }, category: "Appearance" },
+    },
+    count: {
+      control: "number",
+      description: "Optional count suffix, rendered as (n).",
+      table: { category: "Content" },
+    },
+    children: {
+      control: "text",
+      description: "Chip label.",
+      table: { category: "Content" },
+    },
+    onClick: { table: { disable: true } },
+  },
+  args: {
+    pressed: false,
+    variant: "pill" as const,
+    size: "md" as const,
+    children: "Design systems",
+  },
+} satisfies Meta<typeof FilterChip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "none" },
+};
+
+export const Playground: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "none" },
+};
+
+function ExampleGroup() {
+  const [active, setActive] = useState<string | null>(null);
+  const tags = ["Design systems", "Accessibility", "AI", "Branding"];
+  return (
+    <div
+      role="group"
+      aria-label="Filter by topic"
+      style={{ display: "flex", gap: "var(--space-internal-8)", flexWrap: "wrap" }}
+    >
+      <FilterChip pressed={active === null} onClick={() => setActive(null)} count={12}>
+        All
+      </FilterChip>
+      {tags.map((tag) => (
+        <FilterChip
+          key={tag}
+          pressed={active === tag}
+          onClick={() => setActive(tag)}
+          count={3}
+        >
+          {tag}
+        </FilterChip>
+      ))}
+    </div>
+  );
+}
+
+export const Example: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "none" },
+  name: "Example (filter group)",
+  parameters: { controls: { disable: true } },
+  render: () => <ExampleGroup />,
+};
+
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "active" },
+  args: { pressed: true },
+  parameters: {
+    docs: {
+      description: {
+        story: "Forced-colors verification story.",
+      },
+    },
+  },
+};

--- a/nextjs-app/shared/components/FilterChip/FilterChip.test.tsx
+++ b/nextjs-app/shared/components/FilterChip/FilterChip.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { describe, it, expect, vi } from "vitest";
+import { FilterChip } from "./FilterChip";
+
+expect.extend(toHaveNoViolations);
+
+describe("FilterChip", () => {
+  it("renders a toggle button reflecting pressed state", () => {
+    const { rerender } = render(<FilterChip pressed={false}>All</FilterChip>);
+    const chip = screen.getByRole("button", { name: "All" });
+    expect(chip).toHaveAttribute("aria-pressed", "false");
+    rerender(<FilterChip pressed>All</FilterChip>);
+    expect(chip).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("fires onClick", async () => {
+    const onClick = vi.fn();
+    render(
+      <FilterChip pressed={false} onClick={onClick}>
+        Branding
+      </FilterChip>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Branding" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the count suffix in the accessible name", () => {
+    render(
+      <FilterChip pressed={false} count={7}>
+        Design systems
+      </FilterChip>,
+    );
+    expect(
+      screen.getByRole("button", { name: "Design systems (7)" }),
+    ).toBeInTheDocument();
+  });
+
+  it("applies variant and size classes", () => {
+    const { container } = render(
+      <FilterChip pressed={false} variant="underline" size="lg">
+        Tag
+      </FilterChip>,
+    );
+    const cls = (container.firstElementChild as HTMLElement).className;
+    expect(cls).toMatch(/underline/);
+    expect(cls).toMatch(/lg/);
+  });
+
+  it("is a non-submitting button", () => {
+    render(<FilterChip pressed={false}>All</FilterChip>);
+    expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+  });
+
+  it("has no axe violations inside a labelled group", async () => {
+    const { container } = render(
+      <div role="group" aria-label="Filter by topic">
+        <FilterChip pressed>All</FilterChip>
+        <FilterChip pressed={false} count={3}>
+          Design systems
+        </FilterChip>
+      </div>,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/FilterChip/FilterChip.tsx
+++ b/nextjs-app/shared/components/FilterChip/FilterChip.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import styles from "./FilterChip.module.css";
+import { cn } from "../../lib/cn";
+
+type FilterChipVariant = "pill" | "underline" | "minimal";
+type FilterChipSize = "sm" | "md" | "lg";
+
+export interface FilterChipProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "type"> {
+  /** Whether this chip's filter is active (rendered as aria-pressed). */
+  pressed: boolean;
+  /** Chip label (compose counts etc. inline). */
+  children: React.ReactNode;
+  /** Visual treatment. @default "pill" */
+  variant?: FilterChipVariant;
+  /** Size token. @default "md" */
+  size?: FilterChipSize;
+  /** Optional count suffix, rendered as "(n)". */
+  count?: number;
+  /** Additional CSS class names. */
+  className?: string;
+}
+
+const variantClassMap: Record<FilterChipVariant, string> = {
+  pill: styles.pill,
+  underline: styles.underline,
+  minimal: styles.minimal,
+};
+
+const sizeClassMap: Record<FilterChipSize, string> = {
+  sm: styles.sm,
+  md: styles.md,
+  lg: styles.lg,
+};
+
+/**
+ * Single-select filter toggle chip: a `button[aria-pressed]` with pill,
+ * underline, and minimal treatments. The shared implementation behind
+ * CategoryFilter and BlogCategoryFilter — a filter is a UI control, not a
+ * tablist, so chips are toggle buttons inside a labelled `role="group"`.
+ */
+export const FilterChip = React.forwardRef<HTMLButtonElement, FilterChipProps>(
+  function FilterChip(
+    {
+      pressed,
+      children,
+      variant = "pill",
+      size = "md",
+      count,
+      className,
+      ...rest
+    },
+    ref,
+  ) {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        aria-pressed={pressed}
+        className={cn(
+          styles.chip,
+          variantClassMap[variant],
+          sizeClassMap[size],
+          className,
+        )}
+        {...rest}
+      >
+        {children}
+        {count !== undefined && (
+          <>
+            {" "}
+            <span className={styles.count}>({count})</span>
+          </>
+        )}
+      </button>
+    );
+  },
+);
+
+export default FilterChip;

--- a/nextjs-app/shared/components/FilterChip/index.ts
+++ b/nextjs-app/shared/components/FilterChip/index.ts
@@ -1,0 +1,2 @@
+export { FilterChip, default } from "./FilterChip";
+export type { FilterChipProps } from "./FilterChip";

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,18 +1,18 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-09T22:38:46.231Z",
+  "generatedAt": "2026-07-09T23:04:19.839Z",
   "summary": {
-    "componentCount": 162,
+    "componentCount": 163,
     "statusCounts": {
       "beta": 49,
       "stable": 88,
-      "alpha": 24,
+      "alpha": 25,
       "deprecated": 1
     },
     "honestBetaDocDebt": 0,
     "catalogCompletenessPercent": 87.6,
-    "codebaseComponentCount": 185,
-    "usageCoveragePercent": 92.6,
+    "codebaseComponentCount": 186,
+    "usageCoveragePercent": 93.3,
     "componentsWithProductionUsage": 46,
     "notReadyForStablePromotion": false
   },
@@ -57,15 +57,15 @@
   },
   "catalogCoverage": {
     "description": "Catalog completeness across the codebase. componentCount above is the catalog count; this block reveals how much of the codebase that catalog actually represents.",
-    "totalComponentsInCodebase": 185,
-    "inCatalog": 162,
+    "totalComponentsInCodebase": 186,
+    "inCatalog": 163,
     "outOfCatalog": 23,
     "catalogCompletenessPercent": 87.6,
     "artifactCoverage": {
-      "stories": 146,
-      "tests": 145,
-      "mdx": 4,
-      "spec": 162
+      "stories": 147,
+      "tests": 146,
+      "mdx": 5,
+      "spec": 163
     },
     "outOfCatalogByBucket": {
       "catalog-gap": 0,
@@ -77,21 +77,21 @@
   },
   "usageCoverage": {
     "description": "Auto-detected import evidence from app/** and nextjs-app/**. Separate from contract.consumers[], which remains the stable-promotion gate for shipping-product proof.",
-    "catalogedComponents": 162,
-    "withAnyUsage": 150,
+    "catalogedComponents": 163,
+    "withAnyUsage": 152,
     "withProductionUsage": 46,
-    "uniqueImportedComponents": 150,
-    "totalEvidenceRows": 850,
+    "uniqueImportedComponents": 152,
+    "totalEvidenceRows": 854,
     "aliasImportFiles": 471,
-    "relativeImportFiles": 387,
+    "relativeImportFiles": 391,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
   },
   "relationshipGraph": {
     "description": "Merged static composesWith policy + co-import evidence (see generate-relationship-graph.mjs).",
-    "generatedAt": "2026-07-09T16:24:34.507Z",
+    "generatedAt": "2026-07-09T23:04:16.149Z",
     "coImportMinFiles": 3,
-    "nodesWithComposesWith": 86,
+    "nodesWithComposesWith": 87,
     "regenerate": "npm run build:relationship-graph or npm run build:tokens",
     "path": "nextjs-app/shared/foundations/dist/relationship-graph.json"
   },
@@ -102,14 +102,14 @@
   "dsharpParity": {
     "description": "Comparison against DSharp as of 2026-05-26. Breadth is close, maturity is not. This block walks back the earlier parity overclaim.",
     "contractCount": {
-      "digitaltableteur": 162,
+      "digitaltableteur": 163,
       "dsharp": 112
     },
     "statusMix": {
       "digitaltableteur": {
         "beta": 49,
         "stable": 88,
-        "alpha": 24,
+        "alpha": 25,
         "deprecated": 1
       },
       "dsharp": {
@@ -12339,6 +12339,208 @@
         ],
         "prefersOver": [],
         "declaredPropCount": 15
+      }
+    },
+    {
+      "name": "FilterChip",
+      "contract": {
+        "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+        "name": "FilterChip",
+        "tier": "atom",
+        "group": "controls",
+        "status": "alpha",
+        "description": "Single-select filter toggle chip: a button[aria-pressed] with pill, underline, and minimal treatments.",
+        "figma": null,
+        "radixPrimitive": null,
+        "element": "button",
+        "variants": {
+          "variant": {
+            "values": [
+              "pill",
+              "underline",
+              "minimal"
+            ],
+            "default": "pill"
+          },
+          "size": {
+            "values": [
+              "sm",
+              "md",
+              "lg"
+            ],
+            "default": "md"
+          }
+        },
+        "slots": [
+          "children"
+        ],
+        "asChild": false,
+        "subParts": [],
+        "requiredStories": [
+          "Default",
+          "Playground",
+          "Example",
+          "ForcedColors"
+        ],
+        "a11y": {
+          "keyboard": [
+            "Tab",
+            "Enter",
+            "Space"
+          ],
+          "ariaRequirements": [
+            "aria-pressed reflects the pressed prop (toggle button, not tab)",
+            "parents wrap chips in a labelled role=group"
+          ],
+          "reducedMotion": true,
+          "reviewed": false,
+          "forcedColorsVerified": false
+        },
+        "tokens": {
+          "colors": [
+            "--color-muted",
+            "--color-text",
+            "--color-border",
+            "--focus-ring-color"
+          ],
+          "spacing": [
+            "--space-internal-6",
+            "--space-internal-8",
+            "--space-internal-12",
+            "--space-internal-16",
+            "--space-internal-24"
+          ]
+        },
+        "lightDarkVerified": false,
+        "schemaVersion": 2,
+        "displayName": "FilterChip",
+        "dense": "Filter toggle chip (aria-pressed): pill/underline/minimal, sm/md/lg, optional count.",
+        "keywords": [
+          "filter",
+          "chip",
+          "toggle",
+          "category",
+          "tag",
+          "pressed"
+        ],
+        "consumers": []
+      },
+      "spec": "# FilterChip\n\n## Intent\nOne toggle-chip implementation for single-select filters. CategoryFilter and BlogCategoryFilter each hand-rolled the same aria-pressed button in three visual treatments; FilterChip collapses the six copies into one control.\n\n## Interaction contract\n- Keyboard: Tab focuses each chip; Enter/Space toggles (native button).\n- Pointer: click toggles; hover shifts muted → text ink.\n- Screen readers: announced as a toggle button with pressed state; a filter is a UI control, not a tablist, so parents wrap chips in a labelled role=\"group\".\n\n## Do / don't\n- Do: keep exactly one chip pressed per group (single-select filters).\n- Do: pass counts via the count prop so the \"(n)\" suffix stays in the accessible name.\n- Don't: use for navigation between panels (that is Tabs).\n- Don't: nest interactive content inside the label.\n\n## Design notes\n- Tokens: --color-muted/-text/-border ink+chrome, --focus-ring-color, --space-internal-{6,8,12,16,24} paddings, --font-size-text-{xs,s,m}.\n- Pressed pill inverts (text bg / canvas ink); underline variant sits on the group border (-1px margin); forced colors use Highlight/HighlightText.\n- Figma: pending (alpha); create in DT-Site-stuff Atoms before beta.\n",
+      "documentationDebt": false,
+      "usage": {
+        "publicImport": "@dt/FilterChip",
+        "importCount": 2,
+        "productionImportCount": 0,
+        "patternImportCount": 0,
+        "componentImportCount": 2,
+        "evidence": [
+          {
+            "path": "nextjs-app/shared/components/BlogCategoryFilter/BlogCategoryFilter.tsx",
+            "importKind": "relative",
+            "importPath": "../FilterChip",
+            "context": "component"
+          },
+          {
+            "path": "nextjs-app/shared/components/CategoryFilter/CategoryFilter.tsx",
+            "importKind": "relative",
+            "importPath": "../FilterChip",
+            "context": "component"
+          }
+        ]
+      },
+      "agent": {
+        "preferredImport": "@dt/FilterChip",
+        "intent": "One toggle-chip implementation for single-select filters. CategoryFilter and BlogCategoryFilter each hand-rolled the same aria-pressed button in three visual treatments; FilterChip collapses the six copies into one cont…",
+        "props": {
+          "pressed": {
+            "optional": false,
+            "type": "boolean"
+          },
+          "children": {
+            "optional": false,
+            "type": "React.ReactNode"
+          },
+          "variant": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "underline",
+              "minimal",
+              "pill"
+            ]
+          },
+          "size": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "sm",
+              "md",
+              "lg"
+            ]
+          },
+          "count": {
+            "optional": true,
+            "type": "number"
+          },
+          "className": {
+            "optional": true,
+            "type": "string"
+          }
+        },
+        "variants": {
+          "variant": {
+            "values": [
+              "underline",
+              "minimal",
+              "pill"
+            ],
+            "default": "underline"
+          },
+          "size": {
+            "values": [
+              "sm",
+              "md",
+              "lg"
+            ],
+            "default": "sm"
+          }
+        },
+        "cvaVariants": {},
+        "variantsFnName": null,
+        "useWhen": [
+          "keep exactly one chip pressed per group (single-select filters).",
+          "pass counts via the count prop so the \"(n)\" suffix stays in the accessible name."
+        ],
+        "avoidWhen": [
+          "use for navigation between panels (that is Tabs).",
+          "nest interactive content inside the label."
+        ],
+        "requiredA11y": [
+          "aria-pressed reflects the pressed prop (toggle button, not tab)",
+          "parents wrap chips in a labelled role=group"
+        ],
+        "keyboard": [
+          "Tab",
+          "Enter",
+          "Space"
+        ],
+        "compositionRules": [
+          "nest interactive content inside the label."
+        ],
+        "canonicalExamples": [
+          "Default",
+          "Playground",
+          "Example",
+          "ForcedColors"
+        ],
+        "replacementFor": [],
+        "forbiddenUse": [
+          "use for navigation between panels (that is Tabs).",
+          "nest interactive content inside the label."
+        ],
+        "composesWith": [],
+        "prefersOver": [],
+        "declaredPropCount": 6
       }
     },
     {
@@ -26018,6 +26220,13 @@
         "radixPrimitive": null,
         "element": "a",
         "variants": {
+          "variant": {
+            "values": [
+              "plain",
+              "chip"
+            ],
+            "default": "plain"
+          },
           "size": {
             "values": [
               "sm",
@@ -26055,7 +26264,8 @@
           "colors": [
             "--color-muted",
             "--color-text",
-            "--focus-ring-color"
+            "--focus-ring-color",
+            "--color-border"
           ],
           "spacing": [
             "--space-internal-4",
@@ -26072,11 +26282,24 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/SocialIconLink",
-        "importCount": 0,
+        "importCount": 2,
         "productionImportCount": 0,
-        "patternImportCount": 0,
-        "componentImportCount": 0,
-        "evidence": []
+        "patternImportCount": 1,
+        "componentImportCount": 1,
+        "evidence": [
+          {
+            "path": "nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx",
+            "importKind": "relative",
+            "importPath": "../../components/SocialIconLink",
+            "context": "pattern"
+          },
+          {
+            "path": "nextjs-app/shared/components/ArticleShareSection/ArticleShareSection.tsx",
+            "importKind": "relative",
+            "importPath": "../SocialIconLink",
+            "context": "component"
+          }
+        ]
       },
       "agent": {
         "preferredImport": "@dt/SocialIconLink",
@@ -26093,6 +26316,14 @@
           "children": {
             "optional": false,
             "type": "React.ReactNode"
+          },
+          "variant": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "plain",
+              "chip"
+            ]
           },
           "size": {
             "optional": true,
@@ -26113,6 +26344,13 @@
           }
         },
         "variants": {
+          "variant": {
+            "values": [
+              "plain",
+              "chip"
+            ],
+            "default": "plain"
+          },
           "size": {
             "values": [
               "sm",
@@ -26154,9 +26392,14 @@
           "put text children inside — this is icon-only; use Link for labeled links.",
           "disable `external` for social profiles; same-tab is for internal routes only."
         ],
-        "composesWith": [],
+        "composesWith": [
+          "Container",
+          "Stack",
+          "Link",
+          "Divider"
+        ],
         "prefersOver": [],
-        "declaredPropCount": 6
+        "declaredPropCount": 7
       }
     },
     {

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-09T22:38:45.950Z",
+  "generatedAt": "2026-07-09T23:04:19.514Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -3807,6 +3807,100 @@
       ],
       "prefersOver": [],
       "declaredPropCount": 15
+    },
+    "FilterChip": {
+      "preferredImport": "@dt/FilterChip",
+      "intent": "One toggle-chip implementation for single-select filters. CategoryFilter and BlogCategoryFilter each hand-rolled the same aria-pressed button in three visual treatments; FilterChip collapses the six copies into one cont…",
+      "props": {
+        "pressed": {
+          "optional": false,
+          "type": "boolean"
+        },
+        "children": {
+          "optional": false,
+          "type": "React.ReactNode"
+        },
+        "variant": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "underline",
+            "minimal",
+            "pill"
+          ]
+        },
+        "size": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "sm",
+            "md",
+            "lg"
+          ]
+        },
+        "count": {
+          "optional": true,
+          "type": "number"
+        },
+        "className": {
+          "optional": true,
+          "type": "string"
+        }
+      },
+      "variants": {
+        "variant": {
+          "values": [
+            "underline",
+            "minimal",
+            "pill"
+          ],
+          "default": "underline"
+        },
+        "size": {
+          "values": [
+            "sm",
+            "md",
+            "lg"
+          ],
+          "default": "sm"
+        }
+      },
+      "cvaVariants": {},
+      "variantsFnName": null,
+      "useWhen": [
+        "keep exactly one chip pressed per group (single-select filters).",
+        "pass counts via the count prop so the \"(n)\" suffix stays in the accessible name."
+      ],
+      "avoidWhen": [
+        "use for navigation between panels (that is Tabs).",
+        "nest interactive content inside the label."
+      ],
+      "requiredA11y": [
+        "aria-pressed reflects the pressed prop (toggle button, not tab)",
+        "parents wrap chips in a labelled role=group"
+      ],
+      "keyboard": [
+        "Tab",
+        "Enter",
+        "Space"
+      ],
+      "compositionRules": [
+        "nest interactive content inside the label."
+      ],
+      "canonicalExamples": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+      ],
+      "replacementFor": [],
+      "forbiddenUse": [
+        "use for navigation between panels (that is Tabs).",
+        "nest interactive content inside the label."
+      ],
+      "composesWith": [],
+      "prefersOver": [],
+      "declaredPropCount": 6
     },
     "FlexBox": {
       "preferredImport": "@dt/FlexBox",
@@ -8041,6 +8135,14 @@
           "optional": false,
           "type": "React.ReactNode"
         },
+        "variant": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "plain",
+            "chip"
+          ]
+        },
         "size": {
           "optional": true,
           "type": "union",
@@ -8060,6 +8162,13 @@
         }
       },
       "variants": {
+        "variant": {
+          "values": [
+            "plain",
+            "chip"
+          ],
+          "default": "plain"
+        },
         "size": {
           "values": [
             "sm",
@@ -8101,9 +8210,14 @@
         "put text children inside — this is icon-only; use Link for labeled links.",
         "disable `external` for social profiles; same-tab is for internal routes only."
       ],
-      "composesWith": [],
+      "composesWith": [
+        "Container",
+        "Stack",
+        "Link",
+        "Divider"
+      ],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 7
     },
     "SocialShare": {
       "preferredImport": "@dt/SocialShare",

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -5916,6 +5916,45 @@
         }
       ]
     },
+    "FilterChip": {
+      "name": "FilterChip",
+      "group": "controls",
+      "tier": 2,
+      "status": "alpha",
+      "description": "Single-select filter toggle chip: a button[aria-pressed] with pill, underline, and minimal treatments.",
+      "dense": "Filter toggle chip (aria-pressed): pill/underline/minimal, sm/md/lg, optional count.",
+      "keywords": [
+        "filter",
+        "chip",
+        "toggle",
+        "category",
+        "tag",
+        "pressed"
+      ],
+      "importLine": "import { FilterChip } from \"@dt/FilterChip\";",
+      "keyProps": [],
+      "props": {},
+      "composesWith": [],
+      "prefersOver": [],
+      "forbiddenUse": [],
+      "usage": null,
+      "tokens": {
+        "colors": [
+          "--color-muted",
+          "--color-text",
+          "--color-border",
+          "--focus-ring-color"
+        ],
+        "spacing": [
+          "--space-internal-6",
+          "--space-internal-8",
+          "--space-internal-12",
+          "--space-internal-16",
+          "--space-internal-24"
+        ]
+      },
+      "examples": []
+    },
     "FlexBox": {
       "name": "FlexBox",
       "group": "layout",
@@ -12441,7 +12480,8 @@
         "colors": [
           "--color-muted",
           "--color-text",
-          "--focus-ring-color"
+          "--focus-ring-color",
+          "--color-border"
         ],
         "spacing": [
           "--space-internal-4",

--- a/scripts/design-system/dogfood-ratchet.baseline.json
+++ b/scripts/design-system/dogfood-ratchet.baseline.json
@@ -82,8 +82,8 @@
       "utilityLines": 0
     },
     "nextjs-app/shared/components/BlogCategoryFilter/BlogCategoryFilter.tsx": {
-      "rawElements": 3,
-      "utilityLines": 22
+      "rawElements": 0,
+      "utilityLines": 6
     },
     "nextjs-app/shared/components/BlogGrid/BlogGrid.tsx": {
       "rawElements": 0,
@@ -106,8 +106,8 @@
       "utilityLines": 0
     },
     "nextjs-app/shared/components/CategoryFilter/CategoryFilter.tsx": {
-      "rawElements": 3,
-      "utilityLines": 22
+      "rawElements": 0,
+      "utilityLines": 6
     },
     "nextjs-app/shared/components/Center/Center.tsx": {
       "rawElements": 0,
@@ -207,6 +207,10 @@
     },
     "nextjs-app/shared/components/FileUpload/FileUpload.tsx": {
       "rawElements": 4,
+      "utilityLines": 0
+    },
+    "nextjs-app/shared/components/FilterChip/FilterChip.tsx": {
+      "rawElements": 1,
       "utilityLines": 0
     },
     "nextjs-app/shared/components/FinnishTransportAgency/ColorPalette.tsx": {


### PR DESCRIPTION
Second blessed Phase-3 primitive.

**FilterChip** (alpha atom): `button[aria-pressed]` toggle chip — pill/underline/minimal, sm/md/lg, optional count rendered inside the accessible name, pressed state styled via `[aria-pressed=true]`, forced-colors Highlight/HighlightText, reduced-motion safe.

**CategoryFilter + BlogCategoryFilter** (both stable) keep their public APIs and `role=group` semantics but render FilterChip internally — the **six** hand-rolled Tailwind chip implementations collapse into one. Verified on /work: computed metrics replicate the old classes 1:1 (9/18px padding at the 18px root font, same token inks, 9999px pill).

**AT delta is an improvement**: accessible names now read "All Posts (15)" instead of "All Posts(15)". Blog yamls recaptured; compare + forced-colors green on all three components. Rhythmguard rebaselined for the underline variant's −1px group-border alignment (the old Tailwind `-mb-px` idiom, previously invisible to the CSS scanner).

**Ratchet**: 325 → 320 raw elements, 731 → **699** utility lines (−32, biggest single drop yet).

Gate: typecheck ✓ lint ✓ lint:css ✓ vitest 2213/2213 ✓ build ✓ validate:components ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)