### PR TITLE
chore(security): second npm-token tripwire — bare npm_ literals anywhere in staged diff

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -15,6 +15,15 @@ if git diff --cached -U0 | grep -qE '^\+[^+].*_authToken[^=]*=.*(npm_[A-Za-z0-9]
   exit 1
 fi
 
+# Second net (2026-07-10): a bare npm_ granular token pasted ANYWHERE (env
+# file, script constant, doc) — not just on an _authToken line. The npm_
+# prefix + 30+ char run is specific enough that false positives are unlikely;
+# write docs placeholders as npm_XXXX... if one is ever needed.
+if git diff --cached -U0 | grep -qE '^\+[^+].*npm_[A-Za-z0-9]{30,}'; then
+  echo "pre-commit: staged content contains an npm_ granular token literal — unstage it (tokens belong in the gitignored .npm-userconfig, never in git)." >&2
+  exit 1
+fi
+
 npm run check:contrast &&
 npm run lint:css &&
 npm run audit:rhythm:check &&


### PR DESCRIPTION
Hardens the pre-commit secret tripwire from the 2026-07-04 incident. The existing net only fired on `_authToken=` lines; a token pasted as an env value, script constant, or doc snippet passed silently. The second net blocks any staged added line containing an `npm_` granular-token shape (`npm_` + 30+ alphanumerics). Both nets negative-tested with a fake token — each blocks the commit with its own message.

Part of the read-token storage hardening: token lives only in the gitignored `.npm-userconfig` (0600) with a macOS keychain backup for recovery; repo, git history, and npm logs verified clean of token literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)