### PR TITLE
chore(design-system): figma-parity B0+B1 — Satoshi typography live in Figma, quick wires, figma-links ratchet

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -21,6 +21,7 @@ npm run check:token-packages
 npm run check:contract-props
 npm run check:consumers
 npm run check:astryx-roadmap
+npm run check:figma-links
 npm run validate:components
 npm run typecheck
 npm run lint

--- a/nextjs-app/shared/components/DonnyAvatar/DonnyAvatar.contract.json
+++ b/nextjs-app/shared/components/DonnyAvatar/DonnyAvatar.contract.json
@@ -1,163 +1,163 @@
 {
-    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-    "name": "DonnyAvatar",
-    "tier": "molecule",
-    "group": "display",
-    "status": "beta",
-    "description": "The assistant's animated avatar with thinking, speaking, and idle mood states, used inside ChatWidget and Donny surfaces.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-donny-avatar",
-    "radixPrimitive": null,
-    "element": "div",
-    "variants": {
-        "size": {
-            "values": [
-                "sm",
-                "md",
-                "lg",
-                "xl"
-            ],
-            "default": "sm",
-            "propSourced": true
-        }
-    },
-    "slots": [],
-    "asChild": false,
-    "subParts": [],
-    "requiredStories": [
-        "Default",
-        "Playground",
-        "Example",
-        "ForcedColors"
-    ],
-    "a11y": {
-        "keyboard": [],
-        "reducedMotion": true,
-        "reviewed": true,
-        "forcedColorsVerified": true,
-        "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
-    },
-    "tokens": {
-        "colors": [
-            "--color-text"
-        ],
-        "spacing": []
-    },
-    "lightDarkVerified": true,
-    "consumers": [],
-    "schemaVersion": 2,
-    "props": {
-        "state": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "success",
-                "error",
-                "loading",
-                "idle",
-                "listening",
-                "thinking",
-                "searching",
-                "confused",
-                "handoff",
-                "greeting",
-                "acknowledging",
-                "suggesting",
-                "confident",
-                "curious",
-                "celebrating",
-                "apologetic",
-                "typing",
-                "waving",
-                "remembering",
-                "focused",
-                "playful",
-                "impressed",
-                "skeptical",
-                "sleepy",
-                "sleeping"
-            ]
-        },
-        "size": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "sm",
-                "md",
-                "lg",
-                "xl"
-            ]
-        },
-        "className": {
-            "optional": true,
-            "type": "string"
-        },
-        "onTransitionEnd": {
-            "optional": true,
-            "type": "() => void"
-        },
-        "showLabel": {
-            "optional": true,
-            "type": "boolean"
-        },
-        "trackMouse": {
-            "optional": true,
-            "type": "boolean"
-        },
-        "proximitySelectors": {
-            "optional": true,
-            "type": "string[]"
-        },
-        "onProximityChange": {
-            "optional": true,
-            "type": "(isNearTarget: boolean, targetSelector?: string) => void"
-        },
-        "proximityThreshold": {
-            "optional": true,
-            "type": "number"
-        },
-        "enableIdleExpressions": {
-            "optional": true,
-            "type": "boolean"
-        },
-        "idleExpressionInterval": {
-            "optional": true,
-            "type": "number"
-        },
-        "isSpeaking": {
-            "optional": true,
-            "type": "boolean"
-        },
-        "enableSleepDetection": {
-            "optional": true,
-            "type": "boolean"
-        },
-        "sleepyDelay": {
-            "optional": true,
-            "type": "number"
-        },
-        "sleepDelay": {
-            "optional": true,
-            "type": "number"
-        },
-        "decorative": {
-            "optional": true,
-            "type": "boolean"
-        }
-    },
-    "forbiddenUse": [
-        "Bypass design tokens or skip forced-colors verification at beta."
-    ],
-    "displayName": "DonnyAvatar",
-    "keywords": [
-        "donny",
-        "avatar",
-        "chatbot",
-        "mood",
-        "expression"
-    ],
-    "dense": "Donny assistant avatar with mood/action states (distinct eye expressions) used by the chat widget",
-    "usage": {
-        "description": "The assistant's animated avatar with mood states (thinking, speaking, idle) used inside ChatWidget and Donny marketing surfaces."
+  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+  "name": "DonnyAvatar",
+  "tier": "molecule",
+  "group": "display",
+  "status": "beta",
+  "description": "The assistant's animated avatar with thinking, speaking, and idle mood states, used inside ChatWidget and Donny surfaces.",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=492-1578",
+  "radixPrimitive": null,
+  "element": "div",
+  "variants": {
+    "size": {
+      "values": [
+        "sm",
+        "md",
+        "lg",
+        "xl"
+      ],
+      "default": "sm",
+      "propSourced": true
     }
+  },
+  "slots": [],
+  "asChild": false,
+  "subParts": [],
+  "requiredStories": [
+    "Default",
+    "Playground",
+    "Example",
+    "ForcedColors"
+  ],
+  "a11y": {
+    "keyboard": [],
+    "reducedMotion": true,
+    "reviewed": true,
+    "forcedColorsVerified": true,
+    "ariaRequirements": [],
+    "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-10 — Figma link wired to the existing DonnyAvatar component (Atoms page, node 492-1578)."
+  },
+  "tokens": {
+    "colors": [
+      "--color-text"
+    ],
+    "spacing": []
+  },
+  "lightDarkVerified": true,
+  "consumers": [],
+  "schemaVersion": 2,
+  "props": {
+    "state": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "success",
+        "error",
+        "loading",
+        "idle",
+        "listening",
+        "thinking",
+        "searching",
+        "confused",
+        "handoff",
+        "greeting",
+        "acknowledging",
+        "suggesting",
+        "confident",
+        "curious",
+        "celebrating",
+        "apologetic",
+        "typing",
+        "waving",
+        "remembering",
+        "focused",
+        "playful",
+        "impressed",
+        "skeptical",
+        "sleepy",
+        "sleeping"
+      ]
+    },
+    "size": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "sm",
+        "md",
+        "lg",
+        "xl"
+      ]
+    },
+    "className": {
+      "optional": true,
+      "type": "string"
+    },
+    "onTransitionEnd": {
+      "optional": true,
+      "type": "() => void"
+    },
+    "showLabel": {
+      "optional": true,
+      "type": "boolean"
+    },
+    "trackMouse": {
+      "optional": true,
+      "type": "boolean"
+    },
+    "proximitySelectors": {
+      "optional": true,
+      "type": "string[]"
+    },
+    "onProximityChange": {
+      "optional": true,
+      "type": "(isNearTarget: boolean, targetSelector?: string) => void"
+    },
+    "proximityThreshold": {
+      "optional": true,
+      "type": "number"
+    },
+    "enableIdleExpressions": {
+      "optional": true,
+      "type": "boolean"
+    },
+    "idleExpressionInterval": {
+      "optional": true,
+      "type": "number"
+    },
+    "isSpeaking": {
+      "optional": true,
+      "type": "boolean"
+    },
+    "enableSleepDetection": {
+      "optional": true,
+      "type": "boolean"
+    },
+    "sleepyDelay": {
+      "optional": true,
+      "type": "number"
+    },
+    "sleepDelay": {
+      "optional": true,
+      "type": "number"
+    },
+    "decorative": {
+      "optional": true,
+      "type": "boolean"
+    }
+  },
+  "forbiddenUse": [
+    "Bypass design tokens or skip forced-colors verification at beta."
+  ],
+  "displayName": "DonnyAvatar",
+  "keywords": [
+    "donny",
+    "avatar",
+    "chatbot",
+    "mood",
+    "expression"
+  ],
+  "dense": "Donny assistant avatar with mood/action states (distinct eye expressions) used by the chat widget",
+  "usage": {
+    "description": "The assistant's animated avatar with mood states (thinking, speaking, idle) used inside ChatWidget and Donny marketing surfaces."
+  }
 }

