### PR TITLE
docs(design-system): Figma parity B2c+B3a — Menu, Tabs, Card, Select remodeled

### DIFF
--- a/docs/design-system/figma-parity-audit.md
+++ b/docs/design-system/figma-parity-audit.md
@@ -207,13 +207,27 @@ mockups) — out of scope, leave as-is.
   MINTED (DT / Dimension 9999, CORNER_RADIUS, var(--radius-full)), sizes 32/40/48 with 20/24/28
   icons, Icon INSTANCE_SWAP wired to all variants. Both sets verified Light + forced-Dark.
   Ceiling 38 → 37.
-- [ ] **B2c Menu (molecule-tier leftover listed under atoms drift)** — Menu align:3 variants;
-  fold into B3.
-- [ ] **B3 Molecules parity** — drifted (Tabs, Modal, Card, Select, Toast, AlertBanner, Accordion,
-  RadioGroup, SplitButton, EmptyState) + missing stable molecules (EnhancedProjectCard, List,
-  ReadingProgress, AuthorBio, LanguageSwitcher, ValueCard, Pagination, PhoneInput, Combobox,
-  MultiCombobox, ExpandableSection, FormFieldEditorial, ServiceCard, SocialShare, CategoryFilter,
-  SecureCVDownload, SiteTree, FormField).
+- [x] **B2c Menu** — DONE 2026-07-11 (folded into B3a). Menu `align` is popover PLACEMENT
+  (start|center|end, zero visual CSS) — modelled as a usage note in the component description
+  per the geometry/placement-only rule, NOT three identical variants. Icon vectors rebound to
+  color/primary (code truth: `.itemIcon` color); everything else was already bound.
+- [ ] **B3 Molecules parity** — **B3a DONE 2026-07-11 (drifted remodels: Menu, Tabs, Card,
+  Select).** Whole-file dependency scan first: only one dependent instance existed
+  (Select State=Default in an Organism — rename-safe). Tabs rebuilt as a 9-variant set
+  (Variant default|pills|underline × Size sm|md|lg, node **1211-2930**; old single component
+  381:5 deleted, contract + story URLs updated). Card remodeled in place (node id kept):
+  legacy Elevated/Outlined/Filled/Variant4 → Variant default|muted|transparent ×
+  Padding none|sm|md|lg = 12, paddings/gap bound to space/internal tokens, radius fixed 12px
+  (code hardcodes it — not a token, recorded in description). Select remodeled in place:
+  legacy State axis removed (states are props, recorded), Size sm|md|lg from Select.module.css
+  metrics, field chrome corrected to 1px color/border + radius/lg + color/white, chevron
+  color/primary (S/M/L prop values documented as aliases). All four verified in forced Dark.
+  **B3b remaining drifted:** Modal, Toast (position → component property), AlertBanner,
+  EmptyState + beta Accordion, RadioGroup, SplitButton.
+  **B3c missing stable molecules:** EnhancedProjectCard, List, ReadingProgress, AuthorBio,
+  LanguageSwitcher, ValueCard, Pagination, PhoneInput, Combobox, MultiCombobox,
+  ExpandableSection, FormFieldEditorial, ServiceCard, SocialShare, CategoryFilter,
+  SecureCVDownload, SiteTree, FormField.
 - [ ] **B4 Organisms rebind + missing** — blog/work cluster variable rebind + variants;
   ContactFormEditorial build.
 - [ ] **B5 Patterns full sets** — rebuild ContactInquiryPanel; missing stable patterns (GridBlock,

--- a/nextjs-app/shared/components/Link/Link.contract.json
+++ b/nextjs-app/shared/components/Link/Link.contract.json
@@ -96,6 +96,16 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AiUsagePage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
             "since": "2026-06-04"
         },
@@ -107,16 +117,6 @@
         {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Blog/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/SitemapPage/index.ts",
             "since": "2026-06-04"
         }
     ],

--- a/nextjs-app/shared/components/List/List.contract.json
+++ b/nextjs-app/shared/components/List/List.contract.json
@@ -55,6 +55,26 @@
     "consumers": [
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AiUsagePage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/PrivacyPolicyPage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
             "since": "2026-06-04"
         },
