### PR TITLE
chore(design-system): figma-parity B2a — atoms to contract parity, 8 real Figma nodes wired

### DIFF
--- a/nextjs-app/shared/components/Container/Container.contract.json
+++ b/nextjs-app/shared/components/Container/Container.contract.json
@@ -1,374 +1,374 @@
 {
-    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-    "name": "Container",
-    "tier": "atom",
-    "group": "layout",
-    "status": "stable",
-    "description": "Max-width content wrapper with responsive horizontal padding.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-container",
-    "radixPrimitive": null,
-    "element": "div",
-    "variants": {
-        "size": {
-            "values": [
-                "sm",
-                "md",
-                "lg",
-                "xl",
-                "full"
-            ],
-            "default": "lg",
-            "propSourced": true
-        }
-    },
-    "slots": [],
-    "asChild": false,
-    "subParts": [],
-    "requiredStories": [
-        "Default",
-        "Playground",
-        "Example",
-        "ForcedColors"
-    ],
-    "a11y": {
-        "keyboard": [],
-        "ariaRequirements": [],
-        "reducedMotion": true,
-        "reviewed": true,
-        "forcedColorsVerified": true,
-        "accessibilityTreeVerified": true,
-        "realBrowserForcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories; AT snapshots refreshed and compare-clean in all four modes (plain/light/dark/forced-colors); Controls 100% operable + 0 inert. Container carries no color surface of its own (tokens.colors empty; transparent wrapper), so light/dark is a structural no-op. Fixed the stale variants.size.default (\"sm\" → \"lg\") to match the component default and docs."
-    },
-    "tokens": {
-        "colors": [],
-        "spacing": []
-    },
-    "lightDarkVerified": true,
-    "consumers": [
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/blog/[slug]/BlogArticleMdxBody.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/blog/[slug]/ClientArticleShell.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/blog/[slug]/page.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/blog/[slug]/ServerArticleContent.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/blog/[slug]/ServerArticleHero.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/blog/[slug]/ServerArticleMain.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/blog/[slug]/ServerRelatedPosts.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/dev/code-window/page.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/dev/tailwind-test/page.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/layout.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/AboutPage/index.ts",
-            "since": "2026-06-04"
-        }
-    ],
-    "schemaVersion": 2,
-    "props": {
-        "children": {
-            "optional": false,
-            "type": "ReactNode"
-        },
-        "size": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "sm",
-                "md",
-                "lg",
-                "full",
-                "xl"
-            ]
-        },
-        "center": {
-            "optional": true,
-            "type": "boolean"
-        },
-        "className": {
-            "optional": true,
-            "type": "string"
-        },
-        "as": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "symbol",
-                "object",
-                "image",
-                "form",
-                "slot",
-                "style",
-                "title",
-                "button",
-                "search",
-                "article",
-                "dialog",
-                "figure",
-                "img",
-                "link",
-                "main",
-                "menu",
-                "menuitem",
-                "option",
-                "switch",
-                "table",
-                "text",
-                "time",
-                "a",
-                "abbr",
-                "address",
-                "area",
-                "aside",
-                "audio",
-                "b",
-                "base",
-                "bdi",
-                "bdo",
-                "big",
-                "blockquote",
-                "body",
-                "br",
-                "canvas",
-                "caption",
-                "center",
-                "cite",
-                "code",
-                "col",
-                "colgroup",
-                "data",
-                "datalist",
-                "dd",
-                "del",
-                "details",
-                "dfn",
-                "div",
-                "dl",
-                "dt",
-                "em",
-                "embed",
-                "fieldset",
-                "figcaption",
-                "footer",
-                "h1",
-                "h2",
-                "h3",
-                "h4",
-                "h5",
-                "h6",
-                "head",
-                "header",
-                "hgroup",
-                "hr",
-                "html",
-                "i",
-                "iframe",
-                "input",
-                "ins",
-                "kbd",
-                "keygen",
-                "label",
-                "legend",
-                "li",
-                "map",
-                "mark",
-                "meta",
-                "meter",
-                "nav",
-                "noindex",
-                "noscript",
-                "ol",
-                "optgroup",
-                "output",
-                "p",
-                "param",
-                "picture",
-                "pre",
-                "progress",
-                "q",
-                "rp",
-                "rt",
-                "ruby",
-                "s",
-                "samp",
-                "script",
-                "section",
-                "select",
-                "small",
-                "source",
-                "span",
-                "strong",
-                "sub",
-                "summary",
-                "sup",
-                "template",
-                "tbody",
-                "td",
-                "textarea",
-                "tfoot",
-                "th",
-                "thead",
-                "tr",
-                "track",
-                "u",
-                "ul",
-                "var",
-                "video",
-                "wbr",
-                "webview",
-                "svg",
-                "animate",
-                "animateMotion",
-                "animateTransform",
-                "circle",
-                "clipPath",
-                "defs",
-                "desc",
-                "ellipse",
-                "feBlend",
-                "feColorMatrix",
-                "feComponentTransfer",
-                "feComposite",
-                "feConvolveMatrix",
-                "feDiffuseLighting",
-                "feDisplacementMap",
-                "feDistantLight",
-                "feDropShadow",
-                "feFlood",
-                "feFuncA",
-                "feFuncB",
-                "feFuncG",
-                "feFuncR",
-                "feGaussianBlur",
-                "feImage",
-                "feMerge",
-                "feMergeNode",
-                "feMorphology",
-                "feOffset",
-                "fePointLight",
-                "feSpecularLighting",
-                "feSpotLight",
-                "feTile",
-                "feTurbulence",
-                "filter",
-                "foreignObject",
-                "g",
-                "line",
-                "linearGradient",
-                "marker",
-                "mask",
-                "metadata",
-                "mpath",
-                "path",
-                "pattern",
-                "polygon",
-                "polyline",
-                "radialGradient",
-                "rect",
-                "set",
-                "stop",
-                "textPath",
-                "tspan",
-                "use",
-                "view"
-            ]
-        }
-    },
-    "forbiddenUse": [
-        "Nest a Container inside another Container — gutters compound and the measure narrows.",
-        "Use size=\"full\" together with a custom max-width class; pick the size that matches instead."
-    ],
-    "composesWith": [
-        "Section",
-        "Grid",
-        "Stack"
-    ],
-    "displayName": "Container",
-    "keywords": [
-        "container",
-        "max-width",
-        "page width",
-        "wrapper",
-        "gutter",
-        "layout"
-    ],
-    "dense": "Width clamp: size sm 640|md 960|lg 1200 (default)|xl 1440|full; center=true adds auto inline margins; polymorphic as for landmarks (main, section)",
-    "usage": {
-        "description": "Container clamps content to a readable page width and centers it. Pick `size` by the content's measure, not the viewport — `lg` (1200px) is the page default, `sm` suits prose. It renders a `div` unless you pass `as` (use `main`/`section` when the wrapper should also be the landmark). One container per page region; sections stack inside it, not around it.",
-        "bestPractices": [
-            {
-                "guidance": true,
-                "description": "Pick size by content measure: sm for prose, lg for standard pages, xl only for dashboard-density layouts."
-            },
-            {
-                "guidance": true,
-                "description": "Use as=\"main\" (or section) when the container doubles as the landmark, instead of nesting an extra wrapper."
-            },
-            {
-                "guidance": true,
-                "description": "Pair with Section: Section owns vertical rhythm and background, Container owns horizontal clamp."
-            },
-            {
-                "guidance": true,
-                "description": "Keep center on (default); opt out only for asymmetric editorial layouts."
-            },
-            {
-                "guidance": false,
-                "description": "Do not nest containers — you get compounding gutters and a narrowing measure."
-            },
-            {
-                "guidance": false,
-                "description": "Do not use size=\"full\" plus a custom max-width class; pick the size that matches instead."
-            }
-        ]
-    },
-    "playground": {
-        "defaults": {
-            "children": "Clamped content",
-            "size": "lg"
-        }
+  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+  "name": "Container",
+  "tier": "atom",
+  "group": "layout",
+  "status": "stable",
+  "description": "Max-width content wrapper with responsive horizontal padding.",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1178-1654",
+  "radixPrimitive": null,
+  "element": "div",
+  "variants": {
+    "size": {
+      "values": [
+        "sm",
+        "md",
+        "lg",
+        "xl",
+        "full"
+      ],
+      "default": "lg",
+      "propSourced": true
     }
+  },
+  "slots": [],
+  "asChild": false,
+  "subParts": [],
+  "requiredStories": [
+    "Default",
+    "Playground",
+    "Example",
+    "ForcedColors"
+  ],
+  "a11y": {
+    "keyboard": [],
+    "ariaRequirements": [],
+    "reducedMotion": true,
+    "reviewed": true,
+    "forcedColorsVerified": true,
+    "accessibilityTreeVerified": true,
+    "realBrowserForcedColorsVerified": true,
+    "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories; AT snapshots refreshed and compare-clean in all four modes (plain/light/dark/forced-colors); Controls 100% operable + 0 inert. Container carries no color surface of its own (tokens.colors empty; transparent wrapper), so light/dark is a structural no-op. Fixed the stale variants.size.default (\"sm\" → \"lg\") to match the component default and docs. 2026-07-10 — Figma component built (Atoms, node 1178-1654, parity-audit batch B2a): contract axes as variants with DT variable bindings."
+  },
+  "tokens": {
+    "colors": [],
+    "spacing": []
+  },
+  "lightDarkVerified": true,
+  "consumers": [
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/blog/[slug]/BlogArticleMdxBody.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/blog/[slug]/ClientArticleShell.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/blog/[slug]/page.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/blog/[slug]/ServerArticleContent.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/blog/[slug]/ServerArticleHero.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/blog/[slug]/ServerArticleMain.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/blog/[slug]/ServerRelatedPosts.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/dev/code-window/page.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/dev/tailwind-test/page.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/layout.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/components/pages/AboutPage/index.ts",
+      "since": "2026-06-04"
+    }
+  ],
+  "schemaVersion": 2,
+  "props": {
+    "children": {
+      "optional": false,
+      "type": "ReactNode"
+    },
+    "size": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "sm",
+        "md",
+        "lg",
+        "full",
+        "xl"
+      ]
+    },
+    "center": {
+      "optional": true,
+      "type": "boolean"
+    },
+    "className": {
+      "optional": true,
+      "type": "string"
+    },
+    "as": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "symbol",
+        "object",
+        "image",
+        "form",
+        "slot",
+        "style",
+        "title",
+        "button",
+        "search",
+        "article",
+        "dialog",
+        "figure",
+        "img",
+        "link",
+        "main",
+        "menu",
+        "menuitem",
+        "option",
+        "switch",
+        "table",
+        "text",
+        "time",
+        "a",
+        "abbr",
+        "address",
+        "area",
+        "aside",
+        "audio",
+        "b",
+        "base",
+        "bdi",
+        "bdo",
+        "big",
+        "blockquote",
+        "body",
+        "br",
+        "canvas",
+        "caption",
+        "center",
+        "cite",
+        "code",
+        "col",
+        "colgroup",
+        "data",
+        "datalist",
+        "dd",
+        "del",
+        "details",
+        "dfn",
+        "div",
+        "dl",
+        "dt",
+        "em",
+        "embed",
+        "fieldset",
+        "figcaption",
+        "footer",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "head",
+        "header",
+        "hgroup",
+        "hr",
+        "html",
+        "i",
+        "iframe",
+        "input",
+        "ins",
+        "kbd",
+        "keygen",
+        "label",
+        "legend",
+        "li",
+        "map",
+        "mark",
+        "meta",
+        "meter",
+        "nav",
+        "noindex",
+        "noscript",
+        "ol",
+        "optgroup",
+        "output",
+        "p",
+        "param",
+        "picture",
+        "pre",
+        "progress",
+        "q",
+        "rp",
+        "rt",
+        "ruby",
+        "s",
+        "samp",
+        "script",
+        "section",
+        "select",
+        "small",
+        "source",
+        "span",
+        "strong",
+        "sub",
+        "summary",
+        "sup",
+        "template",
+        "tbody",
+        "td",
+        "textarea",
+        "tfoot",
+        "th",
+        "thead",
+        "tr",
+        "track",
+        "u",
+        "ul",
+        "var",
+        "video",
+        "wbr",
+        "webview",
+        "svg",
+        "animate",
+        "animateMotion",
+        "animateTransform",
+        "circle",
+        "clipPath",
+        "defs",
+        "desc",
+        "ellipse",
+        "feBlend",
+        "feColorMatrix",
+        "feComponentTransfer",
+        "feComposite",
+        "feConvolveMatrix",
+        "feDiffuseLighting",
+        "feDisplacementMap",
+        "feDistantLight",
+        "feDropShadow",
+        "feFlood",
+        "feFuncA",
+        "feFuncB",
+        "feFuncG",
+        "feFuncR",
+        "feGaussianBlur",
+        "feImage",
+        "feMerge",
+        "feMergeNode",
+        "feMorphology",
+        "feOffset",
+        "fePointLight",
+        "feSpecularLighting",
+        "feSpotLight",
+        "feTile",
+        "feTurbulence",
+        "filter",
+        "foreignObject",
+        "g",
+        "line",
+        "linearGradient",
+        "marker",
+        "mask",
+        "metadata",
+        "mpath",
+        "path",
+        "pattern",
+        "polygon",
+        "polyline",
+        "radialGradient",
+        "rect",
+        "set",
+        "stop",
+        "textPath",
+        "tspan",
+        "use",
+        "view"
+      ]
+    }
+  },
+  "forbiddenUse": [
+    "Nest a Container inside another Container — gutters compound and the measure narrows.",
+    "Use size=\"full\" together with a custom max-width class; pick the size that matches instead."
+  ],
+  "composesWith": [
+    "Section",
+    "Grid",
+    "Stack"
+  ],
+  "displayName": "Container",
+  "keywords": [
+    "container",
+    "max-width",
+    "page width",
+    "wrapper",
+    "gutter",
+    "layout"
+  ],
+  "dense": "Width clamp: size sm 640|md 960|lg 1200 (default)|xl 1440|full; center=true adds auto inline margins; polymorphic as for landmarks (main, section)",
+  "usage": {
+    "description": "Container clamps content to a readable page width and centers it. Pick `size` by the content's measure, not the viewport — `lg` (1200px) is the page default, `sm` suits prose. It renders a `div` unless you pass `as` (use `main`/`section` when the wrapper should also be the landmark). One container per page region; sections stack inside it, not around it.",
+    "bestPractices": [
+      {
+        "guidance": true,
+        "description": "Pick size by content measure: sm for prose, lg for standard pages, xl only for dashboard-density layouts."
+      },
+      {
+        "guidance": true,
+        "description": "Use as=\"main\" (or section) when the container doubles as the landmark, instead of nesting an extra wrapper."
+      },
+      {
+        "guidance": true,
+        "description": "Pair with Section: Section owns vertical rhythm and background, Container owns horizontal clamp."
+      },
+      {
+        "guidance": true,
+        "description": "Keep center on (default); opt out only for asymmetric editorial layouts."
+      },
+      {
+        "guidance": false,
+        "description": "Do not nest containers — you get compounding gutters and a narrowing measure."
+      },
+      {
+        "guidance": false,
+        "description": "Do not use size=\"full\" plus a custom max-width class; pick the size that matches instead."
+      }
+    ]
+  },
+  "playground": {
+    "defaults": {
+      "children": "Clamped content",
+      "size": "lg"
+    }
+  }
 }

