### PR TITLE
chore(deps): consume @digitaltableteur/react 0.1.6

### DIFF
--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.5
+  - definition: 0.1.6
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.5
+  - definition: 0.1.6
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.5
+  - definition: 0.1.6
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.5
+  - definition: 0.1.6
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.5
+  - definition: 0.1.6
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.5
+  - definition: 0.1.6
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.5
+  - definition: 0.1.6
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.5
+  - definition: 0.1.6
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.5
+  - definition: 0.1.6
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.5
+  - definition: 0.1.6
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.5
+  - definition: 0.1.6
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.5
+  - definition: 0.1.6
   - term: tokens
   - definition: 0.1.0
   - term: tokens-css

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ai-sdk/openai": "^3.0.71",
         "@ai-sdk/react": "^3.0.207",
         "@calcom/embed-react": "^1.5.3",
-        "@digitaltableteur/react": "^0.1.5",
+        "@digitaltableteur/react": "^0.1.6",
         "@digitaltableteur/tokens": "^0.1.0",
         "@digitaltableteur/tokens-css": "^0.1.0",
         "@emailjs/browser": "^4.4.1",
@@ -3429,9 +3429,9 @@
       "license": "MIT"
     },
     "node_modules/@digitaltableteur/react": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.5.tgz",
-      "integrity": "sha512-aLKx/nAXKVrWqYFh1sPH+5pR599SyFRg5p11ZNeqToFJOa2yGXhhk3WlK18QdWLeT7oqLnhfjHbd1CUqY+nuCA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.6.tgz",
+      "integrity": "sha512-XNPUN8+IsXqJA1IUqEmtsII0T0tOoc1tApW77UejnIGCrvv7lRM8a3Krc8TzU/Tk3UEv3oIcHmV7VmuVDrdmSA==",
       "license": "UNLICENSED",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "@ai-sdk/openai": "^3.0.71",
     "@ai-sdk/react": "^3.0.207",
     "@calcom/embed-react": "^1.5.3",
-    "@digitaltableteur/react": "^0.1.5",
+    "@digitaltableteur/react": "^0.1.6",
     "@digitaltableteur/tokens": "^0.1.0",
     "@digitaltableteur/tokens-css": "^0.1.0",
     "@emailjs/browser": "^4.4.1",
@@ -225,6 +225,7 @@
     "ai": "^6.0.205",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dompurify": "^3.4.11",
     "dotenv": "^17.4.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
@@ -266,8 +267,7 @@
     "styled-components": "^6.4.3",
     "tailwind-merge": "^3.6.0",
     "typescript-eslint": "^8.62.1",
-    "zod": "^4.4.3",
-    "dompurify": "^3.4.11"
+    "zod": "^4.4.3"
   },
   "overrides": {
     "@types/react": "$@types/react",


### PR DESCRIPTION
## Summary
- App now on `@digitaltableteur/react@^0.1.6` (published via ds-publish OIDC run 29118165298 after prep #1076): ships the CodeBlockWindow Flight-lazy hydration fix (#1074) and the CodeSnippet export (#1067).
- AboutPageContent's 12 AT yamls recaptured per the consume recipe (they embed the installed package version); diff is exactly the `definition: 0.1.5 → 0.1.6` line in each file, compare-mode green in base/dark/forced-colors.

## Verification
- check:package-registry-resolution ✓, check:storybook-registry-package ✓, check:react-registry-install ✓ (0.1.6, 106 exports, runtime + types)
- Full local gate: typecheck ✓ lint ✓ vitest 2231/2231 ✓ build ✓
- In-browser: /dev/code-window (npm-package import) now hydrates with zero console errors; all code blocks carry module classes; copy buttons enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)