@@ -91,26 +111,6 @@
         {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/LlmComponentSchema/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/NewThingsCo/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx",
             "since": "2026-06-04"
         }
     ],

--- a/nextjs-app/shared/components/Section/Section.contract.json
+++ b/nextjs-app/shared/components/Section/Section.contract.json
@@ -1,219 +1,219 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-  "name": "Section",
-  "tier": "atom",
-  "group": "layout",
-  "status": "stable",
-  "description": "Semantic section wrapper with spacing and background tokens.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1178-1712",
-  "radixPrimitive": null,
-  "element": "section",
-  "variants": {
-    "spacing": {
-      "values": [
-        "none",
-        "sm",
-        "md",
-        "lg",
-        "xl",
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "name": "Section",
+    "tier": "atom",
+    "group": "layout",
+    "status": "stable",
+    "description": "Semantic section wrapper with spacing and background tokens.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1178-1712",
+    "radixPrimitive": null,
+    "element": "section",
+    "variants": {
+        "spacing": {
+            "values": [
+                "none",
+                "sm",
+                "md",
+                "lg",
+                "xl",
+                "hero",
+                "follow"
+            ],
+            "default": "md",
+            "propSourced": true
+        },
+        "background": {
+            "values": [
+                "default",
+                "muted",
+                "accent",
+                "inverse"
+            ],
+            "default": "default",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [],
+        "reducedMotion": true,
+        "reviewed": true,
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true,
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories in all four modes (plain/light/dark/forced-colors); AT snapshots refreshed compare-clean; Controls 100% operable + 0 inert. Unlike a pure wrapper, Section owns a real surface (background=inverse flips bg-foreground/text-background) — eyeballed the Backgrounds story in light and dark: default/muted/inverse track the theme and inverse contrast holds both ways. Fixed two contract defects: element was \"div\" (renders <section>) and variants was empty (spacing + background are the styling axes). 2026-07-10 — Figma component built (Atoms, node 1178-1712, parity-audit batch B2a): contract axes as variants with DT variable bindings."
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/BlogArticleMdxBody.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ServerArticleContent.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ServerArticleMain.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AboutPage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AiUsagePage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Blog/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+            "since": "2026-06-04"
+        }
+    ],
+    "schemaVersion": 2,
+    "props": {
+        "children": {
+            "optional": false,
+            "type": "ReactNode"
+        },
+        "spacing": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "sm",
+                "md",
+                "lg",
+                "none",
+                "xl",
+                "hero",
+                "follow"
+            ]
+        },
+        "background": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "muted",
+                "accent",
+                "default",
+                "inverse"
+            ]
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        },
+        "id": {
+            "optional": true,
+            "type": "string"
+        },
+        "spotlightTarget": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "Nest Sections — bands are siblings; nesting compounds paddings and backgrounds.",
+        "Use Section inside a component or card; it is page architecture, not component padding."
+    ],
+    "composesWith": [
+        "Container",
+        "Title",
+        "Grid"
+    ],
+    "displayName": "Section",
+    "keywords": [
+        "section",
+        "page band",
+        "vertical rhythm",
+        "background",
         "hero",
-        "follow"
-      ],
-      "default": "md",
-      "propSourced": true
+        "landmark"
+    ],
+    "dense": "Page band: spacing none|sm|md (default)|lg|xl + hero/follow pair (hero = roomy top tight bottom, follow = no top), background default|muted|accent|inverse; id/spotlightTarget anchors",
+    "usage": {
+        "description": "Section is the page-level band: it owns vertical rhythm (`spacing`, responsive paddings) and surface (`background`), while Container inside it owns the horizontal clamp. `hero` and `follow` are a pair — the hero band keeps a generous top and tight bottom, and the section right after uses `follow` to avoid a double gap. `inverse` flips to the dark surface with matching text tokens. Give sections an `id` when they are anchor or skip targets.",
+        "bestPractices": [
+            {
+                "guidance": true,
+                "description": "Pair spacing=\"hero\" on the page hero with spacing=\"follow\" on the next section — that is what kills the double gap."
+            },
+            {
+                "guidance": true,
+                "description": "Alternate background=\"muted\" sparingly to group related content; every-other-band zebra striping reads as noise."
+            },
+            {
+                "guidance": true,
+                "description": "Put a Container directly inside; Section handles vertical, Container horizontal."
+            },
+            {
+                "guidance": true,
+                "description": "Give anchor/deep-link targets an id, and use spotlightTarget only when the host app needs stable guided-navigation selectors."
+            },
+            {
+                "guidance": false,
+                "description": "Do not nest Sections — bands are siblings; nesting compounds paddings and backgrounds."
+            },
+            {
+                "guidance": false,
+                "description": "Do not use Section inside components or cards; it is page architecture, not component padding."
+            }
+        ]
     },