--- a/nextjs-app/shared/components/Container/Container.stories.tsx
+++ b/nextjs-app/shared/components/Container/Container.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
   parameters: {
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-container",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1178-1654",
     },
     layout: "centered",
     contractStatus: contract.status,

--- a/nextjs-app/shared/components/FlexBox/FlexBox.contract.json
+++ b/nextjs-app/shared/components/FlexBox/FlexBox.contract.json
@@ -1,192 +1,192 @@
 {
-    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-    "name": "FlexBox",
-    "tier": "atom",
-    "group": "layout",
-    "status": "stable",
-    "description": "Flexbox layout primitive for stacks and rows.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-flex-box",
-    "radixPrimitive": null,
-    "element": "div",
-    "variants": {
-        "align": {
-            "values": [
-                "center",
-                "flex-start",
-                "flex-end",
-                "stretch",
-                "baseline"
-            ],
-            "default": "stretch",
-            "propSourced": true
-        }
-    },
-    "slots": [],
-    "asChild": false,
-    "subParts": [],
-    "requiredStories": [
-        "Default",
-        "Playground",
-        "Example",
-        "ForcedColors"
-    ],
-    "a11y": {
-        "keyboard": [],
-        "ariaRequirements": [],
-        "reducedMotion": true,
-        "reviewed": true,
-        "forcedColorsVerified": true,
-        "accessibilityTreeVerified": true,
-        "realBrowserForcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories in all four modes; AT snapshots bootstrapped (the component had none — snapshot-backfill debt) and compare-clean in plain/light/dark/forced-colors; Controls 9/9 operable + 0 inert. Pure css-less flex passthrough with no color surface (tokens.colors empty), so light/dark is a structural no-op. Fixed a contract defect: variants.align.default was \"center\" but the component default is \"stretch\" (align-items initial)."
-    },
-    "tokens": {
-        "colors": [],
-        "spacing": []
-    },
-    "lightDarkVerified": true,
-    "consumers": [
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/Illustrations/index.ts",
-            "since": "2026-06-04"
-        }
-    ],
-    "schemaVersion": 2,
-    "props": {
-        "direction": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "row",
-                "row-reverse",
-                "column",
-                "column-reverse"
-            ]
-        },
-        "wrap": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "nowrap",
-                "wrap",
-                "wrap-reverse"
-            ]
-        },
-        "justify": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "center",
-                "flex-start",
-                "flex-end",
-                "space-between",
-                "space-around",
-                "space-evenly"
-            ]
-        },
-        "align": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "center",
-                "flex-start",
-                "flex-end",
-                "stretch",
-                "baseline"
-            ]
-        },
-        "alignContent": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "center",
-                "flex-start",
-                "flex-end",
-                "space-between",
-                "space-around",
-                "stretch"
-            ]
-        },
-        "gap": {
-            "optional": true,
-            "type": "string | number"
-        },
-        "rowGap": {
-            "optional": true,
-            "type": "string | number"
-        },
-        "columnGap": {
-            "optional": true,
-            "type": "string | number"
-        },
-        "style": {
-            "optional": true,
-            "type": "React.CSSProperties"
-        },
-        "children": {
-            "optional": false,
-            "type": "React.ReactNode"
-        }
-    },
-    "forbiddenUse": [
-        "Rebuild Grid with wrap and width math — two-dimensional layouts belong to Grid.",
-        "Hardcode magic px strings when a space token exists; the rhythm gate will flag it."
-    ],
-    "composesWith": [
-        "Stack",
-        "Grid",
-        "Spacer"
-    ],
-    "displayName": "FlexBox",
-    "keywords": [
-        "flex",
-        "flexbox",
-        "row",
-        "alignment",
-        "justify",
-        "gap"
-    ],
-    "dense": "Style-prop flexbox (css-less by design): direction/wrap/justify/align/alignContent + gap|rowGap|columnGap (number=px, string=token); passes through div attributes",
-    "usage": {
-        "description": "FlexBox is the free-form single-axis primitive: every flexbox knob exposed as a prop, emitted as inline style — deliberately css-less. Numbers become px gaps; strings pass through, so prefer space tokens (\"var(--space-internal-16)\"). Use it for one-off arrangements where Stack's token scale is too coarse; when you just need vertical rhythm, Stack is the sharper tool.",
-        "bestPractices": [
-            {
-                "guidance": true,
-                "description": "Prefer Stack for standard token-gapped rows/columns; FlexBox is for the layouts Stack cannot express."
-            },
-            {
-                "guidance": true,
-                "description": "Pass string gaps as space tokens; numeric gaps are raw px and should stay rare."
-            },
-            {
-                "guidance": true,
-                "description": "Use align=\"center\" for mixed-height inline clusters (icon + text + badge)."
-            },
-            {
-                "guidance": true,
-                "description": "Lean on the div passthrough for aria roles when the flex row is semantically a group."
-            },
-            {
-                "guidance": false,
-                "description": "Do not rebuild Grid with wrap and width math — two-dimensional layouts belong to Grid."
-            },
-            {
-                "guidance": false,
-                "description": "Do not hardcode magic px strings when a space token exists; the rhythm gate will flag it."
-            }
-        ]
-    },
-    "playground": {
-        "defaults": {
-            "gap": 16,
-            "align": "center",
-            "children": "Flexed content"
-        }
+  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+  "name": "FlexBox",
+  "tier": "atom",
+  "group": "layout",
+  "status": "stable",
+  "description": "Flexbox layout primitive for stacks and rows.",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1176-1698",
+  "radixPrimitive": null,
+  "element": "div",
+  "variants": {
+    "align": {
+      "values": [
+        "center",
+        "flex-start",
+        "flex-end",
+        "stretch",
+        "baseline"
+      ],
+      "default": "stretch",
+      "propSourced": true
     }
+  },
+  "slots": [],
+  "asChild": false,
+  "subParts": [],
+  "requiredStories": [
+    "Default",
+    "Playground",
+    "Example",
+    "ForcedColors"
+  ],
+  "a11y": {
+    "keyboard": [],
+    "ariaRequirements": [],
+    "reducedMotion": true,
+    "reviewed": true,
+    "forcedColorsVerified": true,
+    "accessibilityTreeVerified": true,
+    "realBrowserForcedColorsVerified": true,
+    "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories in all four modes; AT snapshots bootstrapped (the component had none — snapshot-backfill debt) and compare-clean in plain/light/dark/forced-colors; Controls 9/9 operable + 0 inert. Pure css-less flex passthrough with no color surface (tokens.colors empty), so light/dark is a structural no-op. Fixed a contract defect: variants.align.default was \"center\" but the component default is \"stretch\" (align-items initial). 2026-07-10 — Figma component built (Atoms, node 1176-1698, parity-audit batch B2a): contract axes as variants with DT variable bindings."
+  },
+  "tokens": {
+    "colors": [],
+    "spacing": []
+  },
+  "lightDarkVerified": true,
+  "consumers": [
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/components/pages/Work/Illustrations/index.ts",
+      "since": "2026-06-04"
+    }
+  ],
+  "schemaVersion": 2,
+  "props": {
+    "direction": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "row",
+        "row-reverse",
+        "column",
+        "column-reverse"
+      ]
+    },
+    "wrap": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "nowrap",
+        "wrap",
+        "wrap-reverse"
+      ]
+    },
+    "justify": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "center",
+        "flex-start",
+        "flex-end",
+        "space-between",
+        "space-around",
+        "space-evenly"
+      ]
+    },
+    "align": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "center",
+        "flex-start",
+        "flex-end",
+        "stretch",
+        "baseline"
+      ]
+    },
+    "alignContent": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "center",
+        "flex-start",
+        "flex-end",
+        "space-between",
+        "space-around",
+        "stretch"
+      ]
+    },
+    "gap": {
+      "optional": true,
+      "type": "string | number"
+    },
+    "rowGap": {
+      "optional": true,
+      "type": "string | number"
+    },
+    "columnGap": {
+      "optional": true,
+      "type": "string | number"
+    },
+    "style": {
+      "optional": true,
+      "type": "React.CSSProperties"
+    },
+    "children": {
+      "optional": false,
+      "type": "React.ReactNode"
+    }
+  },
+  "forbiddenUse": [
+    "Rebuild Grid with wrap and width math — two-dimensional layouts belong to Grid.",
+    "Hardcode magic px strings when a space token exists; the rhythm gate will flag it."
+  ],
+  "composesWith": [
+    "Stack",
+    "Grid",
+    "Spacer"
+  ],
+  "displayName": "FlexBox",
+  "keywords": [
+    "flex",
+    "flexbox",
+    "row",
+    "alignment",
+    "justify",
+    "gap"
+  ],
+  "dense": "Style-prop flexbox (css-less by design): direction/wrap/justify/align/alignContent + gap|rowGap|columnGap (number=px, string=token); passes through div attributes",
+  "usage": {
+    "description": "FlexBox is the free-form single-axis primitive: every flexbox knob exposed as a prop, emitted as inline style — deliberately css-less. Numbers become px gaps; strings pass through, so prefer space tokens (\"var(--space-internal-16)\"). Use it for one-off arrangements where Stack's token scale is too coarse; when you just need vertical rhythm, Stack is the sharper tool.",
+    "bestPractices": [
+      {
+        "guidance": true,
+        "description": "Prefer Stack for standard token-gapped rows/columns; FlexBox is for the layouts Stack cannot express."
+      },
+      {
+        "guidance": true,
+        "description": "Pass string gaps as space tokens; numeric gaps are raw px and should stay rare."
+      },
+      {
+        "guidance": true,
+        "description": "Use align=\"center\" for mixed-height inline clusters (icon + text + badge)."
+      },
+      {
+        "guidance": true,
+        "description": "Lean on the div passthrough for aria roles when the flex row is semantically a group."
+      },
+      {
+        "guidance": false,
+        "description": "Do not rebuild Grid with wrap and width math — two-dimensional layouts belong to Grid."
+      },
+      {
+        "guidance": false,
+        "description": "Do not hardcode magic px strings when a space token exists; the rhythm gate will flag it."
+      }
+    ]
+  },
+  "playground": {
+    "defaults": {
+      "gap": 16,
+      "align": "center",
+      "children": "Flexed content"
+    }
+  }
 }

