### PR TITLE
chore(design-system): consume @digitaltableteur/react 0.1.5 from the registry

### DIFF
--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.4
+  - definition: 0.1.5
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.4
+  - definition: 0.1.5
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.4
+  - definition: 0.1.5
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.4
+  - definition: 0.1.5
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.4
+  - definition: 0.1.5
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.4
+  - definition: 0.1.5
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.4
+  - definition: 0.1.5
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.4
+  - definition: 0.1.5
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.4
+  - definition: 0.1.5
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.4
+  - definition: 0.1.5
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.4
+  - definition: 0.1.5
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.4
+  - definition: 0.1.5
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ai-sdk/openai": "^3.0.71",
         "@ai-sdk/react": "^3.0.207",
         "@calcom/embed-react": "^1.5.3",
-        "@digitaltableteur/react": "^0.1.4",
+        "@digitaltableteur/react": "^0.1.5",
         "@digitaltableteur/tokens": "^0.1.0",
         "@digitaltableteur/tokens-css": "^0.1.0",
         "@emailjs/browser": "^4.4.1",
@@ -3429,9 +3429,9 @@
       "license": "MIT"
     },
     "node_modules/@digitaltableteur/react": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.4.tgz",
-      "integrity": "sha512-QDGwZxVLLTJiGdQm91/fckv8NIFtYAy7RdI376q22cSZWYTQ4APvlLnxkXCKDl72RtNU1zyMk6eE68v+Zcnaag==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.5.tgz",
+      "integrity": "sha512-aLKx/nAXKVrWqYFh1sPH+5pR599SyFRg5p11ZNeqToFJOa2yGXhhk3WlK18QdWLeT7oqLnhfjHbd1CUqY+nuCA==",
       "license": "UNLICENSED",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "@ai-sdk/openai": "^3.0.71",
     "@ai-sdk/react": "^3.0.207",
     "@calcom/embed-react": "^1.5.3",
-    "@digitaltableteur/react": "^0.1.4",
+    "@digitaltableteur/react": "^0.1.5",
     "@digitaltableteur/tokens": "^0.1.0",
     "@digitaltableteur/tokens-css": "^0.1.0",
     "@emailjs/browser": "^4.4.1",


### PR DESCRIPTION
Consume step for the 0.1.5 publish (TextInput `clearable`/`onClear`/`hideLabel`, #1054/#1063).

- App spec ^0.1.4 → ^0.1.5; lockfile resolves the registry tarball; dist verified to carry the new API.
- Post-publish checks: react-registry-install, registry-token-install, package-registry-resolution, npm-consumer-install, package-registry-status — all pass (read token restored).
- AboutPageContent AT snapshots recaptured: they embed the installed version string, so consume bumps must recapture them or the farm matrix re-reds. Full matrix compare (light+dark) green with 0.1.5 installed.
- Full local gate: typecheck, lint, lint:css, vitest (2227), build, contract gates — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the React package version to 0.1.5.
  * Refreshed About page accessibility snapshots to reflect the updated package version across display modes and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->