### PR TITLE
feat(select): export SelectOptionItem/SelectProps; cover onValueChange

### DIFF
--- a/nextjs-app/shared/components/Select/Select.test.tsx
+++ b/nextjs-app/shared/components/Select/Select.test.tsx
@@ -31,4 +31,41 @@ describe("Select", () => {
     fireEvent.change(select, { target: { value: "option2" } });
     expect(onChange).toHaveBeenCalledWith("option2");
   });
+
+  it("calls onValueChange with the selected value", () => {
+    const onValueChange = vi.fn();
+    render(
+      <Select
+        label="Test Select"
+        options={options}
+        onValueChange={onValueChange}
+      />,
+    );
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "option3" },
+    });
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange).toHaveBeenCalledWith("option3");
+  });
+
+  it("calls onValueChange before the deprecated onChange when both are given", () => {
+    const onValueChange = vi.fn();
+    const onChange = vi.fn();
+    render(
+      <Select
+        label="Test Select"
+        options={options}
+        onValueChange={onValueChange}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "option2" },
+    });
+    expect(onValueChange).toHaveBeenCalledWith("option2");
+    expect(onChange).toHaveBeenCalledWith("option2");
+    expect(onValueChange.mock.invocationCallOrder[0]).toBeLessThan(
+      onChange.mock.invocationCallOrder[0],
+    );
+  });
 });

--- a/nextjs-app/shared/components/Select/Select.tsx
+++ b/nextjs-app/shared/components/Select/Select.tsx
@@ -7,7 +7,7 @@ import Icon from "@dt/Icon";
 import { warnPropRename } from "../../utils/deprecationWarning";
 import { normalizeSizeProp, type SizeUnified } from "../../utils/sizeNormalization";
 
-interface SelectOptionItem {
+export interface SelectOptionItem {
   value: string;
   label: string;
   /** Disables this option. */

--- a/nextjs-app/shared/components/Select/index.ts
+++ b/nextjs-app/shared/components/Select/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Select";
+export type { SelectProps, SelectOptionItem } from "./Select";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -127,6 +127,10 @@ export {
   type SectionProps,
 } from "../../../nextjs-app/shared/components/Section";
 export { default as Select } from "../../../nextjs-app/shared/components/Select/Select";
+export type {
+  SelectOptionItem,
+  SelectProps,
+} from "../../../nextjs-app/shared/components/Select/Select";
 export { default as SelectOption } from "../../../nextjs-app/shared/components/Select/SelectOption";
 export {
   SkipLink,


### PR DESCRIPTION
Two gaps surfaced by the select-spec-evolution harness run, verified against source:

- **SelectOptionItem was not importable**: module-private interface + default-only folder index. Now exported from Select.tsx, the folder index (same shape as Combobox's), and @digitaltableteur/react. Type-only exports — the runtime public-api manifest is unchanged (guard verified 106 exports, package build green).
- **onValueChange had zero test coverage** — only the deprecated onChange path was tested. Added a value assertion and the documented onValueChange-before-onChange ordering guarantee (invocationCallOrder).

Local gate green: typecheck, lint, 2247 tests, build, check:react-package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `onValueChange` callback on Select components, providing the newly selected value.
  - When both callbacks are configured, `onValueChange` runs before the legacy `onChange` callback.
  - Select-related TypeScript types are now publicly available for improved component integration.

- **Tests**
  - Added coverage verifying callback behavior, selected values, and callback execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->