--- a/nextjs-app/shared/components/FlexBox/FlexBox.stories.tsx
+++ b/nextjs-app/shared/components/FlexBox/FlexBox.stories.tsx
@@ -29,7 +29,7 @@ const meta = {
   parameters: {
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-flex-box",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1176-1698",
     },
     layout: "centered",
     contractStatus: contract.status,

--- a/nextjs-app/shared/components/Grid/Grid.contract.json
+++ b/nextjs-app/shared/components/Grid/Grid.contract.json
@@ -1,218 +1,218 @@
 {
-    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-    "name": "Grid",
-    "tier": "atom",
-    "group": "layout",
-    "status": "stable",
-    "description": "CSS grid layout primitive with tokenized gaps.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-grid",
-    "radixPrimitive": null,
-    "element": "div",
-    "variants": {
-        "align": {
-            "values": [
-                "inherit",
-                "center",
-                "flex-start",
-                "flex-end",
-                "stretch",
-                "baseline",
-                "-moz-initial",
-                "initial",
-                "revert",
-                "revert-layer",
-                "unset",
-                "end",
-                "self-end",
-                "self-start",
-                "start",
-                "anchor-center",
-                "normal"
-            ],
-            "default": "inherit",
-            "propSourced": true
-        }
-    },
-    "slots": [],
-    "asChild": false,
-    "subParts": [],
-    "requiredStories": [
-        "Default",
-        "Playground",
-        "Example",
-        "ForcedColors"
-    ],
-    "a11y": {
-        "keyboard": [],
-        "ariaRequirements": [],
-        "reducedMotion": true,
-        "reviewed": true,
-        "forcedColorsVerified": true,
-        "accessibilityTreeVerified": true,
-        "realBrowserForcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories; AT snapshots refreshed compare-clean in all four modes (plain/light/dark/forced-colors); Controls 9/9 operable + 0 inert. Pure two-dimensional layout primitive with no color surface of its own (tokens.colors empty), so light/dark is a structural no-op. The GridProps `[key: string]: any` passthrough is the intentional, documented escape hatch for arbitrary grid CSS props — kept as-is."
-    },
-    "tokens": {
-        "colors": [],
-        "spacing": []
-    },
-    "lightDarkVerified": true,
-    "consumers": [
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/Footer/Footer.tsx",
-            "since": "2026-06-04"
-        }
-    ],
-    "schemaVersion": 2,
-    "props": {
-        "children": {
-            "optional": false,
-            "type": "ReactNode"
-        },
-        "columns": {
-            "optional": true,
-            "type": "number | string"
-        },
-        "rows": {
-            "optional": true,
-            "type": "number | string"
-        },
-        "gap": {
-            "optional": true,
-            "type": "string"
-        },
-        "rowGap": {
-            "optional": true,
-            "type": "string"
-        },
-        "colGap": {
-            "optional": true,
-            "type": "string"
-        },
-        "align": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "inherit",
-                "center",
-                "flex-start",
-                "flex-end",
-                "stretch",
-                "baseline",
-                "-moz-initial",
-                "initial",
-                "revert",
-                "revert-layer",
-                "unset",
-                "end",
-                "self-end",
-                "self-start",
-                "start",
-                "anchor-center",
-                "normal"
-            ]
-        },
-        "justify": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "inherit",
-                "center",
-                "flex-start",
-                "flex-end",
-                "stretch",
-                "baseline",
-                "-moz-initial",
-                "initial",
-                "revert",
-                "revert-layer",
-                "unset",
-                "end",
-                "self-end",
-                "self-start",
-                "start",
-                "anchor-center",
-                "normal",
-                "left",
-                "legacy",
-                "right"
-            ]
-        },
-        "style": {
-            "optional": true,
-            "type": "CSSProperties"
-        },
-        "className": {
-            "optional": true,
-            "type": "string"
-        }
-    },
-    "forbiddenUse": [
-        "Use Grid for single-axis flows — Stack (token gaps) or FlexBox (free-form) read clearer and cost less.",
-        "Size cells by styling children with widths; spans and templates belong on the grid, not in the card."
-    ],
-    "composesWith": [
-        "Card",
-        "Container",
-        "AspectRatio"
-    ],
-    "displayName": "Grid",
-    "keywords": [
-        "grid",
-        "columns",
-        "layout",
-        "span",
-        "grid item",
-        "two dimensional"
-    ],
-    "dense": "CSS-grid wrapper: numeric columns for equal tracks or template strings; gap/rowGap/colGap strings; Grid.Item adds span/rowSpan; extra grid CSS props pass through via style",
-    "usage": {
-        "description": "Grid is the two-dimensional layout primitive: pass `columns` as a number for equal tracks or a template string for custom ones, gaps as CSS strings (prefer space tokens), and wrap children needing to span in `Grid.Item` with `span`/`rowSpan`. Reach for it when both axes matter — card walls, media mosaics, dashboard modules; single-axis flows are Stack/FlexBox territory.",
-        "bestPractices": [
-            {
-                "guidance": true,
-                "description": "Use numeric columns for equal tracks and a template string (e.g. \"2fr 1fr\") only when tracks genuinely differ."
-            },
-            {
-                "guidance": true,
-                "description": "Wrap only the children that span in Grid.Item; plain children flow one per cell without a wrapper."
-            },
-            {
-                "guidance": true,
-                "description": "Set gaps with space tokens (\"var(--space-layout-24)\") so grid gutters follow the page rhythm."
-            },
-            {
-                "guidance": true,
-                "description": "Give featured cards span={2} instead of a wider one-off column template."
-            },
-            {
-                "guidance": false,
-                "description": "Do not use Grid for single-axis flows — Stack (token gaps) or FlexBox (free-form) read clearer and cost less."
-            },
-            {
-                "guidance": false,
-                "description": "Do not size cells by styling children with widths; spans and templates belong on the grid, not in the card."
-            }
-        ],
-        "anatomy": [
-            {
-                "name": "Grid",
-                "required": true,
-                "description": "The display:grid container; columns/rows/gaps and any extra grid CSS via props."
-            },
-            {
-                "name": "Grid.Item",
-                "required": false,
-                "description": "Optional child wrapper adding span/rowSpan; unwrapped children occupy one cell each."
-            }
-        ]
-    },
-    "playground": {
-        "defaults": {
-            "columns": 3,
-            "gap": "1.5rem",
-            "children": "Add Grid.Item children in code"
-        }
+  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+  "name": "Grid",
+  "tier": "atom",
+  "group": "layout",
+  "status": "stable",
+  "description": "CSS grid layout primitive with tokenized gaps.",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1177-1654",
+  "radixPrimitive": null,
+  "element": "div",
+  "variants": {
+    "align": {
+      "values": [
+        "inherit",
+        "center",
+        "flex-start",
+        "flex-end",
+        "stretch",
+        "baseline",
+        "-moz-initial",
+        "initial",
+        "revert",
+        "revert-layer",
+        "unset",
+        "end",
+        "self-end",
+        "self-start",
+        "start",
+        "anchor-center",
+        "normal"
+      ],
+      "default": "inherit",
+      "propSourced": true
     }
+  },
+  "slots": [],
+  "asChild": false,
+  "subParts": [],
+  "requiredStories": [
+    "Default",
+    "Playground",
+    "Example",
+    "ForcedColors"
+  ],
+  "a11y": {
+    "keyboard": [],
+    "ariaRequirements": [],
+    "reducedMotion": true,
+    "reviewed": true,
+    "forcedColorsVerified": true,
+    "accessibilityTreeVerified": true,
+    "realBrowserForcedColorsVerified": true,
+    "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories; AT snapshots refreshed compare-clean in all four modes (plain/light/dark/forced-colors); Controls 9/9 operable + 0 inert. Pure two-dimensional layout primitive with no color surface of its own (tokens.colors empty), so light/dark is a structural no-op. The GridProps `[key: string]: any` passthrough is the intentional, documented escape hatch for arbitrary grid CSS props — kept as-is. 2026-07-10 — Figma component built (Atoms, node 1177-1654, parity-audit batch B2a): contract axes as variants with DT variable bindings."
+  },
+  "tokens": {
+    "colors": [],
+    "spacing": []
+  },
+  "lightDarkVerified": true,
+  "consumers": [
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/patterns/Footer/Footer.tsx",
+      "since": "2026-06-04"
+    }
+  ],
+  "schemaVersion": 2,
+  "props": {
+    "children": {
+      "optional": false,
+      "type": "ReactNode"
+    },
+    "columns": {
+      "optional": true,
+      "type": "number | string"
+    },
+    "rows": {
+      "optional": true,
+      "type": "number | string"
+    },
+    "gap": {
+      "optional": true,
+      "type": "string"
+    },
+    "rowGap": {
+      "optional": true,
+      "type": "string"
+    },
+    "colGap": {
+      "optional": true,
+      "type": "string"
+    },
+    "align": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "inherit",
+        "center",
+        "flex-start",
+        "flex-end",
+        "stretch",
+        "baseline",
+        "-moz-initial",
+        "initial",
+        "revert",
+        "revert-layer",
+        "unset",
+        "end",
+        "self-end",
+        "self-start",
+        "start",
+        "anchor-center",
+        "normal"
+      ]
+    },
+    "justify": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "inherit",
+        "center",
+        "flex-start",
+        "flex-end",
+        "stretch",
+        "baseline",
+        "-moz-initial",
+        "initial",
+        "revert",
+        "revert-layer",
+        "unset",
+        "end",
+        "self-end",
+        "self-start",
+        "start",
+        "anchor-center",
+        "normal",
+        "left",
+        "legacy",
+        "right"
+      ]
+    },
+    "style": {
+      "optional": true,
+      "type": "CSSProperties"
+    },
+    "className": {
+      "optional": true,
+      "type": "string"
+    }
+  },
+  "forbiddenUse": [
+    "Use Grid for single-axis flows — Stack (token gaps) or FlexBox (free-form) read clearer and cost less.",
+    "Size cells by styling children with widths; spans and templates belong on the grid, not in the card."
+  ],
+  "composesWith": [
+    "Card",
+    "Container",
+    "AspectRatio"
+  ],
+  "displayName": "Grid",
+  "keywords": [
+    "grid",
+    "columns",
+    "layout",
+    "span",
+    "grid item",
+    "two dimensional"
+  ],
+  "dense": "CSS-grid wrapper: numeric columns for equal tracks or template strings; gap/rowGap/colGap strings; Grid.Item adds span/rowSpan; extra grid CSS props pass through via style",
+  "usage": {
+    "description": "Grid is the two-dimensional layout primitive: pass `columns` as a number for equal tracks or a template string for custom ones, gaps as CSS strings (prefer space tokens), and wrap children needing to span in `Grid.Item` with `span`/`rowSpan`. Reach for it when both axes matter — card walls, media mosaics, dashboard modules; single-axis flows are Stack/FlexBox territory.",
+    "bestPractices": [
+      {
+        "guidance": true,
+        "description": "Use numeric columns for equal tracks and a template string (e.g. \"2fr 1fr\") only when tracks genuinely differ."
+      },
+      {
+        "guidance": true,
+        "description": "Wrap only the children that span in Grid.Item; plain children flow one per cell without a wrapper."
+      },
+      {
+        "guidance": true,
+        "description": "Set gaps with space tokens (\"var(--space-layout-24)\") so grid gutters follow the page rhythm."
+      },
+      {
+        "guidance": true,
+        "description": "Give featured cards span={2} instead of a wider one-off column template."
+      },
+      {
+        "guidance": false,
+        "description": "Do not use Grid for single-axis flows — Stack (token gaps) or FlexBox (free-form) read clearer and cost less."
+      },
+      {
+        "guidance": false,
+        "description": "Do not size cells by styling children with widths; spans and templates belong on the grid, not in the card."
+      }
+    ],
+    "anatomy": [
+      {
+        "name": "Grid",
+        "required": true,
+        "description": "The display:grid container; columns/rows/gaps and any extra grid CSS via props."
+      },
+      {
+        "name": "Grid.Item",
+        "required": false,
+        "description": "Optional child wrapper adding span/rowSpan; unwrapped children occupy one cell each."
+      }
+    ]
+  },
+  "playground": {
+    "defaults": {
+      "columns": 3,
+      "gap": "1.5rem",
+      "children": "Add Grid.Item children in code"
+    }
+  }
 }

