### PR TITLE
feat(design-system): TextInput clearable/onClear + hideLabel — Phase 3c pivot

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-07-09T23:09:42.284Z",
+  "createdAt": "2026-07-10T07:59:31.059Z",
   "directory": "nextjs-app/shared",
   "findings": [
     {
@@ -4303,6 +4303,26 @@
       "value": "0.625rem"
     },
     {
+      "column": 23,
+      "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f119\u001f23\u001f2.5rem\u001fUnexpected off-scale value \"2.5rem\". Use scale values (nearest: 32px or 32px). (rhythmguard/use-scale)",
+      "line": 119,
+      "rule": "rhythmguard/use-scale",
+      "text": "Unexpected off-scale value \"2.5rem\". Use scale values (nearest: 32px or 32px). (rhythmguard/use-scale)",
+      "type": "off-scale",
+      "value": "2.5rem"
+    },
+    {
+      "column": 11,
+      "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f158\u001f11\u001f-1px\u001fUnexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 158,
+      "rule": "rhythmguard/use-scale",
+      "text": "Unexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "type": "off-scale",
+      "value": "-1px"
+    },
+    {
       "column": 18,
       "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
       "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f5\u001f18\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
@@ -4381,6 +4401,36 @@
       "text": "Unexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
       "value": "1.5rem"
+    },
+    {
+      "column": 23,
+      "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f119\u001f23\u001f2.5rem\u001fUnexpected raw scale value \"2.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 119,
+      "rule": "rhythmguard/prefer-token",
+      "text": "Unexpected raw scale value \"2.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "type": "token-opportunity",
+      "value": "2.5rem"
+    },
+    {
+      "column": 21,
+      "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f135\u001f21\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 135,
+      "rule": "rhythmguard/prefer-token",
+      "text": "Unexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "type": "token-opportunity",
+      "value": "0.5rem"
+    },
+    {
+      "column": 11,
+      "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f158\u001f11\u001f-1px\u001fUnexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 158,
+      "rule": "rhythmguard/prefer-token",
+      "text": "Unexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "type": "token-opportunity",
+      "value": "-1px"
     },
     {
       "column": 25,
@@ -6003,16 +6053,6 @@
       "value": "0.08em"
     },
     {
-      "column": 18,
-      "file": "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/patterns/PricingPageContent/PricingPageContent.module.css\u001f420\u001f18\u001f1px\u001fUnexpected off-scale value \"1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "line": 420,
-      "rule": "rhythmguard/use-scale",
-      "text": "Unexpected off-scale value \"1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "type": "off-scale",
-      "value": "1px"
-    },
-    {
       "column": 25,
       "file": "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.module.css",
       "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/PricingPageContent/PricingPageContent.module.css\u001f239\u001f25\u001f0.6em\u001fUnexpected raw scale value \"0.6em\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
@@ -6041,16 +6081,6 @@
       "text": "Unexpected raw scale value \"0.08em\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
       "value": "0.08em"
-    },
-    {
-      "column": 18,
-      "file": "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/PricingPageContent/PricingPageContent.module.css\u001f420\u001f18\u001f1px\u001fUnexpected raw scale value \"1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 420,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "1px"
     },
     {
       "column": 25,
@@ -7416,6 +7446,6 @@
   "formatVersion": 1,
   "summary": {
     "scaleCleanliness": 92,
-    "totalFindings": 741
+    "totalFindings": 744
   }
 }

--- a/nextjs-app/shared/components/TextInput/TextInput.contract.json
+++ b/nextjs-app/shared/components/TextInput/TextInput.contract.json
@@ -27,7 +27,8 @@
         "Default",
         "Playground",
         "Example",
-        "ForcedColors"
+        "ForcedColors",
+        "Clearable"
     ],
     "a11y": {
         "keyboard": [
@@ -35,7 +36,8 @@
         ],
         "ariaRequirements": [
             "label association",
-            "aria-describedby for error/helper"
+            "aria-describedby for error/helper",
+            "clear button carries a per-field accessible name and returns focus to the input"
         ],
         "reducedMotion": true,
         "reviewed": true,
@@ -161,6 +163,18 @@
             "optional": true,
             "type": "boolean"
         },
+        "clearable": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "onClear": {
+            "optional": true,
+            "type": "() => void"
+        },
+        "hideLabel": {
+            "optional": true,
+            "type": "boolean"
+        },
         "onChange": {
             "optional": true,
             "type": "(value: string | number) => void"
@@ -187,7 +201,7 @@
         "phone",
         "validation"
     ],
