### PR TITLE
chore(design-system): prepare @digitaltableteur/react 0.1.5 — TextInput clearable

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.5 - 2026-07-10
+
+- TextInput gains three additive props (#1054): `clearable` renders a labelled ×-button inside the field chrome while the field has a value (never while disabled); activating it empties the field, clears built-in validation errors, fires `onValueChange("")` then `onClear()`, and returns focus to the input. `hideLabel` visually hides the label while keeping it in the accessibility tree (sr-only). The clear button's accessible name interpolates the field label via the new `inputClearField` i18n key (EN/FI/SV).
+- Non-clearable usage keeps the exact previous DOM (no wrapper element is added unless `clearable` is set); no breaking changes, public runtime API otherwise unchanged from 0.1.4.
+- Verified by the full stable-change evidence bundle: contract + required story with play, unit tests incl. jest-axe and focus behavior, 4-mode accessibility-tree snapshots, controls audit (10/10 operable, 0 inert), forced-colors treatment, and real-browser verification (consumed by EmailSignatureGenerator in #1055).
+
 ## 0.1.4 - 2026-07-09
 
 - Stops shipping a publish-time snapshot of the design-token sheet inside `dist/style.css`: Title, Text, Link, and List no longer side-effect-import `variables.css`, so tokens ship once, via `@digitaltableteur/tokens-css/tokens.css` as the install docs already instruct. Consumers who skipped `tokens-css` and relied on the embedded snapshot must add it now.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/react",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": false,
   "description": "React components and host adapters for the Digitaltableteur design system.",
   "type": "module",


### PR DESCRIPTION
Version + CHANGELOG bump for the 0.1.5 publish carrying the TextInput `clearable`/`onClear`/`hideLabel` API (#1054, consumed in #1055). Publish runs via ds-publish.yml (OIDC Trusted Publisher) after merge; consume commit follows post-publish checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearable text fields with an accessible, in-field clear button.
  * Added an option to visually hide labels while preserving accessibility.
  * Added localized accessible naming for clear buttons.

* **Documentation**
  * Documented the new text field behavior and accessibility details.

* **Chores**
  * Released the React package as version 0.1.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->