--- a/nextjs-app/shared/components/Grid/Grid.stories.tsx
+++ b/nextjs-app/shared/components/Grid/Grid.stories.tsx
@@ -39,7 +39,7 @@ const meta = {
   parameters: {
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-grid",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1177-1654",
     },
     layout: "centered",
     contractStatus: contract.status,

--- a/nextjs-app/shared/components/Icon/Icon.contract.json
+++ b/nextjs-app/shared/components/Icon/Icon.contract.json
@@ -1,268 +1,268 @@
 {
-    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-    "name": "Icon",
-    "tier": "atom",
-    "group": "display",
-    "status": "stable",
-    "description": "Phosphor icon wrapper with size, weight, and motion affordances.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-icon",
-    "radixPrimitive": null,
-    "element": "span",
-    "variants": {
-        "size": {
-            "values": [
-                "2xs",
-                "xs",
-                "sm",
-                "md",
-                "lg",
-                "xl",
-                "2xl"
-            ],
-            "default": "md"
-        }
-    },
-    "slots": [],
-    "asChild": false,
-    "subParts": [],
-    "requiredStories": [
-        "Default",
-        "Playground",
-        "Example",
-        "ForcedColors"
-    ],
-    "a11y": {
-        "keyboard": [],
-        "ariaRequirements": [
-            "decorative icons use aria-hidden",
-            "meaningful icons require aria-label"
-        ],
-        "reducedMotion": true,
-        "reviewed": true,
-        "reviewedNote": "2026-05-26 code review",
-        "forcedColorsVerified": true,
-        "axeTestExempt": "Display-only glyph wrapper",
-        "accessibilityTreeVerified": true,
-        "realBrowserForcedColorsVerified": true
-    },
-    "tokens": {
-        "colors": [
-            "--color-error",
-            "--color-info",
-            "--color-primary",
-            "--color-success",
-            "--color-warning"
-        ],
-        "spacing": []
-    },
-    "lightDarkVerified": true,
-    "consumers": [
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/blog/[slug]/BlogArticleMdxBody.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/blog/[slug]/BlogArticleShare.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/blog/[slug]/page.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/blog/[slug]/ServerArticleContent.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/blog/[slug]/ServerArticleMain.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/dev/code-window/page.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/dev/tailwind-test/page.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/layout.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/lib/siteStructure.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/tools/email-signature/EmailSignatureContent.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/tools/email-signature/page.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
-            "since": "2026-06-04"
-        }
-    ],
-    "schemaVersion": 2,
-    "displayName": "Icon",
-    "props": {
-        "name": {
-            "optional": false,
-            "type": "string"
-        },
-        "weight": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "thin",
-                "light",
-                "regular",
-                "bold",
-                "fill",
-                "duotone"
-            ]
-        },
-        "legacyStyle": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "thin",
-                "light",
-                "regular",
-                "duotone",
-                "solid",
-                "brands"
-            ]
-        },
-        "size": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "sm",
-                "md",
-                "lg",
-                "xl",
-                "2xs",
-                "xs",
-                "2xl"
-            ]
-        },
-        "color": {
-            "optional": true,
-            "type": "string"
-        },
-        "rotate": {
-            "optional": true,
-            "type": "0 | 90 | 180 | 270"
-        },
-        "flip": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "horizontal",
-                "vertical",
-                "both"
-            ]
-        },
-        "spin": {
-            "optional": true,
-            "type": "boolean"
-        },
-        "pulse": {
-            "optional": true,
-            "type": "boolean"
-        },
-        "mirrored": {
-            "optional": true,
-            "type": "boolean"
-        },
-        "ariaLabel": {
-            "optional": true,
-            "type": "string"
-        },
-        "decorative": {
-            "optional": true,
-            "type": "boolean"
-        }
-    },
-    "forbiddenUse": [
-        "pass both `ariaLabel` and `decorative`. The component prefers",
-        "import a Phosphor component directly from `@phosphor-icons/react`"
-    ],
-    "composesWith": [
-        "Button",
-        "Title",
-        "ComplianceCard",
-        "CodeSnippet",
-        "Text",
-        "HelperText"
-    ],
-    "keywords": [
-        "icon",
-        "phosphor",
-        "glyph",
-        "decorative",
-        "aria-label",
-        "spin",
-        "status",
-        "arrow",
-        "caret",
-        "check",
-        "close"
-    ],
-    "dense": "Phosphor icon wrapper; name by PascalCase or slug (FontAwesome aliases kept), 2xs-2xl size ladder, weight, rotate/flip/spin/pulse, decorative by default, ariaLabel switches to role=img",
-    "usage": {
-        "description": "Icon wraps the Phosphor icon set with the project's size ladder, motion affordances, and accessibility defaults. It accepts a Phosphor name (PascalCase like ShareNetwork or a slug like share-network) and stays decorative (aria-hidden) unless you pass ariaLabel, which switches it to role=img with an accessible name. Legacy FontAwesome-style names are aliased so older call sites keep working.",
-        "bestPractices": [
-            {
-                "guidance": true,
-                "description": "Keep icons decorative (no ariaLabel) inside labelled controls; the control's own label is the accessible name."
-            },
-            {
-                "guidance": true,
-                "description": "Pass ariaLabel when the icon is the only content of an interactive element, so the control has a name."
-            },
-            {
-                "guidance": true,
-                "description": "Use spin for loading and pulse for ambient activity; both stop under prefers-reduced-motion."
-            },
-            {
-                "guidance": true,
-                "description": "Pair semantic status icons with visible text; the icon reinforces, the text carries the meaning."
-            },
-            {
-                "guidance": false,
-                "description": "Do not build icon-only buttons from a bare Icon; use Button with icon and accessibleName so focus, hit target and keyboard activation are owned by the right component."
-            },
-            {
-                "guidance": false,
-                "description": "Do not pass both ariaLabel and decorative; they are mutually exclusive and ariaLabel wins."
-            },
-            {
-                "guidance": false,
-                "description": "Do not force brand marks through Icon; anything outside the Phosphor catalogue goes through the image pipeline."
-            }
-        ]
-    },
-    "playground": {
-        "defaults": {
-            "name": "share-network",
-            "size": "lg"
-        }
+  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+  "name": "Icon",
+  "tier": "atom",
+  "group": "display",
+  "status": "stable",
+  "description": "Phosphor icon wrapper with size, weight, and motion affordances.",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1176-1658",
+  "radixPrimitive": null,
+  "element": "span",
+  "variants": {
+    "size": {
+      "values": [
+        "2xs",
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+        "2xl"
+      ],
+      "default": "md"
     }
+  },
+  "slots": [],
+  "asChild": false,
+  "subParts": [],
+  "requiredStories": [
+    "Default",
+    "Playground",
+    "Example",
+    "ForcedColors"
+  ],
+  "a11y": {
+    "keyboard": [],
+    "ariaRequirements": [
+      "decorative icons use aria-hidden",
+      "meaningful icons require aria-label"
+    ],
+    "reducedMotion": true,
+    "reviewed": true,
+    "reviewedNote": "2026-05-26 code review 2026-07-10 — Figma component built (Atoms, node 1176-1658, parity-audit batch B2a): contract axes as variants with DT variable bindings.",
+    "forcedColorsVerified": true,
+    "axeTestExempt": "Display-only glyph wrapper",
+    "accessibilityTreeVerified": true,
+    "realBrowserForcedColorsVerified": true
+  },
+  "tokens": {
+    "colors": [
+      "--color-error",
+      "--color-info",
+      "--color-primary",
+      "--color-success",
+      "--color-warning"
+    ],
+    "spacing": []
+  },
+  "lightDarkVerified": true,
+  "consumers": [
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/blog/[slug]/BlogArticleMdxBody.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/blog/[slug]/BlogArticleShare.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/blog/[slug]/page.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/blog/[slug]/ServerArticleContent.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/blog/[slug]/ServerArticleMain.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/dev/code-window/page.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/dev/tailwind-test/page.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/layout.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/lib/siteStructure.ts",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/tools/email-signature/EmailSignatureContent.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/tools/email-signature/page.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+      "since": "2026-06-04"
+    }
+  ],
+  "schemaVersion": 2,
+  "displayName": "Icon",
+  "props": {
+    "name": {
+      "optional": false,
+      "type": "string"
+    },
+    "weight": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "thin",
+        "light",
+        "regular",
+        "bold",
+        "fill",
+        "duotone"
+      ]
+    },
+    "legacyStyle": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "thin",
+        "light",
+        "regular",
+        "duotone",
+        "solid",
+        "brands"
+      ]
+    },
+    "size": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "sm",
+        "md",
+        "lg",
+        "xl",
+        "2xs",
+        "xs",
+        "2xl"
+      ]
+    },
+    "color": {
+      "optional": true,
+      "type": "string"
+    },
+    "rotate": {
+      "optional": true,
+      "type": "0 | 90 | 180 | 270"
+    },
+    "flip": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "horizontal",
+        "vertical",
+        "both"
+      ]
+    },
+    "spin": {
+      "optional": true,
+      "type": "boolean"
+    },
+    "pulse": {
+      "optional": true,
+      "type": "boolean"
+    },
+    "mirrored": {
+      "optional": true,
+      "type": "boolean"
+    },
+    "ariaLabel": {
+      "optional": true,
+      "type": "string"
+    },
+    "decorative": {
+      "optional": true,
+      "type": "boolean"
+    }
+  },
+  "forbiddenUse": [
+    "pass both `ariaLabel` and `decorative`. The component prefers",
+    "import a Phosphor component directly from `@phosphor-icons/react`"
+  ],
+  "composesWith": [
+    "Button",
+    "Title",
+    "ComplianceCard",
+    "CodeSnippet",
+    "Text",
+    "HelperText"
+  ],
+  "keywords": [
+    "icon",
+    "phosphor",
+    "glyph",
+    "decorative",
+    "aria-label",
+    "spin",
+    "status",
+    "arrow",
+    "caret",
+    "check",
+    "close"
+  ],
+  "dense": "Phosphor icon wrapper; name by PascalCase or slug (FontAwesome aliases kept), 2xs-2xl size ladder, weight, rotate/flip/spin/pulse, decorative by default, ariaLabel switches to role=img",
+  "usage": {
+    "description": "Icon wraps the Phosphor icon set with the project's size ladder, motion affordances, and accessibility defaults. It accepts a Phosphor name (PascalCase like ShareNetwork or a slug like share-network) and stays decorative (aria-hidden) unless you pass ariaLabel, which switches it to role=img with an accessible name. Legacy FontAwesome-style names are aliased so older call sites keep working.",
+    "bestPractices": [
+      {
+        "guidance": true,
+        "description": "Keep icons decorative (no ariaLabel) inside labelled controls; the control's own label is the accessible name."
+      },
+      {
+        "guidance": true,
+        "description": "Pass ariaLabel when the icon is the only content of an interactive element, so the control has a name."
+      },
+      {
+        "guidance": true,
+        "description": "Use spin for loading and pulse for ambient activity; both stop under prefers-reduced-motion."
+      },
+      {
+        "guidance": true,
+        "description": "Pair semantic status icons with visible text; the icon reinforces, the text carries the meaning."
+      },
+      {
+        "guidance": false,
+        "description": "Do not build icon-only buttons from a bare Icon; use Button with icon and accessibleName so focus, hit target and keyboard activation are owned by the right component."
+      },
+      {
+        "guidance": false,
+        "description": "Do not pass both ariaLabel and decorative; they are mutually exclusive and ariaLabel wins."
+      },
+      {
+        "guidance": false,
+        "description": "Do not force brand marks through Icon; anything outside the Phosphor catalogue goes through the image pipeline."
+      }
+    ]
+  },
+  "playground": {
+    "defaults": {
+      "name": "share-network",
+      "size": "lg"
+    }
+  }
 }

