### PR TITLE
fix: MCP tool schemas + CodeBlockWindow RSC-lazy hydration (Codex review round 1)

### DIFF
--- a/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.test.tsx
+++ b/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.test.tsx
@@ -79,6 +79,40 @@ describe("CodeBlockWindow", () => {
     });
   });
 
+  it("introspects children wrapped in React Flight lazy nodes (RSC boundary)", async () => {
+    // Children passed from a server component arrive on the client as
+    // $$typeof react.lazy nodes during hydration; React renders them but
+    // isValidElement returns false, which used to skip the module classes
+    // and disable the copy button only on the client (hydration mismatch).
+    const wrapInFlightLazy = (value: React.ReactNode): React.ReactNode =>
+      ({
+        $$typeof: Symbol.for("react.lazy"),
+        _payload: { status: "fulfilled", value },
+        _init: (payload: { value: React.ReactNode }) => payload.value,
+      }) as unknown as React.ReactNode;
+
+    const user = userEvent.setup();
+    const { container } = render(
+      <CodeBlockWindow title="demo.tsx" language="tsx">
+        {wrapInFlightLazy(buildCodeBlock(sampleCode, "tsx"))}
+      </CodeBlockWindow>,
+    );
+
+    const pre = container.querySelector("pre");
+    const code = container.querySelector("pre code");
+    expect(pre?.className).toMatch(/pre/);
+    expect(code?.className).toMatch(/code/);
+
+    const button = screen.getByRole("button", {
+      name: "Copy code to clipboard",
+    });
+    expect(button).toBeEnabled();
+    await user.click(button);
+    await waitFor(() => {
+      expect(screen.getByText("Copied")).toBeInTheDocument();
+    });
+  });
+
   it("has no accessibility violations", async () => {
     const { container } = render(
       <CodeBlockWindow title="demo.tsx" language="tsx">

--- a/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.tsx
+++ b/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.tsx
@@ -34,7 +34,42 @@ type DataProps = {
 const hasDataAttribute = (props: DataProps, attr: string) =>
   Object.prototype.hasOwnProperty.call(props, attr);
 
+/**
+ * Children that cross a server→client component boundary arrive on the client
+ * as React Flight "lazy" nodes ($$typeof react.lazy) during hydration, NOT as
+ * plain elements — React renders them fine, but React.isValidElement returns
+ * false, so every children introspection below silently fails on the client
+ * while succeeding in SSR, producing a hydration mismatch (missing module
+ * classes, copy button disabled). Unwrap fulfilled lazy nodes before
+ * inspecting; unresolved ones are left alone (introspection then degrades the
+ * same way on both passes).
+ */
+const REACT_LAZY_TYPE = Symbol.for("react.lazy");
+
+type FlightLazyNode = {
+  $$typeof: symbol;
+  _payload?: { status?: string; value?: React.ReactNode };
+};
+
+const isFlightLazyNode = (node: unknown): node is FlightLazyNode =>
+  typeof node === "object" &&
+  node !== null &&
+  (node as FlightLazyNode).$$typeof === REACT_LAZY_TYPE;
+
+const resolveFlightNode = (node: React.ReactNode): React.ReactNode => {
+  let current = node;
+  for (let hops = 0; hops < 10 && isFlightLazyNode(current); hops += 1) {
+    const payload = current._payload;
+    if (!payload || payload.status !== "fulfilled") {
+      return current;
+    }
+    current = payload.value as React.ReactNode;
+  }
+  return current;
+};
+
 const extractCodeText = (value: React.ReactNode): string => {
+  value = resolveFlightNode(value);
   if (typeof value === "string" || typeof value === "number") {
     return String(value);
   }
@@ -54,6 +89,7 @@ const extractCodeText = (value: React.ReactNode): string => {
 };
 
 const hasLineNumbers = (value: React.ReactNode): boolean => {
+  value = resolveFlightNode(value);
   if (Array.isArray(value)) {
     return value.some(hasLineNumbers);
   }
@@ -77,9 +113,10 @@ const isCodeElement = (
 ): node is React.ReactElement<React.ComponentPropsWithoutRef<"code">> =>
   React.isValidElement(node) && node.type === "code";
 
-const enhancePreElement = (preNode: React.ReactNode) => {
+const enhancePreElement = (rawPreNode: React.ReactNode) => {
+  const preNode = resolveFlightNode(rawPreNode);
   if (!isPreElement(preNode)) {
-    return preNode;
+    return rawPreNode;
   }
 
   const preProps = preNode.props;
@@ -87,9 +124,10 @@ const enhancePreElement = (preNode: React.ReactNode) => {
     .filter(Boolean)
     .join(" ");
 
-  const enhancedChildren = React.Children.map(preProps.children, (child) => {
+  const enhancedChildren = React.Children.map(preProps.children, (rawChild) => {
+    const child = resolveFlightNode(rawChild);
     if (!isCodeElement(child)) {
-      return child;
+      return rawChild;
     }
 
     const codeProps = child.props;

--- a/nextjs-app/shared/lib/consulting-tools/consulting-tools.test.ts
+++ b/nextjs-app/shared/lib/consulting-tools/consulting-tools.test.ts
@@ -1,6 +1,27 @@
 import { describe, expect, it, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { CONSULTING_TOOL_NAMES, executeGetHourlyRate } from "./executors";
 import { registerConsultingMcpTools } from "./register-mcp-tools";
+
+type TextContent = { type: string; text: string };
+
+const getText = (result: { content?: unknown }) =>
+  ((result.content as TextContent[] | undefined)?.[0]?.text ?? "") as string;
+
+/** Spin up a real server + client pair over an in-memory transport. */
+async function connectedClient() {
+  const server = new McpServer({ name: "test", version: "0.0.0" });
+  registerConsultingMcpTools(server);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return client;
+}
 
 describe("consulting-tool executors", () => {
   it("exports nine tool names", () => {
@@ -27,5 +48,56 @@ describe("registerConsultingMcpTools", () => {
     expect(count).toBe(9);
     expect(tool).toHaveBeenCalledTimes(9);
     expect(tool.mock.calls[0]?.[3]?.readOnlyHint).toBe(true);
+  });
+
+  it("declares real schemas for every argument-taking tool", () => {
+    // Regression guard: an empty schema makes the SDK strip every argument
+    // before the handler sees it, silently breaking the tool.
+    const tool = vi.fn();
+    const server = { tool } as unknown as Parameters<
+      typeof registerConsultingMcpTools
+    >[0];
+    registerConsultingMcpTools(server);
+
+    const schemas = Object.fromEntries(
+      tool.mock.calls.map((call) => [call[0], call[2]]),
+    );
+    expect(Object.keys(schemas.get_case_study)).toContain("slug");
+    expect(Object.keys(schemas.get_consulting_fit)).toContain("problem");
+    expect(Object.keys(schemas.list_case_studies)).toContain("featuredOnly");
+  });
+
+  it("passes arguments through the real SDK to the handlers", async () => {
+    const client = await connectedClient();
+
+    // arguments survive the SDK parse (this was the empty-schema bug)
+    const fit = await client.callTool({
+      name: "get_consulting_fit",
+      arguments: { problem: "our design system drifted from production code" },
+    });
+    expect(fit.isError ?? false).toBe(false);
+    expect(getText(fit).length).toBeGreaterThan(0);
+
+    // slug round-trip: list first, then fetch one by its slug
+    const list = await client.callTool({
+      name: "list_case_studies",
+      arguments: {},
+    });
+    const studies = JSON.parse(getText(list)) as Array<{ slug: string }>;
+    expect(studies.length).toBeGreaterThan(0);
+
+    const study = await client.callTool({
+      name: "get_case_study",
+      arguments: { slug: studies[0].slug },
+    });
+    expect(study.isError ?? false).toBe(false);
+    expect(getText(study)).toContain(studies[0].slug);
+
+    // unknown slug surfaces the executor's graceful error, not a strip-crash
+    const missing = await client.callTool({
+      name: "get_case_study",
+      arguments: { slug: "definitely-not-a-real-slug" },
+    });
+    expect(missing.isError).toBe(true);
   });
 });

--- a/nextjs-app/shared/lib/consulting-tools/executors.ts
+++ b/nextjs-app/shared/lib/consulting-tools/executors.ts
@@ -25,6 +25,8 @@ export const CONSULTING_TOOL_NAMES = [
 export type ConsultingToolName = (typeof CONSULTING_TOOL_NAMES)[number];
 
 export interface ConsultingToolTextResult {
+  // Index signature required by the MCP SDK's CallToolResult shape.
+  [key: string]: unknown;
   content: [{ type: "text"; text: string }];
   isError?: boolean;
 }

--- a/nextjs-app/shared/lib/consulting-tools/register-mcp-tools.ts
+++ b/nextjs-app/shared/lib/consulting-tools/register-mcp-tools.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 
 import {
   CONSULTING_TOOL_NAMES,
@@ -11,103 +12,106 @@ import {
   executeListExpertiseStacks,
   executeListPricingPackages,
   executeListServices,
-  type ConsultingToolTextResult,
 } from "./executors";
 
 const READ_ONLY = { readOnlyHint: true } as const;
 
-type UntypedToolServer = {
-  tool: (
-    name: string,
-    description: string,
-    schema: Record<string, never>,
-    annotations: typeof READ_ONLY,
-    handler: (args: Record<string, unknown>) => ConsultingToolTextResult,
-  ) => void;
-};
-
-function bindToolServer(server: McpServer): UntypedToolServer {
-  return server as unknown as UntypedToolServer;
-}
-
-/** Register read-only consulting tools on an MCP server instance. */
+/**
+ * Register read-only consulting tools on an MCP server instance.
+ *
+ * Tools that take arguments MUST declare real zod shapes: the SDK parses
+ * arguments against the shape, and an empty shape STRIPS every argument
+ * before the handler sees it (see docs-registry-tools.ts, which learned
+ * this the hard way). Argument-less tools keep an empty shape.
+ */
 export function registerConsultingMcpTools(server: McpServer): number {
-  const tools = bindToolServer(server);
-  const emptySchema = {} as Record<string, never>;
-
-  tools.tool(
+  server.tool(
     "list_case_studies",
     "List Digitaltableteur portfolio case studies with slug, title, category, tags, and URLs.",
-    emptySchema,
+    {
+      featuredOnly: z
+        .boolean()
+        .optional()
+        .describe("Only return featured case studies (default false)"),
+    },
     READ_ONLY,
-    (args) =>
-      executeListCaseStudies({
-        featuredOnly: Boolean(args.featuredOnly),
-      }),
+    async (args) => executeListCaseStudies(args),
   );
 
-  tools.tool(
+  server.tool(
     "get_case_study",
     "Get one case study by URL slug (e.g. dsharp-design-system, helsinki-design-system).",
-    emptySchema,
+    {
+      slug: z
+        .string()
+        .describe(
+          "Case study URL slug from list_case_studies, e.g. \"dsharp-design-system\"",
+        ),
+    },
     READ_ONLY,
-    (args) => executeGetCaseStudy({ slug: String(args.slug ?? "") }),
+    async (args) => executeGetCaseStudy(args),
   );
 
-  tools.tool(
+  server.tool(
     "list_pricing_packages",
     "List fixed consulting packages with EUR price ranges and duration (preferred over hourly for defined outcomes).",
-    emptySchema,
+    {},
     READ_ONLY,
-    () => executeListPricingPackages(),
+    async () => executeListPricingPackages(),
   );
 
-  tools.tool(
+  server.tool(
     "get_hourly_rate",
     "Get typical and range hourly consulting rates in EUR (€90/h typical, €90–150/h depending on scope).",
-    emptySchema,
+    {},
     READ_ONLY,
-    () => executeGetHourlyRate(),
+    async () => executeGetHourlyRate(),
   );
 
-  tools.tool(
+  server.tool(
     "list_services",
     "List core consulting services (design system audit, component library, tokens, AI DesignOps).",
-    emptySchema,
+    {},
     READ_ONLY,
-    () => executeListServices(),
+    async () => executeListServices(),
   );
 
-  tools.tool(
+  server.tool(
     "list_expertise_stacks",
     "List technology and practice areas (React, Next.js, Storybook, Figma, TypeScript, etc.).",
-    emptySchema,
+    {},
     READ_ONLY,
-    () => executeListExpertiseStacks(),
+    async () => executeListExpertiseStacks(),
   );
 
-  tools.tool(
+  server.tool(
     "list_audiences",
     "List client audiences Digitaltableteur serves (startups, scaleups, enterprise, etc.).",
-    emptySchema,
+    {},
     READ_ONLY,
-    () => executeListAudiences(),
+    async () => executeListAudiences(),
   );
 
-  tools.tool(
+  server.tool(
     "get_open_hours",
     "Get Digitaltableteur office hours in Europe/Helsinki timezone.",
-    emptySchema,
+    {},
     READ_ONLY,
-    () => executeGetOpenHours(),
+    async () => executeGetOpenHours(),
   );
 
-  tools.tool(
+  server.tool(
     "get_consulting_fit",
     "Map a visitor problem statement to the best-matching consulting service.",
-    emptySchema,
+    {
+      problem: z
+        .string()
+        .describe(
+          "The visitor's problem statement, e.g. \"our design system has drifted from the product\"",
+        ),
+    },
     READ_ONLY,
-    (args) => executeGetConsultingFit({ problem: String(args.problem ?? "") }),
+    async (args) => executeGetConsultingFit(args),
   );
 
   return CONSULTING_TOOL_NAMES.length;


### PR DESCRIPTION
## Summary
Two confirmed findings from the external Codex review.

**Consulting MCP tools (public, app/mcp + app/api/[transport]):** all nine tools were registered with an empty schema; the MCP SDK parses arguments against the shape, and an empty shape strips every argument before the handler runs — so `get_case_study`, `get_consulting_fit` and `list_case_studies(featuredOnly)` could never receive their inputs. They now declare real zod shapes (same pattern as the docs-registry tools), and the untyped-server cast is gone. New tests run a real McpServer + Client over `InMemoryTransport` and prove arguments round-trip (that test fails on the old code).

**CodeBlockWindow hydration mismatch (root-caused + reproduced):** children passed across a server→client component boundary arrive on the client as React Flight lazy nodes (`$$typeof: Symbol.for("react.lazy")`) during hydration. `React.isValidElement` returns false for them, so `isPreElement`/`extractCodeText`/`hasLineNumbers` silently failed client-side only: missing `.pre`/`.code` module classes and a disabled copy button vs the SSR output. Diagnosed with a live probe (payload arrives `status: "fulfilled"` with the `<pre>` element), and reproduced with the **local** import too, so this hits any RSC-boundary consumer, not just the npm-package dev page. Fix: `resolveFlightNode` unwraps fulfilled lazy nodes (bounded loop) before every children introspection; unresolved nodes degrade identically on both passes.

Note: /dev/code-window imports `@digitaltableteur/react` from npm, so it keeps the old behavior until 0.1.6 ships (already queued); /dev/code-window-local twin verified clean in-browser (fresh tab, zero hydration errors, copy handler reaches the clipboard call).

## Verification
- consulting-tools 5/5 incl. SDK round-trip; CodeBlockWindow 4/4 incl. new flight-lazy regression
- In-browser: hydration error gone on local-import page; module classes present; copy enabled
- Full gate: typecheck ✓ lint ✓ vitest 2230/2230 ✓ build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code block rendering during hydration, including reliable line numbers, styling, and copy functionality.
  * Fixed consulting tool argument handling by adding validation and preserving submitted values.
  * Improved error handling for invalid consulting tool requests.

* **Tests**
  * Added coverage for React Server Component code blocks and end-to-end consulting tool calls.
  * Added checks for complete argument schemas and successful tool responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->