### PR TITLE
refactor(design-system): unify the brand NEW! chip — one composable source

### DIFF
--- a/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.module.css
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.module.css
@@ -26,18 +26,9 @@
 }
 
 .newBadge {
+  composes: brandchip from "../../styles/brand-chip.module.css";
   position: absolute;
   z-index: 2;
-  padding-block: var(--space-internal-4);
-  padding-inline: var(--space-internal-8);
-  border-radius: var(--radius-full);
-  background-color: var(--logo-background);
-  font-family: var(--font-sans);
-  font-size: var(--space-internal-12);
-  font-weight: 700;
-  line-height: 1;
-  letter-spacing: 0.04em;
-  color: var(--logo-color);
   pointer-events: none;
   transform: none;
   inset-block-start: calc(-1 * var(--space-internal-8));

--- a/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.module.css
+++ b/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.module.css
@@ -416,17 +416,8 @@
 }
 
 .newBadge {
+  composes: brandchip from "../../styles/brand-chip.module.css";
   flex-shrink: 0;
-  padding-block: 1px;
-  padding-inline: var(--space-internal-4);
-  border-radius: var(--radius-full);
-  background-color: var(--logo-background);
-  font-family: var(--font-sans);
-  font-size: 0.6875rem;
-  font-weight: 700;
-  line-height: 1;
-  letter-spacing: 0.04em;
-  color: var(--logo-color);
 }
 
 .aaasPanel {

--- a/nextjs-app/shared/styles/brand-chip.module.css
+++ b/nextjs-app/shared/styles/brand-chip.module.css
@@ -1,0 +1,20 @@
+/* Brand "NEW!" chip: the single source for the logo-colored micro-badge used
+ * by ContactInquiryPanel (Book a call tab) and PricingPageContent (AaaS
+ * accordion). Compose it (`composes: brandchip from
+ * "../../styles/brand-chip.module.css"`) and add only positioning locally —
+ * never re-roll the chrome (same rule as field.module.css, #978).
+ * Too small for DS Badge (sm is a 32px control; this is an 18px decoration);
+ * revisit as a Badge tone only if Badge ever grows a micro size. */
+
+.brandchip {
+  padding-block: var(--space-internal-4);
+  padding-inline: var(--space-internal-8);
+  border-radius: var(--radius-full);
+  background-color: var(--logo-background);
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  color: var(--logo-color);
+}

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -1,6 +1,6 @@
 {
   "generatedBy": "npm run lint:css:update",
-  "warningCount": 446,
+  "warningCount": 445,
   "warnings": [
     {
       "id": "app/blog/NextBlogNav.module.css::7::3::order/properties-order::Expected \"margin-inline\" to come before \"max-width\" (order/properties-order)",
@@ -3619,15 +3619,6 @@
       "rule": "order/properties-order",
       "severity": "warning",
       "text": "Expected \"white-space\" to come before \"color\" (order/properties-order)"
-    },
-    {
-      "id": "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.module.css::420::3::order/properties-order::Expected \"padding-block\" to come before \"flex-shrink\" (order/properties-order)",
-      "file": "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.module.css",
-      "line": 420,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"padding-block\" to come before \"flex-shrink\" (order/properties-order)"
     },
     {
       "id": "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.module.css::64::3::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"#041b23\" of \"color\" (scale-unlimited/declaration-strict-value)",


### PR DESCRIPTION
Answering Petri's question: **neither** the pricing accordion nor the contact 'Book a call' NEW! badge consumes DS Badge — both hand-rolled `.newBadge` spans with the same logo-brand recipe and already-drifted metrics (contact 12px/4+8px, pricing 11px/1+4px).

**Why not Badge**: its tones are semantic (error/warning/success/info drive automatic icons + StatusDot) and its smallest size is a 32px control — this is an ~18px decoration. Forcing a `brand` tone would fight both the semantic model and the size scale.

**Instead**: the field-chrome idiom (#978) — `shared/styles/brand-chip.module.css` owns the chrome, both patterns `compose` it and keep only positioning locally. Pricing adopts contact's metrics, verified live on both pages (12px font, 4/8px padding, logo background, full radius). Revisit as a Badge tone only if Badge ever grows a micro size (noted in the file header).

Gate: typecheck ✓ lint ✓ lint:css (baseline −1) ✓ vitest 2216/2216 ✓ build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)