--- a/nextjs-app/shared/components/Icon/Icon.stories.tsx
+++ b/nextjs-app/shared/components/Icon/Icon.stories.tsx
@@ -7,7 +7,7 @@ const meta: Meta<typeof Icon> = {
   parameters: {
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-icon",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1176-1658",
     },
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Section/Section.contract.json
+++ b/nextjs-app/shared/components/Section/Section.contract.json
@@ -1,219 +1,219 @@
 {
-    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-    "name": "Section",
-    "tier": "atom",
-    "group": "layout",
-    "status": "stable",
-    "description": "Semantic section wrapper with spacing and background tokens.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-section",
-    "radixPrimitive": null,
-    "element": "section",
-    "variants": {
-        "spacing": {
-            "values": [
-                "none",
-                "sm",
-                "md",
-                "lg",
-                "xl",
-                "hero",
-                "follow"
-            ],
-            "default": "md",
-            "propSourced": true
-        },
-        "background": {
-            "values": [
-                "default",
-                "muted",
-                "accent",
-                "inverse"
-            ],
-            "default": "default",
-            "propSourced": true
-        }
-    },
-    "slots": [],
-    "asChild": false,
-    "subParts": [],
-    "requiredStories": [
-        "Default",
-        "Playground",
-        "Example",
-        "ForcedColors"
-    ],
-    "a11y": {
-        "keyboard": [],
-        "ariaRequirements": [],
-        "reducedMotion": true,
-        "reviewed": true,
-        "forcedColorsVerified": true,
-        "accessibilityTreeVerified": true,
-        "realBrowserForcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories in all four modes (plain/light/dark/forced-colors); AT snapshots refreshed compare-clean; Controls 100% operable + 0 inert. Unlike a pure wrapper, Section owns a real surface (background=inverse flips bg-foreground/text-background) — eyeballed the Backgrounds story in light and dark: default/muted/inverse track the theme and inverse contrast holds both ways. Fixed two contract defects: element was \"div\" (renders <section>) and variants was empty (spacing + background are the styling axes)."
-    },
-    "tokens": {
-        "colors": [],
-        "spacing": []
-    },
-    "lightDarkVerified": true,
-    "consumers": [
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/blog/[slug]/BlogArticleMdxBody.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/blog/[slug]/page.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/blog/[slug]/ServerArticleContent.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/blog/[slug]/ServerArticleMain.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/AboutPage/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Blog/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Home/HomePage.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts",
-            "since": "2026-06-04"
-        }
-    ],
-    "schemaVersion": 2,
-    "props": {
-        "children": {
-            "optional": false,
-            "type": "ReactNode"
-        },
-        "spacing": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "sm",
-                "md",
-                "lg",
-                "none",
-                "xl",
-                "hero",
-                "follow"
-            ]
-        },
-        "background": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "muted",
-                "accent",
-                "default",
-                "inverse"
-            ]
-        },
-        "className": {
-            "optional": true,
-            "type": "string"
-        },
-        "id": {
-            "optional": true,
-            "type": "string"
-        },
-        "spotlightTarget": {
-            "optional": true,
-            "type": "string"
-        }
-    },
-    "forbiddenUse": [
-        "Nest Sections — bands are siblings; nesting compounds paddings and backgrounds.",
-        "Use Section inside a component or card; it is page architecture, not component padding."
-    ],
-    "composesWith": [
-        "Container",
-        "Title",
-        "Grid"
-    ],
-    "displayName": "Section",
-    "keywords": [
-        "section",
-        "page band",
-        "vertical rhythm",
-        "background",
+  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+  "name": "Section",
+  "tier": "atom",
+  "group": "layout",
+  "status": "stable",
+  "description": "Semantic section wrapper with spacing and background tokens.",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1178-1712",
+  "radixPrimitive": null,
+  "element": "section",
+  "variants": {
+    "spacing": {
+      "values": [
+        "none",
+        "sm",
+        "md",
+        "lg",
+        "xl",
         "hero",
-        "landmark"
-    ],
-    "dense": "Page band: spacing none|sm|md (default)|lg|xl + hero/follow pair (hero = roomy top tight bottom, follow = no top), background default|muted|accent|inverse; id/spotlightTarget anchors",
-    "usage": {
-        "description": "Section is the page-level band: it owns vertical rhythm (`spacing`, responsive paddings) and surface (`background`), while Container inside it owns the horizontal clamp. `hero` and `follow` are a pair — the hero band keeps a generous top and tight bottom, and the section right after uses `follow` to avoid a double gap. `inverse` flips to the dark surface with matching text tokens. Give sections an `id` when they are anchor or skip targets.",
-        "bestPractices": [
-            {
-                "guidance": true,
-                "description": "Pair spacing=\"hero\" on the page hero with spacing=\"follow\" on the next section — that is what kills the double gap."
-            },
-            {
-                "guidance": true,
-                "description": "Alternate background=\"muted\" sparingly to group related content; every-other-band zebra striping reads as noise."
-            },
-            {
-                "guidance": true,
-                "description": "Put a Container directly inside; Section handles vertical, Container horizontal."
-            },
-            {
-                "guidance": true,
-                "description": "Give anchor/deep-link targets an id, and use spotlightTarget only when the host app needs stable guided-navigation selectors."
-            },
-            {
-                "guidance": false,
-                "description": "Do not nest Sections — bands are siblings; nesting compounds paddings and backgrounds."
-            },
-            {
-                "guidance": false,
-                "description": "Do not use Section inside components or cards; it is page architecture, not component padding."
-            }
-        ]
+        "follow"
+      ],
+      "default": "md",
+      "propSourced": true
     },
-    "playground": {
-        "defaults": {
-            "spacing": "md",
-            "background": "default",
-            "children": "Band content"
-        }
+    "background": {
+      "values": [
+        "default",
+        "muted",
+        "accent",
+        "inverse"
+      ],
+      "default": "default",
+      "propSourced": true
     }
+  },
+  "slots": [],
+  "asChild": false,
+  "subParts": [],
+  "requiredStories": [
+    "Default",
+    "Playground",
+    "Example",
+    "ForcedColors"
+  ],
+  "a11y": {
+    "keyboard": [],
+    "ariaRequirements": [],
+    "reducedMotion": true,
+    "reviewed": true,
+    "forcedColorsVerified": true,
+    "accessibilityTreeVerified": true,
+    "realBrowserForcedColorsVerified": true,
+    "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories in all four modes (plain/light/dark/forced-colors); AT snapshots refreshed compare-clean; Controls 100% operable + 0 inert. Unlike a pure wrapper, Section owns a real surface (background=inverse flips bg-foreground/text-background) — eyeballed the Backgrounds story in light and dark: default/muted/inverse track the theme and inverse contrast holds both ways. Fixed two contract defects: element was \"div\" (renders <section>) and variants was empty (spacing + background are the styling axes). 2026-07-10 — Figma component built (Atoms, node 1178-1712, parity-audit batch B2a): contract axes as variants with DT variable bindings."
+  },
+  "tokens": {
+    "colors": [],
+    "spacing": []
+  },
+  "lightDarkVerified": true,
+  "consumers": [
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/blog/[slug]/BlogArticleMdxBody.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/blog/[slug]/page.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/blog/[slug]/ServerArticleContent.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/blog/[slug]/ServerArticleMain.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/components/pages/AboutPage/index.ts",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/components/pages/Blog/index.ts",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts",
+      "since": "2026-06-04"
+    }
+  ],
+  "schemaVersion": 2,
+  "props": {
+    "children": {
+      "optional": false,
+      "type": "ReactNode"
+    },
+    "spacing": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "sm",
+        "md",
+        "lg",
+        "none",
+        "xl",
+        "hero",
+        "follow"
+      ]
+    },
+    "background": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "muted",
+        "accent",
+        "default",
+        "inverse"
+      ]
+    },
+    "className": {
+      "optional": true,
+      "type": "string"
+    },
+    "id": {
+      "optional": true,
+      "type": "string"
+    },
+    "spotlightTarget": {
+      "optional": true,
+      "type": "string"
+    }
+  },
+  "forbiddenUse": [
+    "Nest Sections — bands are siblings; nesting compounds paddings and backgrounds.",
+    "Use Section inside a component or card; it is page architecture, not component padding."
+  ],
+  "composesWith": [
+    "Container",
+    "Title",
+    "Grid"
+  ],
+  "displayName": "Section",
+  "keywords": [
+    "section",
+    "page band",
+    "vertical rhythm",
+    "background",
+    "hero",
+    "landmark"
+  ],
+  "dense": "Page band: spacing none|sm|md (default)|lg|xl + hero/follow pair (hero = roomy top tight bottom, follow = no top), background default|muted|accent|inverse; id/spotlightTarget anchors",
+  "usage": {
+    "description": "Section is the page-level band: it owns vertical rhythm (`spacing`, responsive paddings) and surface (`background`), while Container inside it owns the horizontal clamp. `hero` and `follow` are a pair — the hero band keeps a generous top and tight bottom, and the section right after uses `follow` to avoid a double gap. `inverse` flips to the dark surface with matching text tokens. Give sections an `id` when they are anchor or skip targets.",
+    "bestPractices": [
+      {
+        "guidance": true,
+        "description": "Pair spacing=\"hero\" on the page hero with spacing=\"follow\" on the next section — that is what kills the double gap."
+      },
+      {
+        "guidance": true,
+        "description": "Alternate background=\"muted\" sparingly to group related content; every-other-band zebra striping reads as noise."
+      },
+      {
+        "guidance": true,
+        "description": "Put a Container directly inside; Section handles vertical, Container horizontal."
+      },
+      {
+        "guidance": true,
+        "description": "Give anchor/deep-link targets an id, and use spotlightTarget only when the host app needs stable guided-navigation selectors."
+      },
+      {
+        "guidance": false,
+        "description": "Do not nest Sections — bands are siblings; nesting compounds paddings and backgrounds."
+      },
+      {
+        "guidance": false,
+        "description": "Do not use Section inside components or cards; it is page architecture, not component padding."
+      }
+    ]
+  },
+  "playground": {
+    "defaults": {
+      "spacing": "md",
+      "background": "default",
+      "children": "Band content"
+    }
+  }
 }

--- a/nextjs-app/shared/components/Section/Section.stories.tsx
+++ b/nextjs-app/shared/components/Section/Section.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
   parameters: {
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-section",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1178-1712",
     },
     layout: "centered",
     contractStatus: contract.status,

--- a/nextjs-app/shared/components/Skeleton/Skeleton.contract.json
+++ b/nextjs-app/shared/components/Skeleton/Skeleton.contract.json
@@ -1,167 +1,167 @@
 {
-    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-    "name": "Skeleton",
-    "tier": "atom",
-    "group": "feedback",
-    "status": "stable",
-    "description": "Loading placeholder that mirrors the layout of incoming content.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-skeleton",
-    "radixPrimitive": null,
-    "element": "div",
-    "variants": {
-        "variant": {
-            "values": [
-                "text",
-                "circle",
-                "rect",
-                "avatar",
-                "card"
-            ],
-            "default": "text",
-            "propSourced": true
-        }
-    },
-    "slots": [],
-    "asChild": false,
-    "subParts": [],
-    "requiredStories": [
-        "Default",
-        "Playground",
-        "Example",
-        "ForcedColors"
+  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+  "name": "Skeleton",
+  "tier": "atom",
+  "group": "feedback",
+  "status": "stable",
+  "description": "Loading placeholder that mirrors the layout of incoming content.",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1177-1652",
+  "radixPrimitive": null,
+  "element": "div",
+  "variants": {
+    "variant": {
+      "values": [
+        "text",
+        "circle",
+        "rect",
+        "avatar",
+        "card"
+      ],
+      "default": "text",
+      "propSourced": true
+    }
+  },
+  "slots": [],
+  "asChild": false,
+  "subParts": [],
+  "requiredStories": [
+    "Default",
+    "Playground",
+    "Example",
+    "ForcedColors"
+  ],
+  "a11y": {
+    "keyboard": [],
+    "reducedMotion": true,
+    "reviewed": true,
+    "forcedColorsVerified": true,
+    "ariaRequirements": [
+      "role=status with aria-label naming what is loading",
+      "shimmer suppressed under prefers-reduced-motion"
     ],
-    "a11y": {
-        "keyboard": [],
-        "reducedMotion": true,
-        "reviewed": true,
-        "forcedColorsVerified": true,
-        "ariaRequirements": [
-            "role=status with aria-label naming what is loading",
-            "shimmer suppressed under prefers-reduced-motion"
-        ],
-        "reviewedNote": "2026-07-07 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified; accessibility tree and real-browser forced-colors confirmed in Storybook.",
-        "accessibilityTreeVerified": true,
-        "realBrowserForcedColorsVerified": true
+    "reviewedNote": "2026-07-07 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified; accessibility tree and real-browser forced-colors confirmed in Storybook. 2026-07-10 — Figma component built (Atoms, node 1177-1652, parity-audit batch B2a): contract axes as variants with DT variable bindings.",
+    "accessibilityTreeVerified": true,
+    "realBrowserForcedColorsVerified": true
+  },
+  "tokens": {
+    "colors": [],
+    "spacing": []
+  },
+  "lightDarkVerified": true,
+  "consumers": [
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
+      "since": "2026-06-04"
     },
-    "tokens": {
-        "colors": [],
-        "spacing": []
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+      "since": "2026-06-04"
     },
-    "lightDarkVerified": true,
-    "consumers": [
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx",
-            "since": "2026-06-04"
-        }
-    ],
-    "schemaVersion": 2,
-    "props": {
-        "variant": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "text",
-                "circle",
-                "rect",
-                "avatar",
-                "card"
-            ]
-        },
-        "width": {
-            "optional": true,
-            "type": "number | string"
-        },
-        "height": {
-            "optional": true,
-            "type": "number | string"
-        },
-        "lines": {
-            "optional": true,
-            "type": "number"
-        },
-        "className": {
-            "optional": true,
-            "type": "string"
-        },
-        "label": {
-            "optional": true,
-            "type": "string"
-        },
-        "animate": {
-            "optional": true,
-            "type": "boolean"
-        }
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx",
+      "since": "2026-06-04"
+    }
+  ],
+  "schemaVersion": 2,
+  "props": {
+    "variant": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "text",
+        "circle",
+        "rect",
+        "avatar",
+        "card"
+      ]
     },
