### PR TITLE
fix: GDPR audit-trail minimization, prod guard for /dev routes, test-health persistence honesty (Codex round 2)

### DIFF
--- a/app/api/gdpr/delete-data/route.test.ts
+++ b/app/api/gdpr/delete-data/route.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NextRequest } from "next/server";
 
 import { checkRateLimit } from "../../../lib/rate-limit";
+import { getDatabase } from "../../../lib/mongodb";
 import { POST } from "./route";
 
 vi.mock("../../../lib/rate-limit", () => ({
@@ -82,5 +83,40 @@ describe("GDPR deletion route rate limits", () => {
     expect(checkRateLimitMock.mock.calls[1]?.[0]).toEqual(
       expect.objectContaining({ scope: "gdpr:email" }),
     );
+  });
+});
+
+describe("GDPR deletion audit trail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stores a data-minimised audit record (no user agent, truncated IP, TTL index)", async () => {
+    checkRateLimitMock.mockResolvedValue({
+      limited: false,
+      retryAfterSeconds: 0,
+      remaining: 9,
+      source: "mongodb",
+    });
+
+    const insertOne = vi.fn().mockResolvedValue({ insertedId: "x" });
+    const createIndex = vi.fn().mockResolvedValue("requestedAt_1");
+    const deleteMany = vi.fn().mockResolvedValue({ deletedCount: 2 });
+    vi.mocked(getDatabase).mockResolvedValue({
+      collection: (name: string) =>
+        name === "contacts" ? { deleteMany } : { insertOne, createIndex },
+    } as unknown as Awaited<ReturnType<typeof getDatabase>>);
+
+    const response = await POST(createDeletionRequest());
+
+    expect(response.status).toBe(200);
+    expect(createIndex).toHaveBeenCalledWith(
+      { requestedAt: 1 },
+      expect.objectContaining({ expireAfterSeconds: expect.any(Number) }),
+    );
+    const record = insertOne.mock.calls[0]?.[0];
+    expect(record.email).toBe("person@example.com");
+    expect(record.requestIp).toBe("203.0.113.0");
+    expect(record).not.toHaveProperty("requestUserAgent");
   });
 });

--- a/app/api/gdpr/delete-data/route.ts
+++ b/app/api/gdpr/delete-data/route.ts
@@ -27,6 +27,26 @@ const GDPR_IP_RATE_LIMIT_WINDOW_MS = 900_000; // 15 minutes
 const GDPR_IP_RATE_LIMIT_MAX = 10; // requests per window per IP
 
 /**
+ * Audit-trail retention. The deletion_requests record exists to demonstrate
+ * that an erasure request was honoured (GDPR Art. 5(2) accountability and
+ * Art. 17(3)(e) legal-claims defence), so it keeps the requested email but is
+ * data-minimised: no user agent, IP truncated to network granularity, and the
+ * whole record expires via a TTL index after 12 months.
+ */
+const DELETION_AUDIT_TTL_SECONDS = 60 * 60 * 24 * 365;
+
+/** Truncate an IP to network granularity (IPv4 /24, IPv6 /48-ish). */
+const anonymizeIp = (ip: string): string => {
+  if (ip.includes(":")) {
+    return `${ip.split(":").slice(0, 3).join(":")}::`;
+  }
+  const parts = ip.split(".");
+  return parts.length === 4 ? `${parts.slice(0, 3).join(".")}.0` : "unknown";
+};
+
+let auditTtlIndexEnsured: Promise<unknown> | null = null;
+
+/**
  * POST /api/gdpr/delete-data
  * Request deletion of user data from the database
  */
@@ -124,13 +144,23 @@ export async function POST(request: NextRequest) {
       // addresses are stored. The actual count goes to the audit trail only.
       const deletionResult = await contacts.deleteMany({ email });
 
-      // Log the request for the audit trail
-      await db.collection("deletion_requests").insertOne({
+      // Data-minimised audit trail (see DELETION_AUDIT_TTL_SECONDS note).
+      const deletionRequests = db.collection("deletion_requests");
+      auditTtlIndexEnsured ??= deletionRequests
+        .createIndex(
+          { requestedAt: 1 },
+          { expireAfterSeconds: DELETION_AUDIT_TTL_SECONDS },
+        )
+        .catch((indexError) => {
+          console.error("deletion_requests TTL index error:", indexError);
+          auditTtlIndexEnsured = null;
+        });
+      await auditTtlIndexEnsured;
+      await deletionRequests.insertOne({
         email,
         reason: reason || "User request",
         requestedAt: new Date(),
-        requestIp: ip,
-        requestUserAgent: userAgent,
+        requestIp: anonymizeIp(ip),
         deletedCount: deletionResult.deletedCount,
         status: "completed",
       });

--- a/app/api/test-health/runs/route.ts
+++ b/app/api/test-health/runs/route.ts
@@ -187,13 +187,15 @@ export async function POST(request: NextRequest) {
       ? payload.branch
       : (request.headers.get("x-ci-branch") ?? undefined);
 
-  await saveRun({
+  const persisted = await saveRun({
     ...stored,
     branch,
   });
 
+  // Still 200 so CI ingestion never blocks a pipeline, but the response is
+  // honest about whether the run actually reached the database.
   return NextResponse.json(
-    { status: "ok", runId },
+    { status: persisted ? "ok" : "accepted-not-persisted", runId, persisted },
     {
       status: 200,
       headers: corsHeaders,

--- a/app/dev/layout.tsx
+++ b/app/dev/layout.tsx
@@ -1,0 +1,14 @@
+import { notFound } from "next/navigation";
+
+/**
+ * /dev/* pages are demo and smoke-test harnesses (package consumption checks,
+ * Tailwind dogfood cohort). They must not ship on the production deployment;
+ * previews and local builds keep them (guard keys on VERCEL_ENV, not NODE_ENV,
+ * so `next build && next start` locally still serves them).
+ */
+export default function DevLayout({ children }: { children: React.ReactNode }) {
+  if (process.env.VERCEL_ENV === "production") {
+    notFound();
+  }
+  return children;
+}


### PR DESCRIPTION
## Summary
Remaining accepted findings from the external Codex review (round 1 = #1074).

**GDPR deletion audit trail** ([app/api/gdpr/delete-data/route.ts](../blob/main/app/api/gdpr/delete-data/route.ts)): the audit record kept raw email + IP + user agent indefinitely right after performing erasure. Now data-minimised: user agent dropped, IP truncated to network granularity (/24, IPv6 /48-ish), records auto-expire via a 12-month TTL index, and the retention basis is documented in the code (Art. 5(2) accountability, Art. 17(3)(e) legal-claims defence). Email stays raw so an erasure can still be demonstrated to the data subject or authority. Test pins the minimised shape.

**/dev routes** (code-window, tailwind-test): shared [app/dev/layout.tsx](../blob/main/app/dev/layout.tsx) calls notFound() when VERCEL_ENV=production, so the public deployment 404s them while previews and local prod builds keep the demo/package-smoke pages. Verified: prerender meta shows `"status": 404` under VERCEL_ENV=production; plain builds unchanged.

**test-health ingestion** ([runs/route.ts](../blob/main/app/api/test-health/runs/route.ts)): saveRun()'s boolean is no longer ignored — response reports `persisted: false` / `status: accepted-not-persisted` when the DB is absent or failing (still HTTP 200 so CI never blocks).

## Verification
- GDPR route 3/3 (new audit-shape test), full vitest 2230/2230, typecheck ✓, lint ✓
- Plain build ✓ (dev routes present); VERCEL_ENV=production build ✓ (dev routes prerender as 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)