### PR TITLE
refactor(design-system): EmailSignatureGenerator consumes TextInput clearable — Phase 3c complete

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-07-10T07:59:31.059Z",
+  "createdAt": "2026-07-10T08:09:34.774Z",
   "directory": "nextjs-app/shared",
   "findings": [
     {
@@ -2395,8 +2395,8 @@
     {
       "column": 27,
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css\u001f41\u001f27\u001f20px\u001fUnexpected off-scale value \"20px\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
-      "line": 41,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css\u001f38\u001f27\u001f20px\u001fUnexpected off-scale value \"20px\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
+      "line": 38,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"20px\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -2405,8 +2405,8 @@
     {
       "column": 23,
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css\u001f225\u001f23\u001f2px\u001fUnexpected off-scale value \"2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "line": 225,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css\u001f153\u001f23\u001f2px\u001fUnexpected off-scale value \"2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 153,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -2415,8 +2415,8 @@
     {
       "column": 8,
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css\u001f262\u001f8\u001f2px\u001fUnexpected off-scale value \"2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "line": 262,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css\u001f190\u001f8\u001f2px\u001fUnexpected off-scale value \"2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 190,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -2425,8 +2425,8 @@
     {
       "column": 27,
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css\u001f41\u001f27\u001f20px\u001fUnexpected raw scale value \"20px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 41,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css\u001f38\u001f27\u001f20px\u001fUnexpected raw scale value \"20px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 38,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"20px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -2435,8 +2435,8 @@
     {
       "column": 23,
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css\u001f225\u001f23\u001f2px\u001fUnexpected raw scale value \"2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 225,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css\u001f153\u001f23\u001f2px\u001fUnexpected raw scale value \"2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 153,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -2445,8 +2445,8 @@
     {
       "column": 12,
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css\u001f261\u001f12\u001f4px\u001fUnexpected raw scale value \"4px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 261,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css\u001f189\u001f12\u001f4px\u001fUnexpected raw scale value \"4px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 189,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"4px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -2455,8 +2455,8 @@
     {
       "column": 8,
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css\u001f262\u001f8\u001f2px\u001fUnexpected raw scale value \"2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 262,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css\u001f190\u001f8\u001f2px\u001fUnexpected raw scale value \"2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 190,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",

--- a/nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css
+++ b/nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css
@@ -14,11 +14,8 @@
   --esg-text-secondary: #4b5563;
   --esg-text-muted: #6b7280;
   --esg-text-faint: #9ca3af;
-  --esg-border: #e5e7eb;
-  --esg-border-strong: #d1d5db;
   --esg-surface: #fff;
   --esg-surface-dim: #f3f4f6;
-  --esg-surface-hover: #e5e7eb;
   --esg-toggle-active-bg: #fff;
   --esg-import-border: #9ca3af;
   --esg-import-hover-bg: #f9fafb;
@@ -73,89 +70,20 @@
 
 /* Form Grid - 2 columns */
 
+/* Field rows are DS TextInput (clearable + hideLabel); the component brings
+   its own vertical margins, so the grid only spaces columns. */
+
 .formGrid {
   display: grid;
   margin-block-end: var(--space-layout-24);
   grid-template-columns: 1fr 1fr;
-  gap: var(--space-internal-16);
+  gap: 0 var(--space-internal-16);
 }
 
 @media (width <= 600px) {
   .formGrid {
     grid-template-columns: 1fr;
   }
-}
-
-.inputGroup {
-  display: flex;
-  flex-direction: column;
-}
-
-.inputWrapper {
-  display: flex;
-  position: relative;
-  align-items: center;
-}
-
-.input {
-  padding-block: var(--space-internal-16);
-  padding-inline: var(--space-internal-24);
-  padding-inline-end: var(--space-internal-48);
-  width: 100%;
-  border: 1px solid var(--esg-border);
-  border-radius: 100px;
-  background-color: var(--esg-surface);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
-  font-family: var(--font-text);
-  font-size: 1rem;
-  color: var(--esg-ink);
-  transition:
-    box-shadow var(--duration-fast) ease,
-    border-color var(--duration-fast) ease,
-    background-color var(--duration-fast) ease;
-}
-
-.input::placeholder {
-  color: var(--esg-text-faint);
-}
-
-.input:hover {
-  border-color: var(--esg-border-strong);
-  box-shadow: 0 2px 4px rgb(0 0 0 / 8%);
-}
-
-.input:focus {
-  outline: 2px solid var(--esg-ink);
-  outline-offset: 2px;
-}
-
-.clearButton {
-  display: flex;
-  position: absolute;
-  padding: 0;
-  width: 24px;
-  height: 24px;
-  justify-content: center;
-  align-items: center;
-  border: none;
-  border-radius: 50%;
-  background: transparent;
-  color: var(--esg-text-faint);
-  cursor: pointer;
-  transition:
-    color var(--duration-fast) ease,
-    background-color var(--duration-fast) ease;
-  inset-inline-end: var(--space-internal-16);
-}
-
-.clearButton:hover {
-  background-color: var(--esg-surface-hover);
-  color: var(--esg-ink-soft);
-}
-
-.clearButton:focus-visible {
-  outline: 2px solid var(--esg-ink);
-  outline-offset: 2px;
 }
 
 /* Preview Section */
@@ -432,19 +360,7 @@
   }
 
   .formGrid {
-    gap: var(--space-internal-12);
-  }
-
-  .input {
-    padding-block: var(--space-internal-16);
-    padding-inline: var(--space-internal-16);
-    padding-inline-end: var(--space-internal-40);
-    border-radius: 12px;
-    font-size: 1rem;
-  }
-
-  .clearButton {
-    inset-inline-end: var(--space-internal-12);
+    gap: 0 var(--space-internal-12);
   }
 }
 
@@ -455,6 +371,7 @@
 
 /* Specificity bump: the Title component's own color rule outranks a single
    class, so the heading needs a theme-scoped override like the original had. */
+
 :global(.themeDark) .title {
   color: var(--esg-ink);
 }
@@ -463,8 +380,6 @@
   --esg-page-bg: #1a1a1a;
   --esg-ink: #f9fafb;
   --esg-text-secondary: #9ca3af;
-  --esg-border: #4b5563;
-  --esg-border-strong: #6b7280;
   --esg-text-faint: #6b7280;
   --esg-surface: #2d2d2d;
   --esg-surface-dim: #374151;

--- a/nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.test.tsx
+++ b/nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.test.tsx
@@ -92,7 +92,8 @@ describe("EmailSignatureGenerator", () => {
       const phoneInput = screen.getByPlaceholderText(/\+358|\+46|phone/i);
       fireEvent.change(phoneInput, { target: { value: "+358 45 123 4567" } });
 
-      expect(phoneInput).toHaveValue("+358 45 123 4567");
+      // DS TextInput type="tel" runs libphonenumber's as-you-type formatter.
+      expect(phoneInput).toHaveValue("+358 45 1234567");
     });
   });
 
@@ -198,8 +199,11 @@ describe("EmailSignatureGenerator", () => {
       const linkedinInput = screen.getByPlaceholderText(/linkedin/i);
       fireEvent.change(linkedinInput, { target: { value: "johndoe" } });
 
-      // Should show LinkedIn label in preview
-      expect(screen.getByText("LinkedIn")).toBeInTheDocument();
+      // Should show LinkedIn link in preview ("LinkedIn" text alone also
+      // matches the field's hidden label now).
+      expect(
+        screen.getByRole("link", { name: "LinkedIn" })
+      ).toBeInTheDocument();
     });
   });
 
@@ -274,9 +278,8 @@ describe("EmailSignatureGenerator", () => {
     it("displays instagram link with correct URL", () => {
       render(withI18n(<EmailSignatureGenerator />));
 
-      // Find instagram input (has @username or similar placeholder)
-      const instagramInput = document.getElementById(
-        "instagram",
+      const instagramInput = screen.getByLabelText(
+        "Instagram",
       ) as HTMLInputElement;
       expect(instagramInput).toBeTruthy();
       fireEvent.change(instagramInput, { target: { value: "myinsta" } });

--- a/nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.tsx
+++ b/nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.tsx
@@ -9,6 +9,7 @@ import Button from "@dt/Button";
 import Modal from "@dt/Modal";
 import Toast from "@dt/Toast";
 import Icon from "@dt/Icon";
+import TextInput from "@dt/TextInput";
 
 interface SignatureData {
   name: string;
@@ -21,6 +22,25 @@ interface SignatureData {
   instagram: string;
   tiktok: string;
 }
+
+const SIGNATURE_FIELDS: Array<{
+  field: keyof SignatureData;
+  labelKey: string;
+  labelDefault: string;
+  placeholderKey: string;
+  placeholderDefault: string;
+  type: "text" | "tel";
+}> = [
+  { field: "name", labelKey: "emailSig.nameLabel", labelDefault: "Name", placeholderKey: "emailSig.namePlaceholder", placeholderDefault: "Name", type: "text" },
+  { field: "title", labelKey: "emailSig.titleLabel", labelDefault: "Title", placeholderKey: "emailSig.titlePlaceholder", placeholderDefault: "Position", type: "text" },
+  { field: "phone", labelKey: "emailSig.phoneLabel", labelDefault: "Phone", placeholderKey: "emailSig.phonePlaceholder", placeholderDefault: "Phone nr (optional)", type: "tel" },
+  { field: "linkedin", labelKey: "emailSig.linkedinLabel", labelDefault: "LinkedIn", placeholderKey: "emailSig.linkedinPlaceholder", placeholderDefault: "LinkedIn username", type: "text" },
+  { field: "github", labelKey: "emailSig.githubLabel", labelDefault: "GitHub", placeholderKey: "emailSig.githubPlaceholder", placeholderDefault: "GitHub username", type: "text" },
+  { field: "twitter", labelKey: "emailSig.twitterLabel", labelDefault: "Twitter/X", placeholderKey: "emailSig.twitterPlaceholder", placeholderDefault: "@ Twitter/X handle", type: "text" },
+  { field: "bluesky", labelKey: "emailSig.blueskyLabel", labelDefault: "Bluesky", placeholderKey: "emailSig.blueskyPlaceholder", placeholderDefault: "@ Bluesky handle", type: "text" },
+  { field: "instagram", labelKey: "emailSig.instagramLabel", labelDefault: "Instagram", placeholderKey: "emailSig.instagramPlaceholder", placeholderDefault: "@ Instagram handle", type: "text" },
+  { field: "tiktok", labelKey: "emailSig.tiktokLabel", labelDefault: "TikTok", placeholderKey: "emailSig.tiktokPlaceholder", placeholderDefault: "@ TikTok handle", type: "text" },
+];
 
 export interface EmailSignatureGeneratorProps {
   /** Company name for the signature */
@@ -66,17 +86,12 @@ export const EmailSignatureGenerator: React.FC<EmailSignatureGeneratorProps> = (
 
   const signatureRef = useRef<HTMLDivElement>(null);
 
-  const handleInputChange = useCallback(
-    (field: keyof SignatureData) =>
-      (e: React.ChangeEvent<HTMLInputElement>) => {
-        setFormData((prev) => ({ ...prev, [field]: e.target.value }));
-      },
+  const handleValueChange = useCallback(
+    (field: keyof SignatureData) => (value: string | number) => {
+      setFormData((prev) => ({ ...prev, [field]: String(value) }));
+    },
     []
   );
-
-  const handleClearField = useCallback((field: keyof SignatureData) => {
-    setFormData((prev) => ({ ...prev, [field]: "" }));
-  }, []);
 
   const generateSignatureHTML = useCallback((): string => {
     const { name, title, phone, twitter, linkedin, github, bluesky, instagram, tiktok } = formData;
@@ -342,248 +357,22 @@ export const EmailSignatureGenerator: React.FC<EmailSignatureGeneratorProps> = (
 
         {/* Form Grid - 2 columns */}
         <div className={styles.formGrid}>
-          <div className={styles.inputGroup}>
-            <div className={styles.inputWrapper}>
-              <input
-                id="name"
-                type="text"
-                value={formData.name}
-                onChange={handleInputChange("name")}
-                placeholder={t("emailSig.namePlaceholder", {
-                  defaultValue: "Name",
+          {SIGNATURE_FIELDS.map(
+            ({ field, labelKey, labelDefault, placeholderKey, placeholderDefault, type }) => (
+              <TextInput
+                key={field}
+                label={t(labelKey, { defaultValue: labelDefault })}
+                hideLabel
+                clearable
+                type={type}
+                value={formData[field]}
+                onValueChange={handleValueChange(field)}
+                placeholder={t(placeholderKey, {
+                  defaultValue: placeholderDefault,
                 })}
-                className={styles.input}
               />
-              {formData.name && (
-                <button
-                  type="button"
-                  onClick={() => handleClearField("name")}
-                  className={styles.clearButton}
-                  aria-label={t("emailSig.clearField", {
-                    defaultValue: "Clear field",
-                  })}
-                >
-                  <Icon name="x" size={16} decorative />
-                </button>
-              )}
-            </div>
-          </div>
-
-          <div className={styles.inputGroup}>
-            <div className={styles.inputWrapper}>
-              <input
-                id="title"
-                type="text"
-                value={formData.title}
-                onChange={handleInputChange("title")}
-                placeholder={t("emailSig.titlePlaceholder", {
-                  defaultValue: "Position",
-                })}
-                className={styles.input}
-              />
-              {formData.title && (
-                <button
-                  type="button"
-                  onClick={() => handleClearField("title")}
-                  className={styles.clearButton}
-                  aria-label={t("emailSig.clearField", {
-                    defaultValue: "Clear field",
-                  })}
-                >
-                  <Icon name="x" size={16} decorative />
-                </button>
-              )}
-            </div>
-          </div>
-
-          <div className={styles.inputGroup}>
-            <div className={styles.inputWrapper}>
-              <input
-                id="phone"
-                type="tel"
-                value={formData.phone}
-                onChange={handleInputChange("phone")}
-                placeholder={t("emailSig.phonePlaceholder", {
-                  defaultValue: "Phone nr (optional)",
-                })}
-                className={styles.input}
-              />
-              {formData.phone && (
-                <button
-                  type="button"
-                  onClick={() => handleClearField("phone")}
-                  className={styles.clearButton}
-                  aria-label={t("emailSig.clearField", {
-                    defaultValue: "Clear field",
-                  })}
-                >
-                  <Icon name="x" size={16} decorative />
-                </button>
-              )}
-            </div>
-          </div>
-
-          <div className={styles.inputGroup}>
-            <div className={styles.inputWrapper}>
-              <input
-                id="linkedin"
-                type="text"
-                value={formData.linkedin}
-                onChange={handleInputChange("linkedin")}
-                placeholder={t("emailSig.linkedinPlaceholder", {
-                  defaultValue: "LinkedIn username",
-                })}
-                className={styles.input}
-              />
-              {formData.linkedin && (
-                <button
-                  type="button"
-                  onClick={() => handleClearField("linkedin")}
-                  className={styles.clearButton}
-                  aria-label={t("emailSig.clearField", {
-                    defaultValue: "Clear field",
-                  })}
-                >
-                  <Icon name="x" size={16} decorative />
-                </button>
-              )}
-            </div>
-          </div>
-
-          <div className={styles.inputGroup}>
-            <div className={styles.inputWrapper}>
-              <input
-                id="github"
-                type="text"
-                value={formData.github}
-                onChange={handleInputChange("github")}
-                placeholder={t("emailSig.githubPlaceholder", {
-                  defaultValue: "GitHub username",
-                })}
-                className={styles.input}
-              />
-              {formData.github && (
-                <button
-                  type="button"
-                  onClick={() => handleClearField("github")}
-                  className={styles.clearButton}
-                  aria-label={t("emailSig.clearField", {
-                    defaultValue: "Clear field",
-                  })}
-                >
-                  <Icon name="x" size={16} decorative />
-                </button>
-              )}
-            </div>
-          </div>
-
-          <div className={styles.inputGroup}>
-            <div className={styles.inputWrapper}>
-              <input
-                id="twitter"
-                type="text"
-                value={formData.twitter}
-                onChange={handleInputChange("twitter")}
-                placeholder={t("emailSig.twitterPlaceholder", {
-                  defaultValue: "@ Twitter/X handle",
-                })}
-                className={styles.input}
-              />
-              {formData.twitter && (
-                <button
-                  type="button"
-                  onClick={() => handleClearField("twitter")}
-                  className={styles.clearButton}
-                  aria-label={t("emailSig.clearField", {
-                    defaultValue: "Clear field",
-                  })}
-                >
-                  <Icon name="x" size={16} decorative />
-                </button>
-              )}
-            </div>
-          </div>
-
-          <div className={styles.inputGroup}>
-            <div className={styles.inputWrapper}>
-              <input
-                id="bluesky"
-                type="text"
-                value={formData.bluesky}
-                onChange={handleInputChange("bluesky")}
-                placeholder={t("emailSig.blueskyPlaceholder", {
-                  defaultValue: "@ Bluesky handle",
-                })}
-                className={styles.input}
-              />
-              {formData.bluesky && (
-                <button
-                  type="button"
-                  onClick={() => handleClearField("bluesky")}
-                  className={styles.clearButton}
-                  aria-label={t("emailSig.clearField", {
-                    defaultValue: "Clear field",
-                  })}
-                >
-                  <Icon name="x" size={16} decorative />
-                </button>
-              )}
-            </div>
-          </div>
-
-          <div className={styles.inputGroup}>
-            <div className={styles.inputWrapper}>
-              <input
-                id="instagram"
-                type="text"
-                value={formData.instagram}
-                onChange={handleInputChange("instagram")}
-                placeholder={t("emailSig.instagramPlaceholder", {
-                  defaultValue: "@ Instagram handle",
-                })}
-                className={styles.input}
-              />
-              {formData.instagram && (
-                <button
-                  type="button"
-                  onClick={() => handleClearField("instagram")}
-                  className={styles.clearButton}
-                  aria-label={t("emailSig.clearField", {
-                    defaultValue: "Clear field",
-                  })}
-                >
-                  <Icon name="x" size={16} decorative />
-                </button>
-              )}
-            </div>
-          </div>
-
-          <div className={styles.inputGroup}>
-            <div className={styles.inputWrapper}>
-              <input
-                id="tiktok"
-                type="text"
-                value={formData.tiktok}
-                onChange={handleInputChange("tiktok")}
-                placeholder={t("emailSig.tiktokPlaceholder", {
-                  defaultValue: "@ TikTok handle",
-                })}
-                className={styles.input}
-              />
-              {formData.tiktok && (
-                <button
-                  type="button"
-                  onClick={() => handleClearField("tiktok")}
-                  className={styles.clearButton}
-                  aria-label={t("emailSig.clearField", {
-                    defaultValue: "Clear field",
-                  })}
-                >
-                  <Icon name="x" size={16} decorative />
-                </button>
-              )}
-            </div>
-          </div>
+            )
+          )}
         </div>
 
         {/* Preview Section */}

--- a/nextjs-app/shared/components/HelperText/HelperText.contract.json
+++ b/nextjs-app/shared/components/HelperText/HelperText.contract.json
@@ -54,6 +54,16 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/EmailSignatureContent.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
             "since": "2026-06-04"
         },
@@ -90,11 +100,6 @@
         {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/patterns/CVDownloadSection/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/index.ts",
             "since": "2026-06-04"
         }
     ],

--- a/nextjs-app/shared/components/Label/Label.contract.json
+++ b/nextjs-app/shared/components/Label/Label.contract.json
@@ -49,6 +49,16 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/EmailSignatureContent.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
             "since": "2026-06-04"
         },
@@ -85,11 +95,6 @@
         {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/patterns/CVDownloadSection/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/index.ts",
             "since": "2026-06-04"
         }
     ],

--- a/nextjs-app/shared/components/TextInput/TextInput.contract.json
+++ b/nextjs-app/shared/components/TextInput/TextInput.contract.json
@@ -75,6 +75,16 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/EmailSignatureContent.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
             "since": "2026-06-04"
         },

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-10T07:49:56.044Z",
+  "generatedAt": "2026-07-10T08:10:01.976Z",
   "summary": {
     "componentCount": 163,
     "statusCounts": {
@@ -81,8 +81,8 @@
     "withAnyUsage": 152,
     "withProductionUsage": 46,
     "uniqueImportedComponents": 152,
-    "totalEvidenceRows": 855,
-    "aliasImportFiles": 472,
+    "totalEvidenceRows": 856,
+    "aliasImportFiles": 473,
     "relativeImportFiles": 391,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
@@ -14188,6 +14188,16 @@
           },
           {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/EmailSignatureContent.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/page.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
             "since": "2026-06-04"
           },
@@ -14224,11 +14234,6 @@
           {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/patterns/CVDownloadSection/index.ts",
-            "since": "2026-06-04"
-          },
-          {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/index.ts",
             "since": "2026-06-04"
           }
         ],
@@ -15835,6 +15840,16 @@
           },
           {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/EmailSignatureContent.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/page.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
             "since": "2026-06-04"
           },
@@ -15871,11 +15886,6 @@
           {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/patterns/CVDownloadSection/index.ts",
-            "since": "2026-06-04"
-          },
-          {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/index.ts",
             "since": "2026-06-04"
           }
         ],
@@ -30109,6 +30119,16 @@
           },
           {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/EmailSignatureContent.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/tools/email-signature/page.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
             "since": "2026-06-04"
           },
@@ -30285,10 +30305,10 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/TextInput",
-        "importCount": 10,
+        "importCount": 11,
         "productionImportCount": 0,
         "patternImportCount": 0,
-        "componentImportCount": 6,
+        "componentImportCount": 7,
         "evidence": [
           {
             "path": "nextjs-app/shared/components/ChatWidget/emailWorkflow/FieldPrompt.tsx",
@@ -30298,6 +30318,12 @@
           },
           {
             "path": "nextjs-app/shared/components/ContactForm/ContactForm.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TextInput",
+            "context": "component"
+          },
+          {
+            "path": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.tsx",
             "importKind": "alias",
             "importPath": "@dt/TextInput",
             "context": "component"
@@ -31584,8 +31610,8 @@
         "composesWith": [
           "Button",
           "Text",
-          "Modal",
           "TextInput",
+          "Modal",
           "CheckboxGroup",
           "TextArea"
         ],

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-10T07:47:59.697Z",
+  "generatedAt": "2026-07-10T08:10:01.682Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -9775,8 +9775,8 @@
       "composesWith": [
         "Button",
         "Text",
-        "Modal",
         "TextInput",
+        "Modal",
         "CheckboxGroup",
         "TextArea"
       ],

--- a/nextjs-app/shared/locales/en/translation.json
+++ b/nextjs-app/shared/locales/en/translation.json
@@ -1311,7 +1311,6 @@
     "instagramPlaceholder": "@username",
     "tiktokLabel": "TikTok",
     "tiktokPlaceholder": "@username",
-    "clearField": "Clear field",
     "previewLabel": "Preview",
     "switchToLight": "Switch to light mode",
     "switchToDark": "Switch to dark mode",

--- a/nextjs-app/shared/locales/fi/translation.json
+++ b/nextjs-app/shared/locales/fi/translation.json
@@ -1314,7 +1314,6 @@
     "instagramPlaceholder": "@käyttäjänimi",
     "tiktokLabel": "TikTok",
     "tiktokPlaceholder": "@käyttäjänimi",
-    "clearField": "Tyhjennä kenttä",
     "previewLabel": "Esikatselu",
     "switchToLight": "Vaihda vaaleaan tilaan",
     "switchToDark": "Vaihda tummaan tilaan",

--- a/nextjs-app/shared/locales/sv/translation.json
+++ b/nextjs-app/shared/locales/sv/translation.json
@@ -1324,7 +1324,6 @@
     "instagramPlaceholder": "@användarnamn",
     "tiktokLabel": "TikTok",
     "tiktokPlaceholder": "@användarnamn",
-    "clearField": "Rensa fält",
     "previewLabel": "Förhandsgranskning",
     "switchToLight": "Byt till ljust läge",
     "switchToDark": "Byt till mörkt läge",

--- a/scripts/design-system/dogfood-ratchet.baseline.json
+++ b/scripts/design-system/dogfood-ratchet.baseline.json
@@ -186,7 +186,7 @@
       "utilityLines": 0
     },
     "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.tsx": {
-      "rawElements": 44,
+      "rawElements": 26,
       "utilityLines": 0
     },
     "nextjs-app/shared/components/EnhancedArticleCard/EnhancedArticleCard.tsx": {

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -1,6 +1,6 @@
 {
   "generatedBy": "npm run lint:css:update",
-  "warningCount": 445,
+  "warningCount": 444,
   "warnings": [
     {
       "id": "app/blog/NextBlogNav.module.css::7::3::order/properties-order::Expected \"margin-inline\" to come before \"max-width\" (order/properties-order)",
@@ -678,148 +678,139 @@
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::316::43::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::244::43::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "line": 316,
+      "line": 244,
       "column": 43,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::317::24::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::245::24::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "line": 317,
+      "line": 245,
       "column": 24,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::318::42::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::246::42::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "line": 318,
+      "line": 246,
       "column": 42,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::319::20::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::247::20::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "line": 319,
+      "line": 247,
       "column": 20,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::320::31::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::248::31::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "line": 320,
+      "line": 248,
       "column": 31,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::324::48::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::252::48::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "line": 324,
+      "line": 252,
       "column": 48,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::328::43::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::256::43::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "line": 328,
+      "line": 256,
       "column": 43,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::329::46::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::257::46::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "line": 329,
+      "line": 257,
       "column": 46,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::330::24::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::258::24::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "line": 330,
+      "line": 258,
       "column": 24,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::331::33::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::259::33::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "line": 331,
+      "line": 259,
       "column": 33,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::332::20::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::260::20::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "line": 332,
+      "line": 260,
       "column": 20,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::333::25::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::261::25::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "line": 333,
+      "line": 261,
       "column": 25,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::337::42::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::265::42::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "line": 337,
+      "line": 265,
       "column": 42,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::338::48::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::266::48::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "line": 338,
+      "line": 266,
       "column": 48,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::415::1::no-descending-specificity::Expected selector \".tipsList li\" to come before selector \".instructionList li:last-child\", at line 401 (no-descending-specificity)",
+      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::343::1::no-descending-specificity::Expected selector \".tipsList li\" to come before selector \".instructionList li:last-child\", at line 329 (no-descending-specificity)",
       "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "line": 415,
+      "line": 343,
       "column": 1,
       "rule": "no-descending-specificity",
       "severity": "warning",
-      "text": "Expected selector \".tipsList li\" to come before selector \".instructionList li:last-child\", at line 401 (no-descending-specificity)"
-    },
-    {
-      "id": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css::458::1::rule-empty-line-before::Expected empty line before rule (rule-empty-line-before)",
-      "file": "nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.module.css",
-      "line": 458,
-      "column": 1,
-      "rule": "rule-empty-line-before",
-      "severity": "warning",
-      "text": "Expected empty line before rule (rule-empty-line-before)"
+      "text": "Expected selector \".tipsList li\" to come before selector \".instructionList li:last-child\", at line 329 (no-descending-specificity)"
     },
     {
       "id": "nextjs-app/shared/components/EnhancedArticleCard/EnhancedArticleCard.module.css::18::3::order/properties-order::Expected \"border-color\" to come before \"background-color\" (order/properties-order)",


### PR DESCRIPTION
## Phase 3c pivot, PR 2 of 2 (consume)

Follows #1054. Replaces the generator's nine hand-rolled `div > input + conditional ×-button` rows with a data-driven map over DS `TextInput clearable hideLabel` — the generator's form is now a pure DS consumer (net **−259 lines**).

### What changed
- Nine field rows → one `SIGNATURE_FIELDS` map; labels reuse the existing `emailSig.*Label` keys (EN/FI/SV, all nine already existed). `hideLabel` keeps the placeholder-only look while giving every input a real sr-only label — before, the inputs had no accessible name beyond the placeholder.
- Phone field gains DS tel behavior for free: libphonenumber as-you-type formatting + validation error state.
- Deleted bespoke `.input` / `.inputWrapper` / `.clearButton` CSS incl. responsive overrides, plus the three `--esg-*` tokens only they consumed; grid now spaces columns only (TextInput brings vertical rhythm). Orphaned `emailSig.clearField` removed from all three locales.
- Tests updated to the new behavior (formatted tel value, label-based queries, link-role query where the hidden label made bare-text queries ambiguous).

### Ratchet + baselines
- Dogfood ratchet: generator 44 → 26 raw elements; **total 321 → 303** (largest remaining raw-input cluster gone; net across both 3c PRs: 320 → 303).
- Stylelint baseline 445 → 444 (one warning resolved by the CSS deletion); rhythmguard line-keyed renumber; `audit:consumers` adds the generator + tools-page edges to TextInput/Label/HelperText.
- No AT recapture needed: EmailSignatureGenerator is beta with no snapshot dir (it was not in promotion wave 3; the pivot note claiming otherwise was wrong).

### Verification
Real browser on `/tools/email-signature` (dev): type → clear × appears → click clears field, unmounts button, refocuses input, preview resets; light, dark and both HC themes; tel validation error state renders in DS chrome; zero console warnings/errors. AT tree: nine named textboxes.

Local gate: typecheck, lint, lint:css, full vitest (283 files / 2227 tests), build — all exit 0. Farm parity: build:tokens, check:contract-props, check:consumers, validate:components — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)