-    "dense": "labelled single-line field: text/number/email/password/search/tel, built-in email + phone validation, own error/helperText, sm/md/lg; onValueChange(value)",
+    "dense": "labelled single-line field: text/number/email/tel/password/search, built-in email+phone validation, error/helperText, sm/md/lg; onValueChange(value); clearable ×-button (onClear); hideLabel",
     "usage": {
         "description": "TextInput is the standard single-line field: label, control, helper and error text in one component. The email and tel types add built-in validation (typo suggestions for common email domains, libphonenumber formatting for phone numbers); error overrides the helper line and wires aria-invalid.",
         "bestPractices": [
@@ -206,6 +220,14 @@
             {
                 "guidance": true,
                 "description": "Use helperText for format hints before errors happen (We never share this address)."
+            },
+            {
+                "guidance": true,
+                "description": "Use clearable for fields users iterate on (search boxes, filters, generators); the ×-button appears only while there is a value and hands focus back to the input."
+            },
+            {
+                "guidance": true,
+                "description": "Reserve hideLabel for dense compositions where surrounding design carries the affordance; the label stays in the accessibility tree, so still write a real one."
             },
             {
                 "guidance": false,

--- a/nextjs-app/shared/components/TextInput/TextInput.module.css
+++ b/nextjs-app/shared/components/TextInput/TextInput.module.css
@@ -106,3 +106,61 @@
     accent-color: var(--color-primary);
   }
 }
+
+/* Clearable affordance (v1.2.0) */
+
+.inputShell {
+  display: flex;
+  position: relative;
+  align-items: center;
+}
+
+.inputClearable {
+  padding-inline-end: 2.5rem;
+}
+
+.clearButton {
+  display: flex;
+  position: absolute;
+  padding: 0;
+  width: 1.5rem;
+  height: 1.5rem;
+  justify-content: center;
+  align-items: center;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: none;
+  color: var(--color-primary);
+  cursor: pointer;
+  inset-inline-end: 0.5rem;
+}
+
+.clearButton:focus-visible {
+  outline: var(--focus-ring-width, 2px) solid var(--focus-ring-color, var(--color-primary));
+  outline-offset: var(--focus-ring-offset, 2px);
+}
+
+@media (forced-colors: active) {
+  .clearButton {
+    color: ButtonText;
+  }
+
+  .clearButton:focus-visible {
+    outline: 3px solid Highlight;
+    outline-offset: 2px;
+  }
+}
+
+/* Visually hidden label (hideLabel) — stays in the accessibility tree. */
+
+.srOnly {
+  position: absolute;
+  margin: -1px;
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  border: 0;
+  white-space: nowrap;
+  clip-path: inset(50%);
+  overflow: hidden;
+}

--- a/nextjs-app/shared/components/TextInput/TextInput.spec.md
+++ b/nextjs-app/shared/components/TextInput/TextInput.spec.md
@@ -13,10 +13,18 @@ error wiring so the consumer's form code is a sequence of
   submit handler). ArrowUp / ArrowDown bumps `type="number"`
   values.
 - Pointer: click focuses; selection works as native.
+- Clearable: with `clearable`, a ×-button renders inside the field
+  chrome while the field has a value (never while disabled). It is
+  the next Tab stop after the input; activating it empties the
+  field, clears any built-in validation error, fires
+  `onValueChange("")` then `onClear()`, and returns focus to the
+  input. Its accessible name interpolates the field label
+  (`inputClearField`: "Clear {{field}}", EN/FI/SV).
 - Screen readers: the label is announced first via the native
-  `<label htmlFor>` binding. On invalid state the description
-  (linked via `aria-describedby` to the error helper) is announced
-  on focus.
+  `<label htmlFor>` binding. With `hideLabel` the label is
+  visually hidden but stays in the accessibility tree. On invalid
+  state the description (linked via `aria-describedby` to the error
+  helper) is announced on focus.
 
 ## Do / don't
 - Do: use `onValueChange` (the new contract). The legacy `onChange`
@@ -31,6 +39,11 @@ error wiring so the consumer's form code is a sequence of
   `value` as controlled; mixing them produces drift.
 - Don't: use TextInput for multi-line text. Use **TextArea**, which
   shares the label + helper contract but carries multi-line UX.
+- Do: use `clearable` on fields users iterate on (search, filters,
+  generators) instead of hand-rolling an adjacent ×-button.
+- Don't: treat `hideLabel` as permission to skip the label. The label
+  is still required and still read by assistive tech; `hideLabel`
+  only removes it visually for dense compositions.
 
 ## Design notes
 - Tokens: control surface uses `--color-surface`; border uses

--- a/nextjs-app/shared/components/TextInput/TextInput.stories.tsx
+++ b/nextjs-app/shared/components/TextInput/TextInput.stories.tsx
@@ -128,6 +128,33 @@ DisabledInput.args = {
   disabled: true,
 };
 
+export const Clearable: Story = {
+  tags: ["beta-matrix"],
+  args: {
+    label: "storyInputTextLabel",
+    type: "text",
+    placeholder: "storyInputTextPlaceholder",
+    clearable: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "clearable renders a labelled ×-button inside the field while it has a value; activating it empties the field, fires onValueChange('') + onClear, and returns focus to the input.",
+      },
+    },
+  },
+  render: (args) => <InputStory {...args} />,
+  // Play types but never clears: the settled state must keep the clear
+  // button visible so AT capture records it in the accessibility tree.
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = await canvas.findByLabelText(/text input/i);
+    await userEvent.type(input, "Hello");
+    await canvas.findByRole("button", { name: /clear/i });
+  },
+};
+
 export const Default = TextInputStory;
 export const Playground: Story = {
   parameters: { a11y: { disable: true, test: "off" } },

--- a/nextjs-app/shared/components/TextInput/TextInput.test.tsx
+++ b/nextjs-app/shared/components/TextInput/TextInput.test.tsx
@@ -1,19 +1,34 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
 import { describe, it, expect, vi } from "vitest";
 import Input from "./TextInput";
+
+expect.extend(toHaveNoViolations);
 
 // Mock i18next for testing
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string) => {
+    t: (key: string, options?: Record<string, unknown>) => {
       const translations: Record<string, string> = {
         inputValidationEmailInvalid: "Please enter a valid email address",
         inputValidationPhoneInvalid: "Invalid phone number format",
+        inputClearField: "Clear {{field}}",
       };
-      return translations[key] || key;
+      const template = translations[key] || key;
+      return template.replace(/\{\{(\w+)\}\}/g, (_, name) =>
+        String(options?.[name] ?? "")
+      );
     },
   }),