-    "forbiddenUse": [
-        "use Skeleton for measurable work (uploads, multi-step jobs); that is Progress territory.",
-        "leave skeletons on screen after content fails to load; resolve to an error state instead."
-    ],
-    "prefersOver": [
-        "Spinner when the loading region has a layout worth mirroring"
-    ],
-    "displayName": "Skeleton",
-    "keywords": [
-        "skeleton",
-        "placeholder",
-        "loading",
-        "shimmer",
-        "ghost",
-        "content loading",
-        "lazy"
-    ],
-    "dense": "layout-mirroring loading placeholder; variant text|circle|rect|avatar|card, text takes lines, free width/height; role=status, shimmer respects reduced motion",
-    "usage": {
-        "description": "Skeleton holds the shape of content that is still loading so the layout never jumps: pick the variant that mirrors what will appear (text with a lines count, avatar, card, or free-form rect/circle sized via width/height) and compose several to sketch the incoming view. Each skeleton is a polite role=status with an aria-label; the shimmer is decorative and turns off under prefers-reduced-motion. Family rule: Skeleton for layouts, Spinner for sub-second unknown waits, Progress for measurable work.",
-        "bestPractices": [
-            {
-                "guidance": true,
-                "description": "Mirror the real layout — same widths, heights, and rhythm as the content that will replace it — so the swap is seamless."
-            },
-            {
-                "guidance": true,
-                "description": "Name what is loading in the label prop (\"Loading article\", not \"Loading content\") for assistive tech."
-            },
-            {
-                "guidance": true,
-                "description": "Compose variants (avatar + text lines inside a card) to sketch whole modules; see the ComposedPage example."
-            },
-            {
-                "guidance": true,
-                "description": "Give one composed region one label and mark the rest decorative where possible; a page of chattering live regions is noise."
-            },
-            {
-                "guidance": false,
-                "description": "Do not keep skeletons on screen when loading fails — resolve to an error state; a forever-shimmer reads as a hang."
-            },
-            {
-                "guidance": false,
-                "description": "Do not use Skeleton for measurable work like uploads; Progress communicates completion, Skeleton only promises layout."
-            }
-        ]
+    "width": {
+      "optional": true,
+      "type": "number | string"
     },
-    "playground": {
-        "defaults": {
-            "variant": "text",
-            "lines": 3,
-            "animate": true
-        }
+    "height": {
+      "optional": true,
+      "type": "number | string"
     },
-    "composesWith": [
-        "Text",
-        "Card",
-        "Avatar",
-        "Spinner",
-        "Progress"
+    "lines": {
+      "optional": true,
+      "type": "number"
+    },
+    "className": {
+      "optional": true,
+      "type": "string"
+    },
+    "label": {
+      "optional": true,
+      "type": "string"
+    },
+    "animate": {
+      "optional": true,
+      "type": "boolean"
+    }
+  },
+  "forbiddenUse": [
+    "use Skeleton for measurable work (uploads, multi-step jobs); that is Progress territory.",
+    "leave skeletons on screen after content fails to load; resolve to an error state instead."
+  ],
+  "prefersOver": [
+    "Spinner when the loading region has a layout worth mirroring"
+  ],
+  "displayName": "Skeleton",
+  "keywords": [
+    "skeleton",
+    "placeholder",
+    "loading",
+    "shimmer",
+    "ghost",
+    "content loading",
+    "lazy"
+  ],
+  "dense": "layout-mirroring loading placeholder; variant text|circle|rect|avatar|card, text takes lines, free width/height; role=status, shimmer respects reduced motion",
+  "usage": {
+    "description": "Skeleton holds the shape of content that is still loading so the layout never jumps: pick the variant that mirrors what will appear (text with a lines count, avatar, card, or free-form rect/circle sized via width/height) and compose several to sketch the incoming view. Each skeleton is a polite role=status with an aria-label; the shimmer is decorative and turns off under prefers-reduced-motion. Family rule: Skeleton for layouts, Spinner for sub-second unknown waits, Progress for measurable work.",
+    "bestPractices": [
+      {
+        "guidance": true,
+        "description": "Mirror the real layout — same widths, heights, and rhythm as the content that will replace it — so the swap is seamless."
+      },
+      {
+        "guidance": true,
+        "description": "Name what is loading in the label prop (\"Loading article\", not \"Loading content\") for assistive tech."
+      },
+      {
+        "guidance": true,
+        "description": "Compose variants (avatar + text lines inside a card) to sketch whole modules; see the ComposedPage example."
+      },
+      {
+        "guidance": true,
+        "description": "Give one composed region one label and mark the rest decorative where possible; a page of chattering live regions is noise."
+      },
+      {
+        "guidance": false,
+        "description": "Do not keep skeletons on screen when loading fails — resolve to an error state; a forever-shimmer reads as a hang."
+      },
+      {
+        "guidance": false,
+        "description": "Do not use Skeleton for measurable work like uploads; Progress communicates completion, Skeleton only promises layout."
+      }
     ]
+  },
+  "playground": {
+    "defaults": {
+      "variant": "text",
+      "lines": 3,
+      "animate": true
+    }
+  },
+  "composesWith": [
+    "Text",
+    "Card",
+    "Avatar",
+    "Spinner",
+    "Progress"
+  ]
 }

--- a/nextjs-app/shared/components/Skeleton/Skeleton.stories.tsx
+++ b/nextjs-app/shared/components/Skeleton/Skeleton.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Skeleton> = {
   parameters: {
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-skeleton",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1177-1652",
     },
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/SkipLink/SkipLink.contract.json
+++ b/nextjs-app/shared/components/SkipLink/SkipLink.contract.json
@@ -1,131 +1,131 @@
 {
-    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-    "name": "SkipLink",
-    "tier": "atom",
-    "group": "navigation",
-    "status": "stable",
-    "description": "Skip-to-main link shown on keyboard focus.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-skip-link",
-    "radixPrimitive": null,
-    "element": "a",
-    "variants": {},
-    "asChild": false,
-    "subParts": [],
-    "requiredStories": [
-        "Default",
-        "Playground",
-        "Example",
-        "ForcedColors"
+  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+  "name": "SkipLink",
+  "tier": "atom",
+  "group": "navigation",
+  "status": "stable",
+  "description": "Skip-to-main link shown on keyboard focus.",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1177-1644",
+  "radixPrimitive": null,
+  "element": "a",
+  "variants": {},
+  "asChild": false,
+  "subParts": [],
+  "requiredStories": [
+    "Default",
+    "Playground",
+    "Example",
+    "ForcedColors"
+  ],
+  "a11y": {
+    "keyboard": [
+      "Tab — first focusable element on the page; reveals the link.",
+      "Enter — jumps focus to the main content target."
     ],
-    "a11y": {
-        "keyboard": [
-            "Tab — first focusable element on the page; reveals the link.",
-            "Enter — jumps focus to the main content target."
-        ],
-        "ariaRequirements": [
-            "Renders a real `<a href=\"#main-content\">` so the browser moves focus to the target region natively; no ARIA needed.",
-            "Visually hidden off-screen until focused, then revealed as a high-contrast pill — never `display:none` (which would drop it from the tab order)."
-        ],
-        "reducedMotion": true,
-        "reviewed": true,
-        "forcedColorsVerified": true,
-        "accessibilityTreeVerified": true,
-        "realBrowserForcedColorsVerified": true,
-        "reviewedNote": "2026-07-05 — beta→stable (fleet #15): renders a real <a> (contract element corrected div→a). The reveal slide (transition: inset-block-start) is already guarded by a prefers-reduced-motion:reduce { transition:none } block, so reducedMotion is honest. --color-primary/--color-white token pairing holds contrast across all 4 themes. Re-verified: axe + plays green in light/dark/forced-colors, 100% controls operable / 0 inert, AT snapshots captured 4 modes. 2026-05-28 origin: Breadth beta port, keyboard/ARIA reviewed, ForcedColors story + Storybook axe gate."
+    "ariaRequirements": [
+      "Renders a real `<a href=\"#main-content\">` so the browser moves focus to the target region natively; no ARIA needed.",
+      "Visually hidden off-screen until focused, then revealed as a high-contrast pill — never `display:none` (which would drop it from the tab order)."
+    ],
+    "reducedMotion": true,
+    "reviewed": true,
+    "forcedColorsVerified": true,
+    "accessibilityTreeVerified": true,
+    "realBrowserForcedColorsVerified": true,
+    "reviewedNote": "2026-07-05 — beta→stable (fleet #15): renders a real <a> (contract element corrected div→a). The reveal slide (transition: inset-block-start) is already guarded by a prefers-reduced-motion:reduce { transition:none } block, so reducedMotion is honest. --color-primary/--color-white token pairing holds contrast across all 4 themes. Re-verified: axe + plays green in light/dark/forced-colors, 100% controls operable / 0 inert, AT snapshots captured 4 modes. 2026-05-28 origin: Breadth beta port, keyboard/ARIA reviewed, ForcedColors story + Storybook axe gate. 2026-07-10 — Figma component built (Atoms, node 1177-1644, parity-audit batch B2a): contract axes as variants with DT variable bindings."
+  },
+  "tokens": {
+    "colors": [],
+    "spacing": []
+  },
+  "lightDarkVerified": true,
+  "consumers": [
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/dev/tailwind-test/page.tsx",
+      "since": "2026-06-04"
     },
-    "tokens": {
-        "colors": [],
-        "spacing": []
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/layout.tsx",
+      "since": "2026-06-04"
     },
-    "lightDarkVerified": true,
-    "consumers": [
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/dev/tailwind-test/page.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/layout.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/navigation/index.ts",
-            "since": "2026-06-04"
-        }
-    ],
-    "slots": [],
-    "schemaVersion": 2,
-    "props": {
-        "href": {
-            "optional": true,
-            "type": "string"
-        },
-        "children": {
-            "optional": true,
-            "type": "React.ReactNode"
-        },
-        "className": {
-            "optional": true,
-            "type": "string"
-        }
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/patterns/index.ts",
+      "since": "2026-06-04"
     },
-    "forbiddenUse": [
-        "Hide it with display:none or visibility:hidden — it must stay in the tab order; the component already handles visual hiding.",
-        "Render it anywhere but first in the layout — it must be the first focusable element to be reachable."
-    ],
-    "composesWith": [
-        "NavLink"
-    ],
-    "displayName": "SkipLink",
-    "keywords": [
-        "skip link",
-        "skip to content",
-        "keyboard",
-        "accessibility",
-        "focus",
-        "landmark"
-    ],
-    "dense": "Visually hidden anchor that surfaces as a high-contrast pill on keyboard focus; jumps to #main-content (href overridable); belongs as the first focusable element of the page",
-    "usage": {
-        "description": "SkipLink lets keyboard and switch users bypass repeated chrome: visually hidden until focused, it surfaces as a high-contrast pill and jumps to the main content anchor (default `#main-content`). Render it as the first focusable element inside the layout so it is the very first Tab stop on every page, and keep the target id stable on the main wrapper.",
-        "bestPractices": [
-            {
-                "guidance": true,
-                "description": "Render it first inside the layout/body so the first Tab press reveals it on every page."
-            },
-            {
-                "guidance": true,
-                "description": "Keep the target id stable on the main wrapper and matching href (default #main-content)."
-            },
-            {
-                "guidance": true,
-                "description": "Keep the label an action phrase (\"Skip to main content\") — it is announced in isolation."
-            },
-            {
-                "guidance": true,
-                "description": "Re-test with Tab after layout changes; a skip link that never receives focus is dead code."
-            },
-            {
-                "guidance": false,
-                "description": "Do not hide it with display:none or visibility:hidden overrides — it must remain focusable; the component already handles visual hiding."
-            },
-            {
-                "guidance": false,
-                "description": "Do not add several skip links unless each targets a distinct landmark; one to main content is the baseline."
-            }
-        ]
-    },
-    "playground": {
-        "defaults": {
-            "href": "#main-content",
-            "children": "Skip to main content"
-        }
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/patterns/navigation/index.ts",
+      "since": "2026-06-04"
     }
+  ],
+  "slots": [],
+  "schemaVersion": 2,
+  "props": {
+    "href": {
+      "optional": true,
+      "type": "string"
+    },
+    "children": {
+      "optional": true,
+      "type": "React.ReactNode"
+    },
+    "className": {
+      "optional": true,
+      "type": "string"
+    }
+  },
+  "forbiddenUse": [
+    "Hide it with display:none or visibility:hidden — it must stay in the tab order; the component already handles visual hiding.",
+    "Render it anywhere but first in the layout — it must be the first focusable element to be reachable."
+  ],
+  "composesWith": [
+    "NavLink"
+  ],
+  "displayName": "SkipLink",
+  "keywords": [
+    "skip link",
+    "skip to content",
+    "keyboard",
+    "accessibility",
+    "focus",
+    "landmark"
+  ],
+  "dense": "Visually hidden anchor that surfaces as a high-contrast pill on keyboard focus; jumps to #main-content (href overridable); belongs as the first focusable element of the page",
+  "usage": {
+    "description": "SkipLink lets keyboard and switch users bypass repeated chrome: visually hidden until focused, it surfaces as a high-contrast pill and jumps to the main content anchor (default `#main-content`). Render it as the first focusable element inside the layout so it is the very first Tab stop on every page, and keep the target id stable on the main wrapper.",
+    "bestPractices": [
+      {
+        "guidance": true,
+        "description": "Render it first inside the layout/body so the first Tab press reveals it on every page."
+      },
+      {
+        "guidance": true,
+        "description": "Keep the target id stable on the main wrapper and matching href (default #main-content)."
+      },
+      {
+        "guidance": true,
+        "description": "Keep the label an action phrase (\"Skip to main content\") — it is announced in isolation."
+      },
+      {
+        "guidance": true,
+        "description": "Re-test with Tab after layout changes; a skip link that never receives focus is dead code."
+      },
+      {
+        "guidance": false,
+        "description": "Do not hide it with display:none or visibility:hidden overrides — it must remain focusable; the component already handles visual hiding."
+      },
+      {
+        "guidance": false,
+        "description": "Do not add several skip links unless each targets a distinct landmark; one to main content is the baseline."
+      }
+    ]
+  },
+  "playground": {
+    "defaults": {
+      "href": "#main-content",
+      "children": "Skip to main content"
+    }
+  }
 }

--- a/nextjs-app/shared/components/SkipLink/SkipLink.stories.tsx
+++ b/nextjs-app/shared/components/SkipLink/SkipLink.stories.tsx
@@ -47,7 +47,7 @@ const meta = {
   parameters: {
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-skip-link",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1177-1644",
     },
     layout: "padded",
     contractStatus: contract.status,

--- a/nextjs-app/shared/components/Stack/Stack.contract.json
+++ b/nextjs-app/shared/components/Stack/Stack.contract.json
@@ -1,391 +1,391 @@
 {
-    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-    "name": "Stack",
-    "tier": "atom",
-    "group": "layout",
-    "status": "stable",
-    "description": "Flex stack primitive for vertical and horizontal rhythm.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-stack",
-    "radixPrimitive": null,
-    "element": "div",
-    "variants": {
-        "align": {
-            "values": [
-                "stretch",
-                "start",
-                "center",
-                "end"
-            ],
-            "default": "stretch",
-            "propSourced": true
-        }
-    },
-    "slots": [],
-    "asChild": false,
-    "subParts": [],
-    "requiredStories": [
-        "Default",
-        "Playground",
-        "Example",
-        "ForcedColors"
-    ],
-    "a11y": {
-        "keyboard": [],
-        "ariaRequirements": [
-            "Stack is a presentational flex container with no role of its own; it inherits the semantics of its `as` element (default `div`). Use `as=\"ul\"`/`\"ol\"` with `li` children when the group is semantically a list so assistive tech announces list role and item count."
-        ],
-        "reducedMotion": true,
-        "reviewed": true,
-        "forcedColorsVerified": true,
-        "accessibilityTreeVerified": true,
-        "realBrowserForcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all stories in all four modes (plain/light/dark/forced); AT snapshots refreshed compare-clean (only change is the dropped Work-in-progress badge line); Controls operable + 0 inert; no motion in the CSS so reducedMotion is trivially honest. Fixed real defect: `align` claimed `@default \"center\"` in the JSDoc and `variants.align.default`/order in the contract, but the component defaults to `stretch` (matching sibling FlexBox); corrected the JSDoc, union order (stretch first), and contract so the derived default is honest and sync-stable — zero render change since the runtime default was already `stretch`."
-    },
-    "tokens": {
-        "colors": [],
-        "spacing": []
-    },
-    "lightDarkVerified": true,
-    "consumers": [
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/dev/tailwind-test/page.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/layout.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Home/HomePage.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/HomeHero/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/navigation/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/SiteFooter/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx",
-            "since": "2026-06-04"
-        }
-    ],
-    "schemaVersion": 2,
-    "props": {
-        "children": {
-            "optional": false,
-            "type": "ReactNode"
-        },
-        "direction": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "horizontal",
-                "vertical"
-            ]
-        },
-        "gap": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "sm",
-                "md",
-                "lg",
-                "none",
-                "xl",
-                "xs"
-            ]
-        },
-        "align": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "stretch",
-                "start",
-                "center",
-                "end"
-            ]
-        },
-        "justify": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "center",
-                "end",
-                "start",
-                "between",
-                "around"
-            ]
-        },
-        "wrap": {
-            "optional": true,
-            "type": "boolean"
-        },
-        "className": {
-            "optional": true,
-            "type": "string"
-        },
-        "as": {
-            "optional": true,
-            "type": "union",
-            "values": [
-                "symbol",
-                "object",
-                "image",
-                "form",
-                "slot",
-                "style",
-                "title",
-                "button",
-                "search",
-                "article",
-                "dialog",
-                "figure",
-                "img",
-                "link",
-                "main",
-                "menu",
-                "menuitem",
-                "option",
-                "switch",
-                "table",
-                "text",
-                "time",
-                "a",
-                "abbr",
-                "address",
-                "area",
-                "aside",
-                "audio",
-                "b",
-                "base",
-                "bdi",
-                "bdo",
-                "big",
-                "blockquote",
-                "body",
-                "br",
-                "canvas",
-                "caption",
-                "center",
-                "cite",
-                "code",
-                "col",
-                "colgroup",
-                "data",
-                "datalist",
-                "dd",
-                "del",
-                "details",
-                "dfn",
-                "div",
-                "dl",
-                "dt",
-                "em",
-                "embed",
-                "fieldset",
-                "figcaption",
-                "footer",
-                "h1",
-                "h2",
-                "h3",
-                "h4",
-                "h5",
-                "h6",
-                "head",
-                "header",
-                "hgroup",
-                "hr",
-                "html",
-                "i",
-                "iframe",
-                "input",
-                "ins",
-                "kbd",
-                "keygen",
-                "label",
-                "legend",
-                "li",
-                "map",
-                "mark",
-                "meta",
-                "meter",
-                "nav",
-                "noindex",
-                "noscript",
-                "ol",
-                "optgroup",
-                "output",
-                "p",
-                "param",
-                "picture",
-                "pre",
-                "progress",
-                "q",
-                "rp",
-                "rt",
-                "ruby",
-                "s",
-                "samp",
-                "script",
-                "section",
-                "select",
-                "small",
-                "source",
-                "span",
-                "strong",
-                "sub",
-                "summary",
-                "sup",
-                "template",
-                "tbody",
-                "td",
-                "textarea",
-                "tfoot",
-                "th",
-                "thead",
-                "tr",
-                "track",
-                "u",
-                "ul",
-                "var",
-                "video",
-                "wbr",
-                "webview",
-                "svg",
-                "animate",
-                "animateMotion",
-                "animateTransform",
-                "circle",
-                "clipPath",
-                "defs",
-                "desc",
-                "ellipse",
-                "feBlend",
-                "feColorMatrix",
-                "feComponentTransfer",
-                "feComposite",
-                "feConvolveMatrix",
-                "feDiffuseLighting",
-                "feDisplacementMap",
-                "feDistantLight",
-                "feDropShadow",
-                "feFlood",
-                "feFuncA",
-                "feFuncB",
-                "feFuncG",
-                "feFuncR",
-                "feGaussianBlur",
-                "feImage",
-                "feMerge",
-                "feMergeNode",
-                "feMorphology",
-                "feOffset",
-                "fePointLight",
-                "feSpecularLighting",
-                "feSpotLight",
-                "feTile",
-                "feTurbulence",
-                "filter",
-                "foreignObject",
-                "g",
-                "line",
-                "linearGradient",
-                "marker",
-                "mask",
-                "metadata",
-                "mpath",
-                "path",
-                "pattern",
-                "polygon",
-                "polyline",
-                "radialGradient",
-                "rect",
-                "set",
-                "stop",
-                "textPath",
-                "tspan",
-                "use",
-                "view"
-            ]
-        }
-    },
-    "forbiddenUse": [
-        "Nest Stacks purely to sum gaps — pick the right gap token on one Stack instead.",
-        "Add margins to Stack children — the gap owns the spacing and margins fight it.",
-        "Use it when items need individual offsets or a non-token gap (that's FlexBox) or when both axes matter (that's Grid)."
-    ],
-    "composesWith": [
-        "Card",
-        "Text",
-        "Button"
-    ],
-    "displayName": "Stack",
-    "keywords": [
-        "stack",
-        "vertical rhythm",
-        "spacing",
-        "flex column",
-        "gap",
-        "list layout"
-    ],
-    "dense": "Token-gapped flex: direction vertical|horizontal, gap none|xs 4|sm 8|md 16 (default)|lg 24|xl 32px, align/justify shorthands, wrap; polymorphic as (ul/ol for semantic lists)",
-    "usage": {
-        "description": "Stack is the default way to space siblings: a flex column (or row) whose `gap` comes from a fixed token scale, so vertical rhythm stays on the grid without margin fiddling. Use `as=\"ul\"` with `li` children when the stack is semantically a list. If items need individual offsets or non-token gaps, that's FlexBox; if both axes matter, Grid.",
-        "bestPractices": [
-            {
-                "guidance": true,
-                "description": "Default to gap=\"md\" (16px) for content rhythm; xs/sm for dense clusters, lg/xl between groups."
-            },
-            {
-                "guidance": true,
-                "description": "Use direction=\"horizontal\" with align=\"center\" for inline clusters like actions or metadata rows."
-            },
-            {
-                "guidance": true,
-                "description": "Set wrap for chip/tag rows so they reflow instead of overflowing."
-            },
-            {
-                "guidance": true,
-                "description": "Use as=\"ul\"/\"ol\" (with li children) when the group is semantically a list."
-            },
-            {
-                "guidance": false,
-                "description": "Do not nest Stacks purely to sum gaps — pick the right gap on one Stack."
-            },
-            {
-                "guidance": false,
-                "description": "Do not add margins to Stack children; the gap owns the spacing, margins fight it."
-            }
-        ]
-    },
-    "playground": {
-        "defaults": {
-            "gap": "md",
-            "children": "Stacked content"
-        }
+  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+  "name": "Stack",
+  "tier": "atom",
+  "group": "layout",
+  "status": "stable",
+  "description": "Flex stack primitive for vertical and horizontal rhythm.",
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1176-1676",
+  "radixPrimitive": null,
+  "element": "div",
+  "variants": {
+    "align": {
+      "values": [
+        "stretch",
+        "start",
+        "center",
+        "end"
+      ],
+      "default": "stretch",
+      "propSourced": true
     }
+  },
+  "slots": [],
+  "asChild": false,
+  "subParts": [],
+  "requiredStories": [
+    "Default",
+    "Playground",
+    "Example",
+    "ForcedColors"
+  ],
+  "a11y": {
+    "keyboard": [],
+    "ariaRequirements": [
+      "Stack is a presentational flex container with no role of its own; it inherits the semantics of its `as` element (default `div`). Use `as=\"ul\"`/`\"ol\"` with `li` children when the group is semantically a list so assistive tech announces list role and item count."
+    ],
+    "reducedMotion": true,
+    "reviewed": true,
+    "forcedColorsVerified": true,
+    "accessibilityTreeVerified": true,
+    "realBrowserForcedColorsVerified": true,
+    "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all stories in all four modes (plain/light/dark/forced); AT snapshots refreshed compare-clean (only change is the dropped Work-in-progress badge line); Controls operable + 0 inert; no motion in the CSS so reducedMotion is trivially honest. Fixed real defect: `align` claimed `@default \"center\"` in the JSDoc and `variants.align.default`/order in the contract, but the component defaults to `stretch` (matching sibling FlexBox); corrected the JSDoc, union order (stretch first), and contract so the derived default is honest and sync-stable — zero render change since the runtime default was already `stretch`. 2026-07-10 — Figma component built (Atoms, node 1176-1676, parity-audit batch B2a): contract axes as variants with DT variable bindings."
+  },
+  "tokens": {
+    "colors": [],
+    "spacing": []
+  },
+  "lightDarkVerified": true,
+  "consumers": [
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/dev/tailwind-test/page.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "app/layout.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/patterns/HomeHero/index.ts",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/patterns/index.ts",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/patterns/navigation/index.ts",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/patterns/SiteFooter/index.ts",
+      "since": "2026-06-04"
+    },
+    {
+      "repo": "digitaltableteur/digitaltableteur",
+      "path": "nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx",
+      "since": "2026-06-04"
+    }
+  ],
+  "schemaVersion": 2,
+  "props": {
+    "children": {
+      "optional": false,
+      "type": "ReactNode"
+    },
+    "direction": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "horizontal",
+        "vertical"
+      ]
+    },
+    "gap": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "sm",
+        "md",
+        "lg",
+        "none",
+        "xl",
+        "xs"
+      ]
+    },
+    "align": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "stretch",
+        "start",
+        "center",
+        "end"
+      ]
+    },
+    "justify": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "center",
+        "end",
+        "start",
+        "between",
+        "around"
+      ]
+    },
+    "wrap": {
+      "optional": true,
+      "type": "boolean"
+    },
+    "className": {
+      "optional": true,
+      "type": "string"
+    },
+    "as": {
+      "optional": true,
+      "type": "union",
+      "values": [
+        "symbol",
+        "object",
+        "image",
+        "form",
+        "slot",
+        "style",
+        "title",
+        "button",
+        "search",
+        "article",
+        "dialog",
+        "figure",
+        "img",
+        "link",
+        "main",
+        "menu",
+        "menuitem",
+        "option",
+        "switch",
+        "table",
+        "text",
+        "time",
+        "a",
+        "abbr",
+        "address",
+        "area",
+        "aside",
+        "audio",
+        "b",
+        "base",
+        "bdi",
+        "bdo",
+        "big",
+        "blockquote",
+        "body",
+        "br",
+        "canvas",
+        "caption",
+        "center",
+        "cite",
+        "code",
+        "col",
+        "colgroup",
+        "data",
+        "datalist",
+        "dd",
+        "del",
+        "details",
+        "dfn",
+        "div",
+        "dl",
+        "dt",
+        "em",
+        "embed",
+        "fieldset",
+        "figcaption",
+        "footer",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "head",
+        "header",
+        "hgroup",
+        "hr",
+        "html",
+        "i",
+        "iframe",
+        "input",
+        "ins",
+        "kbd",
+        "keygen",
+        "label",
+        "legend",
+        "li",
+        "map",
+        "mark",
+        "meta",
+        "meter",
+        "nav",
+        "noindex",
+        "noscript",
+        "ol",
+        "optgroup",
+        "output",
+        "p",
+        "param",
+        "picture",
+        "pre",
+        "progress",
+        "q",
+        "rp",
+        "rt",
+        "ruby",
+        "s",
+        "samp",
+        "script",
+        "section",
+        "select",
+        "small",
+        "source",
+        "span",
+        "strong",
+        "sub",
+        "summary",
+        "sup",
+        "template",
+        "tbody",
+        "td",
+        "textarea",
+        "tfoot",
+        "th",
+        "thead",
+        "tr",
+        "track",
+        "u",
+        "ul",
+        "var",
+        "video",
+        "wbr",
+        "webview",
+        "svg",
+        "animate",
+        "animateMotion",
+        "animateTransform",
+        "circle",
+        "clipPath",
+        "defs",
+        "desc",
+        "ellipse",
+        "feBlend",
+        "feColorMatrix",
+        "feComponentTransfer",
+        "feComposite",
+        "feConvolveMatrix",
+        "feDiffuseLighting",
+        "feDisplacementMap",
+        "feDistantLight",
+        "feDropShadow",
+        "feFlood",
+        "feFuncA",
+        "feFuncB",
+        "feFuncG",
+        "feFuncR",
+        "feGaussianBlur",
+        "feImage",
+        "feMerge",
+        "feMergeNode",
+        "feMorphology",
+        "feOffset",
+        "fePointLight",
+        "feSpecularLighting",
+        "feSpotLight",
+        "feTile",
+        "feTurbulence",
+        "filter",
+        "foreignObject",
+        "g",
+        "line",
+        "linearGradient",
+        "marker",
+        "mask",
+        "metadata",
+        "mpath",
+        "path",
+        "pattern",
+        "polygon",
+        "polyline",
+        "radialGradient",
+        "rect",
+        "set",
+        "stop",
+        "textPath",
+        "tspan",
+        "use",
+        "view"
+      ]
+    }
+  },
+  "forbiddenUse": [
+    "Nest Stacks purely to sum gaps — pick the right gap token on one Stack instead.",
+    "Add margins to Stack children — the gap owns the spacing and margins fight it.",
+    "Use it when items need individual offsets or a non-token gap (that's FlexBox) or when both axes matter (that's Grid)."
+  ],
+  "composesWith": [
+    "Card",
+    "Text",
+    "Button"
+  ],
+  "displayName": "Stack",
+  "keywords": [
+    "stack",
+    "vertical rhythm",
+    "spacing",
+    "flex column",
+    "gap",
+    "list layout"
+  ],
+  "dense": "Token-gapped flex: direction vertical|horizontal, gap none|xs 4|sm 8|md 16 (default)|lg 24|xl 32px, align/justify shorthands, wrap; polymorphic as (ul/ol for semantic lists)",
+  "usage": {
+    "description": "Stack is the default way to space siblings: a flex column (or row) whose `gap` comes from a fixed token scale, so vertical rhythm stays on the grid without margin fiddling. Use `as=\"ul\"` with `li` children when the stack is semantically a list. If items need individual offsets or non-token gaps, that's FlexBox; if both axes matter, Grid.",
+    "bestPractices": [
+      {
+        "guidance": true,
+        "description": "Default to gap=\"md\" (16px) for content rhythm; xs/sm for dense clusters, lg/xl between groups."
+      },
+      {
+        "guidance": true,
+        "description": "Use direction=\"horizontal\" with align=\"center\" for inline clusters like actions or metadata rows."
+      },
+      {
+        "guidance": true,
+        "description": "Set wrap for chip/tag rows so they reflow instead of overflowing."
+      },
+      {
+        "guidance": true,
+        "description": "Use as=\"ul\"/\"ol\" (with li children) when the group is semantically a list."
+      },
+      {
+        "guidance": false,
+        "description": "Do not nest Stacks purely to sum gaps — pick the right gap on one Stack."
+      },
+      {
+        "guidance": false,
+        "description": "Do not add margins to Stack children; the gap owns the spacing, margins fight it."
+      }
+    ]
+  },
+  "playground": {
+    "defaults": {
+      "gap": "md",
+      "children": "Stacked content"
+    }
+  }
 }

