### PR TITLE
fix(design-system): dash list markers no longer overflow the list's left edge

### DIFF
--- a/nextjs-app/shared/components/List/List.module.css
+++ b/nextjs-app/shared/components/List/List.module.css
@@ -16,6 +16,13 @@
   overflow-wrap: break-word;
 }
 
+/* The em-dash string marker renders outside the li box and is wider than the
+   16px default padding, so it would hang past the list's left edge.
+   Font-relative padding because marker width tracks the type size. */
+.markerDash {
+  padding-inline-start: 2em;
+}
+
 /* Spacing classes */
 .spacingCompact li {
   margin-block-end: var(--space-internal-4);

--- a/nextjs-app/shared/components/List/List.test.tsx
+++ b/nextjs-app/shared/components/List/List.test.tsx
@@ -66,6 +66,13 @@ describe("List", () => {
     expect(container.firstChild).toHaveStyle({ listStyleType: '"— "' });
   });
 
+  it("gives the dash marker enough inline padding to stay inside the list box", () => {
+    const { container } = render(<List items={items} listStyleType="dash" />);
+    expect((container.firstChild as HTMLElement).className).toMatch(/markerDash/);
+    const { container: plain } = render(<List items={items} />);
+    expect((plain.firstChild as HTMLElement).className).not.toMatch(/markerDash/);
+  });
+
   it("applies custom inline styles", () => {
     const { container } = render(
       <List items={items} style={{ color: "red" }} />,

--- a/nextjs-app/shared/components/List/List.tsx
+++ b/nextjs-app/shared/components/List/List.tsx
@@ -97,7 +97,11 @@ export const List = React.forwardRef<
   return (
     <Tag
       ref={ref}
-      className={`${styles.list} ${sizeClass} ${lineHeightClass} ${spacingClass} ${className}`.trim()}
+      className={`${styles.list} ${sizeClass} ${lineHeightClass} ${spacingClass} ${
+        listStyleType === "dash" ? styles.markerDash : ""
+      } ${className}`
+        .replace(/\s+/g, " ")
+        .trim()}
       style={combinedStyle}
       role={role}
     >


### PR DESCRIPTION
## Summary
Owner-reported: the em-dash markers hung left of the content column. Root cause: string markers render **outside** the li box, and `— ` is wider than List's 16px default `padding-inline-start`, so the marker painted past the ul's left edge (previously masked by a page-level 24px `ul` rule that #1083 retired with the rest of the page stylesheet). `listStyleType="dash"` now carries font-relative `2em` inline padding — font-relative because marker width tracks the type size. Scoped to `dash` only: `none` renders a blank marker (nothing to overflow) and ProcessBlock's lists zero their padding and draw their own ::before markers.

## Verification
- Live (fresh dev server + fresh tab, zero console errors): all six privacy-policy lists flush with the paragraph edge, 32px marker room, wrapped lines align under first-line text
- List 16/16 tests incl. new regression (markerDash class applies for dash, absent otherwise)
- Full gate: typecheck ✓ lint ✓ lint:css ✓ vitest 2248/2248 ✓ build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)