### PR TITLE
chore(deps): consume @digitaltableteur/tokens-css 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@calcom/embed-react": "^1.5.3",
         "@digitaltableteur/react": "^0.1.6",
         "@digitaltableteur/tokens": "^0.1.0",
-        "@digitaltableteur/tokens-css": "^0.1.0",
+        "@digitaltableteur/tokens-css": "^0.1.1",
         "@emailjs/browser": "^4.4.1",
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^10.0.1",
@@ -3452,9 +3452,9 @@
       "license": "UNLICENSED"
     },
     "node_modules/@digitaltableteur/tokens-css": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@digitaltableteur/tokens-css/-/tokens-css-0.1.0.tgz",
-      "integrity": "sha512-5dFiittFS5f6AMeM0uJ2YZw+OLAjHN6oxLOaOi1dhdDv4Ul/v48znVkDm+hqj/OjPT38cOsT12drFi8T51Ig1g==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@digitaltableteur/tokens-css/-/tokens-css-0.1.1.tgz",
+      "integrity": "sha512-83uwL3EKgHHBJcwlAThzg7v7Ghs8TPgDqTo3YIvM5sQMU5dpj7BlpwkXxXzcs5H57oxpT7lEoC2eHKNu1Vz8jw==",
       "license": "UNLICENSED"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "@calcom/embed-react": "^1.5.3",
     "@digitaltableteur/react": "^0.1.6",
     "@digitaltableteur/tokens": "^0.1.0",
-    "@digitaltableteur/tokens-css": "^0.1.0",
+    "@digitaltableteur/tokens-css": "^0.1.1",
     "@emailjs/browser": "^4.4.1",
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary
App on `@digitaltableteur/tokens-css@^0.1.1` (published via ds-publish run 29119053336 after prep #1078). Ships the two dark-theme token fixes that postdated 0.1.0: `--link-color` → `var(--color-primary)` (#1051) and dark `--color-muted` → `#949494` (#1064). Installed tokens.css verified to carry both fixed values. `@digitaltableteur/tokens` stays 0.1.0 (content byte-identical to registry).

## Verification
- check:package-registry-resolution ✓, check:storybook-registry-package ✓, check:registry-token-install ✓ (tokens-css@0.1.1, 184 tokens)
- Full local gate: typecheck ✓ lint ✓ vitest 2231/2231 ✓ build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)