--- a/nextjs-app/shared/components/Stack/Stack.stories.tsx
+++ b/nextjs-app/shared/components/Stack/Stack.stories.tsx
@@ -25,7 +25,7 @@ const meta = {
   parameters: {
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-stack",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1176-1676",
     },
     layout: "centered",
     contractStatus: contract.status,

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-10T15:00:33.839Z",
+  "generatedAt": "2026-07-10T15:25:05.796Z",
   "summary": {
     "componentCount": 163,
     "statusCounts": {
@@ -9186,7 +9186,7 @@
         "group": "layout",
         "status": "stable",
         "description": "Max-width content wrapper with responsive horizontal padding.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-container",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1178-1654",
         "radixPrimitive": null,
         "element": "div",
         "variants": {
@@ -9219,7 +9219,7 @@
           "forcedColorsVerified": true,
           "accessibilityTreeVerified": true,
           "realBrowserForcedColorsVerified": true,
-          "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories; AT snapshots refreshed and compare-clean in all four modes (plain/light/dark/forced-colors); Controls 100% operable + 0 inert. Container carries no color surface of its own (tokens.colors empty; transparent wrapper), so light/dark is a structural no-op. Fixed the stale variants.size.default (\"sm\" → \"lg\") to match the component default and docs."
+          "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories; AT snapshots refreshed and compare-clean in all four modes (plain/light/dark/forced-colors); Controls 100% operable + 0 inert. Container carries no color surface of its own (tokens.colors empty; transparent wrapper), so light/dark is a structural no-op. Fixed the stale variants.size.default (\"sm\" → \"lg\") to match the component default and docs. 2026-07-10 — Figma component built (Atoms, node 1178-1654, parity-audit batch B2a): contract axes as variants with DT variable bindings."
         },
         "tokens": {
           "colors": [],
@@ -12563,7 +12563,7 @@
         "group": "layout",
         "status": "stable",
         "description": "Flexbox layout primitive for stacks and rows.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-flex-box",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1176-1698",
         "radixPrimitive": null,
         "element": "div",
         "variants": {
@@ -12596,7 +12596,7 @@
           "forcedColorsVerified": true,
           "accessibilityTreeVerified": true,
           "realBrowserForcedColorsVerified": true,
-          "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories in all four modes; AT snapshots bootstrapped (the component had none — snapshot-backfill debt) and compare-clean in plain/light/dark/forced-colors; Controls 9/9 operable + 0 inert. Pure css-less flex passthrough with no color surface (tokens.colors empty), so light/dark is a structural no-op. Fixed a contract defect: variants.align.default was \"center\" but the component default is \"stretch\" (align-items initial)."
+          "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories in all four modes; AT snapshots bootstrapped (the component had none — snapshot-backfill debt) and compare-clean in plain/light/dark/forced-colors; Controls 9/9 operable + 0 inert. Pure css-less flex passthrough with no color surface (tokens.colors empty), so light/dark is a structural no-op. Fixed a contract defect: variants.align.default was \"center\" but the component default is \"stretch\" (align-items initial). 2026-07-10 — Figma component built (Atoms, node 1176-1698, parity-audit batch B2a): contract axes as variants with DT variable bindings."
         },
         "tokens": {
           "colors": [],
@@ -13554,7 +13554,7 @@
         "group": "layout",
         "status": "stable",
         "description": "CSS grid layout primitive with tokenized gaps.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-grid",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1177-1654",
         "radixPrimitive": null,
         "element": "div",
         "variants": {
@@ -13599,7 +13599,7 @@
           "forcedColorsVerified": true,
           "accessibilityTreeVerified": true,
           "realBrowserForcedColorsVerified": true,
-          "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories; AT snapshots refreshed compare-clean in all four modes (plain/light/dark/forced-colors); Controls 9/9 operable + 0 inert. Pure two-dimensional layout primitive with no color surface of its own (tokens.colors empty), so light/dark is a structural no-op. The GridProps `[key: string]: any` passthrough is the intentional, documented escape hatch for arbitrary grid CSS props — kept as-is."
+          "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories; AT snapshots refreshed compare-clean in all four modes (plain/light/dark/forced-colors); Controls 9/9 operable + 0 inert. Pure two-dimensional layout primitive with no color surface of its own (tokens.colors empty), so light/dark is a structural no-op. The GridProps `[key: string]: any` passthrough is the intentional, documented escape hatch for arbitrary grid CSS props — kept as-is. 2026-07-10 — Figma component built (Atoms, node 1177-1654, parity-audit batch B2a): contract axes as variants with DT variable bindings."
         },
         "tokens": {
           "colors": [],
@@ -14485,7 +14485,7 @@
         "group": "display",
         "status": "stable",
         "description": "Phosphor icon wrapper with size, weight, and motion affordances.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-icon",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1176-1658",
         "radixPrimitive": null,
         "element": "span",
         "variants": {
@@ -14519,7 +14519,7 @@
           ],
           "reducedMotion": true,
           "reviewed": true,
-          "reviewedNote": "2026-05-26 code review",
+          "reviewedNote": "2026-05-26 code review 2026-07-10 — Figma component built (Atoms, node 1176-1658, parity-audit batch B2a): contract axes as variants with DT variable bindings.",
           "forcedColorsVerified": true,
           "axeTestExempt": "Display-only glyph wrapper",
           "accessibilityTreeVerified": true,
@@ -23741,7 +23741,7 @@
         "group": "layout",
         "status": "stable",
         "description": "Semantic section wrapper with spacing and background tokens.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-section",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1178-1712",
         "radixPrimitive": null,
         "element": "section",
         "variants": {
@@ -23786,7 +23786,7 @@
           "forcedColorsVerified": true,
           "accessibilityTreeVerified": true,
           "realBrowserForcedColorsVerified": true,
-          "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories in all four modes (plain/light/dark/forced-colors); AT snapshots refreshed compare-clean; Controls 100% operable + 0 inert. Unlike a pure wrapper, Section owns a real surface (background=inverse flips bg-foreground/text-background) — eyeballed the Backgrounds story in light and dark: default/muted/inverse track the theme and inverse contrast holds both ways. Fixed two contract defects: element was \"div\" (renders <section>) and variants was empty (spacing + background are the styling axes)."
+          "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories in all four modes (plain/light/dark/forced-colors); AT snapshots refreshed compare-clean; Controls 100% operable + 0 inert. Unlike a pure wrapper, Section owns a real surface (background=inverse flips bg-foreground/text-background) — eyeballed the Backgrounds story in light and dark: default/muted/inverse track the theme and inverse contrast holds both ways. Fixed two contract defects: element was \"div\" (renders <section>) and variants was empty (spacing + background are the styling axes). 2026-07-10 — Figma component built (Atoms, node 1178-1712, parity-audit batch B2a): contract axes as variants with DT variable bindings."
         },
         "tokens": {
           "colors": [],
@@ -25587,7 +25587,7 @@
         "group": "feedback",
         "status": "stable",
         "description": "Loading placeholder that mirrors the layout of incoming content.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-skeleton",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1177-1652",
         "radixPrimitive": null,
         "element": "div",
         "variants": {
@@ -25621,7 +25621,7 @@
             "role=status with aria-label naming what is loading",
             "shimmer suppressed under prefers-reduced-motion"
           ],
-          "reviewedNote": "2026-07-07 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified; accessibility tree and real-browser forced-colors confirmed in Storybook.",
+          "reviewedNote": "2026-07-07 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified; accessibility tree and real-browser forced-colors confirmed in Storybook. 2026-07-10 — Figma component built (Atoms, node 1177-1652, parity-audit batch B2a): contract axes as variants with DT variable bindings.",
           "accessibilityTreeVerified": true,
           "realBrowserForcedColorsVerified": true
         },
@@ -26026,7 +26026,7 @@
         "group": "navigation",
         "status": "stable",
         "description": "Skip-to-main link shown on keyboard focus.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-skip-link",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1177-1644",
         "radixPrimitive": null,
         "element": "a",
         "variants": {},
@@ -26052,7 +26052,7 @@
           "forcedColorsVerified": true,
           "accessibilityTreeVerified": true,
           "realBrowserForcedColorsVerified": true,
-          "reviewedNote": "2026-07-05 — beta→stable (fleet #15): renders a real <a> (contract element corrected div→a). The reveal slide (transition: inset-block-start) is already guarded by a prefers-reduced-motion:reduce { transition:none } block, so reducedMotion is honest. --color-primary/--color-white token pairing holds contrast across all 4 themes. Re-verified: axe + plays green in light/dark/forced-colors, 100% controls operable / 0 inert, AT snapshots captured 4 modes. 2026-05-28 origin: Breadth beta port, keyboard/ARIA reviewed, ForcedColors story + Storybook axe gate."
+          "reviewedNote": "2026-07-05 — beta→stable (fleet #15): renders a real <a> (contract element corrected div→a). The reveal slide (transition: inset-block-start) is already guarded by a prefers-reduced-motion:reduce { transition:none } block, so reducedMotion is honest. --color-primary/--color-white token pairing holds contrast across all 4 themes. Re-verified: axe + plays green in light/dark/forced-colors, 100% controls operable / 0 inert, AT snapshots captured 4 modes. 2026-05-28 origin: Breadth beta port, keyboard/ARIA reviewed, ForcedColors story + Storybook axe gate. 2026-07-10 — Figma component built (Atoms, node 1177-1644, parity-audit batch B2a): contract axes as variants with DT variable bindings."
         },
         "tokens": {
           "colors": [],
@@ -27477,7 +27477,7 @@
         "group": "layout",
         "status": "stable",
         "description": "Flex stack primitive for vertical and horizontal rhythm.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-stack",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1176-1676",
         "radixPrimitive": null,
         "element": "div",
         "variants": {
@@ -27511,7 +27511,7 @@
           "forcedColorsVerified": true,
           "accessibilityTreeVerified": true,
           "realBrowserForcedColorsVerified": true,
-          "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all stories in all four modes (plain/light/dark/forced); AT snapshots refreshed compare-clean (only change is the dropped Work-in-progress badge line); Controls operable + 0 inert; no motion in the CSS so reducedMotion is trivially honest. Fixed real defect: `align` claimed `@default \"center\"` in the JSDoc and `variants.align.default`/order in the contract, but the component defaults to `stretch` (matching sibling FlexBox); corrected the JSDoc, union order (stretch first), and contract so the derived default is honest and sync-stable — zero render change since the runtime default was already `stretch`."
+          "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all stories in all four modes (plain/light/dark/forced); AT snapshots refreshed compare-clean (only change is the dropped Work-in-progress badge line); Controls operable + 0 inert; no motion in the CSS so reducedMotion is trivially honest. Fixed real defect: `align` claimed `@default \"center\"` in the JSDoc and `variants.align.default`/order in the contract, but the component defaults to `stretch` (matching sibling FlexBox); corrected the JSDoc, union order (stretch first), and contract so the derived default is honest and sync-stable — zero render change since the runtime default was already `stretch`. 2026-07-10 — Figma component built (Atoms, node 1176-1676, parity-audit batch B2a): contract axes as variants with DT variable bindings."
         },
         "tokens": {
           "colors": [],

--- a/scripts/design-system/figma-links.baseline.json
+++ b/scripts/design-system/figma-links.baseline.json
@@ -1,4 +1,4 @@
 {
-  "stablePlaceholderCeiling": 46,
+  "stablePlaceholderCeiling": 38,
   "note": "Ratchet: lower this in the PR that wires real Figma nodes; see docs/design-system/figma-parity-audit.md"
 }


### PR DESCRIPTION
Figma side: Title/Text remodeled to the 7-size contract ramp (token clamp maxima, color/title
and copy-color bindings, base 60px variant repurposed as xxl 112); Link remodeled size×underline
(3×3, link/color bound); Avatar extended to 16 (variant×8 rem sizes, stale 56px LG rescaled to
3rem/48); Label/HelperText/Divider rebound to their CSS tokens; new sets built for Container
(true max-widths), Icon (7 sizes), Section (7 spacings × 4 backgrounds, desktop padding scale),
Stack (4 aligns), FlexBox (5 aligns incl. baseline), Skeleton (5 shapes), SkipLink, Grid (align
modelled as prop per audit rule). All variable-bound; Section dark-mode verified.

Repo side: 8 contract figma URLs + story design links wired to the new numeric nodes;
figma-links ratchet ceiling 46 → 38.

Remaining in B2: Button axis remodel + IconButton build (B2b, own session).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
