### PR TITLE
docs(design-system): Figma parity B3b — 7 drifted molecules remodeled

### DIFF
--- a/docs/design-system/figma-parity-audit.md
+++ b/docs/design-system/figma-parity-audit.md
@@ -222,8 +222,36 @@ mockups) — out of scope, leave as-is.
   legacy State axis removed (states are props, recorded), Size sm|md|lg from Select.module.css
   metrics, field chrome corrected to 1px color/border + radius/lg + color/white, chevron
   color/primary (S/M/L prop values documented as aliases). All four verified in forced Dark.
-  **B3b remaining drifted:** Modal, Toast (position → component property), AlertBanner,
-  EmptyState + beta Accordion, RadioGroup, SplitButton.
+  **B3b DONE 2026-07-11 (drifted remodels: Modal, Toast, AlertBanner, EmptyState + beta
+  Accordion, RadioGroup, SplitButton; bonus Radio size fix).** Whole-file dependency scan
+  found ONE dependent (CodeSnippet's copySplitButton — rename-safe, SplitButton set id kept).
+  Toast in place: legacy Intent axis (incl. pre-tone Default variant, deleted) → Tone × Size
+  = 12, paddings/gap/radius bound (lg inline 20px raw — code references --space-internal-20
+  which is a PHANTOM token, no definition anywhere; fix chip spawned), font sizes button-s/m/l
+  clamp maxima 16/18/20, warning ink color/warning/text, position documented as
+  placement-only prop (Menu.align precedent). AlertBanner in place: Intent → Tone, text ink
+  rebound per-tone hardcodes → color/text (code truth), icons likewise, warning 16%/46%.
+  **NEW RECIPE CONFIRMED: variable-bound SOLID paint opacity renders correctly in the default
+  mode but is DROPPED under setExplicitVariableModeForCollection** — the color-mix() tint had
+  to move to the B2a wash idiom (opaque color/surface fill + absolute STRETCH tint rect with
+  NODE opacity 0.12/0.16 + separate border rect at 0.4/0.46); always verify tints in forced
+  Dark, the light render lies. EmptyState in place: SM/MD/LG → sm/md/lg, Title instances
+  re-propped to the xxs/xs/s contract map (were all 's' = 36px), paddings/gaps bound.
+  Modal rebuilt as Severity set **node 1222-2927** (old single 384:13 combined via
+  combineAsVariants → new id, contract + story URLs updated): 4px severity top rail,
+  semantic icon 32 (STATUS_COLORS incl. warning → color/warning/contrast), close X (muted),
+  432 dialog width (30vw code truth); plain wide dialog + isLoading/animation recorded as
+  props. Accordion rebuilt as Variant set **node 1223-2915** (contained | enclosed | divided;
+  old 381:17 combined → new id, URLs updated): chrome rebound color/primary → color/border,
+  radius/lg, chevron color/muted, trigger Satoshi Medium; type single|multiple = behavioral
+  prop. RadioGroup rebuilt as Orientation × Size = 6 set **node 1227-2963** (old 383:36 →
+  new id, URLs updated): composes the Radio atom via instance Size props, legend
+  color/title 17/600, option gap space/layout/16. Radio atom (beta, 372-27) resized in
+  place to code truth 16/20/24 (dot = size−10) + lowercase Size values; its legacy State
+  axis kept for now — full contract alignment is B6. SplitButton in place (set id kept):
+  9 → Variant × Surface × Size = 27 lowercase, surfaces driven through the composed Button
+  set instances' Surface property (visuals inherit Button code truth; menuAlign =
+  placement-only prop note). All seven verified in forced Dark.
   **B3c missing stable molecules:** EnhancedProjectCard, List, ReadingProgress, AuthorBio,
   LanguageSwitcher, ValueCard, Pagination, PhoneInput, Combobox, MultiCombobox,
   ExpandableSection, FormFieldEditorial, ServiceCard, SocialShare, CategoryFilter,