+}));
+
+// The clear button's Icon is decorative; a stub keeps the registry (and its
+// full @phosphor-icons/react surface) out of this suite's partial mock.
+vi.mock("@dt/Icon", () => ({
+  default: ({ name }: { name: string }) => (
+    <span data-testid={`icon-${name}`} aria-hidden="true" />
+  ),
 }));
 
 // Mock Phosphor icons to avoid React context issues in tests
@@ -176,6 +191,118 @@ describe("Input", () => {
       });
       const errorElement = screen.getByRole("alert");
       expect(errorElement).toHaveTextContent("Invalid email");
+    });
+  });
+
+  describe("clearable", () => {
+    it("shows no clear button while the field is empty", () => {
+      renderInput({ label: "Name", type: "text", clearable: true });
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+
+    it("shows a clear button named after the field once there is a value", () => {
+      renderInput({ label: "Name", type: "text", clearable: true });
+      fireEvent.change(screen.getByLabelText("Name"), {
+        target: { value: "Ada" },
+      });
+      expect(
+        screen.getByRole("button", { name: "Clear Name" })
+      ).toBeInTheDocument();
+    });
+
+    it("clears the value, fires onValueChange('') + onClear, and refocuses the input", () => {
+      const onValueChange = vi.fn();
+      const onClear = vi.fn();
+      renderInput({
+        label: "Name",
+        type: "text",
+        clearable: true,
+        onValueChange,
+        onClear,
+      });
+      const input = screen.getByLabelText("Name");
+      fireEvent.change(input, { target: { value: "Ada" } });
+      fireEvent.click(screen.getByRole("button", { name: "Clear Name" }));
+
+      expect(input).toHaveValue("");
+      expect(onValueChange).toHaveBeenLastCalledWith("");
+      expect(onClear).toHaveBeenCalledTimes(1);
+      expect(input).toHaveFocus();
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+
+    it("clears a controlled value back through onValueChange", () => {
+      const onValueChange = vi.fn();
+      renderInput({
+        label: "Name",
+        type: "text",
+        clearable: true,
+        value: "Ada",
+        onValueChange,
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Clear Name" }));
+      expect(onValueChange).toHaveBeenLastCalledWith("");
+    });
+
+    it("clears a built-in validation error along with the value", () => {
+      renderInput({ label: "Email", type: "email", clearable: true });
+      const input = screen.getByLabelText("Email");
+      fireEvent.change(input, { target: { value: "not-an-email" } });
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Clear Email" }));
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("hides the clear button while disabled", () => {
+      renderInput({
+        label: "Name",
+        type: "text",
+        clearable: true,
+        value: "Ada",
+        disabled: true,
+      });
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+
+    it("uses a non-submitting button", () => {
+      renderInput({ label: "Name", type: "text", clearable: true, value: "Ada" });
+      expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+    });
+  });
+
+  describe("hideLabel", () => {
+    it("keeps the label associated and accessible", () => {
+      renderInput({ label: "Name", type: "text", hideLabel: true });
+      expect(screen.getByLabelText("Name")).toBeInTheDocument();
+    });
+
+    it("applies the visually-hidden class to the label", () => {
+      renderInput({ label: "Name", type: "text", hideLabel: true });
+      const label = screen.getByText("Name");
+      expect(label.className).toMatch(/srOnly/);
+    });
+  });
+
+  describe("axe", () => {
+    it("has no violations with a populated clearable field and hidden label", async () => {
+      const { container } = render(
+        <Input
+          label="Name"
+          type="text"
+          clearable
+          hideLabel
+          value="Ada"
+          helperText="As it should appear in the signature"
+        />
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
+
+    it("has no violations in the error state", async () => {
+      const { container } = render(
+        <Input label="Email" type="email" clearable value="x" error="Invalid email" />
+      );
+      expect(await axe(container)).toHaveNoViolations();
     });
   });
 });

--- a/nextjs-app/shared/components/TextInput/TextInput.tsx
+++ b/nextjs-app/shared/components/TextInput/TextInput.tsx
@@ -9,6 +9,7 @@ import React, { useEffect, useId, useRef, useState } from "react";
 import styles from "./TextInput.module.css";
 import Label from "@dt/Label";
 import HelperText from "@dt/HelperText";
+import Icon from "@dt/Icon";
 import { useTranslate } from "../../lib/translation";
 import {
   parsePhoneNumber,
@@ -43,6 +44,14 @@ export interface TextInputProps
   /** Disables the input. Declared explicitly (not just via the native attribute extension) so the agent-blocks prop extraction sees it. */
   disabled?: boolean;
 
+  // NEW PROPS (v1.2.0)
+  /** Shows a labelled ×-button inside the field chrome while the field has a value; clearing returns focus to the input */
+  clearable?: boolean;
+  /** Called after the clear button empties the field (onValueChange also fires with "") */
+  onClear?: () => void;
+  /** Visually hides the label (kept in the accessibility tree); use where surrounding design carries the affordance */
+  hideLabel?: boolean;
+
   // DEPRECATED PROPS
   /** @deprecated Use onValueChange instead. Will be removed in v2.0.0 */
   onChange?: (value: string | number) => void;
@@ -60,6 +69,9 @@ const TextInput: React.FC<TextInputProps> = ({
   // New props (v1.1.0)
   size = "md",
   onValueChange,
+  clearable = false,
+  onClear,
+  hideLabel = false,
   // Deprecated props
   onChange,
   disabled = false,
@@ -90,6 +102,7 @@ const TextInput: React.FC<TextInputProps> = ({
     (value === "" ? undefined : value) ?? defaultValue ?? ""
   );
   const syncedOnce = useRef(false);
+  const inputRef = useRef<HTMLInputElement>(null);
   const [phoneError, setPhoneError] = useState("");
   const [emailError, setEmailError] = useState("");
 
@@ -167,28 +180,62 @@ const TextInput: React.FC<TextInputProps> = ({
     }
   };
 
+  const handleClear = () => {
+    setInputValue("");
+    setPhoneError("");
+    setEmailError("");
+    if (effectiveOnChange) effectiveOnChange("");
+    if (onClear) onClear();
+    inputRef.current?.focus();
+  };
+
+  const showClearButton = clearable && !disabled && inputValue !== "";
+
+  const inputElement = (
+    <input
+      ref={inputRef}
+      id={inputId}
+      name={label.replace(/\s+/g, "-").toLowerCase()}
+      className={`${styles.input} ${styles[`input--${normalizedSize}`]} ${clearable ? styles.inputClearable : ""} ${hasError ? styles.error : ""}`}
+      type={type}
+      placeholder={placeholder}
+      value={inputValue}
+      onChange={handleChange}
+      disabled={disabled}
+      aria-invalid={hasError || undefined}
+      aria-describedby={describedBy}
+      {...rest}
+    />
+  );
+
   return (
     <div className={styles.inputContainer}>
       <Label
         htmlFor={inputId}
         required={!!rest.required}
         disabled={disabled}
+        className={hideLabel ? styles.srOnly : undefined}
       >
         {label}
       </Label>
-      <input
-        id={inputId}
-        name={label.replace(/\s+/g, "-").toLowerCase()}
-        className={`${styles.input} ${styles[`input--${normalizedSize}`]} ${hasError ? styles.error : ""}`}
-        type={type}
-        placeholder={placeholder}
-        value={inputValue}
-        onChange={handleChange}
-        disabled={disabled}
-        aria-invalid={hasError || undefined}
-        aria-describedby={describedBy}
-        {...rest}
-      />
+      {/* Non-clearable consumers keep the exact previous DOM (no wrapper). */}
+      {clearable ? (
+        <div className={styles.inputShell}>
+          {inputElement}
+          {showClearButton && (
+            <button
+              type="button"
+              className={styles.clearButton}
+              onClick={handleClear}
+              aria-label={t("inputClearField", { field: label })}
+            >
+              <Icon name="x" size={16} decorative />
+            </button>
+          )}
+        </div>
+      ) : (
+        inputElement
+      )}
       {hasError && (
         <HelperText id={errorId} state="error">
           {errorMessage}

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--clearable.dark.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--clearable.dark.yaml
@@ -1,0 +1,5 @@
+- text: Text Input
+- textbox "Text Input":
+  - /placeholder: Enter text
+  - text: Hello
+- button "Clear Text Input"

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--clearable.forced-colors.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--clearable.forced-colors.yaml
@@ -1,0 +1,5 @@
+- text: Text Input
+- textbox "Text Input":
+  - /placeholder: Enter text
+  - text: Hello
+- button "Clear Text Input"

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--clearable.light.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--clearable.light.yaml
@@ -1,0 +1,5 @@
+- text: Text Input
+- textbox "Text Input":
+  - /placeholder: Enter text
+  - text: Hello
+- button "Clear Text Input"

--- a/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--clearable.yaml
+++ b/nextjs-app/shared/components/TextInput/__a11y-snapshots__/forms-textinput--clearable.yaml
@@ -1,0 +1,5 @@
+- text: Text Input
+- textbox "Text Input":
+  - /placeholder: Enter text
+  - text: Hello
+- button "Clear Text Input"

--- a/nextjs-app/shared/components/TextInput/schema.json
+++ b/nextjs-app/shared/components/TextInput/schema.json
@@ -27,6 +27,12 @@
         "label": "helper text",
         "role": "text",
         "description": "Guidance or error message below input."
+      },
+      {
+        "id": "clearButton",
+        "label": "clear button",
+        "role": "button",
+        "description": "Optional ×-button (clearable prop) inside the field chrome; rendered only while the field has a value and is not disabled. Accessible name interpolates the field label (i18n key inputClearField)."
       }
     ]
   },
@@ -91,6 +97,10 @@
       {
         "trigger": "Input change (type=email)",
         "effect": "Validates email regex, updates inputValue, calls onChange, shows emailError if invalid."
+      },
+      {
+        "trigger": "Clear button click (clearable)",
+        "effect": "Empties the field, clears built-in validation errors, calls onValueChange('') and onClear(), returns focus to the input."
       }
     ],
     "feedback": {
@@ -160,6 +170,8 @@
     "Controlled component: parent manages value via onChange callback.",
     "onChange receives string (text) or number (type=number).",
     "Label has tooltip support (error message shown in tooltip).",
-    "i18n keys: inputValidationPhoneInvalid, inputValidationEmailInvalid."
+    "clearable renders a ×-button while the field has a value; onClear fires after clearing; focus returns to the input.",
+    "hideLabel visually hides the label but keeps it in the accessibility tree.",
+    "i18n keys: inputValidationPhoneInvalid, inputValidationEmailInvalid, inputClearField."
   ]
 }

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-09T23:04:19.839Z",
+  "generatedAt": "2026-07-10T07:49:56.044Z",
   "summary": {
     "componentCount": 163,
     "statusCounts": {
@@ -81,8 +81,8 @@
     "withAnyUsage": 152,
     "withProductionUsage": 46,
     "uniqueImportedComponents": 152,
-    "totalEvidenceRows": 854,
-    "aliasImportFiles": 471,
+    "totalEvidenceRows": 855,
+    "aliasImportFiles": 472,
     "relativeImportFiles": 391,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
@@ -14734,10 +14734,10 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Icon",
-        "importCount": 74,
+        "importCount": 75,
         "productionImportCount": 6,
         "patternImportCount": 5,
-        "componentImportCount": 32,
+        "componentImportCount": 33,
         "evidence": [
           {
             "path": "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
@@ -30061,7 +30061,8 @@
           "Default",
           "Playground",
           "Example",
-          "ForcedColors"
+          "ForcedColors",
+          "Clearable"
         ],
         "a11y": {
           "keyboard": [
@@ -30069,7 +30070,8 @@
           ],
           "ariaRequirements": [
             "label association",
-            "aria-describedby for error/helper"
+            "aria-describedby for error/helper",
+            "clear button carries a per-field accessible name and returns focus to the input"
           ],
           "reducedMotion": true,
           "reviewed": true,
@@ -30195,6 +30197,18 @@
             "optional": true,
             "type": "boolean"
           },
+          "clearable": {
+            "optional": true,
+            "type": "boolean"
+          },
+          "onClear": {
+            "optional": true,
+            "type": "() => void"
+          },
+          "hideLabel": {
+            "optional": true,
+            "type": "boolean"
+          },
           "onChange": {
             "optional": true,
             "type": "(value: string | number) => void"
@@ -30221,7 +30235,7 @@
           "phone",
           "validation"
         ],
-        "dense": "labelled single-line field: text/number/email/password/search/tel, built-in email + phone validation, own error/helperText, sm/md/lg; onValueChange(value)",
+        "dense": "labelled single-line field: text/number/email/tel/password/search, built-in email+phone validation, error/helperText, sm/md/lg; onValueChange(value); clearable ×-button (onClear); hideLabel",
         "usage": {
           "description": "TextInput is the standard single-line field: label, control, helper and error text in one component. The email and tel types add built-in validation (typo suggestions for common email domains, libphonenumber formatting for phone numbers); error overrides the helper line and wires aria-invalid.",
           "bestPractices": [
@@ -30242,6 +30256,14 @@
               "description": "Use helperText for format hints before errors happen (We never share this address)."
             },
             {
+              "guidance": true,
+              "description": "Use clearable for fields users iterate on (search boxes, filters, generators); the ×-button appears only while there is a value and hands focus back to the input."
+            },
+            {
+              "guidance": true,
+              "description": "Reserve hideLabel for dense compositions where surrounding design carries the affordance; the label stays in the accessibility tree, so still write a real one."
+            },
+            {
               "guidance": false,
               "description": "Do not build multi-line entry with TextInput; use TextArea."
             },
@@ -30259,7 +30281,7 @@
           }
         }
       },
-      "spec": "# TextInput\n\n## Intent\nProvide the canonical labelled text input with built-in validation for\nthe two types that always validate (email, tel) so consumers don't\nre-implement format checks per form. TextInput absorbs the label / helper /\nerror wiring so the consumer's form code is a sequence of\n`{ label, value, onValueChange, error }` quadruples — nothing else.\n\n## Interaction contract\n- Keyboard: native single-line input. Tab moves focus; characters\n  type into the field; Enter submits the containing form (no custom\n  submit handler). ArrowUp / ArrowDown bumps `type=\"number\"`\n  values.\n- Pointer: click focuses; selection works as native.\n- Screen readers: the label is announced first via the native\n  `<label htmlFor>` binding. On invalid state the description\n  (linked via `aria-describedby` to the error helper) is announced\n  on focus.\n\n## Do / don't\n- Do: use `onValueChange` (the new contract). The legacy `onChange`\n  still works but emits a deprecation warning in dev.\n- Do: pair `type=\"email\"` and `type=\"tel\"` with the built-in\n  validators. The component will surface format issues without\n  consumer wiring.\n- Don't: ship a form that relies on the email validator as the only\n  verification step. The validator is for UX; the server must verify\n  too.\n- Don't: pass a `value` plus a `defaultValue`. The component treats\n  `value` as controlled; mixing them produces drift.\n- Don't: use TextInput for multi-line text. Use **TextArea**, which\n  shares the label + helper contract but carries multi-line UX.\n\n## Design notes\n- Tokens: control surface uses `--color-surface`; border uses\n  `--color-border` (default) or `--color-error-border` (error).\n  Height is `--input-height-md` by default; `--input-height-sm` and\n  `--input-height-lg` via the `size` prop. Padding is\n  `--space-internal-12` inline.\n- Figma: https://www.figma.com/design/digitaltableteur/input — three\n  sizes, four states (default / focus / error / disabled), six\n  types via the `type` prop.\n- The `name` attribute is derived from the label so form submission\n  always has a stable key. Consumers can override by passing `name`\n  via the rest-spread.\n- Phone formatter is `formatIncompletePhoneNumber` from\n  `libphonenumber-js`; validator is `parsePhoneNumber(...).isValid()`.\n  Empty values pass validation so optional phone fields don't trigger\n  errors on mount.\n- Email suggestion uses `suggestEmailCorrection` which checks against\n  a known set of common domain typos; suggestions surface via the\n  same `error` channel as a friendly message.\n",
+      "spec": "# TextInput\n\n## Intent\nProvide the canonical labelled text input with built-in validation for\nthe two types that always validate (email, tel) so consumers don't\nre-implement format checks per form. TextInput absorbs the label / helper /\nerror wiring so the consumer's form code is a sequence of\n`{ label, value, onValueChange, error }` quadruples — nothing else.\n\n## Interaction contract\n- Keyboard: native single-line input. Tab moves focus; characters\n  type into the field; Enter submits the containing form (no custom\n  submit handler). ArrowUp / ArrowDown bumps `type=\"number\"`\n  values.\n- Pointer: click focuses; selection works as native.\n- Clearable: with `clearable`, a ×-button renders inside the field\n  chrome while the field has a value (never while disabled). It is\n  the next Tab stop after the input; activating it empties the\n  field, clears any built-in validation error, fires\n  `onValueChange(\"\")` then `onClear()`, and returns focus to the\n  input. Its accessible name interpolates the field label\n  (`inputClearField`: \"Clear {{field}}\", EN/FI/SV).\n- Screen readers: the label is announced first via the native\n  `<label htmlFor>` binding. With `hideLabel` the label is\n  visually hidden but stays in the accessibility tree. On invalid\n  state the description (linked via `aria-describedby` to the error\n  helper) is announced on focus.\n\n## Do / don't\n- Do: use `onValueChange` (the new contract). The legacy `onChange`\n  still works but emits a deprecation warning in dev.\n- Do: pair `type=\"email\"` and `type=\"tel\"` with the built-in\n  validators. The component will surface format issues without\n  consumer wiring.\n- Don't: ship a form that relies on the email validator as the only\n  verification step. The validator is for UX; the server must verify\n  too.\n- Don't: pass a `value` plus a `defaultValue`. The component treats\n  `value` as controlled; mixing them produces drift.\n- Don't: use TextInput for multi-line text. Use **TextArea**, which\n  shares the label + helper contract but carries multi-line UX.\n- Do: use `clearable` on fields users iterate on (search, filters,\n  generators) instead of hand-rolling an adjacent ×-button.\n- Don't: treat `hideLabel` as permission to skip the label. The label\n  is still required and still read by assistive tech; `hideLabel`\n  only removes it visually for dense compositions.\n\n## Design notes\n- Tokens: control surface uses `--color-surface`; border uses\n  `--color-border` (default) or `--color-error-border` (error).\n  Height is `--input-height-md` by default; `--input-height-sm` and\n  `--input-height-lg` via the `size` prop. Padding is\n  `--space-internal-12` inline.\n- Figma: https://www.figma.com/design/digitaltableteur/input — three\n  sizes, four states (default / focus / error / disabled), six\n  types via the `type` prop.\n- The `name` attribute is derived from the label so form submission\n  always has a stable key. Consumers can override by passing `name`\n  via the rest-spread.\n- Phone formatter is `formatIncompletePhoneNumber` from\n  `libphonenumber-js`; validator is `parsePhoneNumber(...).isValid()`.\n  Empty values pass validation so optional phone fields don't trigger\n  errors on mount.\n- Email suggestion uses `suggestEmailCorrection` which checks against\n  a known set of common domain typos; suggestions surface via the\n  same `error` channel as a friendly message.\n",
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/TextInput",
@@ -30386,6 +30408,18 @@
             "optional": true,
             "type": "boolean"
           },
+          "clearable": {
+            "optional": true,
+            "type": "boolean"
+          },
+          "onClear": {
+            "optional": true,
+            "type": "() => void"
+          },
+          "hideLabel": {
+            "optional": true,
+            "type": "boolean"
+          },
           "onChange": {
             "optional": true,
             "type": "(value: string | number) => void"
@@ -30425,16 +30459,19 @@
         "variantsFnName": "textInputVariants",
         "useWhen": [
           "use `onValueChange` (the new contract). The legacy `onChange`",
-          "pair `type=\"email\"` and `type=\"tel\"` with the built-in"
+          "pair `type=\"email\"` and `type=\"tel\"` with the built-in",
+          "use `clearable` on fields users iterate on (search, filters,"
         ],
         "avoidWhen": [
           "ship a form that relies on the email validator as the only",
           "pass a `value` plus a `defaultValue`. The component treats",
-          "use TextInput for multi-line text. Use **TextArea**, which"
+          "use TextInput for multi-line text. Use **TextArea**, which",
+          "treat `hideLabel` as permission to skip the label. The label"
         ],
         "requiredA11y": [
           "label association",
-          "aria-describedby for error/helper"
+          "aria-describedby for error/helper",
+          "clear button carries a per-field accessible name and returns focus to the input"
         ],
         "keyboard": [
           "Tab"
@@ -30451,7 +30488,8 @@
         "forbiddenUse": [
           "ship a form that relies on the email validator as the only",
           "pass a `value` plus a `defaultValue`. The component treats",
-          "use TextInput for multi-line text. Use **TextArea**, which"
+          "use TextInput for multi-line text. Use **TextArea**, which",
+          "treat `hideLabel` as permission to skip the label. The label"
         ],
         "composesWith": [
           "Text",
@@ -30462,7 +30500,7 @@
           "CheckboxGroup"
         ],
         "prefersOver": [],
-        "declaredPropCount": 10
+        "declaredPropCount": 13
       }
     },
     {

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-09T23:04:19.514Z",
+  "generatedAt": "2026-07-10T07:47:59.697Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -9399,6 +9399,18 @@
           "optional": true,
           "type": "boolean"
         },
+        "clearable": {
+          "optional": true,
+          "type": "boolean"
+        },
+        "onClear": {
+          "optional": true,
+          "type": "() => void"
+        },
+        "hideLabel": {
+          "optional": true,
+          "type": "boolean"
+        },
         "onChange": {
           "optional": true,
           "type": "(value: string | number) => void"
@@ -9438,16 +9450,19 @@
       "variantsFnName": "textInputVariants",
       "useWhen": [
         "use `onValueChange` (the new contract). The legacy `onChange`",
-        "pair `type=\"email\"` and `type=\"tel\"` with the built-in"
+        "pair `type=\"email\"` and `type=\"tel\"` with the built-in",
+        "use `clearable` on fields users iterate on (search, filters,"
       ],
       "avoidWhen": [
         "ship a form that relies on the email validator as the only",
         "pass a `value` plus a `defaultValue`. The component treats",
-        "use TextInput for multi-line text. Use **TextArea**, which"
+        "use TextInput for multi-line text. Use **TextArea**, which",
+        "treat `hideLabel` as permission to skip the label. The label"
       ],
       "requiredA11y": [
         "label association",
-        "aria-describedby for error/helper"
+        "aria-describedby for error/helper",
+        "clear button carries a per-field accessible name and returns focus to the input"
       ],
       "keyboard": [
         "Tab"
@@ -9464,7 +9479,8 @@
       "forbiddenUse": [
         "ship a form that relies on the email validator as the only",
         "pass a `value` plus a `defaultValue`. The component treats",
-        "use TextInput for multi-line text. Use **TextArea**, which"
+        "use TextInput for multi-line text. Use **TextArea**, which",
+        "treat `hideLabel` as permission to skip the label. The label"
       ],
       "composesWith": [
         "Text",
@@ -9475,7 +9491,7 @@
         "CheckboxGroup"
       ],
       "prefersOver": [],
-      "declaredPropCount": 10
+      "declaredPropCount": 13
     },
     "ThemeProvider": {
       "preferredImport": "@dt/ThemeProvider",

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -14341,7 +14341,7 @@
       "tier": 1,
       "status": "stable",
       "description": "Labeled text input with validation, helper text, and size tokens.",
-      "dense": "labelled single-line field: text/number/email/password/search/tel, built-in email + phone validation, own error/helperText, sm/md/lg; onValueChange(value)",
+      "dense": "labelled single-line field: text/number/email/tel/password/search, built-in email+phone validation, error/helperText, sm/md/lg; onValueChange(value); clearable ×-button (onClear); hideLabel",
       "keywords": [
         "text input",
         "input",
@@ -14436,6 +14436,18 @@
           "optional": true,
           "type": "boolean"
         },
+        "clearable": {
+          "optional": true,
+          "type": "boolean"
+        },
+        "onClear": {
+          "optional": true,
+          "type": "() => void"
+        },
+        "hideLabel": {
+          "optional": true,
+          "type": "boolean"
+        },
         "onChange": {
           "optional": true,
           "type": "(value: string | number) => void"
@@ -14472,6 +14484,14 @@
           {
             "guidance": true,
             "description": "Use helperText for format hints before errors happen (We never share this address)."
+          },
+          {
+            "guidance": true,
+            "description": "Use clearable for fields users iterate on (search boxes, filters, generators); the ×-button appears only while there is a value and hands focus back to the input."
+          },
+          {
+            "guidance": true,
+            "description": "Reserve hideLabel for dense compositions where surrounding design carries the affordance; the label stays in the accessibility tree, so still write a real one."
           },
           {
             "guidance": false,

--- a/nextjs-app/shared/locales/en/translation.json
+++ b/nextjs-app/shared/locales/en/translation.json
@@ -263,6 +263,7 @@
   "contactValidationMessageRequired": "Message is required",
   "inputValidationEmailInvalid": "Please enter a valid email address",
   "inputValidationPhoneInvalid": "Invalid phone number format",
+  "inputClearField": "Clear {{field}}",
   "shareOnInstagram": "Share on Instagram",
   "shareOnTwitter": "Share on Twitter",
   "shareOnFacebook": "Share on Facebook",

--- a/nextjs-app/shared/locales/fi/translation.json
+++ b/nextjs-app/shared/locales/fi/translation.json
@@ -266,6 +266,7 @@
   "contactValidationMessageRequired": "Viesti on pakollinen",
   "inputValidationEmailInvalid": "Syötä kelvollinen sähköpostiosoite",
   "inputValidationPhoneInvalid": "Virheellinen puhelinnumeron muoto",
+  "inputClearField": "Tyhjennä kenttä {{field}}",
   "shareOnInstagram": "Jaa Instagramissa",
   "shareOnTwitter": "Jaa Twitterissä",
   "shareOnFacebook": "Jaa Facebookissa",

--- a/nextjs-app/shared/locales/sv/translation.json
+++ b/nextjs-app/shared/locales/sv/translation.json
@@ -266,6 +266,7 @@
   "contactValidationMessageRequired": "Meddelande krävs",
   "inputValidationEmailInvalid": "Ange en giltig e-postadress",
   "inputValidationPhoneInvalid": "Ogiltigt telefonnummerformat",
+  "inputClearField": "Rensa fältet {{field}}",
   "shareOnInstagram": "Dela på Instagram",
   "shareOnTwitter": "Dela på Twitter",
   "shareOnFacebook": "Dela på Facebook",

--- a/scripts/design-system/dogfood-ratchet.baseline.json
+++ b/scripts/design-system/dogfood-ratchet.baseline.json
@@ -386,7 +386,7 @@
       "utilityLines": 0
     },
     "nextjs-app/shared/components/TextInput/TextInput.tsx": {
-      "rawElements": 1,
+      "rawElements": 2,
       "utilityLines": 0
     },
     "nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.tsx": {


### PR DESCRIPTION
## Phase 3c pivot, PR 1 of 2 (build-then-consume)

The audited CopyField premise was wrong (EmailSignatureGenerator's nine repeated rows are input+clear, not input+copy), so 3c pivots to extending the stable TextInput with the capability the generator hand-rolls nine times.

### API (additive, stable component)
- `clearable?: boolean` — labelled ×-button inside the field chrome while the field has a value (never while disabled). Activating it empties the field, clears built-in validation errors, fires `onValueChange('')` + `onClear()`, and returns focus to the input.
- `onClear?: () => void`
- `hideLabel?: boolean` — visually hides the label, keeps it in the accessibility tree (sr-only). Included because the generator's rows are placeholder-only; a real (hidden) label is a strict a11y upgrade over placeholder-as-name. Carbon/Polaris-standard affordance.

### Evidence (full stable-change burden)
- Contract: 3 new props, new required `Clearable` story, a11y requirement for the per-field clear-button name; dense updated.
- i18n: `inputClearField` = "Clear {{field}}" EN/FI/SV; accessible name interpolates the field label (`button "Clear Text Input"` in the AT tree).
- Story with play (types, never clears — settled state keeps the button in AT capture); 4-mode AT snapshots captured via the runner; existing 16 yamls byte-identical (non-clearable consumers keep the exact previous DOM — no wrapper).
- Unit tests: clear/refocus/controlled/disabled/error-reset/hideLabel + jest-axe (populated clearable + error state). 24 pass.
- `audit:controls --effects`: 10/10 operable, 0 inert.
- Forced colors: ButtonText + Highlight focus ring.
- Real-browser verify on the story: click clears value, button unmounts, focus returns to input.

### Ratchet + baselines
- Dogfood ratchet 320→321 raw: the one new element is the DS primitive's own clear `<button>` (primitives own their raw elements). PR 2 removes 18+ from the generator.
- Rhythm baseline +5 line-keyed entries (sr-only clip pattern + button geometry).

Local gate: typecheck, lint, lint:css, full vitest (283 files/2227 tests), build — all exit 0. Farm-parity add-on: build:tokens, check:contract-props, check:consumers — pass.

Rides the next @digitaltableteur/react publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional clear button to text inputs when a value is present.
  * Clearing a field resets validation errors, triggers configured callbacks, and returns focus to the input.
  * Added support for visually hiding labels while keeping them accessible to assistive technologies.
  * Added localized accessible labels for clear actions in English, Finnish, and Swedish.

* **Accessibility**
  * Added focus styling, forced-colors support, and accessibility coverage for the new interactions.

* **Documentation**
  * Updated usage guidance and examples for clearable inputs and hidden labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->