### PR TITLE
refactor(privacy-policy): full DS parity swap — first view under the consumption mandate

### DIFF
--- a/nextjs-app/shared/components/List/List.contract.json
+++ b/nextjs-app/shared/components/List/List.contract.json
@@ -173,7 +173,8 @@
                 "lower-alpha",
                 "upper-alpha",
                 "lower-roman",
-                "upper-roman"
+                "upper-roman",
+                "dash"
             ]
         },
         "spacing": {

--- a/nextjs-app/shared/components/List/List.module.css
+++ b/nextjs-app/shared/components/List/List.module.css
@@ -8,11 +8,12 @@
 }
 
 .list li {
+  /* Measure is governed by the container, like all prose; items only get
+     word-level wrapping protection. (A 20ch max-inline-size + hyphens:auto
+     default used to live here — every real consumer overrode it.) */
   margin-block-end: var(--space-internal-8);
-  max-inline-size: 20ch; /* or max-width: 20ch */
   white-space: normal;
   overflow-wrap: break-word;
-  hyphens: auto;
 }
 
 /* Spacing classes */

--- a/nextjs-app/shared/components/List/List.stories.tsx
+++ b/nextjs-app/shared/components/List/List.stories.tsx
@@ -76,6 +76,7 @@ const meta: Meta<typeof List> = {
         "lower-roman",
         "upper-roman",
         "none",
+        "dash",
       ],
       description: "CSS list-style-type",
     },

--- a/nextjs-app/shared/components/List/List.test.tsx
+++ b/nextjs-app/shared/components/List/List.test.tsx
@@ -61,6 +61,11 @@ describe("List", () => {
     expect(container.firstChild).toHaveStyle({ listStyleType: "circle" });
   });
 
+  it("maps listStyleType='dash' to an em-dash string marker", () => {
+    const { container } = render(<List items={items} listStyleType="dash" />);
+    expect(container.firstChild).toHaveStyle({ listStyleType: '"— "' });
+  });
+
   it("applies custom inline styles", () => {
     const { container } = render(
       <List items={items} style={{ color: "red" }} />,

--- a/nextjs-app/shared/components/List/List.tsx
+++ b/nextjs-app/shared/components/List/List.tsx
@@ -14,7 +14,8 @@ type ListStyleType =
   | "upper-alpha"
   | "lower-roman"
   | "upper-roman"
-  | "none";
+  | "none"
+  | "dash";
 
 export interface ListProps {
   items: React.ReactNode[];
@@ -82,7 +83,11 @@ export const List = React.forwardRef<
   const spacingClass = spacingClassMap[spacing] || "";
 
   const resolvedListStyleType =
-    listStyleType === "none" ? ('" "' as ListStyleType) : listStyleType;
+    listStyleType === "none"
+      ? ('" "' as ListStyleType)
+      : listStyleType === "dash"
+        ? ('"— "' as ListStyleType)
+        : listStyleType;
 
   const combinedStyle = {
     ...style,

--- a/nextjs-app/shared/components/Timestamp/Timestamp.contract.json
+++ b/nextjs-app/shared/components/Timestamp/Timestamp.contract.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "name": "Timestamp",
+    "tier": "atom",
+    "group": "display",
+    "status": "alpha",
+    "description": "Formats a date or time value into human-readable text: relative for recency, absolute for precision, or auto to switch between them. Modeled on the Astryx Timestamp reference.",
+    "figma": null,
+    "radixPrimitive": null,
+    "element": "time",
+    "variants": {
+        "size": {
+            "values": ["xxs", "xs", "s", "m", "l", "xl", "xxl"],
+            "default": "s",
+            "propSourced": true
+        },
+        "tone": {
+            "values": ["default", "muted"],
+            "default": "muted",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": ["Default", "Playground", "Example", "ForcedColors"],
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [
+            "Renders a semantic <time> element with a machine-readable dateTime attribute.",
+            "Relative output carries the full date as a native tooltip (title) so the precise moment stays discoverable."
+        ],
+        "reducedMotion": true,
+        "reviewed": false,
+        "forcedColorsVerified": false
+    },
+    "tokens": {
+        "colors": ["--color-text", "--color-muted"],
+        "spacing": []
+    },
+    "lightDarkVerified": false
+}

--- a/nextjs-app/shared/components/Timestamp/Timestamp.mdx
+++ b/nextjs-app/shared/components/Timestamp/Timestamp.mdx
@@ -1,0 +1,31 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './Timestamp.stories.tsx';
+
+<Meta of={Stories} />
+
+# Timestamp
+
+**Status:** alpha · **Tier:** atom · **Group:** display
+
+## In use
+See the **Example** story for the canonical production composition.
+
+## How to use
+
+```tsx
+import { Timestamp } from '@dt/Timestamp';
+
+<Timestamp />
+```
+
+## When to use
+- TODO
+
+## When not to use
+- TODO
+
+## Accessibility
+- TODO: keyboard, ARIA, focus, reduced motion
+
+## Promotion notes
+- Promote to stable after AT snapshots + production consumer documented.

--- a/nextjs-app/shared/components/Timestamp/Timestamp.module.css
+++ b/nextjs-app/shared/components/Timestamp/Timestamp.module.css
@@ -1,0 +1,43 @@
+.timestamp {
+  font-family: var(--primary-body-font);
+  font-style: normal;
+  font-variant-numeric: tabular-nums;
+}
+
+.toneDefault {
+  color: var(--color-text);
+}
+
+.toneMuted {
+  color: var(--color-muted);
+}
+
+/* Text ladder, same tokens as Text. */
+
+.sizeXXS {
+  font-size: var(--font-size-text-xxs);
+}
+
+.sizeXS {
+  font-size: var(--font-size-text-xs);
+}
+
+.sizeS {
+  font-size: var(--font-size-text-s);
+}
+
+.sizeM {
+  font-size: var(--font-size-text-m);
+}
+
+.sizeL {
+  font-size: var(--font-size-text-l);
+}
+
+.sizeXL {
+  font-size: var(--font-size-text-xl);
+}
+
+.sizeXXL {
+  font-size: var(--font-size-text-xxl);
+}

--- a/nextjs-app/shared/components/Timestamp/Timestamp.spec.md
+++ b/nextjs-app/shared/components/Timestamp/Timestamp.spec.md
@@ -1,0 +1,17 @@
+# Timestamp
+
+## Intent
+TODO: What job does Timestamp perform for users?
+
+## Interaction contract
+- Keyboard: TODO
+- Pointer: TODO
+- Screen readers: TODO
+
+## Do / don't
+- Do: TODO
+- Don't: TODO
+
+## Design notes
+- Tokens: TODO
+- Figma: TODO

--- a/nextjs-app/shared/components/Timestamp/Timestamp.stories.tsx
+++ b/nextjs-app/shared/components/Timestamp/Timestamp.stories.tsx
@@ -1,0 +1,184 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import React from "react";
+import { Timestamp } from "./Timestamp";
+import Text from "@dt/Text";
+import contract from "./Timestamp.contract.json";
+
+/**
+ * Every story pins `value` and `now` so relative output is deterministic:
+ * AT snapshots and visual baselines must never ride on wall-clock time.
+ */
+const FIXED_NOW = "2026-02-19T19:00:00Z";
+const RECENT = "2026-02-19T17:00:00Z"; // 2 hours before FIXED_NOW
+const OLDER = "2025-11-29T12:00:00Z";
+
+const meta = {
+  title: "Atoms/Timestamp",
+  component: Timestamp,
+  parameters: {
+    layout: "centered",
+    a11y: { test: "error" },
+    contractStatus: contract.status,
+    docs: {
+      description: {
+        component: contract.description,
+      },
+    },
+  },
+  // Custom MDX docs pages exist for all catalog entries; do not also enable autodocs
+  // or Storybook will treat it as conflicting sources of truth for the docs page.
+  tags: ["!autodocs"],
+  argTypes: {
+    value: {
+      control: "text",
+      description: "ISO 8601 string, Unix seconds, or Date to display.",
+      table: { category: "Content", type: { summary: "string | number | Date" } },
+    },
+    format: {
+      control: { type: "select" },
+      options: [
+        "auto",
+        "relative",
+        "date",
+        "date_time",
+        "time",
+        "system_date",
+        "system_date_time",
+        "system_time",
+      ],
+      description:
+        "Display format; auto shows relative time until autoThreshold, then the full date.",
+      table: { category: "Appearance", defaultValue: { summary: "auto" } },
+    },
+    autoThreshold: {
+      control: "number",
+      description: "Seconds before auto switches from relative to date_time.",
+      table: { category: "Behavior", defaultValue: { summary: "604800" } },
+    },
+    size: {
+      control: { type: "select" },
+      options: ["xxs", "xs", "s", "m", "l", "xl", "xxl"],
+      description: "Text-ladder size.",
+      table: { category: "Appearance", defaultValue: { summary: "s" } },
+    },
+    tone: {
+      control: "radio",
+      options: ["default", "muted"],
+      description: "Color role: body text or muted metadata.",
+      table: { category: "Appearance", defaultValue: { summary: "muted" } },
+    },
+    showTimezone: {
+      control: "boolean",
+      description: "Append the timezone abbreviation to time-bearing formats.",
+      table: { category: "Appearance", defaultValue: { summary: "false" } },
+    },
+    tooltip: {
+      control: "boolean",
+      description: "Native full-date tooltip on relative output.",
+      table: { category: "Behavior", defaultValue: { summary: "true" } },
+    },
+    live: {
+      control: "boolean",
+      description: "Tick relative output while mounted (30s cadence).",
+      table: { category: "Behavior", defaultValue: { summary: "false" } },
+    },
+    now: {
+      control: "text",
+      description:
+        "Reference now for deterministic relative output (stories/tests).",
+      table: { category: "Advanced", type: { summary: "string | number | Date" } },
+    },
+    locale: {
+      control: "text",
+      description: "Locale override; defaults to the active site language.",
+      table: { category: "Advanced", type: { summary: "string" } },
+    },
+    className: {
+      control: "text",
+      description: "Optional className passthrough.",
+      table: { category: "Advanced" },
+    },
+  },
+  args: {
+    value: RECENT,
+    now: FIXED_NOW,
+    format: "auto",
+    size: "s",
+    tone: "muted",
+    showTimezone: false,
+    tooltip: true,
+    live: false,
+    locale: "",
+    className: "",
+  },
+} satisfies Meta<typeof Timestamp>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  globals: { forcedColors: "none" },
+};
+
+export const Playground: Story = {
+  globals: { forcedColors: "none" },
+};
+
+export const Formats: Story = {
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story:
+          "All display formats against the same fixed value: user-facing date/date_time/time and the system variants for logs and dev tools.",
+      },
+    },
+  },
+  render: () => (
+    <div style={{ display: "grid", gap: "0.5rem" }}>
+      {(
+        [
+          "relative",
+          "date",
+          "date_time",
+          "time",
+          "system_date",
+          "system_date_time",
+          "system_time",
+        ] as const
+      ).map((format) => (
+        <Text as="p" size="s" key={format}>
+          {format}: <Timestamp value={OLDER} now={FIXED_NOW} format={format} />
+        </Text>
+      ))}
+    </div>
+  ),
+};
+
+export const Example: Story = {
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story:
+          "In-copy composition, the privacy-policy idiom: a label with an absolute date.",
+      },
+    },
+  },
+  render: () => (
+    <Text as="p" size="xs">
+      Last updated: <Timestamp value={OLDER} format="date" now={FIXED_NOW} />
+    </Text>
+  ),
+};
+
+export const ForcedColors: Story = {
+  globals: { forcedColors: "active" },
+  parameters: {
+    docs: {
+      description: {
+        story: "Forced-colors verification story.",
+      },
+    },
+  },
+};