-    "background": {
-      "values": [
-        "default",
-        "muted",
-        "accent",
-        "inverse"
-      ],
-      "default": "default",
-      "propSourced": true
+    "playground": {
+        "defaults": {
+            "spacing": "md",
+            "background": "default",
+            "children": "Band content"
+        }
     }
-  },
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [],
-    "reducedMotion": true,
-    "reviewed": true,
-    "forcedColorsVerified": true,
-    "accessibilityTreeVerified": true,
-    "realBrowserForcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories in all four modes (plain/light/dark/forced-colors); AT snapshots refreshed compare-clean; Controls 100% operable + 0 inert. Unlike a pure wrapper, Section owns a real surface (background=inverse flips bg-foreground/text-background) — eyeballed the Backgrounds story in light and dark: default/muted/inverse track the theme and inverse contrast holds both ways. Fixed two contract defects: element was \"div\" (renders <section>) and variants was empty (spacing + background are the styling axes). 2026-07-10 — Figma component built (Atoms, node 1178-1712, parity-audit batch B2a): contract axes as variants with DT variable bindings."
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "consumers": [
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "app/blog/[slug]/BlogArticleMdxBody.tsx",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "app/blog/[slug]/page.tsx",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "app/blog/[slug]/ServerArticleContent.tsx",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "app/blog/[slug]/ServerArticleMain.tsx",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/pages/AboutPage/index.ts",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/pages/Blog/index.ts",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/pages/Home/HomePage.tsx",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts",
-      "since": "2026-06-04"
-    }
-  ],
-  "schemaVersion": 2,
-  "props": {
-    "children": {
-      "optional": false,
-      "type": "ReactNode"
-    },
-    "spacing": {
-      "optional": true,
-      "type": "union",
-      "values": [
-        "sm",
-        "md",
-        "lg",
-        "none",
-        "xl",
-        "hero",
-        "follow"
-      ]
-    },
-    "background": {
-      "optional": true,
-      "type": "union",
-      "values": [
-        "muted",
-        "accent",
-        "default",
-        "inverse"
-      ]
-    },
-    "className": {
-      "optional": true,
-      "type": "string"
-    },
-    "id": {
-      "optional": true,
-      "type": "string"
-    },
-    "spotlightTarget": {
-      "optional": true,
-      "type": "string"
-    }
-  },
-  "forbiddenUse": [
-    "Nest Sections — bands are siblings; nesting compounds paddings and backgrounds.",
-    "Use Section inside a component or card; it is page architecture, not component padding."
-  ],
-  "composesWith": [
-    "Container",
-    "Title",
-    "Grid"
-  ],
-  "displayName": "Section",
-  "keywords": [
-    "section",
-    "page band",
-    "vertical rhythm",
-    "background",
-    "hero",
-    "landmark"
-  ],
-  "dense": "Page band: spacing none|sm|md (default)|lg|xl + hero/follow pair (hero = roomy top tight bottom, follow = no top), background default|muted|accent|inverse; id/spotlightTarget anchors",
-  "usage": {
-    "description": "Section is the page-level band: it owns vertical rhythm (`spacing`, responsive paddings) and surface (`background`), while Container inside it owns the horizontal clamp. `hero` and `follow` are a pair — the hero band keeps a generous top and tight bottom, and the section right after uses `follow` to avoid a double gap. `inverse` flips to the dark surface with matching text tokens. Give sections an `id` when they are anchor or skip targets.",
-    "bestPractices": [
-      {
-        "guidance": true,
-        "description": "Pair spacing=\"hero\" on the page hero with spacing=\"follow\" on the next section — that is what kills the double gap."
-      },
-      {
-        "guidance": true,
-        "description": "Alternate background=\"muted\" sparingly to group related content; every-other-band zebra striping reads as noise."
-      },
-      {
-        "guidance": true,
-        "description": "Put a Container directly inside; Section handles vertical, Container horizontal."
-      },
-      {
-        "guidance": true,
-        "description": "Give anchor/deep-link targets an id, and use spotlightTarget only when the host app needs stable guided-navigation selectors."
-      },
-      {
-        "guidance": false,
-        "description": "Do not nest Sections — bands are siblings; nesting compounds paddings and backgrounds."
-      },
-      {
-        "guidance": false,
-        "description": "Do not use Section inside components or cards; it is page architecture, not component padding."
-      }
-    ]
-  },
-  "playground": {
-    "defaults": {
-      "spacing": "md",
-      "background": "default",
-      "children": "Band content"
-    }
-  }
 }

