### PR TITLE
chore(design-system): figma-parity B2b — Button remodel + IconButton (#1069 plan)

### DIFF
--- a/docs/design-system/figma-parity-audit.md
+++ b/docs/design-system/figma-parity-audit.md
@@ -194,11 +194,19 @@ mockups) — out of scope, leave as-is.
   46 → 38. Figma API gotchas (resize resets hug sizing; variable-bound paints drop paint
   opacity — use a node-opacity wash layer; shared TEXT property propagates characters) are
   recorded in the session memory (project_promotion_workflow.md).
-- [ ] **B2b Button remodel + IconButton** — Button set 406:1569 from legacy axes
-  (Variant(9) × Size × State × Inverse, 108 variants) to contract variant × tone × surface ×
-  size; decide state-axis modelling and record it in the component description (candidate: keep
-  State as an extra Figma-only axis, or split surface into sub-sets per the >30-variant rule).
-  Build IconButton to the same matrix. Own session — largest single work unit.
+- [x] **B2b Button remodel + IconButton** — DONE (2026-07-10). Button 406:1569 remodeled in
+  place to the full contract product variant × tone × surface × size = 135 variants (single set,
+  not sub-sets: instances can toggle surface, and the audit gap metric counts the axis product).
+  State/Inverse axes REMOVED — the 72 State=Disabled/Loading variants had zero dependent
+  instances (verified by whole-file scan; all 48 deps incl. SplitButton/CodeSnippet/ContactForm
+  are State=Default and follow node ids through renames); disabled/loading are boolean props,
+  not contract axes; Inverse=True mapped to Surface=onDark. Tone visually collapses on
+  onDark/onBrand (code truth: Button.module.css surface overrides ignore the accent) — recorded
+  in the set description. Master icon slots hidden uniformly (Has Icon default false). IconButton
+  built new (Atoms, node 1194-1733, own section): 135 circle variants, radius/full variable
+  MINTED (DT / Dimension 9999, CORNER_RADIUS, var(--radius-full)), sizes 32/40/48 with 20/24/28
+  icons, Icon INSTANCE_SWAP wired to all variants. Both sets verified Light + forced-Dark.
+  Ceiling 38 → 37.
 - [ ] **B2c Menu (molecule-tier leftover listed under atoms drift)** — Menu align:3 variants;
   fold into B3.
 - [ ] **B3 Molecules parity** — drifted (Tabs, Modal, Card, Select, Toast, AlertBanner, Accordion,

--- a/nextjs-app/shared/components/IconButton/IconButton.contract.json
+++ b/nextjs-app/shared/components/IconButton/IconButton.contract.json
@@ -5,7 +5,7 @@
     "group": "actions",
     "status": "stable",
     "description": "Icon-only action button. Wraps @dt/Button in its rounded icon-only form with an enforced accessible label, sharing Button's variant (weight) x tone (semantic) matrix and surface awareness.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-icon-button",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1194-1733",
     "radixPrimitive": null,
     "element": "button",
     "variants": {

--- a/nextjs-app/shared/components/IconButton/IconButton.stories.tsx
+++ b/nextjs-app/shared/components/IconButton/IconButton.stories.tsx
@@ -21,7 +21,7 @@ const meta = {
   parameters: {
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-icon-button",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1194-1733",
     },
     layout: "centered",
     contractStatus: contract.status,

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-10T15:25:05.796Z",
+  "generatedAt": "2026-07-10T16:24:26.714Z",
   "summary": {
     "componentCount": 163,
     "statusCounts": {
@@ -14990,7 +14990,7 @@
         "group": "actions",
         "status": "stable",
         "description": "Icon-only action button. Wraps @dt/Button in its rounded icon-only form with an enforced accessible label, sharing Button's variant (weight) x tone (semantic) matrix and surface awareness.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-icon-button",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1194-1733",
         "radixPrimitive": null,
         "element": "button",
         "variants": {

--- a/scripts/design-system/figma-links.baseline.json
+++ b/scripts/design-system/figma-links.baseline.json
@@ -1,4 +1,4 @@
 {
-  "stablePlaceholderCeiling": 38,
+  "stablePlaceholderCeiling": 37,
   "note": "Ratchet: lower this in the PR that wires real Figma nodes; see docs/design-system/figma-parity-audit.md"
 }


### PR DESCRIPTION
## Summary
- **Button (Figma 406:1569) remodeled in place** from legacy `Variant(9) × Size × State × Inverse` (108 variants) to the contract axes `variant(3) × tone(5) × surface(3) × size(3)` = **135 variants**, all colors/padding/gap/radius bound to DT variables per Button.module.css (tone→accent map, surface overrides, sm/md/lg = 32/40/48, Satoshi Regular 16/18/20).
- **State/Inverse axes removed**: whole-file scan showed all 48 dependent instances (SplitButton, CodeSnippet, CodeBlockWindow, ContactForm, Card, navs) sit on State=Default and follow node ids through renames; disabled/loading are boolean props, not contract axes; Inverse=True → Surface=onDark. Decisions recorded in the component description.
- **IconButton built** (Atoms, node **1194-1733**, own section): 135 circular variants (32/40/48 with 20/24/28 icons), `radius/full` variable minted (DT / Dimension, 9999, CORNER_RADIUS, `var(--radius-full)`), Icon INSTANCE_SWAP wired to every variant; description records the modelling calls.
- Both sets verified in Light and forced-Dark modes; CodeSnippet spot-checked for drift (clean).
- Repo wiring: IconButton contract + story figma URLs → real node; `check:figma-links` ceiling **38 → 37**.

## Verification (local, full gate)
- check:figma-links 37/37 ✓, build:tokens ✓, check:contract-props ✓, check:consumers ✓, validate:components ✓
- typecheck ✓, lint ✓, vitest 2227/2227 ✓, next build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)