--- a/nextjs-app/shared/components/Timestamp/Timestamp.test.tsx
+++ b/nextjs-app/shared/components/Timestamp/Timestamp.test.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import Timestamp, { formatTimestamp } from "./Timestamp";
+
+expect.extend(toHaveNoViolations);
+
+vi.mock("../../lib/translation", () => {
+  const t = (key: string, fallback?: string) => fallback ?? key;
+  return {
+    useTranslate: () => t,
+    useLocalization: () => ({
+      translate: t,
+      language: "en",
+      resolvedLanguage: "en",
+      changeLanguage: vi.fn(),
+      getResourceBundle: vi.fn(),
+    }),
+  };
+});
+
+const NOW = new Date("2026-02-19T19:00:00Z");
+const TWO_HOURS_AGO = new Date("2026-02-19T17:00:00Z");
+const OLDER = new Date("2025-11-29T12:00:00Z");
+
+describe("formatTimestamp", () => {
+  it("renders relative labels for recent values", () => {
+    expect(formatTimestamp(TWO_HOURS_AGO, NOW, "relative", "en", false, 604800)).toBe(
+      "2 hours ago",
+    );
+  });
+
+  it("auto switches from relative to date_time at the threshold", () => {
+    expect(
+      formatTimestamp(TWO_HOURS_AGO, NOW, "auto", "en", false, 604800),
+    ).toBe("2 hours ago");
+    expect(formatTimestamp(OLDER, NOW, "auto", "en", false, 604800)).toMatch(
+      /Nov.*2025/,
+    );
+  });
+
+  it("formats absolute date with a short month", () => {
+    expect(formatTimestamp(OLDER, NOW, "date", "en", false, 604800)).toMatch(
+      /^Nov 29, 2025$|^29 Nov 2025$/,
+    );
+  });
+
+  it("formats system variants as ISO-style local time", () => {
+    expect(formatTimestamp(OLDER, NOW, "system_date", "en", false, 604800)).toMatch(
+      /^\d{4}-\d{2}-\d{2}$/,
+    );
+    expect(
+      formatTimestamp(OLDER, NOW, "system_date_time", "en", false, 604800),
+    ).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+  });
+
+  it("localizes output (Finnish date shape differs from English)", () => {
+    const fi = formatTimestamp(OLDER, NOW, "date", "fi", false, 604800);
+    const en = formatTimestamp(OLDER, NOW, "date", "en", false, 604800);
+    // ICU renders fi short-month dates numerically ("29.11.2025"); the exact
+    // shape is Intl's business, locale divergence is ours to guarantee.
+    expect(fi).toContain("2025");
+    expect(fi).not.toBe(en);
+  });
+});
+
+describe("Timestamp", () => {
+  it("renders a semantic time element with a machine-readable dateTime", () => {
+    render(<Timestamp value="2025-11-29T12:00:00Z" format="date" now={NOW} />);
+    const time = document.querySelector("time");
+    expect(time).toBeInTheDocument();
+    expect(time).toHaveAttribute("dateTime", "2025-11-29T12:00:00.000Z");
+  });
+
+  it("shows a full-date tooltip on relative output and none on absolute", () => {
+    render(
+      <Timestamp value={TWO_HOURS_AGO} format="relative" now={NOW} />,
+    );
+    expect(screen.getByText("2 hours ago")).toHaveAttribute("title");
+
+    render(<Timestamp value={OLDER} format="date" now={NOW} />);
+    const absolute = document.querySelectorAll("time")[1];
+    expect(absolute).not.toHaveAttribute("title");
+  });
+
+  it("accepts Unix seconds", () => {
+    render(
+      <Timestamp
+        value={Math.floor(OLDER.getTime() / 1000)}
+        format="system_date"
+        now={NOW}
+      />,
+    );
+    expect(document.querySelector("time")?.textContent).toMatch(
+      /^\d{4}-\d{2}-\d{2}$/,
+    );
+  });
+
+  it("renders nothing readable for invalid values without crashing", () => {
+    render(<Timestamp value="not-a-date" format="date" now={NOW} />);
+    const time = document.querySelector("time");
+    expect(time?.textContent).toBe("");
+    expect(time).not.toHaveAttribute("dateTime");
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <p>
+        Last updated:{" "}
+        <Timestamp value={OLDER} format="date" now={NOW} />
+      </p>,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/Timestamp/Timestamp.tsx
+++ b/nextjs-app/shared/components/Timestamp/Timestamp.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import React from "react";
+import { useLocalization } from "../../lib/translation";
+import styles from "./Timestamp.module.css";
+
+/**
+ * Display format, mirroring the Astryx Timestamp reference
+ * (https://astryx.atmeta.com/components/Timestamp): user-facing `date`,
+ * `date_time`, `time` and `relative`; ISO-style `system_*` variants for
+ * developer surfaces; `auto` switches from relative to date_time once the
+ * value is older than `autoThreshold`.
+ */
+export type TimestampFormat =
+  | "auto"
+  | "relative"
+  | "date"
+  | "date_time"
+  | "time"
+  | "system_date"
+  | "system_date_time"
+  | "system_time";
+
+export type TimestampSize = "xxs" | "xs" | "s" | "m" | "l" | "xl" | "xxl";
+
+export interface TimestampProps {
+  /** The date/time to display: ISO 8601 string, Unix seconds, or Date. */
+  value: string | number | Date;
+  /** Display format. @default "auto" */
+  format?: TimestampFormat;
+  /**
+   * Seconds after which `auto` switches from relative to date_time.
+   * @default 604800 (7 days)
+   */
+  autoThreshold?: number;
+  /** Text-ladder size. @default "s" */
+  size?: TimestampSize;
+  /** Color role: body text or muted metadata. @default "muted" */
+  tone?: "default" | "muted";
+  /** Append the timezone abbreviation (date_time/time/system equivalents). @default false */
+  showTimezone?: boolean;
+  /** Native tooltip with the full date when showing relative time. @default true */
+  tooltip?: boolean;
+  /** Keep relative output ticking while mounted. @default false */
+  live?: boolean;
+  /**
+   * Reference "now" for relative/auto output. Defaults to render time; pass a
+   * fixed value in stories/tests for deterministic output.
+   */
+  now?: string | number | Date;
+  /** Locale override; defaults to the active site language. */
+  locale?: string;
+  /** Optional className passthrough. */
+  className?: string;
+}
+
+const SIZE_CLASS: Record<TimestampSize, string> = {
+  xxs: styles.sizeXXS,
+  xs: styles.sizeXS,
+  s: styles.sizeS,
+  m: styles.sizeM,
+  l: styles.sizeL,
+  xl: styles.sizeXL,
+  xxl: styles.sizeXXL,
+};
+
+const toDate = (value: string | number | Date): Date => {
+  if (value instanceof Date) return value;
+  if (typeof value === "number") {
+    // Unix seconds (Astryx convention); treat obviously-millisecond values as ms.
+    return new Date(value > 1e12 ? value : value * 1000);
+  }
+  return new Date(value);
+};
+
+const pad = (n: number) => String(n).padStart(2, "0");
+
+const systemDate = (d: Date) =>
+  `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+const systemTime = (d: Date) =>
+  `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+
+const timezoneAbbreviation = (d: Date, locale: string) => {
+  const part = new Intl.DateTimeFormat(locale, { timeZoneName: "short" })
+    .formatToParts(d)
+    .find((p) => p.type === "timeZoneName");
+  return part ? part.value : "";
+};
+
+const RELATIVE_STEPS: Array<{
+  limit: number;
+  divisor: number;
+  unit: Intl.RelativeTimeFormatUnit;
+}> = [
+  { limit: 60, divisor: 1, unit: "second" },
+  { limit: 3600, divisor: 60, unit: "minute" },
+  { limit: 86400, divisor: 3600, unit: "hour" },
+  { limit: 604800, divisor: 86400, unit: "day" },
+  { limit: 2629800, divisor: 604800, unit: "week" },
+  { limit: 31557600, divisor: 2629800, unit: "month" },
+  { limit: Infinity, divisor: 31557600, unit: "year" },
+];
+
+const relativeLabel = (date: Date, nowDate: Date, locale: string) => {
+  const deltaSeconds = Math.round((date.getTime() - nowDate.getTime()) / 1000);
+  const magnitude = Math.abs(deltaSeconds);
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+  if (magnitude < 45) return rtf.format(0, "second"); // "now"
+  const step =
+    RELATIVE_STEPS.find((s) => magnitude < s.limit) ??
+    RELATIVE_STEPS[RELATIVE_STEPS.length - 1];
+  return rtf.format(Math.round(deltaSeconds / step.divisor), step.unit);
+};
+
+/** Pure formatter, exported for tests. */
+export const formatTimestamp = (
+  date: Date,
+  nowDate: Date,
+  format: TimestampFormat,
+  locale: string,
+  showTimezone: boolean,
+  autoThreshold: number,
+): string => {
+  const resolved: Exclude<TimestampFormat, "auto"> =
+    format === "auto"
+      ? Math.abs(nowDate.getTime() - date.getTime()) / 1000 < autoThreshold
+        ? "relative"
+        : "date_time"
+      : format;
+
+  const tz = showTimezone ? ` ${timezoneAbbreviation(date, locale)}` : "";
+
+  switch (resolved) {
+    case "relative":
+      return relativeLabel(date, nowDate, locale);
+    case "date":
+      return new Intl.DateTimeFormat(locale, {
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+      }).format(date);
+    case "date_time":
+      return (
+        new Intl.DateTimeFormat(locale, {
+          day: "numeric",
+          month: "short",
+          year: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+        }).format(date) + tz
+      );
+    case "time":
+      return (
+        new Intl.DateTimeFormat(locale, {
+          hour: "2-digit",
+          minute: "2-digit",
+        }).format(date) + tz
+      );
+    case "system_date":
+      return systemDate(date);
+    case "system_date_time":
+      return `${systemDate(date)} ${systemTime(date)}${tz}`;
+    case "system_time":
+      return `${systemTime(date)}${tz}`;
+  }
+};
+
+/**
+ * Formats a date or time value into human-readable text: relative for
+ * recency, absolute for precision, or `auto` to switch between them.
+ * Renders a semantic `<time>` with a machine-readable dateTime attribute;
+ * relative modes carry the full date as a native tooltip.
+ */
+export const Timestamp = React.forwardRef<HTMLTimeElement, TimestampProps>(
+  function Timestamp(
+    {
+      value,
+      format = "auto",
+      autoThreshold = 604800,
+      size = "s",
+      tone = "muted",
+      showTimezone = false,
+      tooltip = true,
+      live = false,
+      now,
+      locale,
+      className = "",
+    },
+    ref,
+  ) {
+    const { resolvedLanguage } = useLocalization();
+    const activeLocale = locale || resolvedLanguage || "en";
+    const date = toDate(value);
+
+    // Ticks only when live; otherwise "now" is captured per render pass.
+    const [tick, setTick] = React.useState(0);
+    const nowDate = React.useMemo(
+      () => (now !== undefined ? toDate(now) : new Date()),
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- tick forces live re-evaluation
+      [now, tick],
+    );
+
+    React.useEffect(() => {
+      if (!live || now !== undefined) return;
+      if (format !== "relative" && format !== "auto") return;
+      const interval = window.setInterval(() => setTick((v) => v + 1), 30_000);
+      return () => window.clearInterval(interval);
+    }, [live, now, format]);
+
+    const isValid = !Number.isNaN(date.getTime());
+    const label = isValid
+      ? formatTimestamp(
+          date,
+          nowDate,
+          format,
+          activeLocale,
+          showTimezone,
+          autoThreshold,
+        )
+      : "";
+
+    const showsRelative =
+      format === "relative" ||
+      (format === "auto" &&
+        isValid &&
+        Math.abs(nowDate.getTime() - date.getTime()) / 1000 < autoThreshold);
+
+    const fullDate =
+      isValid && tooltip && showsRelative
+        ? new Intl.DateTimeFormat(activeLocale, {
+            dateStyle: "medium",
+            timeStyle: "short",
+          }).format(date)
+        : undefined;
+
+    return (
+      <time
+        ref={ref}
+        dateTime={isValid ? date.toISOString() : undefined}
+        title={fullDate}
+        className={`${styles.timestamp} ${SIZE_CLASS[size]} ${
+          tone === "muted" ? styles.toneMuted : styles.toneDefault
+        } ${className}`.trim()}
+        // Relative output derives from render-time "now"; server and client
+        // can legitimately differ by a tick (React-sanctioned use of
+        // suppressHydrationWarning for timestamps).
+        suppressHydrationWarning
+      >
+        {label}
+      </time>
+    );
+  },
+);
+
+export default Timestamp;

--- a/nextjs-app/shared/components/Timestamp/index.ts
+++ b/nextjs-app/shared/components/Timestamp/index.ts
@@ -1,0 +1,6 @@
+export { default, Timestamp, formatTimestamp } from "./Timestamp";
+export type {
+  TimestampProps,
+  TimestampFormat,
+  TimestampSize,
+} from "./Timestamp";

--- a/nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.module.css
+++ b/nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.module.css
@@ -64,3 +64,7 @@
     margin-top: 1.5rem;
   }
 }
+
+.preLine {
+  white-space: pre-line;
+}

--- a/nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.test.tsx
+++ b/nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "../../../../../test-utils/render";
 import { PrivacyPolicyPage } from "./PrivacyPolicyPage";
@@ -18,9 +18,14 @@ describe("PrivacyPolicyPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders back button when onBack is provided", () => {
-    const onBack = vi.fn();
-    renderWithProviders(<PrivacyPolicyPage onBack={onBack} />);
-    expect(screen.getByRole("button", { name: /Back/i })).toBeInTheDocument();
+  it("renders the policy sections as a marker-less list layout", () => {
+    renderWithProviders(<PrivacyPolicyPage />);
+    // DS structure after the dogfooding swaps: Text paragraphs, DS List items,
+    // DS Section wrappers (the dead onBack back-button affordance is gone).
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.getAllByRole("list").length).toBe(6);
+    expect(
+      screen.getAllByText(/Last updated/i)[0].closest("p"),
+    ).toBeInTheDocument();
   });
 });

--- a/nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx
+++ b/nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import Link from "@dt/Link";
 import List from "@dt/List";
+import Timestamp from "@dt/Timestamp";
 import { Section } from "@dt/Section";
 import Text from "@dt/Text";
 import Title from "@dt/Title";
@@ -102,7 +103,8 @@ export function PrivacyPolicyPage() {
       </Title>
       <Text as="p" size="xs">{t("privacyPolicyIntro")}</Text>
       <Text as="p" size="xs">
-        <em>{t("privacyPolicyLastUpdated")}</em>
+        {t("privacyPolicyLastUpdatedLabel")}{" "}
+        <Timestamp value="2025-11-29" format="date" size="xs" />
       </Text>
 
       <Section spacing="none">

--- a/nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx
+++ b/nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import Button from "@dt/Button";
 import Icon from "@dt/Icon";
+import Text from "@dt/Text";
 import Title from "@dt/Title";
 import styles from "../AiUsagePage/AiUsagePage.module.css";
 
@@ -132,25 +133,25 @@ export function PrivacyPolicyPage({ onBack }: { onBack?: () => void }) {
       <Title level={1} size="xs">
         {t("privacyPolicyHeading")}
       </Title>
-      <p>{t("privacyPolicyIntro")}</p>
-      <p>
+      <Text as="p" size="xs">{t("privacyPolicyIntro")}</Text>
+      <Text as="p" size="xs">
         <em>{t("privacyPolicyLastUpdated")}</em>
-      </p>
+      </Text>
 
       <section>
         <Title level={2} size="xxs">
           {t("privacyPolicyControllerTitle")}
         </Title>
-        <p style={{ whiteSpace: "pre-line" }}>
+        <Text as="p" size="xs" className={styles.preLine}>
           {t("privacyPolicyControllerBody")}
-        </p>
+        </Text>
       </section>
 
       <section>
         <Title level={2} size="xxs">
           {t("privacyPolicyPurposeTitle")}
         </Title>
-        <p>{t("privacyPolicyPurposeBody")}</p>
+        <Text as="p" size="xs">{t("privacyPolicyPurposeBody")}</Text>
       </section>
 
       <section>
@@ -160,131 +161,131 @@ export function PrivacyPolicyPage({ onBack }: { onBack?: () => void }) {
         <Title level={3} size="xxs">
           {t("privacyPolicyContactFormSubtitle")}
         </Title>
-        <p>{t("privacyPolicyContactFormIntro")}</p>
+        <Text as="p" size="xs">{t("privacyPolicyContactFormIntro")}</Text>
         <ul>
           {whatWeCollect.map((key) => (
             <li key={key}>
-              <p>{t(key)}</p>
+              <Text as="p" size="xs">{t(key)}</Text>
             </li>
           ))}
         </ul>
-        <p>{t("privacyPolicyContactFormUsage")}</p>
+        <Text as="p" size="xs">{t("privacyPolicyContactFormUsage")}</Text>
 
         <Title level={3} size="xxs">
           {t("privacyPolicyWebsiteVisitorsSubtitle")}
         </Title>
-        <p>{t("privacyPolicyWebsiteVisitorsIntro")}</p>
+        <Text as="p" size="xs">{t("privacyPolicyWebsiteVisitorsIntro")}</Text>
         <ul>
           {websiteVisitors.map((key) => (
             <li key={key}>
-              <p>{t(key)}</p>
+              <Text as="p" size="xs">{t(key)}</Text>
             </li>
           ))}
         </ul>
-        <p>{t("privacyPolicyWebsiteVisitorsUsage")}</p>
+        <Text as="p" size="xs">{t("privacyPolicyWebsiteVisitorsUsage")}</Text>
       </section>
 
       <section>
         <Title level={2} size="xxs">
           {t("privacyPolicyLegalBasisTitle")}
         </Title>
-        <p>{t("privacyPolicyLegalBasisBody")}</p>
+        <Text as="p" size="xs">{t("privacyPolicyLegalBasisBody")}</Text>
       </section>
 
       <section>
         <Title level={2} size="xxs">
           {t("privacyPolicySharingTitle")}
         </Title>
-        <p>{t("privacyPolicySharingIntro")}</p>
+        <Text as="p" size="xs">{t("privacyPolicySharingIntro")}</Text>
         <ul>
           {sharingItems.map((key) => (
             <li key={key}>
-              <p>{t(key)}</p>
+              <Text as="p" size="xs">{t(key)}</Text>
             </li>
           ))}
         </ul>
-        <p>{t("privacyPolicySharingFooter")}</p>
+        <Text as="p" size="xs">{t("privacyPolicySharingFooter")}</Text>
       </section>
 
       <section>
         <Title level={2} size="xxs">
           {t("privacyPolicyTransfersTitle")}
         </Title>
-        <p>{t("privacyPolicyTransfersBody")}</p>
+        <Text as="p" size="xs">{t("privacyPolicyTransfersBody")}</Text>
       </section>
 
       <section>
         <Title level={2} size="xxs">
           {t("privacyPolicyCookiesTitle")}
         </Title>
-        <p>{t("privacyPolicyCookiesIntro")}</p>
-        <p>{t("privacyPolicyCookiesTypes")}</p>
+        <Text as="p" size="xs">{t("privacyPolicyCookiesIntro")}</Text>
+        <Text as="p" size="xs">{t("privacyPolicyCookiesTypes")}</Text>
         <ul>
           {cookiesItems.map((key) => (
             <li key={key}>
-              <p>{t(key)}</p>
+              <Text as="p" size="xs">{t(key)}</Text>
             </li>
           ))}
         </ul>
-        <p>{t("privacyPolicyCookiesControl")}</p>
+        <Text as="p" size="xs">{t("privacyPolicyCookiesControl")}</Text>
       </section>
 
       <section>
         <Title level={2} size="xxs">
           {t("privacyPolicyRetentionTitle")}
         </Title>
-        <p>{t("privacyPolicyRetentionBody")}</p>
+        <Text as="p" size="xs">{t("privacyPolicyRetentionBody")}</Text>
       </section>
 
       <section>
         <Title level={2} size="xxs">
           {t("privacyPolicyYourRightsTitle")}
         </Title>
-        <p>{t("privacyPolicyYourRightsIntro")}</p>
+        <Text as="p" size="xs">{t("privacyPolicyYourRightsIntro")}</Text>
         <ul>
           {rights.map((key) => (
             <li key={key}>
-              <p>{t(key)}</p>
+              <Text as="p" size="xs">{t(key)}</Text>
             </li>
           ))}
         </ul>
-        <p>{t("privacyPolicyRightsExercise")}</p>
-        <p>{t("privacyPolicyRightsComplaint")}</p>
+        <Text as="p" size="xs">{t("privacyPolicyRightsExercise")}</Text>
+        <Text as="p" size="xs">{t("privacyPolicyRightsComplaint")}</Text>
       </section>
 
       <section>
         <Title level={2} size="xxs">
           {t("privacyPolicySecurityTitle")}
         </Title>
-        <p>{t("privacyPolicySecurityIntro")}</p>
+        <Text as="p" size="xs">{t("privacyPolicySecurityIntro")}</Text>
         <ul>
           {securityItems.map((key) => (
             <li key={key}>
-              <p>{t(key)}</p>
+              <Text as="p" size="xs">{t(key)}</Text>
             </li>
           ))}
         </ul>
-        <p>{t("privacyPolicySecurityFooter")}</p>
+        <Text as="p" size="xs">{t("privacyPolicySecurityFooter")}</Text>
       </section>
 
       <section>
         <Title level={2} size="xxs">
           {t("privacyPolicyChangesTitle")}
         </Title>
-        <p>{t("privacyPolicyChangesBody")}</p>
+        <Text as="p" size="xs">{t("privacyPolicyChangesBody")}</Text>
       </section>
 
       <section>
         <Title level={2} size="xxs">
           {t("privacyPolicyContactTitle")}
         </Title>
-        <p>
+        <Text as="p" size="xs">
           {renderContactLinks(
             t("privacyPolicyContactBody"),
             "mail@digitaltableteur.com",
             "+358 45 657 4469",
           )}
-        </p>
+        </Text>
       </section>
     </div>
   );

--- a/nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx
+++ b/nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx
@@ -3,29 +3,30 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
+import Link from "@dt/Link";
 import List from "@dt/List";
 import { Section } from "@dt/Section";
 import Text from "@dt/Text";
 import Title from "@dt/Title";
 import styles from "../AiUsagePage/AiUsagePage.module.css";
 
-const renderContactLinks = (text: string, email: string, phone: string) => {
+const renderContactLinks = (text: string, email: string, phone?: string) => {
   // Split by email first
   const emailParts = text.split(email);
   if (emailParts.length !== 2) return text;
 
   const [beforeEmail, afterEmail] = emailParts;
 
-  // Split the afterEmail part by phone
-  const phoneParts = afterEmail.split(phone);
-  if (phoneParts.length !== 2) {
-    // Phone not found, just render email
+  // Split the afterEmail part by phone (when given)
+  const phoneParts = phone ? afterEmail.split(phone) : [afterEmail];
+  if (!phone || phoneParts.length !== 2) {
+    // Phone absent or not found, just render email
     return (
       <>
         {beforeEmail}
-        <a href={`mailto:${email}`} className={styles.emailLink}>
+        <Link href={`mailto:${email}`} size="sm">
           {email}
-        </a>
+        </Link>
         {afterEmail}
       </>
     );
@@ -35,13 +36,13 @@ const renderContactLinks = (text: string, email: string, phone: string) => {
   return (
     <>
       {beforeEmail}
-      <a href={`mailto:${email}`} className={styles.emailLink}>
+      <Link href={`mailto:${email}`} size="sm">
         {email}
-      </a>
+      </Link>
       {betweenEmailPhone}
-      <a href={`tel:${phone.replace(/\s/g, "")}`} className={styles.emailLink}>
+      <Link href={`tel:${phone.replace(/\s/g, "")}`} size="sm">
         {phone}
-      </a>
+      </Link>
       {afterPhone}
     </>
   );
@@ -109,7 +110,10 @@ export function PrivacyPolicyPage() {
           {t("privacyPolicyControllerTitle")}
         </Title>
         <Text as="p" size="xs" className={styles.preLine}>
-          {t("privacyPolicyControllerBody")}
+          {renderContactLinks(
+            t("privacyPolicyControllerBody"),
+            "mail@digitaltableteur.com",
+          )}
         </Text>
       </Section>
 

--- a/nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx
+++ b/nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import Button from "@dt/Button";
 import Icon from "@dt/Icon";
+import List from "@dt/List";
 import Text from "@dt/Text";
 import Title from "@dt/Title";
 import styles from "../AiUsagePage/AiUsagePage.module.css";
@@ -162,26 +163,14 @@ export function PrivacyPolicyPage({ onBack }: { onBack?: () => void }) {
           {t("privacyPolicyContactFormSubtitle")}
         </Title>
         <Text as="p" size="xs">{t("privacyPolicyContactFormIntro")}</Text>
-        <ul>
-          {whatWeCollect.map((key) => (
-            <li key={key}>
-              <Text as="p" size="xs">{t(key)}</Text>
-            </li>
-          ))}
-        </ul>
+        <List as="ul" size="xs" listStyleType="none" items={whatWeCollect.map((key) => t(key))} />
         <Text as="p" size="xs">{t("privacyPolicyContactFormUsage")}</Text>
 
         <Title level={3} size="xxs">
           {t("privacyPolicyWebsiteVisitorsSubtitle")}
         </Title>
         <Text as="p" size="xs">{t("privacyPolicyWebsiteVisitorsIntro")}</Text>
-        <ul>
-          {websiteVisitors.map((key) => (
-            <li key={key}>
-              <Text as="p" size="xs">{t(key)}</Text>
-            </li>
-          ))}
-        </ul>
+        <List as="ul" size="xs" listStyleType="none" items={websiteVisitors.map((key) => t(key))} />
         <Text as="p" size="xs">{t("privacyPolicyWebsiteVisitorsUsage")}</Text>
       </section>
 
@@ -197,13 +186,7 @@ export function PrivacyPolicyPage({ onBack }: { onBack?: () => void }) {
           {t("privacyPolicySharingTitle")}
         </Title>
         <Text as="p" size="xs">{t("privacyPolicySharingIntro")}</Text>
-        <ul>
-          {sharingItems.map((key) => (
-            <li key={key}>
-              <Text as="p" size="xs">{t(key)}</Text>
-            </li>
-          ))}
-        </ul>
+        <List as="ul" size="xs" listStyleType="none" items={sharingItems.map((key) => t(key))} />
         <Text as="p" size="xs">{t("privacyPolicySharingFooter")}</Text>
       </section>
 
@@ -220,13 +203,7 @@ export function PrivacyPolicyPage({ onBack }: { onBack?: () => void }) {
         </Title>
         <Text as="p" size="xs">{t("privacyPolicyCookiesIntro")}</Text>
         <Text as="p" size="xs">{t("privacyPolicyCookiesTypes")}</Text>
-        <ul>
-          {cookiesItems.map((key) => (
-            <li key={key}>
-              <Text as="p" size="xs">{t(key)}</Text>
-            </li>
-          ))}
-        </ul>
+        <List as="ul" size="xs" listStyleType="none" items={cookiesItems.map((key) => t(key))} />
         <Text as="p" size="xs">{t("privacyPolicyCookiesControl")}</Text>
       </section>
 
@@ -242,13 +219,7 @@ export function PrivacyPolicyPage({ onBack }: { onBack?: () => void }) {
           {t("privacyPolicyYourRightsTitle")}
         </Title>
         <Text as="p" size="xs">{t("privacyPolicyYourRightsIntro")}</Text>
-        <ul>
-          {rights.map((key) => (
-            <li key={key}>
-              <Text as="p" size="xs">{t(key)}</Text>
-            </li>
-          ))}
-        </ul>
+        <List as="ul" size="xs" listStyleType="none" items={rights.map((key) => t(key))} />
         <Text as="p" size="xs">{t("privacyPolicyRightsExercise")}</Text>
         <Text as="p" size="xs">{t("privacyPolicyRightsComplaint")}</Text>
       </section>
@@ -258,13 +229,7 @@ export function PrivacyPolicyPage({ onBack }: { onBack?: () => void }) {
           {t("privacyPolicySecurityTitle")}
         </Title>
         <Text as="p" size="xs">{t("privacyPolicySecurityIntro")}</Text>
-        <ul>
-          {securityItems.map((key) => (
-            <li key={key}>
-              <Text as="p" size="xs">{t(key)}</Text>
-            </li>
-          ))}
-        </ul>
+        <List as="ul" size="xs" listStyleType="none" items={securityItems.map((key) => t(key))} />
         <Text as="p" size="xs">{t("privacyPolicySecurityFooter")}</Text>
       </section>
 

--- a/nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx
+++ b/nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx
@@ -128,14 +128,14 @@ export function PrivacyPolicyPage() {
           {t("privacyPolicyContactFormSubtitle")}
         </Title>
         <Text as="p" size="xs">{t("privacyPolicyContactFormIntro")}</Text>
-        <List as="ul" size="xs" listStyleType="none" items={whatWeCollect.map((key) => t(key))} />
+        <List as="ul" size="xs" listStyleType="dash" items={whatWeCollect.map((key) => t(key))} />
         <Text as="p" size="xs">{t("privacyPolicyContactFormUsage")}</Text>
 
         <Title level={3} size="xxs">
           {t("privacyPolicyWebsiteVisitorsSubtitle")}
         </Title>
         <Text as="p" size="xs">{t("privacyPolicyWebsiteVisitorsIntro")}</Text>
-        <List as="ul" size="xs" listStyleType="none" items={websiteVisitors.map((key) => t(key))} />
+        <List as="ul" size="xs" listStyleType="dash" items={websiteVisitors.map((key) => t(key))} />
         <Text as="p" size="xs">{t("privacyPolicyWebsiteVisitorsUsage")}</Text>
       </Section>
 
@@ -151,7 +151,7 @@ export function PrivacyPolicyPage() {
           {t("privacyPolicySharingTitle")}
         </Title>
         <Text as="p" size="xs">{t("privacyPolicySharingIntro")}</Text>
-        <List as="ul" size="xs" listStyleType="none" items={sharingItems.map((key) => t(key))} />
+        <List as="ul" size="xs" listStyleType="dash" items={sharingItems.map((key) => t(key))} />
         <Text as="p" size="xs">{t("privacyPolicySharingFooter")}</Text>
       </Section>
 
@@ -168,7 +168,7 @@ export function PrivacyPolicyPage() {
         </Title>
         <Text as="p" size="xs">{t("privacyPolicyCookiesIntro")}</Text>
         <Text as="p" size="xs">{t("privacyPolicyCookiesTypes")}</Text>
-        <List as="ul" size="xs" listStyleType="none" items={cookiesItems.map((key) => t(key))} />
+        <List as="ul" size="xs" listStyleType="dash" items={cookiesItems.map((key) => t(key))} />
         <Text as="p" size="xs">{t("privacyPolicyCookiesControl")}</Text>
       </Section>
 
@@ -184,7 +184,7 @@ export function PrivacyPolicyPage() {
           {t("privacyPolicyYourRightsTitle")}
         </Title>
         <Text as="p" size="xs">{t("privacyPolicyYourRightsIntro")}</Text>
-        <List as="ul" size="xs" listStyleType="none" items={rights.map((key) => t(key))} />
+        <List as="ul" size="xs" listStyleType="dash" items={rights.map((key) => t(key))} />
         <Text as="p" size="xs">{t("privacyPolicyRightsExercise")}</Text>
         <Text as="p" size="xs">{t("privacyPolicyRightsComplaint")}</Text>
       </Section>
@@ -194,7 +194,7 @@ export function PrivacyPolicyPage() {
           {t("privacyPolicySecurityTitle")}
         </Title>
         <Text as="p" size="xs">{t("privacyPolicySecurityIntro")}</Text>
-        <List as="ul" size="xs" listStyleType="none" items={securityItems.map((key) => t(key))} />
+        <List as="ul" size="xs" listStyleType="dash" items={securityItems.map((key) => t(key))} />
         <Text as="p" size="xs">{t("privacyPolicySecurityFooter")}</Text>
       </Section>
 

--- a/nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx
+++ b/nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx
@@ -3,29 +3,11 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-import Button from "@dt/Button";
-import Icon from "@dt/Icon";
 import List from "@dt/List";
 import { Section } from "@dt/Section";
 import Text from "@dt/Text";
 import Title from "@dt/Title";
 import styles from "../AiUsagePage/AiUsagePage.module.css";
-
-const renderEmailLink = (text: string, email: string) => {
-  if (!text.includes(email)) {
-    return text;
-  }
-  const [before, after = ""] = text.split(email);
-  return (
-    <>
-      {before}
-      <a href={`mailto:${email}`} className={styles.emailLink}>
-        {email}
-      </a>
-      {after}
-    </>
-  );
-};
 
 const renderContactLinks = (text: string, email: string, phone: string) => {
   // Split by email first
@@ -65,7 +47,7 @@ const renderContactLinks = (text: string, email: string, phone: string) => {
   );
 };
 
-export function PrivacyPolicyPage({ onBack }: { onBack?: () => void }) {
+export function PrivacyPolicyPage() {
   const { t } = useTranslation();
 
   const whatWeCollect = [
@@ -113,24 +95,6 @@ export function PrivacyPolicyPage({ onBack }: { onBack?: () => void }) {
 
   return (
     <div className={styles.policyPage}>
-      {onBack ? (
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            marginBottom: "1.5rem",
-          }}
-        >
-          <Button variant="secondary" size="md" onClick={onBack}>
-            <Icon
-              name="arrow-left"
-              ariaLabel={t("back")}
-              style={{ marginInlineEnd: 8 }}
-            />
-            {t("back")}
-          </Button>
-        </div>
-      ) : null}
 
       <Title level={1} size="xs">
         {t("privacyPolicyHeading")}

--- a/nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx
+++ b/nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import Button from "@dt/Button";
 import Icon from "@dt/Icon";
 import List from "@dt/List";
+import { Section } from "@dt/Section";
 import Text from "@dt/Text";
 import Title from "@dt/Title";
 import styles from "../AiUsagePage/AiUsagePage.module.css";
@@ -139,23 +140,23 @@ export function PrivacyPolicyPage({ onBack }: { onBack?: () => void }) {
         <em>{t("privacyPolicyLastUpdated")}</em>
       </Text>
 
-      <section>
+      <Section spacing="none">
         <Title level={2} size="xxs">
           {t("privacyPolicyControllerTitle")}
         </Title>
         <Text as="p" size="xs" className={styles.preLine}>
           {t("privacyPolicyControllerBody")}
         </Text>
-      </section>
+      </Section>
 
-      <section>
+      <Section spacing="none">
         <Title level={2} size="xxs">
           {t("privacyPolicyPurposeTitle")}
         </Title>
         <Text as="p" size="xs">{t("privacyPolicyPurposeBody")}</Text>
-      </section>
+      </Section>
 
-      <section>
+      <Section spacing="none">
         <Title level={2} size="xxs">
           {t("privacyPolicyWhatWeCollectTitle")}
         </Title>
@@ -172,32 +173,32 @@ export function PrivacyPolicyPage({ onBack }: { onBack?: () => void }) {
         <Text as="p" size="xs">{t("privacyPolicyWebsiteVisitorsIntro")}</Text>
         <List as="ul" size="xs" listStyleType="none" items={websiteVisitors.map((key) => t(key))} />
         <Text as="p" size="xs">{t("privacyPolicyWebsiteVisitorsUsage")}</Text>
-      </section>
+      </Section>
 
-      <section>
+      <Section spacing="none">
         <Title level={2} size="xxs">
           {t("privacyPolicyLegalBasisTitle")}
         </Title>
         <Text as="p" size="xs">{t("privacyPolicyLegalBasisBody")}</Text>
-      </section>
+      </Section>
 
-      <section>
+      <Section spacing="none">
         <Title level={2} size="xxs">
           {t("privacyPolicySharingTitle")}
         </Title>
         <Text as="p" size="xs">{t("privacyPolicySharingIntro")}</Text>
         <List as="ul" size="xs" listStyleType="none" items={sharingItems.map((key) => t(key))} />
         <Text as="p" size="xs">{t("privacyPolicySharingFooter")}</Text>
-      </section>
+      </Section>
 
-      <section>
+      <Section spacing="none">
         <Title level={2} size="xxs">
           {t("privacyPolicyTransfersTitle")}
         </Title>
         <Text as="p" size="xs">{t("privacyPolicyTransfersBody")}</Text>
-      </section>
+      </Section>
 
-      <section>
+      <Section spacing="none">
         <Title level={2} size="xxs">
           {t("privacyPolicyCookiesTitle")}
         </Title>
@@ -205,16 +206,16 @@ export function PrivacyPolicyPage({ onBack }: { onBack?: () => void }) {
         <Text as="p" size="xs">{t("privacyPolicyCookiesTypes")}</Text>
         <List as="ul" size="xs" listStyleType="none" items={cookiesItems.map((key) => t(key))} />
         <Text as="p" size="xs">{t("privacyPolicyCookiesControl")}</Text>
-      </section>
+      </Section>
 
-      <section>
+      <Section spacing="none">
         <Title level={2} size="xxs">
           {t("privacyPolicyRetentionTitle")}
         </Title>
         <Text as="p" size="xs">{t("privacyPolicyRetentionBody")}</Text>
-      </section>
+      </Section>
 
-      <section>
+      <Section spacing="none">
         <Title level={2} size="xxs">
           {t("privacyPolicyYourRightsTitle")}
         </Title>
@@ -222,25 +223,25 @@ export function PrivacyPolicyPage({ onBack }: { onBack?: () => void }) {
         <List as="ul" size="xs" listStyleType="none" items={rights.map((key) => t(key))} />
         <Text as="p" size="xs">{t("privacyPolicyRightsExercise")}</Text>
         <Text as="p" size="xs">{t("privacyPolicyRightsComplaint")}</Text>
-      </section>
+      </Section>
 
-      <section>
+      <Section spacing="none">
         <Title level={2} size="xxs">
           {t("privacyPolicySecurityTitle")}
         </Title>
         <Text as="p" size="xs">{t("privacyPolicySecurityIntro")}</Text>
         <List as="ul" size="xs" listStyleType="none" items={securityItems.map((key) => t(key))} />
         <Text as="p" size="xs">{t("privacyPolicySecurityFooter")}</Text>
-      </section>
+      </Section>
 
-      <section>
+      <Section spacing="none">
         <Title level={2} size="xxs">
           {t("privacyPolicyChangesTitle")}
         </Title>
         <Text as="p" size="xs">{t("privacyPolicyChangesBody")}</Text>
-      </section>
+      </Section>
 
-      <section>
+      <Section spacing="none">
         <Title level={2} size="xxs">
           {t("privacyPolicyContactTitle")}
         </Title>
@@ -251,7 +252,7 @@ export function PrivacyPolicyPage({ onBack }: { onBack?: () => void }) {
             "+358 45 657 4469",
           )}
         </Text>
-      </section>
+      </Section>
     </div>
   );
 }

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-10T16:24:26.714Z",
+  "generatedAt": "2026-07-11T07:47:39.964Z",
   "summary": {
     "componentCount": 163,
     "statusCounts": {
@@ -13,7 +13,7 @@
     "catalogCompletenessPercent": 87.6,
     "codebaseComponentCount": 186,
     "usageCoveragePercent": 93.3,
-    "componentsWithProductionUsage": 46,
+    "componentsWithProductionUsage": 47,
     "notReadyForStablePromotion": false
   },
   "exportPolicy": {
@@ -79,10 +79,10 @@
     "description": "Auto-detected import evidence from app/** and nextjs-app/**. Separate from contract.consumers[], which remains the stable-promotion gate for shipping-product proof.",
     "catalogedComponents": 163,
     "withAnyUsage": 152,
-    "withProductionUsage": 46,
+    "withProductionUsage": 47,
     "uniqueImportedComponents": 152,
-    "totalEvidenceRows": 856,
-    "aliasImportFiles": 473,
+    "totalEvidenceRows": 857,
+    "aliasImportFiles": 474,
     "relativeImportFiles": 391,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
@@ -4773,8 +4773,8 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Button",
-        "importCount": 67,
-        "productionImportCount": 8,
+        "importCount": 66,
+        "productionImportCount": 7,
         "patternImportCount": 6,
         "componentImportCount": 32,
         "evidence": [
@@ -4815,12 +4815,6 @@
             "context": "production"
           },
           {
-            "path": "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/Button",
-            "context": "production"
-          },
-          {
             "path": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
             "importKind": "alias",
             "importPath": "@dt/Button",
@@ -4846,6 +4840,12 @@
           },
           {
             "path": "nextjs-app/shared/patterns/HighlightSection/HighlightSection.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Button",
+            "context": "pattern"
+          },
+          {
+            "path": "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
             "importKind": "alias",
             "importPath": "@dt/Button",
             "context": "pattern"
@@ -9888,8 +9888,8 @@
           "animations",
           "Stack",
           "Link",
-          "Badge",
-          "Checkbox"
+          "ScrollIndicator",
+          "Badge"
         ],
         "prefersOver": [],
         "declaredPropCount": 5
@@ -14750,8 +14750,8 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Icon",
-        "importCount": 75,
-        "productionImportCount": 6,
+        "importCount": 74,
+        "productionImportCount": 5,
         "patternImportCount": 5,
         "componentImportCount": 33,
         "evidence": [
@@ -14781,12 +14781,6 @@
           },
           {
             "path": "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullSvPage.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/Icon",
-            "context": "production"
-          },
-          {
-            "path": "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
             "importKind": "alias",
             "importPath": "@dt/Icon",
             "context": "production"
@@ -14823,6 +14817,12 @@
           },
           {
             "path": "nextjs-app/shared/components/Accordion/Accordion.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Icon",
+            "context": "component"
+          },
+          {
+            "path": "nextjs-app/shared/components/AlertBanner/AlertBanner.tsx",
             "importKind": "alias",
             "importPath": "@dt/Icon",
             "context": "component"
@@ -17139,7 +17139,8 @@
               "lower-alpha",
               "upper-alpha",
               "lower-roman",
-              "upper-roman"
+              "upper-roman",
+              "dash"
             ]
           },
           "spacing": {
@@ -17236,11 +17237,17 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/List",
-        "importCount": 3,
-        "productionImportCount": 0,
+        "importCount": 4,
+        "productionImportCount": 1,
         "patternImportCount": 2,
         "componentImportCount": 1,
         "evidence": [
+          {
+            "path": "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/List",
+            "context": "production"
+          },
           {
             "path": "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx",
             "importKind": "alias",
@@ -17322,7 +17329,8 @@
               "lower-alpha",
               "upper-alpha",
               "lower-roman",
-              "upper-roman"
+              "upper-roman",
+              "dash"
             ]
           },
           "spacing": {
@@ -17375,8 +17383,9 @@
           "Bypass design tokens or skip forced-colors verification at beta."
         ],
         "composesWith": [
+          "Text",
           "Title",
-          "Text"
+          "Section"
         ],
         "prefersOver": [],
         "declaredPropCount": 9
@@ -23957,11 +23966,17 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Section",
-        "importCount": 21,
-        "productionImportCount": 1,
+        "importCount": 22,
+        "productionImportCount": 2,
         "patternImportCount": 20,
         "componentImportCount": 0,
         "evidence": [
+          {
+            "path": "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Section",
+            "context": "production"
+          },
           {
             "path": "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
             "importKind": "relative",
@@ -24024,12 +24039,6 @@
           },
           {
             "path": "nextjs-app/shared/patterns/ManifestoSection/ManifestoSection.tsx",
-            "importKind": "relative",
-            "importPath": "../../components/Section",
-            "context": "pattern"
-          },
-          {
-            "path": "nextjs-app/shared/patterns/ProjectDetailTemplate/ProjectDetailTemplate.tsx",
             "importKind": "relative",
             "importPath": "../../components/Section",
             "context": "pattern"
@@ -24105,10 +24114,10 @@
         "composesWith": [
           "Container",
           "animations",
+          "Title",
           "BlogCategoryFilter",
           "BlogGrid",
-          "Pagination",
-          "EnhancedArticleCard"
+          "Pagination"
         ],
         "prefersOver": [],
         "declaredPropCount": 6
@@ -29599,13 +29608,19 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Text",
-        "importCount": 80,
-        "productionImportCount": 19,
+        "importCount": 81,
+        "productionImportCount": 20,
         "patternImportCount": 10,
         "componentImportCount": 27,
         "evidence": [
           {
             "path": "nextjs-app/shared/components/pages/Colophon/ColophonPage.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Text",
+            "context": "production"
+          },
+          {
+            "path": "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
             "importKind": "alias",
             "importPath": "@dt/Text",
             "context": "production"
@@ -29666,12 +29681,6 @@
           },
           {
             "path": "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/Text",
-            "context": "production"
-          },
-          {
-            "path": "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx",
             "importKind": "alias",
             "importPath": "@dt/Text",
             "context": "production"

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,19 +1,19 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-11T07:47:39.964Z",
+  "generatedAt": "2026-07-11T07:57:15.091Z",
   "summary": {
-    "componentCount": 163,
+    "componentCount": 164,
     "statusCounts": {
       "beta": 48,
       "stable": 89,
-      "alpha": 25,
+      "alpha": 26,
       "deprecated": 1
     },
     "honestBetaDocDebt": 0,
-    "catalogCompletenessPercent": 87.6,
-    "codebaseComponentCount": 186,
-    "usageCoveragePercent": 93.3,
-    "componentsWithProductionUsage": 47,
+    "catalogCompletenessPercent": 87.7,
+    "codebaseComponentCount": 187,
+    "usageCoveragePercent": 92.7,
+    "componentsWithProductionUsage": 48,
     "notReadyForStablePromotion": false
   },
   "exportPolicy": {
@@ -57,15 +57,15 @@
   },
   "catalogCoverage": {
     "description": "Catalog completeness across the codebase. componentCount above is the catalog count; this block reveals how much of the codebase that catalog actually represents.",
-    "totalComponentsInCodebase": 186,
-    "inCatalog": 163,
+    "totalComponentsInCodebase": 187,
+    "inCatalog": 164,
     "outOfCatalog": 23,
-    "catalogCompletenessPercent": 87.6,
+    "catalogCompletenessPercent": 87.7,
     "artifactCoverage": {
-      "stories": 147,
-      "tests": 146,
-      "mdx": 5,
-      "spec": 163
+      "stories": 148,
+      "tests": 147,
+      "mdx": 6,
+      "spec": 164
     },
     "outOfCatalogByBucket": {
       "catalog-gap": 0,
@@ -77,12 +77,12 @@
   },
   "usageCoverage": {
     "description": "Auto-detected import evidence from app/** and nextjs-app/**. Separate from contract.consumers[], which remains the stable-promotion gate for shipping-product proof.",
-    "catalogedComponents": 163,
+    "catalogedComponents": 164,
     "withAnyUsage": 152,
-    "withProductionUsage": 47,
+    "withProductionUsage": 48,
     "uniqueImportedComponents": 152,
-    "totalEvidenceRows": 857,
-    "aliasImportFiles": 474,
+    "totalEvidenceRows": 859,
+    "aliasImportFiles": 476,
     "relativeImportFiles": 391,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
@@ -102,14 +102,14 @@
   "dsharpParity": {
     "description": "Comparison against DSharp as of 2026-05-26. Breadth is close, maturity is not. This block walks back the earlier parity overclaim.",
     "contractCount": {
-      "digitaltableteur": 163,
+      "digitaltableteur": 164,
       "dsharp": 112
     },
     "statusMix": {
       "digitaltableteur": {
         "beta": 48,
         "stable": 89,
-        "alpha": 25,
+        "alpha": 26,
         "deprecated": 1
       },
       "dsharp": {
@@ -3168,8 +3168,8 @@
           "FlexBox",
           "Link",
           "Button",
-          "Checkbox",
-          "TextArea"
+          "Grid",
+          "Checkbox"
         ],
         "prefersOver": [],
         "declaredPropCount": 11
@@ -9889,7 +9889,7 @@
           "Stack",
           "Link",
           "ScrollIndicator",
-          "Badge"
+          "BlogCategoryFilter"
         ],
         "prefersOver": [],
         "declaredPropCount": 5
@@ -16604,11 +16604,17 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Link",
-        "importCount": 14,
-        "productionImportCount": 0,
+        "importCount": 15,
+        "productionImportCount": 1,
         "patternImportCount": 2,
         "componentImportCount": 11,
         "evidence": [
+          {
+            "path": "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Link",
+            "context": "production"
+          },
           {
             "path": "nextjs-app/shared/patterns/Footer/Footer.tsx",
             "importKind": "alias",
@@ -16671,12 +16677,6 @@
           },
           {
             "path": "nextjs-app/shared/components/SiteTree/SiteTree.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/Link",
-            "context": "component"
-          },
-          {
-            "path": "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx",
             "importKind": "alias",
             "importPath": "@dt/Link",
             "context": "component"
@@ -16747,12 +16747,12 @@
           "override the underline via inline styles; the token-driven treatment"
         ],
         "composesWith": [
+          "Text",
           "Badge",
+          "Title",
           "Checkbox",
           "TextInput",
-          "Text",
-          "Button",
-          "Grid"
+          "Button"
         ],
         "prefersOver": [
           "Button with href for body-copy links"
@@ -17385,6 +17385,7 @@
         "composesWith": [
           "Text",
           "Title",
+          "Link",
           "Section"
         ],
         "prefersOver": [],
@@ -29608,7 +29609,7 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Text",
-        "importCount": 81,
+        "importCount": 82,
         "productionImportCount": 20,
         "patternImportCount": 10,
         "componentImportCount": 27,
@@ -30542,8 +30543,8 @@
           "Button",
           "TextArea",
           "Badge",
-          "Checkbox",
-          "CheckboxGroup"
+          "CheckboxGroup",
+          "Checkbox"
         ],
         "prefersOver": [],
         "declaredPropCount": 13
@@ -30755,6 +30756,195 @@
         ],
         "prefersOver": [],
         "declaredPropCount": 2
+      }
+    },
+    {
+      "name": "Timestamp",
+      "contract": {
+        "$schema": "../../../scripts/design-system/contract.schema.json",
+        "name": "Timestamp",
+        "tier": "atom",
+        "group": "display",
+        "status": "alpha",
+        "description": "Formats a date or time value into human-readable text: relative for recency, absolute for precision, or auto to switch between them. Modeled on the Astryx Timestamp reference.",
+        "figma": null,
+        "radixPrimitive": null,
+        "element": "time",
+        "variants": {
+          "size": {
+            "values": [
+              "xxs",
+              "xs",
+              "s",
+              "m",
+              "l",
+              "xl",
+              "xxl"
+            ],
+            "default": "s",
+            "propSourced": true
+          },
+          "tone": {
+            "values": [
+              "default",
+              "muted"
+            ],
+            "default": "muted",
+            "propSourced": true
+          }
+        },
+        "slots": [],
+        "asChild": false,
+        "subParts": [],
+        "requiredStories": [
+          "Default",
+          "Playground",
+          "Example",
+          "ForcedColors"
+        ],
+        "a11y": {
+          "keyboard": [],
+          "ariaRequirements": [
+            "Renders a semantic <time> element with a machine-readable dateTime attribute.",
+            "Relative output carries the full date as a native tooltip (title) so the precise moment stays discoverable."
+          ],
+          "reducedMotion": true,
+          "reviewed": false,
+          "forcedColorsVerified": false
+        },
+        "tokens": {
+          "colors": [
+            "--color-text",
+            "--color-muted"
+          ],
+          "spacing": []
+        },
+        "lightDarkVerified": false
+      },
+      "spec": "# Timestamp\n\n## Intent\nTODO: What job does Timestamp perform for users?\n\n## Interaction contract\n- Keyboard: TODO\n- Pointer: TODO\n- Screen readers: TODO\n\n## Do / don't\n- Do: TODO\n- Don't: TODO\n\n## Design notes\n- Tokens: TODO\n- Figma: TODO\n",
+      "documentationDebt": false,
+      "usage": {
+        "publicImport": "@dt/Timestamp",
+        "importCount": 0,
+        "productionImportCount": 0,
+        "patternImportCount": 0,
+        "componentImportCount": 0,
+        "evidence": []
+      },
+      "agent": {
+        "preferredImport": "@dt/Timestamp",
+        "intent": "Formats a date or time value into human-readable text: relative for recency, absolute for precision, or auto to switch between them. Modeled on the Astryx Timestamp reference.",
+        "props": {
+          "value": {
+            "optional": false,
+            "type": "string | number | Date"
+          },
+          "format": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "auto",
+              "date",
+              "time",
+              "relative",
+              "date_time",
+              "system_date",
+              "system_date_time",
+              "system_time"
+            ]
+          },
+          "autoThreshold": {
+            "optional": true,
+            "type": "number"
+          },
+          "size": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "s",
+              "xl",
+              "xs",
+              "xxs",
+              "m",
+              "l",
+              "xxl"
+            ]
+          },
+          "tone": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "default",
+              "muted"
+            ]
+          },
+          "showTimezone": {
+            "optional": true,
+            "type": "boolean"
+          },
+          "tooltip": {
+            "optional": true,
+            "type": "boolean"
+          },
+          "live": {
+            "optional": true,
+            "type": "boolean"
+          },
+          "now": {
+            "optional": true,
+            "type": "string | number | Date"
+          },
+          "locale": {
+            "optional": true,
+            "type": "string"
+          },
+          "className": {
+            "optional": true,
+            "type": "string"
+          }
+        },
+        "variants": {
+          "size": {
+            "values": [
+              "s",
+              "xl",
+              "xs",
+              "xxs",
+              "m",
+              "l",
+              "xxl"
+            ],
+            "default": "s"
+          },
+          "tone": {
+            "values": [
+              "default",
+              "muted"
+            ],
+            "default": "default"
+          }
+        },
+        "cvaVariants": {},
+        "variantsFnName": null,
+        "useWhen": [],
+        "avoidWhen": [],
+        "requiredA11y": [
+          "Renders a semantic <time> element with a machine-readable dateTime attribute.",
+          "Relative output carries the full date as a native tooltip (title) so the precise moment stays discoverable."
+        ],
+        "keyboard": [],
+        "compositionRules": [],
+        "canonicalExamples": [
+          "Default",
+          "Playground",
+          "Example",
+          "ForcedColors"
+        ],
+        "replacementFor": [],
+        "forbiddenUse": [],
+        "composesWith": [],
+        "prefersOver": [],
+        "declaredPropCount": 11
       }
     },
     {

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-11T07:47:39.691Z",
+  "generatedAt": "2026-07-11T07:57:14.817Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -908,8 +908,8 @@
         "FlexBox",
         "Link",
         "Button",
-        "Checkbox",
-        "TextArea"
+        "Grid",
+        "Checkbox"
       ],
       "prefersOver": [],
       "declaredPropCount": 11
@@ -3054,7 +3054,7 @@
         "Stack",
         "Link",
         "ScrollIndicator",
-        "Badge"
+        "BlogCategoryFilter"
       ],
       "prefersOver": [],
       "declaredPropCount": 5
@@ -5083,12 +5083,12 @@
         "override the underline via inline styles; the token-driven treatment"
       ],
       "composesWith": [
+        "Text",
         "Badge",
+        "Title",
         "Checkbox",
         "TextInput",
-        "Text",
-        "Button",
-        "Grid"
+        "Button"
       ],
       "prefersOver": [
         "Button with href for body-copy links"
@@ -5294,6 +5294,7 @@
       "composesWith": [
         "Text",
         "Title",
+        "Link",
         "Section"
       ],
       "prefersOver": [],
@@ -9489,8 +9490,8 @@
         "Button",
         "TextArea",
         "Badge",
-        "Checkbox",
-        "CheckboxGroup"
+        "CheckboxGroup",
+        "Checkbox"
       ],
       "prefersOver": [],
       "declaredPropCount": 13
@@ -9544,6 +9545,121 @@
       ],
       "prefersOver": [],
       "declaredPropCount": 2
+    },
+    "Timestamp": {
+      "preferredImport": "@dt/Timestamp",
+      "intent": "Formats a date or time value into human-readable text: relative for recency, absolute for precision, or auto to switch between them. Modeled on the Astryx Timestamp reference.",
+      "props": {
+        "value": {
+          "optional": false,
+          "type": "string | number | Date"
+        },
+        "format": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "auto",
+            "date",
+            "time",
+            "relative",
+            "date_time",
+            "system_date",
+            "system_date_time",
+            "system_time"
+          ]
+        },
+        "autoThreshold": {
+          "optional": true,
+          "type": "number"
+        },
+        "size": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "s",
+            "xl",
+            "xs",
+            "xxs",
+            "m",
+            "l",
+            "xxl"
+          ]
+        },
+        "tone": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "default",
+            "muted"
+          ]
+        },
+        "showTimezone": {
+          "optional": true,
+          "type": "boolean"
+        },
+        "tooltip": {
+          "optional": true,
+          "type": "boolean"
+        },
+        "live": {
+          "optional": true,
+          "type": "boolean"
+        },
+        "now": {
+          "optional": true,
+          "type": "string | number | Date"
+        },
+        "locale": {
+          "optional": true,
+          "type": "string"
+        },
+        "className": {
+          "optional": true,
+          "type": "string"
+        }
+      },
+      "variants": {
+        "size": {
+          "values": [
+            "s",
+            "xl",
+            "xs",
+            "xxs",
+            "m",
+            "l",
+            "xxl"
+          ],
+          "default": "s"
+        },
+        "tone": {
+          "values": [
+            "default",
+            "muted"
+          ],
+          "default": "default"
+        }
+      },
+      "cvaVariants": {},
+      "variantsFnName": null,
+      "useWhen": [],
+      "avoidWhen": [],
+      "requiredA11y": [
+        "Renders a semantic <time> element with a machine-readable dateTime attribute.",
+        "Relative output carries the full date as a native tooltip (title) so the precise moment stays discoverable."
+      ],
+      "keyboard": [],
+      "compositionRules": [],
+      "canonicalExamples": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+      ],
+      "replacementFor": [],
+      "forbiddenUse": [],
+      "composesWith": [],
+      "prefersOver": [],
+      "declaredPropCount": 11
     },
     "Title": {
       "preferredImport": "@dt/Title",

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-10T08:10:01.682Z",
+  "generatedAt": "2026-07-11T07:47:39.691Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -3053,8 +3053,8 @@
         "animations",
         "Stack",
         "Link",
-        "Badge",
-        "Checkbox"
+        "ScrollIndicator",
+        "Badge"
       ],
       "prefersOver": [],
       "declaredPropCount": 5
@@ -5238,7 +5238,8 @@
             "lower-alpha",
             "upper-alpha",
             "lower-roman",
-            "upper-roman"
+            "upper-roman",
+            "dash"
           ]
         },
         "spacing": {
@@ -5291,8 +5292,9 @@
         "Bypass design tokens or skip forced-colors verification at beta."
       ],
       "composesWith": [
+        "Text",
         "Title",
-        "Text"
+        "Section"
       ],
       "prefersOver": [],
       "declaredPropCount": 9
@@ -7416,10 +7418,10 @@
       "composesWith": [
         "Container",
         "animations",
+        "Title",
         "BlogCategoryFilter",
         "BlogGrid",
-        "Pagination",
-        "EnhancedArticleCard"
+        "Pagination"
       ],
       "prefersOver": [],
       "declaredPropCount": 6

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -8099,7 +8099,7 @@
         },
         {
           "name": "listStyleType",
-          "type": "none | decimal | circle | square | disc | decimal-leading-zero | lower-alpha | upper-alpha | lower-roman | upper-roman",
+          "type": "none | decimal | circle | square | disc | decimal-leading-zero | lower-alpha | upper-alpha | lower-roman | upper-roman | dash",
           "required": false
         },
         {
@@ -8166,7 +8166,8 @@
             "lower-alpha",
             "upper-alpha",
             "lower-roman",
-            "upper-roman"
+            "upper-roman",
+            "dash"
           ]
         },
         "spacing": {

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -14598,6 +14598,30 @@
       },
       "examples": []
     },
+    "Timestamp": {
+      "name": "Timestamp",
+      "group": "display",
+      "tier": 2,
+      "status": "alpha",
+      "description": "Formats a date or time value into human-readable text: relative for recency, absolute for precision, or auto to switch between them. Modeled on the Astryx Timestamp reference.",
+      "dense": "",
+      "keywords": [],
+      "importLine": "import Timestamp from \"@dt/Timestamp\";",
+      "keyProps": [],
+      "props": {},
+      "composesWith": [],
+      "prefersOver": [],
+      "forbiddenUse": [],
+      "usage": null,
+      "tokens": {
+        "colors": [
+          "--color-text",
+          "--color-muted"
+        ],
+        "spacing": []
+      },
+      "examples": []
+    },
     "Title": {
       "name": "Title",
       "group": "display",

--- a/nextjs-app/shared/locales/en/translation.json
+++ b/nextjs-app/shared/locales/en/translation.json
@@ -740,7 +740,7 @@
   "aiPolicyContactBody": "For questions, requests, or concerns about this AI use & transparency statement, contact: mail@digitaltableteur.com or +358 45 657 4469",
   "privacyPolicyHeading": "Privacy Policy",
   "privacyPolicyIntro": "Digitaltableteur respects your privacy and is committed to protecting your personal data. This policy explains what information we collect, how we use it, and your rights under the General Data Protection Regulation (GDPR) and other applicable data protection laws.",
-  "privacyPolicyLastUpdated": "Last updated: 29 November 2025",
+  "privacyPolicyLastUpdatedLabel": "Last updated:",
   "privacyPolicyControllerTitle": "Controller",
   "privacyPolicyControllerBody": "Petri Lahdelma (Digitaltableteur)\nHelsinki, Finland\nEmail: mail@digitaltableteur.com",
   "privacyPolicyPurposeTitle": "What is this policy for?",

--- a/nextjs-app/shared/locales/fi/translation.json
+++ b/nextjs-app/shared/locales/fi/translation.json
@@ -743,7 +743,7 @@
   "aiPolicyContactBody": "Kysymyksiä, pyyntöjä tai huolia tästä tekoälyn käyttö & läpinäkyvyysselosteesta, ota yhteyttä: mail@digitaltableteur.com tai +358 45 657 4469",
   "privacyPolicyHeading": "Tietosuojalauseke",
   "privacyPolicyIntro": "Digitaltableteur kunnioittaa yksityisyyttäsi ja sitoutuu suojelemaan henkilötietojasi. Tämä käytäntö selittää, mitä tietoja keräämme, miten niitä käytämme ja oikeutesi yleisen tietosuoja-asetuksen (GDPR) ja muiden sovellettavien tietosuojalakien mukaisesti.",
-  "privacyPolicyLastUpdated": "Viimeksi päivitetty: 29. marraskuuta 2025",
+  "privacyPolicyLastUpdatedLabel": "Viimeksi päivitetty:",
   "privacyPolicyControllerTitle": "Rekisterinpitäjä",
   "privacyPolicyControllerBody": "Petri Lahdelma (Digitaltableteur)\nHelsinki, Suomi\nSähköposti: mail@digitaltableteur.com",
   "privacyPolicyPurposeTitle": "Mitä tämä käytäntö on?",

--- a/nextjs-app/shared/locales/sv/translation.json
+++ b/nextjs-app/shared/locales/sv/translation.json
@@ -744,7 +744,7 @@
   "privacyPolicyMetaTitle": "Integritetspolicy",
   "privacyPolicyMetaDescription": "Digitaltableteurs integritetspolicy beskriver hur vi behandlar personuppgifter i enlighet med GDPR (dataskyddsförordningen).",
   "privacyPolicyHeading": "Integritetspolicy",
-  "privacyPolicyLastUpdated": "Senast uppdaterad: 29 november 2025",
+  "privacyPolicyLastUpdatedLabel": "Senast uppdaterad:",
   "privacyPolicyIntro": "Digitaltableteur, driven av Petri Lahdelma, respekterar din integritet och åtar sig att skydda dina personuppgifter i enlighet med EU:s allmänna dataskyddsförordning (GDPR) och finsk dataskyddslagstiftning. Denna policy förklarar vilka data vi samlar in, varför vi samlar in dem och dina rättigheter.",
   "privacyPolicyControllerTitle": "Personuppgiftsansvarig",
   "privacyPolicyControllerBody": "Petri Lahdelma (Digitaltableteur)\nHelsingfors, Finland\nE-post: mail@digitaltableteur.com",

--- a/scripts/design-system/dogfood-ratchet.baseline.json
+++ b/scripts/design-system/dogfood-ratchet.baseline.json
@@ -441,10 +441,6 @@
       "rawElements": 1,
       "utilityLines": 0
     },
-    "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx": {
-      "rawElements": 10,
-      "utilityLines": 0
-    },
     "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx": {
       "rawElements": 1,
       "utilityLines": 0


### PR DESCRIPTION
## Summary
First view executed under [full-consumption-mandate.md](../blob/main/docs/design-system/full-consumption-mandate.md) with the preview-driven loop (live browser side by side, one component per change, measured parity before/after each swap). **One PR per view, one commit per change** (10 commits).

- `<p>` ×29 → `Text as="p" size="xs"` (parity: identical at desktop; DS fluid ramp below)
- **DS List bug found + fixed**: default `max-inline-size: 20ch` + `hyphens:auto` forced narrow hyphenated columns; both existing consumers already overrode it (verified live byte-identical after removal)
- `<ul>` ×6 → `List` (indent/margins/spacing measured identical)
- `<section>` ×12 → `Section spacing="none"` (2rem rhythm, zero padding, bg token matches body in all themes)
- dead `onBack` affordance + `renderEmailLink` deleted (single consumer never passed it; removes raw div + 2 inline styles); test updated
- **List gains `listStyleType="dash"`** (em-dash string marker, additive) — owner call; page lists use it
- contact + controller email/tel → **DS Link** (mailto/tel are non-external: no icon; controller email newly linked per owner call)
- **NEW: Timestamp atom (alpha)** modeled on [Astryx Timestamp](https://astryx.atmeta.com/components/Timestamp): Intl-localized relative/auto/date/date_time/time/system_* formats, timezone suffix, full-date tooltip on relative, live ticking, deterministic `now` prop, semantic `<time dateTime>` with suppressHydrationWarning; 10 unit tests incl. axe
- "Last updated" line → label-only i18n key (EN/FI/SV) + `<Timestamp format="date">` (renders locale-correct short-month date)
- dogfood ratchet: **PrivacyPolicyPage cleared, 10 raw elements → 0** (baseline 303 → 293)

Remaining on this page (not counted by the ratchet, awaiting owner calls): the `.policyPage` wrapper div + page stylesheet vs Container (600 vs 640px measure), Link inherit-size for inline copy on mobile.

## Verification
Every swap measured live in the preview (computed styles + screenshots) before commit; full gate: typecheck ✓ lint ✓ lint:css ✓ vitest 2242/2242 ✓ build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Timestamp component supporting relative, date, time, timezone, localization, tooltips, and live updates.
  * Added dash-style list markers.
* **Enhancements**
  * Improved list text wrapping for better readability.
  * Updated the Privacy Policy page with consistent design-system components, semantic dates, translated labels, and linked contact details.
* **Documentation**
  * Added Timestamp documentation, usage examples, accessibility guidance, and Storybook stories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->