--- a/nextjs-app/shared/components/Tabs/Tabs.contract.json
+++ b/nextjs-app/shared/components/Tabs/Tabs.contract.json
@@ -5,7 +5,7 @@
     "group": "navigation",
     "status": "stable",
     "description": "Tablist navigation with keyboard support, a sliding selection indicator, and per-item icon/count.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=381-5",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1211-2930",
     "radixPrimitive": null,
     "element": "div",
     "variants": {

--- a/nextjs-app/shared/components/Tabs/Tabs.stories.tsx
+++ b/nextjs-app/shared/components/Tabs/Tabs.stories.tsx
@@ -50,7 +50,7 @@ const meta: Meta<typeof Tabs> = {
   parameters: {
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=381-5",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1211-2930",
     },
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Text/Text.contract.json
+++ b/nextjs-app/shared/components/Text/Text.contract.json
@@ -103,12 +103,12 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+            "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
             "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+            "path": "nextjs-app/shared/components/pages/AiUsagePage/index.ts",
             "since": "2026-06-04"
         }
     ],

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-11T08:14:01.960Z",
+  "generatedAt": "2026-07-11T09:36:37.548Z",
   "summary": {
     "componentCount": 164,
     "statusCounts": {
@@ -81,17 +81,17 @@
     "withAnyUsage": 153,
     "withProductionUsage": 49,
     "uniqueImportedComponents": 153,
-    "totalEvidenceRows": 861,
-    "aliasImportFiles": 478,
+    "totalEvidenceRows": 864,
+    "aliasImportFiles": 481,
     "relativeImportFiles": 391,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
   },
   "relationshipGraph": {
     "description": "Merged static composesWith policy + co-import evidence (see generate-relationship-graph.mjs).",
-    "generatedAt": "2026-07-11T08:13:59.225Z",
+    "generatedAt": "2026-07-11T09:36:34.646Z",
     "coImportMinFiles": 3,
-    "nodesWithComposesWith": 88,
+    "nodesWithComposesWith": 87,
     "regenerate": "npm run build:relationship-graph or npm run build:tokens",
     "path": "nextjs-app/shared/foundations/dist/relationship-graph.json"
   },
@@ -4773,19 +4773,13 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Button",
-        "importCount": 66,
-        "productionImportCount": 7,
+        "importCount": 65,
+        "productionImportCount": 6,
         "patternImportCount": 6,
         "componentImportCount": 32,
         "evidence": [
           {
             "path": "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/Button",
-            "context": "production"
-          },
-          {
-            "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
             "importKind": "alias",
             "importPath": "@dt/Button",
             "context": "production"
@@ -4846,6 +4840,12 @@
           },
           {
             "path": "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Button",
+            "context": "pattern"
+          },
+          {
+            "path": "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx",
             "importKind": "alias",
             "importPath": "@dt/Button",
             "context": "pattern"
@@ -9557,8 +9557,8 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Container",
-        "importCount": 32,
-        "productionImportCount": 4,
+        "importCount": 33,
+        "productionImportCount": 5,
         "patternImportCount": 23,
         "componentImportCount": 4,
         "evidence": [
@@ -9572,6 +9572,12 @@
             "path": "app/blog/[slug]/ServerRelatedPosts.tsx",
             "importKind": "relative",
             "importPath": "@/nextjs-app/shared/components/Container",
+            "context": "production"
+          },
+          {
+            "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Container",
             "context": "production"
           },
           {
@@ -9624,12 +9630,6 @@
           },
           {
             "path": "nextjs-app/shared/patterns/CTASection/CTASection.tsx",
-            "importKind": "relative",
-            "importPath": "../../components/Container",
-            "context": "pattern"
-          },
-          {
-            "path": "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx",
             "importKind": "relative",
             "importPath": "../../components/Container",
             "context": "pattern"
@@ -9887,9 +9887,9 @@
           "Section",
           "animations",
           "Link",
-          "Stack",
           "Title",
-          "ScrollIndicator"
+          "List",
+          "Text"
         ],
         "prefersOver": [],
         "declaredPropCount": 5
@@ -14750,19 +14750,13 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Icon",
-        "importCount": 74,
-        "productionImportCount": 5,
+        "importCount": 73,
+        "productionImportCount": 4,
         "patternImportCount": 5,
         "componentImportCount": 33,
         "evidence": [
           {
             "path": "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/Icon",
-            "context": "production"
-          },
-          {
-            "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
             "importKind": "alias",
             "importPath": "@dt/Icon",
             "context": "production"
@@ -14823,6 +14817,12 @@
           },
           {
             "path": "nextjs-app/shared/components/AlertBanner/AlertBanner.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Icon",
+            "context": "component"
+          },
+          {
+            "path": "nextjs-app/shared/components/Badge/Badge.tsx",
             "importKind": "alias",
             "importPath": "@dt/Icon",
             "context": "component"
@@ -16606,11 +16606,17 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Link",
-        "importCount": 15,
-        "productionImportCount": 1,
+        "importCount": 16,
+        "productionImportCount": 2,
         "patternImportCount": 2,
         "componentImportCount": 11,
         "evidence": [
+          {
+            "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Link",
+            "context": "production"
+          },
           {
             "path": "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
             "importKind": "alias",
@@ -16673,12 +16679,6 @@
           },
           {
             "path": "nextjs-app/shared/components/PersonCard/PersonCard.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/Link",
-            "context": "component"
-          },
-          {
-            "path": "nextjs-app/shared/components/SiteTree/SiteTree.tsx",
             "importKind": "alias",
             "importPath": "@dt/Link",
             "context": "component"
@@ -16753,8 +16753,8 @@
         "composesWith": [
           "Text",
           "Title",
-          "Badge",
           "Container",
+          "Badge",
           "Checkbox",
           "TextInput"
         ],
@@ -17241,11 +17241,17 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/List",
-        "importCount": 4,
-        "productionImportCount": 1,
+        "importCount": 5,
+        "productionImportCount": 2,
         "patternImportCount": 2,
         "componentImportCount": 1,
         "evidence": [
+          {
+            "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/List",
+            "context": "production"
+          },
           {
             "path": "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
             "importKind": "alias",
@@ -17391,8 +17397,8 @@
           "Title",
           "Container",
           "Link",
-          "Timestamp",
-          "Section"
+          "Section",
+          "Timestamp"
         ],
         "prefersOver": [],
         "declaredPropCount": 9
@@ -23973,11 +23979,17 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Section",
-        "importCount": 22,
-        "productionImportCount": 2,
+        "importCount": 23,
+        "productionImportCount": 3,
         "patternImportCount": 20,
         "componentImportCount": 0,
         "evidence": [
+          {
+            "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Section",
+            "context": "production"
+          },
           {
             "path": "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
             "importKind": "alias",
@@ -24040,12 +24052,6 @@
           },
           {
             "path": "nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.tsx",
-            "importKind": "relative",
-            "importPath": "../../components/Section",
-            "context": "pattern"
-          },
-          {
-            "path": "nextjs-app/shared/patterns/ManifestoSection/ManifestoSection.tsx",
             "importKind": "relative",
             "importPath": "../../components/Section",
             "context": "pattern"
@@ -24124,7 +24130,7 @@
           "Title",
           "Link",
           "List",
-          "Timestamp"
+          "Text"
         ],
         "prefersOver": [],
         "declaredPropCount": 6
@@ -24295,11 +24301,7 @@
         "forbiddenUse": [
           "Bypass design tokens or skip forced-colors verification at beta."
         ],
-        "composesWith": [
-          "Section",
-          "Container",
-          "animations"
-        ],
+        "composesWith": [],
         "prefersOver": [],
         "declaredPropCount": 3
       }
@@ -28861,7 +28863,7 @@
         "group": "navigation",
         "status": "stable",
         "description": "Tablist navigation with keyboard support, a sliding selection indicator, and per-item icon/count.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=381-5",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1211-2930",
         "radixPrimitive": null,
         "element": "div",
         "variants": {
@@ -29615,11 +29617,17 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Text",
-        "importCount": 82,
-        "productionImportCount": 20,
+        "importCount": 83,
+        "productionImportCount": 21,
         "patternImportCount": 10,
         "componentImportCount": 27,
         "evidence": [
+          {
+            "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Text",
+            "context": "production"
+          },
           {
             "path": "nextjs-app/shared/components/pages/Colophon/ColophonPage.tsx",
             "importKind": "alias",
@@ -29682,12 +29690,6 @@
           },
           {
             "path": "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/Text",
-            "context": "production"
-          },
-          {
-            "path": "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx",
             "importKind": "alias",
             "importPath": "@dt/Text",
             "context": "production"

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-11T08:14:01.688Z",
+  "generatedAt": "2026-07-11T09:36:37.279Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -3052,9 +3052,9 @@
         "Section",
         "animations",
         "Link",
-        "Stack",
         "Title",
-        "ScrollIndicator"
+        "List",
+        "Text"
       ],
       "prefersOver": [],
       "declaredPropCount": 5
@@ -5087,8 +5087,8 @@
       "composesWith": [
         "Text",
         "Title",
-        "Badge",
         "Container",
+        "Badge",
         "Checkbox",
         "TextInput"
       ],
@@ -5298,8 +5298,8 @@
         "Title",
         "Container",
         "Link",
-        "Timestamp",
-        "Section"
+        "Section",
+        "Timestamp"
       ],
       "prefersOver": [],
       "declaredPropCount": 9
@@ -7426,7 +7426,7 @@
         "Title",
         "Link",
         "List",
-        "Timestamp"
+        "Text"
       ],
       "prefersOver": [],
       "declaredPropCount": 6
@@ -7476,11 +7476,7 @@
       "forbiddenUse": [
         "Bypass design tokens or skip forced-colors verification at beta."
       ],
-      "composesWith": [
-        "Section",
-        "Container",
-        "animations"
-      ],
+      "composesWith": [],
       "prefersOver": [],
       "declaredPropCount": 3
     },


### PR DESCRIPTION
Repo side of the Figma parity B2c+B3a batch (Figma work already done in file PC2UPdYwm8qGt6ZTg0AakF, verified light + forced-Dark).

- Menu: align modelled as placement-only usage note; icon fills rebound to color/primary
- Tabs: rebuilt as a 9-variant set (Variant default|pills|underline x Size sm|md|lg), new node 1211-2930; contract + story URLs updated (old node deleted after a zero-dependents whole-file scan)
- Card: in-place remodel to Variant x Padding = 12 with space/internal bindings
- Select: State axis removed (props, not contract axes), Size sm|md|lg per CSS truth, field chrome corrected
- Consumers refresh after #1086 (AiUsagePage now consumes Link/List/Section/Text)
- figma-parity-audit.md: B2c ticked, B3a logged, B3b/B3c remainder enumerated

Gate: typecheck, lint, 2246 tests, build - all exit 0. check:figma-links ceiling untouched (no placeholder wired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)