### PR TITLE
fix(pricing,footer): phantom --space-layout-12/-56 — collapsed spacing restored

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-07-11T10:16:28.968Z",
+  "createdAt": "2026-07-11T14:43:55.471Z",
   "directory": "nextjs-app/shared",
   "findings": [
     {
@@ -5805,8 +5805,8 @@
     {
       "column": 19,
       "file": "nextjs-app/shared/patterns/Footer/Footer.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/patterns/Footer/Footer.module.css\u001f24\u001f19\u001f6px\u001fUnexpected off-scale value \"6px\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
-      "line": 24,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/patterns/Footer/Footer.module.css\u001f45\u001f19\u001f6px\u001fUnexpected off-scale value \"6px\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
+      "line": 45,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"6px\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -5815,28 +5815,8 @@
     {
       "column": 19,
       "file": "nextjs-app/shared/patterns/Footer/Footer.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/patterns/Footer/Footer.module.css\u001f76\u001f19\u001f6px\u001fUnexpected off-scale value \"6px\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
-      "line": 76,
-      "rule": "rhythmguard/use-scale",
-      "text": "Unexpected off-scale value \"6px\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
-      "type": "off-scale",
-      "value": "6px"
-    },
-    {
-      "column": 19,
-      "file": "nextjs-app/shared/patterns/Footer/Footer.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/Footer/Footer.module.css\u001f24\u001f19\u001f6px\u001fUnexpected raw scale value \"6px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 24,
-      "rule": "rhythmguard/prefer-token",
-      "text": "Unexpected raw scale value \"6px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "type": "token-opportunity",
-      "value": "6px"
-    },
-    {
-      "column": 19,
-      "file": "nextjs-app/shared/patterns/Footer/Footer.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/Footer/Footer.module.css\u001f76\u001f19\u001f6px\u001fUnexpected raw scale value \"6px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 76,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/Footer/Footer.module.css\u001f45\u001f19\u001f6px\u001fUnexpected raw scale value \"6px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 45,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"6px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -5845,8 +5825,8 @@
     {
       "column": 21,
       "file": "nextjs-app/shared/patterns/Footer/Footer.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/Footer/Footer.module.css\u001f108\u001f21\u001f2rem\u001fUnexpected raw scale value \"2rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 108,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/Footer/Footer.module.css\u001f77\u001f21\u001f2rem\u001fUnexpected raw scale value \"2rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 77,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"2rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -7386,6 +7366,6 @@
   "formatVersion": 1,
   "summary": {
     "scaleCleanliness": 92,
-    "totalFindings": 738
+    "totalFindings": 736
   }
 }

--- a/nextjs-app/shared/patterns/Footer/Footer.module.css
+++ b/nextjs-app/shared/patterns/Footer/Footer.module.css
@@ -8,37 +8,6 @@
   text-align: left;
 }
 
-.footerLinksRow {
-  display: flex;
-  margin-block: var(--space-layout-12);
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: flex-start;
-  gap: var(--space-layout-12);
-}
-
-.footerLinksRow a {
-  position: relative;
-  text-decoration: none;
-  color: var(--inverted-text-color);
-  padding-bottom: 6px;
-}
-
-.footerLinksRow a::after {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  height: 6px;
-  background-color: var(--underline-accent-color, currentcolor);
-  transition: opacity 0.2s ease;
-  opacity: 0;
-  content: "";
-  mask-image: var(--wavy-underline-mask);
-  mask-repeat: repeat-x;
-  mask-size: 16px 6px;
-}
-
 .socialLinks {
   display: flex;
   margin-block: var(--space-layout-16);

--- a/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.module.css
+++ b/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.module.css
@@ -81,7 +81,7 @@
   }
 
   .heroBleedContent {
-    padding-block: var(--space-layout-56);
+    padding-block: var(--space-layout-64);
     padding-inline: var(--page-margin-desktop);
   }
 }
@@ -311,7 +311,7 @@
   display: flex;
   flex-direction: column;
   padding: var(--space-layout-24);
-  gap: var(--space-layout-12);
+  gap: var(--space-layout-16);
   border: 1px solid var(--color-border);
   border-radius: var(--space-layout-16);
 }
@@ -402,7 +402,7 @@
   display: inline-flex;
   flex-wrap: nowrap;
   align-items: center;
-  gap: var(--space-layout-12);
+  gap: var(--space-layout-8);
   min-width: 0;
 }
 


### PR DESCRIPTION
Scoped phantom-token sweep (follow-up to #1090). Neither 12 nor 56 exists in the layout scale; every fallback-less reference computed to 0 per the invalid-at-computed-value rule.

- **Pricing hero (desktop ≥1024)**: the phantom layout-56 override cancelled the valid mobile layout-48 padding — desktop rendered padding-block 0, LESS than mobile. Now layout-64, the intended step up from the base 48. Measured 0px -> 64px at 1280w.
- **packageCard gap**: collapsed -> 16px (layout-16, inside the card's layout-24 padding).
- **aaasTriggerHeading gap**: collapsed -> 8px (layout-8; inline title + NEW-chip cluster).
- **Footer .footerLinksRow**: referenced by no component — dead CSS deleted rather than retokened; Footer story verified unchanged (15 links, chrome intact). Footer itself remains a 0-consumer deprecation candidate.

rhythmguard missingTokens for these two files is now zero. Remaining phantoms are docs-only (FoundationDoc layout-12, stories/Docs Icons space-* family) — left for the missing-token gate follow-up.

Verified in live preview (before/after computed values on the exact boxes) + full local gate: typecheck, lint, 2255 tests, build; stylelint baseline unchanged, rhythm baseline renumbered only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)