--- a/nextjs-app/shared/components/Accordion/Accordion.contract.json
+++ b/nextjs-app/shared/components/Accordion/Accordion.contract.json
@@ -5,7 +5,7 @@
     "group": "structure",
     "status": "beta",
     "description": "Coordinated disclosure group: single or multiple open sections, animated reveal, keyboard-operable triggers.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=381-17",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1223-2915",
     "radixPrimitive": null,
     "element": "div",
     "variants": {

--- a/nextjs-app/shared/components/Accordion/Accordion.stories.tsx
+++ b/nextjs-app/shared/components/Accordion/Accordion.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof Accordion> = {
   parameters: {
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=381-17",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1223-2915",
     },
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/Modal/Modal.contract.json
+++ b/nextjs-app/shared/components/Modal/Modal.contract.json
@@ -5,7 +5,7 @@
     "group": "overlay",
     "status": "stable",
     "description": "Modal dialog for confirmations, forms, and focused tasks.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=384-13",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1222-2927",
     "radixPrimitive": null,
     "element": "div",
     "variants": {

--- a/nextjs-app/shared/components/Modal/Modal.stories.tsx
+++ b/nextjs-app/shared/components/Modal/Modal.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
   parameters: {
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=384-13",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1222-2927",
     },
     contractStatus: contract.status,
     a11y: { test: "error" },

--- a/nextjs-app/shared/components/RadioGroup/RadioGroup.contract.json
+++ b/nextjs-app/shared/components/RadioGroup/RadioGroup.contract.json
@@ -5,7 +5,7 @@
     "group": "form",
     "status": "beta",
     "description": "Accessible radio button group with legend and validation.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=383-36",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1227-2963",
     "radixPrimitive": null,
     "element": "div",
     "variants": {

--- a/nextjs-app/shared/components/RadioGroup/RadioGroup.stories.tsx
+++ b/nextjs-app/shared/components/RadioGroup/RadioGroup.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
   parameters: {
     design: {
       type: "figma",
-      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=383-36",
+      url: "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1227-2963",
     },
     layout: "padded",
     contractStatus: contract.status,

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-11T10:24:57.591Z",
+  "generatedAt": "2026-07-11T10:52:16.007Z",
   "summary": {
     "componentCount": 164,
     "statusCounts": {
@@ -144,7 +144,7 @@
         "group": "structure",
         "status": "beta",
         "description": "Coordinated disclosure group: single or multiple open sections, animated reveal, keyboard-operable triggers.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=381-17",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1223-2915",
         "radixPrimitive": null,
         "element": "div",
         "variants": {
@@ -16495,6 +16495,16 @@
           },
           {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AccessibilityPage/index.ts",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
             "since": "2026-06-04"
           },
@@ -16506,16 +16516,6 @@
           {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
-            "since": "2026-06-04"
-          },
-          {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
-            "since": "2026-06-04"
-          },
-          {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Blog/index.ts",
             "since": "2026-06-04"
           }
         ],
@@ -17025,6 +17025,16 @@
         "consumers": [
           {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AccessibilityPage/index.ts",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
             "since": "2026-06-04"
           },
@@ -17071,16 +17081,6 @@
           {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Work/GarageJunction/index.ts",
-            "since": "2026-06-04"
-          },
-          {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
-            "since": "2026-06-04"
-          },
-          {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/index.ts",
             "since": "2026-06-04"
           }
         ],
@@ -18774,7 +18774,7 @@
         "group": "overlay",
         "status": "stable",
         "description": "Modal dialog for confirmations, forms, and focused tasks.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=384-13",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1222-2927",
         "radixPrimitive": null,
         "element": "div",
         "variants": {
@@ -23246,7 +23246,7 @@
         "group": "form",
         "status": "beta",
         "description": "Accessible radio button group with legend and validation.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=383-36",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1227-2963",
         "radixPrimitive": null,
         "element": "div",
         "variants": {
@@ -23854,6 +23854,16 @@
           },
           {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/AccessibilityPage/index.ts",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
             "since": "2026-06-04"
           },
@@ -23870,16 +23880,6 @@
           {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
-            "since": "2026-06-04"
-          },
-          {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Blog/index.ts",
-            "since": "2026-06-04"
-          },
-          {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Home/HomePage.tsx",
             "since": "2026-06-04"
           }
         ],
@@ -29495,12 +29495,12 @@
           },
           {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+            "path": "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
             "since": "2026-06-04"
           },
           {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/AiUsagePage/index.ts",
+            "path": "nextjs-app/shared/components/pages/AccessibilityPage/index.ts",
             "since": "2026-06-04"
           }
         ],


### PR DESCRIPTION
Figma parity batch B3b per docs/design-system/figma-parity-audit.md. Whole-file dependency scan first: one dependent instance (CodeSnippet copySplitButton, rename-safe).

**In place (ids kept):** Toast (legacy Intent/5 incl. pre-tone Default -> Tone x Size = 12, bound paddings/radius, button-s/m/l font maxima, position = placement-only prop note), AlertBanner (Intent -> Tone, per-tone hardcoded ink -> color/text, warning 16%/46%, tint moved to the wash-layer idiom), EmptyState (sm/md/lg casing, Title xxs/xs/s per contract map, bound spacing), SplitButton (9 -> Variant x Surface x Size = 27 via composed Button instances), Radio atom (16/20/24 code-truth sizes).

**Rebuilt as sets (URL swaps in this PR):** Modal -> Severity set 1222-2927 (rail + semantic icon + close X + 30vw width), Accordion -> Variant set 1223-2915 (contained|enclosed|divided, color/border chrome), RadioGroup -> Orientation x Size set 1227-2963.

**New recipe (in audit doc):** variable-bound SOLID paint opacity renders in the default mode but is DROPPED under setExplicitVariableModeForCollection — tints must use the node-opacity wash idiom; always verify in forced Dark.

**Found in passing:** --space-internal-20 is a phantom token (only reference is Toast lg padding; defined nowhere) — lg toasts render with zero padding. Fix chip spawned separately.

Local gate green: typecheck, lint, 2245 tests, build, contract-props, consumers, agent-docs. figma-links ceiling unchanged 37 (no placeholders involved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)