--- a/nextjs-app/shared/components/DonnyAvatar/DonnyAvatar.stories.tsx
+++ b/nextjs-app/shared/components/DonnyAvatar/DonnyAvatar.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof DonnyAvatar> = {
   parameters: {
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-donny-avatar",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=492-1578",
     },
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/NavLink/NavLink.contract.json
+++ b/nextjs-app/shared/components/NavLink/NavLink.contract.json
@@ -1,167 +1,167 @@
 {
-    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-    "name": "NavLink",
-    "tier": "atom",
-    "group": "navigation",
-    "status": "stable",
-    "description": "Navigation anchor primitive used inside `SiteHeader`, `Footer`, and in-page navs. Renders an underlying `next/link` and applies the `aria-current='page'` token when the active route matches.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-nav-link",
-    "radixPrimitive": null,
-    "element": "a",
-    "variants": {},
-    "slots": [],
-    "asChild": false,
-    "subParts": [],
-    "requiredStories": [
-        "Default",
-        "Playground",
-        "Example",
-        "ForcedColors"
+  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+  "name": "NavLink",
+  "tier": "atom",
+  "group": "navigation",
+  "status": "stable",
+  "description": "Navigation anchor primitive used inside `SiteHeader`, `Footer`, and in-page navs. Renders an underlying `next/link` and applies the `aria-current='page'` token when the active route matches.",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=516-3146",
+  "radixPrimitive": null,
+  "element": "a",
+  "variants": {},
+  "slots": [],
+  "asChild": false,
+  "subParts": [],
+  "requiredStories": [
+    "Default",
+    "Playground",
+    "Example",
+    "ForcedColors"
+  ],
+  "a11y": {
+    "keyboard": [
+      "Tab — focusable.",
+      "Enter — follows the link."
     ],
-    "a11y": {
-        "keyboard": [
-            "Tab — focusable.",
-            "Enter — follows the link."
-        ],
-        "ariaRequirements": [
-            "Sets `aria-current='page'` on the active route so the active nav item is announced.",
-            "Renders a real `<a>` (via next/link) for native browser behaviour."
-        ],
-        "reducedMotion": true,
-        "reviewed": true,
-        "forcedColorsVerified": true,
-        "accessibilityTreeVerified": true,
-        "realBrowserForcedColorsVerified": true,
-        "reviewedNote": "2026-07-05 — beta→stable (fleet #13): renders a real next/link <a>, aria-current='page' on the active route. Fixed a reduced-motion gap — the transition-colors fade now carries motion-reduce:transition-none so a11y.reducedMotion is literally honest (matches Pagination / ValueCard); unit-tested. Styling is a deliberate className contract (active/inactiveClassName), so exact + activeClassName are EFFECT_EXEMPT in audit:controls with unit tests covering the active/inactive class swap. Re-verified: axe + plays green in light/dark/forced-colors, 100% controls operable / 0 inert, AT snapshots captured 4 modes. 2026-05-28 origin: Bucket-1 beta port, keyboard/ARIA reviewed, ForcedColors story + Storybook axe gate."
+    "ariaRequirements": [
+      "Sets `aria-current='page'` on the active route so the active nav item is announced.",
+      "Renders a real `<a>` (via next/link) for native browser behaviour."
+    ],
+    "reducedMotion": true,
+    "reviewed": true,
+    "forcedColorsVerified": true,
+    "accessibilityTreeVerified": true,
+    "realBrowserForcedColorsVerified": true,
+    "reviewedNote": "2026-07-05 — beta→stable (fleet #13): renders a real next/link <a>, aria-current='page' on the active route. Fixed a reduced-motion gap — the transition-colors fade now carries motion-reduce:transition-none so a11y.reducedMotion is literally honest (matches Pagination / ValueCard); unit-tested. Styling is a deliberate className contract (active/inactiveClassName), so exact + activeClassName are EFFECT_EXEMPT in audit:controls with unit tests covering the active/inactive class swap. Re-verified: axe + plays green in light/dark/forced-colors, 100% controls operable / 0 inert, AT snapshots captured 4 modes. 2026-05-28 origin: Bucket-1 beta port, keyboard/ARIA reviewed, ForcedColors story + Storybook axe gate. 2026-07-10 — Figma link wired to the existing NavLink component set (Patterns page, node 516-3146); parity uplift tracked in docs/design-system/figma-parity-audit.md B5."
+  },
+  "tokens": {
+    "colors": [
+      "--color-text",
+      "--color-link",
+      "--color-link-hover"
+    ],
+    "spacing": [],
+    "typography": [
+      "--font-size-md"
+    ]
+  },
+  "lightDarkVerified": true,
+  "consumers": [
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/dev/tailwind-test/page.tsx",
+      "since": "2026-06-04"
     },
-    "tokens": {
-        "colors": [
-            "--color-text",
-            "--color-link",
-            "--color-link-hover"
-        ],
-        "spacing": [],
-        "typography": [
-            "--font-size-md"
-        ]
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/layout.tsx",
+      "since": "2026-06-04"
     },
-    "lightDarkVerified": true,
-    "consumers": [
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/dev/tailwind-test/page.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/layout.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/navigation/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/SiteHeader/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx",
-            "since": "2026-06-04"
-        }
-    ],
-    "schemaVersion": 2,
-    "props": {
-        "href": {
-            "optional": false,
-            "type": "string"
-        },
-        "children": {
-            "optional": false,
-            "type": "ReactNode"
-        },
-        "exact": {
-            "optional": true,
-            "type": "boolean"
-        },
-        "className": {
-            "optional": true,
-            "type": "string"
-        },
-        "activeClassName": {
-            "optional": true,
-            "type": "string"
-        },
-        "inactiveClassName": {
-            "optional": true,
-            "type": "string"
-        }
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/patterns/index.ts",
+      "since": "2026-06-04"
     },
-    "forbiddenUse": [
-        "Use inside body prose — that is `Link`.",
-        "Use as a button — primary actions belong on `Button`."
-    ],
-    "composesWith": [
-        "Link",
-        "SkipLink",
-        "LanguageSwitcher"
-    ],
-    "displayName": "NavLink",
-    "keywords": [
-        "nav link",
-        "navigation",
-        "active state",
-        "aria-current",
-        "menu link",
-        "header"
-    ],
-    "dense": "Next.js nav link deriving active state from usePathname (prefix match, exact opt-in); sets aria-current=page; styled via className/activeClassName/inactiveClassName (Tailwind-token defaults by design)",
-    "usage": {
-        "description": "NavLink is the router-aware navigation link for site chrome: headers, drawers, and sidebars. It compares the current pathname against `href` — prefix match by default, exact with `exact` — and reflects the result both as `aria-current=\"page\"` and as the active/inactive class pair. Use it inside a labelled `<nav>`; for inline prose links use Link instead. Styling is deliberately className-driven (Tailwind tokens by default) so each navigation surface owns its look while the active-state contract stays shared.",
-        "bestPractices": [
-            {
-                "guidance": true,
-                "description": "Wrap groups in a labelled <nav aria-label=\"Primary\"> so assistive tech can jump to the landmark."
-            },
-            {
-                "guidance": true,
-                "description": "Use exact on short roots like \"/\" — prefix matching would otherwise mark Home active on every route."
-            },
-            {
-                "guidance": true,
-                "description": "Keep active styling redundant with aria-current: weight or underline plus color, never color alone."
-            },
-            {
-                "guidance": true,
-                "description": "Override className/activeClassName per surface instead of wrapping; the active-state logic is the shared part."
-            },
-            {
-                "guidance": false,
-                "description": "Do not use NavLink for inline body links — that is Link's job; NavLink's route tracking is navigation-chrome behavior."
-            },
-            {
-                "guidance": false,
-                "description": "Do not hand-set aria-current on children; the component derives it from the route."
-            }
-        ]
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/patterns/navigation/index.ts",
+      "since": "2026-06-04"
     },
-    "playground": {
-        "defaults": {
-            "href": "/work",
-            "children": "Work"
-        }
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/patterns/SiteHeader/index.ts",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx",
+      "since": "2026-06-04"
     }
+  ],
+  "schemaVersion": 2,
+  "props": {
+    "href": {
+      "optional": false,
+      "type": "string"
+    },
+    "children": {
+      "optional": false,
+      "type": "ReactNode"
+    },
+    "exact": {
+      "optional": true,
+      "type": "boolean"
+    },
+    "className": {
+      "optional": true,
+      "type": "string"
+    },
+    "activeClassName": {
+      "optional": true,
+      "type": "string"
+    },
+    "inactiveClassName": {
+      "optional": true,
+      "type": "string"
+    }
+  },
+  "forbiddenUse": [
+    "Use inside body prose — that is `Link`.",
+    "Use as a button — primary actions belong on `Button`."
+  ],
+  "composesWith": [
+    "Link",
+    "SkipLink",
+    "LanguageSwitcher"
+  ],
+  "displayName": "NavLink",
+  "keywords": [
+    "nav link",
+    "navigation",
+    "active state",
+    "aria-current",
+    "menu link",
+    "header"
+  ],
+  "dense": "Next.js nav link deriving active state from usePathname (prefix match, exact opt-in); sets aria-current=page; styled via className/activeClassName/inactiveClassName (Tailwind-token defaults by design)",
+  "usage": {
+    "description": "NavLink is the router-aware navigation link for site chrome: headers, drawers, and sidebars. It compares the current pathname against `href` — prefix match by default, exact with `exact` — and reflects the result both as `aria-current=\"page\"` and as the active/inactive class pair. Use it inside a labelled `<nav>`; for inline prose links use Link instead. Styling is deliberately className-driven (Tailwind tokens by default) so each navigation surface owns its look while the active-state contract stays shared.",
+    "bestPractices": [
+      {
+        "guidance": true,
+        "description": "Wrap groups in a labelled <nav aria-label=\"Primary\"> so assistive tech can jump to the landmark."
+      },
+      {
+        "guidance": true,
+        "description": "Use exact on short roots like \"/\" — prefix matching would otherwise mark Home active on every route."
+      },
+      {
+        "guidance": true,
+        "description": "Keep active styling redundant with aria-current: weight or underline plus color, never color alone."
+      },
+      {
+        "guidance": true,
+        "description": "Override className/activeClassName per surface instead of wrapping; the active-state logic is the shared part."
+      },
+      {
+        "guidance": false,
+        "description": "Do not use NavLink for inline body links — that is Link's job; NavLink's route tracking is navigation-chrome behavior."
+      },
+      {
+        "guidance": false,
+        "description": "Do not hand-set aria-current on children; the component derives it from the route."
+      }
+    ]
+  },
+  "playground": {
+    "defaults": {
+      "href": "/work",
+      "children": "Work"
+    }
+  }
 }

--- a/nextjs-app/shared/components/NavLink/NavLink.stories.tsx
+++ b/nextjs-app/shared/components/NavLink/NavLink.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
   parameters: {
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-nav-link",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=516-3146",
     },
     layout: "centered",
     contractStatus: contract.status,

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-10T14:38:15.719Z",
+  "generatedAt": "2026-07-10T15:00:33.839Z",
   "summary": {
     "componentCount": 163,
     "statusCounts": {
@@ -10607,7 +10607,7 @@
         "group": "display",
         "status": "beta",
         "description": "The assistant's animated avatar with thinking, speaking, and idle mood states, used inside ChatWidget and Donny surfaces.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-donny-avatar",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=492-1578",
         "radixPrimitive": null,
         "element": "div",
         "variants": {
@@ -10637,7 +10637,7 @@
           "reviewed": true,
           "forcedColorsVerified": true,
           "ariaRequirements": [],
-          "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+          "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-10 — Figma link wired to the existing DonnyAvatar component (Atoms page, node 492-1578)."
         },
         "tokens": {
           "colors": [
@@ -19630,7 +19630,7 @@
         "group": "navigation",
         "status": "stable",
         "description": "Navigation anchor primitive used inside `SiteHeader`, `Footer`, and in-page navs. Renders an underlying `next/link` and applies the `aria-current='page'` token when the active route matches.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-nav-link",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=516-3146",
         "radixPrimitive": null,
         "element": "a",
         "variants": {},
@@ -19657,7 +19657,7 @@
           "forcedColorsVerified": true,
           "accessibilityTreeVerified": true,
           "realBrowserForcedColorsVerified": true,
-          "reviewedNote": "2026-07-05 — beta→stable (fleet #13): renders a real next/link <a>, aria-current='page' on the active route. Fixed a reduced-motion gap — the transition-colors fade now carries motion-reduce:transition-none so a11y.reducedMotion is literally honest (matches Pagination / ValueCard); unit-tested. Styling is a deliberate className contract (active/inactiveClassName), so exact + activeClassName are EFFECT_EXEMPT in audit:controls with unit tests covering the active/inactive class swap. Re-verified: axe + plays green in light/dark/forced-colors, 100% controls operable / 0 inert, AT snapshots captured 4 modes. 2026-05-28 origin: Bucket-1 beta port, keyboard/ARIA reviewed, ForcedColors story + Storybook axe gate."
+          "reviewedNote": "2026-07-05 — beta→stable (fleet #13): renders a real next/link <a>, aria-current='page' on the active route. Fixed a reduced-motion gap — the transition-colors fade now carries motion-reduce:transition-none so a11y.reducedMotion is literally honest (matches Pagination / ValueCard); unit-tested. Styling is a deliberate className contract (active/inactiveClassName), so exact + activeClassName are EFFECT_EXEMPT in audit:controls with unit tests covering the active/inactive class swap. Re-verified: axe + plays green in light/dark/forced-colors, 100% controls operable / 0 inert, AT snapshots captured 4 modes. 2026-05-28 origin: Bucket-1 beta port, keyboard/ARIA reviewed, ForcedColors story + Storybook axe gate. 2026-07-10 — Figma link wired to the existing NavLink component set (Patterns page, node 516-3146); parity uplift tracked in docs/design-system/figma-parity-audit.md B5."
         },
         "tokens": {
           "colors": [

--- a/package.json
+++ b/package.json
@@ -182,7 +182,8 @@
     "capture:a11y-snapshots": "node scripts/design-system/capture-story-a11y-snapshots.mjs",
     "promote:stable-atoms": "node scripts/design-system/promote-stable-atoms.mjs",
     "check:bundle-budgets": "node scripts/design-system/check-bundle-budgets.mjs",
-    "check:dogfood-ratchet": "node scripts/design-system/check-dogfood-ratchet.mjs"
+    "check:dogfood-ratchet": "node scripts/design-system/check-dogfood-ratchet.mjs",
+    "check:figma-links": "node scripts/design-system/check-figma-links.mjs"
   },
   "dependencies": {
     "@ai-sdk/mcp": "^1.0.51",

--- a/scripts/design-system/check-figma-links.mjs
+++ b/scripts/design-system/check-figma-links.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * Figma-link ratchet: stable contracts must not gain placeholder Figma links.
+ *
+ * A "placeholder" is any contract `figma` value without a real numeric node id
+ * (node-id=<digits>-<digits>). The committed ceiling in figma-links.baseline.json
+ * can only go DOWN — lower it in the same PR that wires real nodes. The backfill
+ * plan lives in docs/design-system/figma-parity-audit.md.
+ *
+ * This is a static check: it cannot detect numeric links whose node was later
+ * deleted in Figma (those are caught by the audit's live scan).
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const BASELINE_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "figma-links.baseline.json",
+);
+
+const REAL_NODE = /node-id=\d+[-:]\d+/;
+
+const contractFiles = [];
+const walk = (dir) => {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) walk(p);
+    else if (entry.name.endsWith(".contract.json")) contractFiles.push(p);
+  }
+};
+walk(join(ROOT, "nextjs-app", "shared", "components"));
+walk(join(ROOT, "nextjs-app", "shared", "patterns"));
+
+const stablePlaceholders = [];
+for (const file of contractFiles) {
+  const contract = JSON.parse(readFileSync(file, "utf8"));
+  if (contract.status !== "stable") continue;
+  if (typeof contract.figma !== "string" || !REAL_NODE.test(contract.figma)) {
+    stablePlaceholders.push(contract.name);
+  }
+}
+
+const baseline = JSON.parse(readFileSync(BASELINE_PATH, "utf8"));
+const ceiling = baseline.stablePlaceholderCeiling;
+const count = stablePlaceholders.length;
+
+if (count > ceiling) {
+  console.error(
+    `✖ figma-links ratchet: ${count} stable contracts have placeholder Figma links (ceiling ${ceiling}).`,
+  );
+  console.error(
+    `  New stable contracts need a real numeric Figma node (build it first — see docs/design-system/figma-parity-audit.md).`,
+  );
+  console.error(`  Placeholders: ${stablePlaceholders.sort().join(", ")}`);
+  process.exit(1);
+}
+
+if (count < ceiling) {
+  console.error(
+    `✖ figma-links ratchet: count dropped to ${count} but the ceiling is still ${ceiling}.`,
+  );
+  console.error(
+    `  Tighten scripts/design-system/figma-links.baseline.json to ${count} in this PR so progress cannot regress.`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `✓ figma-links ratchet: ${count}/${ceiling} stable contracts with placeholder Figma links (can only decrease)`,
+);

--- a/scripts/design-system/figma-links.baseline.json
+++ b/scripts/design-system/figma-links.baseline.json
@@ -1,0 +1,4 @@
+{
+  "stablePlaceholderCeiling": 46,
+  "note": "Ratchet: lower this in the PR that wires real Figma nodes; see docs/design-system/figma-parity-audit.md"
+}


### PR DESCRIPTION
B0 (Figma side, per docs/design-system/figma-parity-audit.md): all 7 Syne text styles
migrated to Satoshi Bold with 120% line-height (sizes already matched the variables.css
clamp maxima); 3 missing heading styles added (title-xxl 112, title-xs 28, title-xxs 22);
Syne swept from Foundations/Atoms/Molecules/Patterns canvases and from Title/Modal/EmptyState
internals; Kbd DM Mono and NewsBulletin Red Hat Mono → Source Code Pro (--font-mono parity).
All four DS pages verified 0 remaining Syne/DM Mono/Red Hat Mono text segments.

B1 (repo side): NavLink contract wired to existing Figma set 516-3146, DonnyAvatar to
492-1578 (+ story design URLs); Figma set 374:10 renamed Inputs → TextInput; new
check:figma-links ratchet (stable placeholder ceiling 46, both directions negative-tested)
wired into pre-push.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
