### PR TITLE
chore(release): prep @digitaltableteur/react 0.1.6 — CodeSnippet export + CodeBlockWindow RSC-lazy fix

### DIFF
--- a/nextjs-app/shared/components/CodeSnippet/CodeSnippet.tsx
+++ b/nextjs-app/shared/components/CodeSnippet/CodeSnippet.tsx
@@ -6,15 +6,7 @@ import Text from "@dt/Text";
 import Button from "@dt/Button";
 import SplitButton from "@dt/SplitButton";
 import Toast from "@dt/Toast";
-import Prism from "prismjs";
-import "prismjs/components/prism-typescript";
-import "prismjs/components/prism-javascript";
-import "prismjs/components/prism-python";
-import "prismjs/components/prism-go";
-import "prismjs/components/prism-rust";
-import "prismjs/components/prism-json";
-import "prismjs/components/prism-bash";
-import "prismjs/components/prism-markup";
+import Prism from "./prismSetup";
 
 export type SupportedLanguage =
   | "javascript"

--- a/nextjs-app/shared/components/CodeSnippet/prismSetup.ts
+++ b/nextjs-app/shared/components/CodeSnippet/prismSetup.ts
@@ -1,0 +1,19 @@
+import Prism from "prismjs";
+import "prismjs/components/prism-typescript";
+import "prismjs/components/prism-javascript";
+import "prismjs/components/prism-python";
+import "prismjs/components/prism-go";
+import "prismjs/components/prism-rust";
+import "prismjs/components/prism-json";
+import "prismjs/components/prism-bash";
+import "prismjs/components/prism-markup";
+
+/**
+ * Prism with the supported language grammars registered. Kept in its own
+ * module so the side-effect `prismjs/components/*` imports never appear in
+ * CodeSnippet's emitted type declarations: prismjs is BUNDLED into the
+ * published package (not a dependency), so a clean consumer has no prismjs
+ * types and would fail typechecking (TS2882) on any leaked import. The value
+ * import below is type-elided as long as Prism stays out of exported types.
+ */
+export default Prism;

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.6 - 2026-07-10
+
+- Exports `CodeSnippet` (stable since #1067) with its prop types; public-api manifest now lists 106 exports.
+- Fixes a hydration mismatch in `CodeBlockWindow` when its children cross a server→client component boundary (#1074): React Flight delivers such children as lazy nodes during hydration, which fail `React.isValidElement`, so the component skipped its `pre`/`code` class enhancement and disabled the copy button on the client only. Fulfilled lazy nodes are now unwrapped before any children introspection; unresolved nodes degrade identically on server and client. Reproduced and verified in-browser plus a unit regression with a synthetic Flight-lazy child.
+- No other public runtime API changes from 0.1.5.
+- Verified by the full local gate plus `check:react-package` and `check:react-public-api`.
+
 ## 0.1.5 - 2026-07-10
 
 - TextInput gains three additive props (#1054): `clearable` renders a labelled ×-button inside the field chrome while the field has a value (never while disabled); activating it empties the field, clears built-in validation errors, fires `onValueChange("")` then `onClear()`, and returns focus to the input. `hideLabel` visually hides the label while keeping it in the accessibility tree (sr-only). The clear button's accessible name interpolates the field label via the new `inputClearField` i18n key (EN/FI/SV).

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/react",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": false,
   "description": "React components and host adapters for the Digitaltableteur design system.",
   "type": "module",


### PR DESCRIPTION
## Summary
- Version bump 0.1.5 → 0.1.6 + CHANGELOG: first release carrying the `CodeSnippet` export (#1067) and the CodeBlockWindow Flight-lazy hydration fix (#1074).
- Pre-publish catch: the strict consumer-install harness (skipLibCheck:false) failed on `CodeSnippet.d.ts` preserving `prismjs/components/*` side-effect imports — prismjs is bundled, not a dependency, so clean consumers have no prism types (TS2882). Grammar registration moved to `prismSetup.ts`; the value import elides from the emitted declarations, `CodeSnippet.d.ts` is now prism-free.

## Verification
- `check:react-publish-preflight -- --strict --require-clearance`: **22/22, clearance recorded**
- `check:react-package` (106 exports, 1.01 MiB), `check:npm-consumer-install` green after the fix
- Full local gate: typecheck ✓ lint ✓ vitest ✓ build ✓ (via preflight + explicit build)

Publish follows via the sanctioned `ds-publish.yml` OIDC workflow off main, then the consume bump PR (with AboutPageContent AT recapture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public `CodeSnippet` exports, including their prop types.
  * Expanded code highlighting support for TypeScript, JavaScript, Python, Go, Rust, JSON, Bash, and markup.

* **Bug Fixes**
  * Fixed a React hydration issue in code blocks, restoring consistent styling and copy-button behavior across server and client rendering.

* **Chores**
  * Released React package version 0.1.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->