### PR TITLE
fix(blog): tag filter selection no longer reverts on statically-rendered prod

### DIFF
--- a/nextjs-app/shared/hooks/useBlogFilter.test.tsx
+++ b/nextjs-app/shared/hooks/useBlogFilter.test.tsx
@@ -1,0 +1,60 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { useBlogFilter } from "./useBlogFilter";
+import type { BlogPostEntry } from "../data/blogPosts";
+
+// Simulate a statically-rendered production page: the navigation adapter's
+// searchParams NEVER updates after a client-side push (Next's useSearchParams
+// does not re-render on soft navigations in static prerenders). This is the
+// environment where the tag selection used to revert instantly
+// (Codex-migration regression #6).
+const staticEmptyParams = new URLSearchParams();
+const push = vi.fn();
+vi.mock("../lib/navigation", () => ({
+  useNavigationSearchParams: () => staticEmptyParams,
+  useNavigationPathname: () => "/blog",
+  useNavigationRouter: () => ({ push, replace: vi.fn() }),
+}));
+
+const posts = [
+  { slug: "a", title: "A", tags: ["AI"], publishedAt: "2026-01-02" },
+  { slug: "b", title: "B", tags: ["Design Systems"], publishedAt: "2026-01-01" },
+  { slug: "c", title: "C", tags: ["AI", "Design Systems"], publishedAt: "2026-01-03" },
+] as unknown as BlogPostEntry[];
+
+describe("useBlogFilter", () => {
+  it("keeps a fresh selection even when searchParams never updates after push (static prod)", () => {
+    const { result } = renderHook(() => useBlogFilter({ posts }));
+
+    expect(result.current.selectedTag).toBeNull();
+    expect(result.current.filteredPosts).toHaveLength(3);
+
+    act(() => {
+      result.current.setSelectedTag("AI");
+    });
+
+    // The old sync effect compared against selectedTag and reverted this to
+    // null because searchParams still said no tag.
+    expect(result.current.selectedTag).toBe("AI");
+    expect(result.current.filteredPosts.map((p) => p.slug)).toEqual(["c", "a"]);
+    expect(push).toHaveBeenCalledWith("/blog?tag=AI", { scroll: false });
+  });
+
+  it("clears back to all posts", () => {
+    const { result } = renderHook(() => useBlogFilter({ posts }));
+    act(() => {
+      result.current.setSelectedTag("AI");
+    });
+    act(() => {
+      result.current.setSelectedTag(null);
+    });
+    expect(result.current.selectedTag).toBeNull();
+    expect(result.current.filteredPosts).toHaveLength(3);
+  });
+
+  it("derives tags and counts", () => {
+    const { result } = renderHook(() => useBlogFilter({ posts }));
+    expect(result.current.allTags).toEqual(["AI", "Design Systems"]);
+    expect(result.current.tagCounts).toEqual({ AI: 2, "Design Systems": 2 });
+  });
+});

--- a/nextjs-app/shared/hooks/useBlogFilter.ts
+++ b/nextjs-app/shared/hooks/useBlogFilter.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback, useEffect } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import {
   useNavigationPathname,
   useNavigationRouter,
@@ -45,13 +45,20 @@ export function useBlogFilter({
     urlTag || null
   );
 
-  // Sync state with URL on mount and URL changes
+  // One-way URL → state sync for deep links and back/forward. Only reacts
+  // when the URL value ACTUALLY changes; comparing against selectedTag (the
+  // old deps) reverted fresh clicks whenever searchParams lagged the push —
+  // permanently so on statically-rendered production pages, where the
+  // navigation adapter's searchParams never updates after a client push
+  // (Codex-migration regression #6).
+  const lastUrlTag = useRef<string | null>(urlTag || null);
   useEffect(() => {
     const currentUrlTag = searchParams.get(tagParam);
-    if (currentUrlTag !== selectedTag) {
+    if (currentUrlTag !== lastUrlTag.current) {
+      lastUrlTag.current = currentUrlTag;
       setSelectedTagState(currentUrlTag);
     }
-  }, [searchParams, tagParam, selectedTag]);
+  }, [searchParams, tagParam]);
 
   // Extract all unique tags from posts
   const allTags = useMemo(() => {
@@ -102,6 +109,7 @@ export function useBlogFilter({
   // Update URL and state when tag changes
   const setSelectedTag = useCallback(
     (tag: string | null) => {
+      lastUrlTag.current = tag;
       setSelectedTagState(tag);
 
       // Update URL


### PR DESCRIPTION
Petri reported the blog tag filter dead after #1050 while the work-page filter kept working. Investigation cleared #1050 (FilterChip fires onClick correctly; local dev fully works) and found **Codex-migration regression #6**: when `useBlogFilter` switched to the navigation adapter (`d1839c3ec`), its URL→state sync effect kept `selectedTag` in the deps — every fresh click got compared against the not-yet-updated `searchParams` and **reverted**. Dev re-settles because the adapter's searchParams eventually updates; on **statically-rendered production** Next's `useSearchParams` never updates after a client push, so the revert was permanent. Reproduced on www.digitaltableteur.com: URL flips to `?tag=AI` (client-side — a page-survival marker proved no reload), UI stays on "All Posts".

**Fix**: one-way URL→state sync keyed on the URL value actually changing (`lastUrlTag` ref) — user selections are never reverted; deep links and back/forward still sync via the adapter's popstate read.

**Verification**: new regression test simulates the static-prod adapter (searchParams frozen after push) — fails against the old hook, passes now. Live check: click → pressed chip + `?tag=Design+Systems` + filtered list. Full gate: typecheck ✓ lint ✓ vitest 2216/2216 ✓.

Work-page filter was never affected (plain useState, no URL sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)