### PR TITLE
fix(toast): lg padding phantom token — rendered 0, now 16/24

### DIFF
--- a/docs/design-system/figma-parity-audit.md
+++ b/docs/design-system/figma-parity-audit.md
@@ -226,8 +226,11 @@ mockups) — out of scope, leave as-is.
   Accordion, RadioGroup, SplitButton; bonus Radio size fix).** Whole-file dependency scan
   found ONE dependent (CodeSnippet's copySplitButton — rename-safe, SplitButton set id kept).
   Toast in place: legacy Intent axis (incl. pre-tone Default variant, deleted) → Tone × Size
-  = 12, paddings/gap/radius bound (lg inline 20px raw — code references --space-internal-20
-  which is a PHANTOM token, no definition anywhere; fix chip spawned), font sizes button-s/m/l
+  = 12, paddings/gap/radius bound (lg inline: code referenced --space-internal-20, a PHANTOM
+  token defined nowhere — per CSS spec the whole padding declaration was invalid at
+  computed-value time and lg toasts rendered with 0 padding; fixed to --space-internal-24
+  on 2026-07-11, empirically verified 0px -> 16px/24px, Figma lg variants rebound to
+  space/internal/24 to match — the scale has no 20 step), font sizes button-s/m/l
   clamp maxima 16/18/20, warning ink color/warning/text, position documented as
   placement-only prop (Menu.align precedent). AlertBanner in place: Intent → Tone, text ink
   rebound per-tone hardcodes → color/text (code truth), icons likewise, warning 16%/46%.

--- a/nextjs-app/shared/components/Toast/Toast.module.css
+++ b/nextjs-app/shared/components/Toast/Toast.module.css
@@ -61,7 +61,7 @@
 }
 
 .toast--lg {
-  padding: var(--space-internal-16) var(--space-internal-20);
+  padding: var(--space-internal-16) var(--space-internal-24);
   font-size: var(--font-size-button-l);
 }
 


### PR DESCRIPTION
Fixes the phantom-token render bug found during Figma B3b: .toast--lg declared padding with var(--space-internal-20), which is defined nowhere (the internal scale has no 20 step). Per CSS spec the declaration is invalid at computed-value time, so lg toasts rendered with ZERO padding (the invalid declaration also overrides the base 12/16 cascade value — verified empirically in Storybook: 0px before, 16px 24px after).

Fix: --space-internal-24, keeping the padding progression monotonic (sm 8/12, md 12/16, lg 16/24). No new token minted per owner direction. Figma Toast lg variants rebound to space/internal/24; audit doc note updated.

Guardrail context: rhythmguard REPORTS missing tokens but they sit outside the --fail-on-new-drift finding set, so this class never fails a commit. Remaining true phantoms found in the same sweep (all fallback-less, all compute to 0): --space-layout-12 (PricingPageContent gaps x2, Footer margin/gap, FoundationDoc), --space-layout-56 (PricingPageContent padding-block), and the --space-md/sm/lg/xl/xs/xxl family in stories/Docs/Icons.module.css. Neither 12 nor 56 exists in the layout scale. Follow-up sweep + gate proposal in session notes.

Local gate green: typecheck, lint, 2245 tests, build; rhythm + stylelint baselines unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed large toast notifications displaying with no padding.
  * Updated large toast horizontal spacing for consistent sizing and alignment.

* **Documentation**
  * Updated the design-system audit with corrected large toast spacing values and token references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->