### PR TITLE
fix(forms): helper text always renders alongside error; consecutive helper lines stack as one block

### DIFF
--- a/nextjs-app/shared/components/Checkbox/Checkbox.tsx
+++ b/nextjs-app/shared/components/Checkbox/Checkbox.tsx
@@ -28,7 +28,7 @@ export interface CheckboxProps
   id?: string;
   /** Error message under the control; sets aria-invalid and aria-describedby. */
   error?: string;
-  /** Supporting text under the control; suppressed while `error` is set. */
+  /** Supporting text under the control; always rendered, below `error` when both are set. */
   helperText?: string;
 }
 
@@ -112,7 +112,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     const describedBy =
       [
         error ? errorId : null,
-        helperText && !error ? helperId : null,
+        helperText ? helperId : null,
         props["aria-describedby"],
       ]
         .filter(Boolean)
@@ -164,13 +164,14 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           {showLabel && label}
         </Label>
       </div>
-      {error ? (
+      {error && (
         <HelperText id={errorId} state="error">
           {error}
         </HelperText>
-      ) : helperText ? (
+      )}
+      {helperText && (
         <HelperText id={helperId}>{helperText}</HelperText>
-      ) : null}
+      )}
       </>
     );
   },

--- a/nextjs-app/shared/components/Combobox/Combobox.stories.tsx
+++ b/nextjs-app/shared/components/Combobox/Combobox.stories.tsx
@@ -123,7 +123,7 @@ export const WithError: Story = {
     docs: {
       description: {
         story:
-          "error replaces the helper line, colors the control, and sets aria-invalid on the trigger.",
+          "error renders above the helper line, colors the control, and sets aria-invalid on the trigger.",
       },
     },
   },

--- a/nextjs-app/shared/components/Combobox/Combobox.test.tsx
+++ b/nextjs-app/shared/components/Combobox/Combobox.test.tsx
@@ -78,7 +78,7 @@ describe("Combobox", () => {
     );
   });
 
-  it("wires only the rendered error text when an error replaces helper text", () => {
+  it("wires error and helper text together when both are set", () => {
     render(
       <Combobox
         id="timeline"
@@ -93,11 +93,17 @@ describe("Combobox", () => {
 
     const trigger = screen.getByRole("combobox", { name: "Timeline" });
     expect(trigger).toHaveAttribute("aria-invalid", "true");
-    expect(trigger).toHaveAttribute("aria-describedby", "timeline-error");
+    expect(trigger).toHaveAttribute(
+      "aria-describedby",
+      "timeline-error timeline-helper",
+    );
     expect(screen.getByText("Timeline is required")).toHaveAttribute(
       "id",
       "timeline-error",
     );
-    expect(screen.queryByText("Choose a timeline")).not.toBeInTheDocument();
+    expect(screen.getByText("Choose a timeline")).toHaveAttribute(
+      "id",
+      "timeline-helper",
+    );
   });
 });

--- a/nextjs-app/shared/components/Combobox/Combobox.tsx
+++ b/nextjs-app/shared/components/Combobox/Combobox.tsx
@@ -37,7 +37,7 @@ export interface ComboboxProps {
   placeholder?: string;
   /** Assistive text below the field */
   helperText?: string;
-  /** Error message; replaces the helper line and sets aria-invalid */
+  /** Error message; renders above the helper line and sets aria-invalid */
   error?: string;
   /** Marks the field required. @default false */
   required?: boolean;
@@ -82,7 +82,7 @@ export const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(
 
     const describedBy = [
       error ? errorId : null,
-      !error && helperText ? helperId : null,
+      helperText ? helperId : null,
     ]
       .filter(Boolean)
       .join(" ");
@@ -331,13 +331,14 @@ export const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(
           {mounted && dropdown && createPortal(dropdown, document.body)}
         </div>
 
-        {error ? (
+        {error && (
           <HelperText id={errorId} state="error">
             {error}
           </HelperText>
-        ) : helperText ? (
+        )}
+        {helperText && (
           <HelperText id={helperId}>{helperText}</HelperText>
-        ) : null}
+        )}
       </div>
     );
   },

--- a/nextjs-app/shared/components/FileUpload/FileUpload.stories.tsx
+++ b/nextjs-app/shared/components/FileUpload/FileUpload.stories.tsx
@@ -134,7 +134,7 @@ SizeRejection.parameters = {
   docs: {
     description: {
       story:
-        "Rejection state: an oversized pick is dropped, the input resets, and sizeErrorMessage replaces the helper until the next pick.",
+        "Rejection state: an oversized pick is dropped, the input resets, and sizeErrorMessage renders above the helper until the next pick.",
     },
   },
 };

--- a/nextjs-app/shared/components/FileUpload/FileUpload.tsx
+++ b/nextjs-app/shared/components/FileUpload/FileUpload.tsx
@@ -24,7 +24,7 @@ export interface FileUploadProps {
   maxSizeInBytes?: number;
   /** Error shown when a picked file exceeds maxSizeInBytes */
   sizeErrorMessage?: string;
-  /** External error message; replaces the helper line */
+  /** External error message; renders above the helper line */
   error?: string;
   /** Controlled File value */
   value?: File | null;
@@ -140,12 +140,15 @@ const FileUpload: React.FC<FileUploadProps> = ({
     />
   );
 
-  const helper = displayError ? (
-    <HelperText id={errorId} state="error">
-      {displayError}
-    </HelperText>
-  ) : (
-    helperText && <HelperText id={helperTextId}>{helperText}</HelperText>
+  const helper = (
+    <>
+      {displayError && (
+        <HelperText id={errorId} state="error">
+          {displayError}
+        </HelperText>
+      )}
+      {helperText && <HelperText id={helperTextId}>{helperText}</HelperText>}
+    </>
   );
 
   if (isEditorial) {

--- a/nextjs-app/shared/components/HelperText/HelperText.module.css
+++ b/nextjs-app/shared/components/HelperText/HelperText.module.css
@@ -9,6 +9,18 @@
   color: var(--color-primary);
 }
 
+/* Consecutive helper lines (error stacked above helper) read as one block */
+
+.helperText + .helperText {
+  margin-block-start: 0;
+}
+
+@supports selector(:has(*)) {
+  .helperText:has(+ .helperText) {
+    margin-block-end: var(--space-internal-4);
+  }
+}
+
 .icon {
   display: inline-flex;
   flex-shrink: 0;

--- a/nextjs-app/shared/components/MultiCombobox/MultiCombobox.test.tsx
+++ b/nextjs-app/shared/components/MultiCombobox/MultiCombobox.test.tsx
@@ -145,7 +145,7 @@ describe("MultiCombobox", () => {
     );
   });
 
-  it("wires only the rendered error text when an error replaces helper text", () => {
+  it("wires error and helper text together when both are set", () => {
     render(
       <MultiCombobox
         id="project-type"
@@ -160,11 +160,17 @@ describe("MultiCombobox", () => {
 
     const input = screen.getByRole("combobox", { name: "Project type" });
     expect(input).toHaveAttribute("aria-invalid", "true");
-    expect(input).toHaveAttribute("aria-describedby", "project-type-error");
+    expect(input).toHaveAttribute(
+      "aria-describedby",
+      "project-type-error project-type-helper",
+    );
     expect(screen.getByText("Pick at least one project type")).toHaveAttribute(
       "id",
       "project-type-error",
     );
-    expect(screen.queryByText("Choose at least one")).not.toBeInTheDocument();
+    expect(screen.getByText("Choose at least one")).toHaveAttribute(
+      "id",
+      "project-type-helper",
+    );
   });
 });

--- a/nextjs-app/shared/components/MultiCombobox/MultiCombobox.tsx
+++ b/nextjs-app/shared/components/MultiCombobox/MultiCombobox.tsx
@@ -38,7 +38,7 @@ export interface MultiComboboxProps {
   placeholder?: string;
   /** Assistive text below the field */
   helperText?: string;
-  /** Error message; replaces the helper line and sets aria-invalid */
+  /** Error message; renders above the helper line and sets aria-invalid */
   error?: string;
   /** Marks the field required. @default false */
   required?: boolean;
@@ -91,7 +91,7 @@ export function MultiCombobox({
 
   const describedBy = [
     error ? errorId : null,
-    !error && helperText ? helperId : null,
+    helperText ? helperId : null,
   ]
     .filter(Boolean)
     .join(" ");
@@ -401,13 +401,14 @@ export function MultiCombobox({
         {mounted && dropdown && createPortal(dropdown, document.body)}
       </div>
 
-      {error ? (
+      {error && (
         <HelperText id={errorId} state="error">
           {error}
         </HelperText>
-      ) : helperText ? (
+      )}
+      {helperText && (
         <HelperText id={helperId}>{helperText}</HelperText>
-      ) : null}
+      )}
     </div>
   );
 }

--- a/nextjs-app/shared/components/PhoneInput/PhoneInput.stories.tsx
+++ b/nextjs-app/shared/components/PhoneInput/PhoneInput.stories.tsx
@@ -115,7 +115,7 @@ WithError.parameters = {
   docs: {
     description: {
       story:
-        "error replaces the helper line, sets aria-invalid, and links to the input via aria-describedby. Validate on submit with isValidPhoneNumber.",
+        "error renders above the helper line, sets aria-invalid, and links to the input via aria-describedby. Validate on submit with isValidPhoneNumber.",
     },
   },
 };

--- a/nextjs-app/shared/components/PhoneInput/PhoneInput.test.tsx
+++ b/nextjs-app/shared/components/PhoneInput/PhoneInput.test.tsx
@@ -34,12 +34,12 @@ describe("PhoneInput", () => {
     expect(screen.getByText("Invalid phone number")).toBeInTheDocument();
   });
 
-  it("does not render helper text when error is present", () => {
+  it("renders helper text alongside the error", () => {
     render(
       <PhoneInput label="Phone" error="Invalid" helperText="Helper text" />,
     );
     expect(screen.getByText("Invalid")).toBeInTheDocument();
-    expect(screen.queryByText("Helper text")).not.toBeInTheDocument();
+    expect(screen.getByText("Helper text")).toBeInTheDocument();
   });
 
   it("calls onChange when value changes", async () => {

--- a/nextjs-app/shared/components/PhoneInput/PhoneInput.tsx
+++ b/nextjs-app/shared/components/PhoneInput/PhoneInput.tsx
@@ -11,7 +11,7 @@ export interface PhoneInputProps {
   label: string;
   /** Phone number value (E.164 format) */
   value?: string;
-  /** Error message; replaces the helper line */
+  /** Error message; renders above the helper line */
   error?: string;
   /** Helper text below the input */
   helperText?: string;
@@ -45,7 +45,7 @@ export const PhoneInput: React.FC<PhoneInputProps> = ({
   const fieldId = providedId ?? `phone-input-${generatedId}`;
   const errorId = `${fieldId}-error`;
   const helperId = `${fieldId}-helper`;
-  const describedBy = [error ? errorId : null, helperText && !error ? helperId : null]
+  const describedBy = [error ? errorId : null, helperText ? helperId : null]
     .filter(Boolean)
     .join(" ");
 
@@ -71,13 +71,14 @@ export const PhoneInput: React.FC<PhoneInputProps> = ({
         international
         defaultCountry={defaultCountry}
       />
-      {error ? (
+      {error && (
         <HelperText id={errorId} state="error">
           {error}
         </HelperText>
-      ) : helperText ? (
+      )}
+      {helperText && (
         <HelperText id={helperId}>{helperText}</HelperText>
-      ) : null}
+      )}
     </div>
   );
 };

--- a/nextjs-app/shared/components/RadioGroup/RadioGroup.tsx
+++ b/nextjs-app/shared/components/RadioGroup/RadioGroup.tsx
@@ -31,7 +31,7 @@ export interface RadioGroupProps {
   disabled?: boolean;
   /** Error message; announces via role=alert and sets aria-invalid */
   error?: string;
-  /** Helper copy below the group; suppressed while error is set */
+  /** Helper copy below the group; always rendered, alongside error when both are set */
   helperText?: string;
   /** Merged onto the fieldset */
   className?: string;

--- a/nextjs-app/shared/components/Select/Select.stories.tsx
+++ b/nextjs-app/shared/components/Select/Select.stories.tsx
@@ -246,7 +246,7 @@ WithError.tags = ["example"];
 WithError.parameters = {
   docs: {
     description: {
-      story: "error replaces the helper line, sets aria-invalid, and announces via role=alert.",
+      story: "error renders above the helper line, sets aria-invalid, and announces via role=alert.",
     },
   },
 };

--- a/nextjs-app/shared/components/Select/Select.tsx
+++ b/nextjs-app/shared/components/Select/Select.tsx
@@ -20,7 +20,7 @@ export interface SelectProps
   label: string;
   /** Option objects with value, label, and optional disabled; children override this */
   options?: SelectOptionItem[];
-  /** Supporting text under the control; suppressed while `error` is set. */
+  /** Supporting text under the control; always rendered, below `error` when both are set. */
   helperText?: string;
   /** Error message under the control; sets aria-invalid and aria-describedby. */
   error?: string;
@@ -82,7 +82,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
     const describedBy =
       [
         error ? errorId : null,
-        helperText && !error ? helperId : null,
+        helperText ? helperId : null,
         rest["aria-describedby"],
       ]
         .filter(Boolean)
@@ -148,7 +148,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
             {error}
           </HelperText>
         )}
-        {helperText && !error && (
+        {helperText && (
           <HelperText id={helperId}>{helperText}</HelperText>
         )}
       </div>

--- a/nextjs-app/shared/components/Switch/Switch.stories.tsx
+++ b/nextjs-app/shared/components/Switch/Switch.stories.tsx
@@ -265,7 +265,7 @@ export const WithError: Story = {
     docs: {
       description: {
         story:
-          "The control owns its error: it replaces the helper line, sets aria-invalid, and announces via role=alert. Useful when an immediate toggle fails server-side.",
+          "The control owns its error: it renders above the helper line, sets aria-invalid, and announces via role=alert. Useful when an immediate toggle fails server-side.",
       },
     },
   },

--- a/nextjs-app/shared/components/Switch/Switch.tsx
+++ b/nextjs-app/shared/components/Switch/Switch.tsx
@@ -21,7 +21,7 @@ export interface SwitchProps
   label?: React.ReactNode;
   /** Where the label sits relative to the control. @default "right" */
   labelPlacement?: "right" | "left" | "top";
-  /** Supporting text rendered beneath the control; suppressed while `error` is set. */
+  /** Supporting text rendered beneath the control; always rendered, below `error` when both are set. */
   helperText?: string;
   /** Error message beneath the control; sets aria-invalid and aria-describedby. */
   error?: string;
@@ -60,7 +60,7 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
     const switchId = id ?? generatedId;
     const labelId = label ? `${switchId}-label` : undefined;
     const errorId = error ? `${switchId}-error` : undefined;
-    const helperId = helperText && !error ? `${switchId}-helper` : undefined;
+    const helperId = helperText ? `${switchId}-helper` : undefined;
     const describedBy =
       [errorId, helperId, rest["aria-describedby"]].filter(Boolean).join(" ") ||
       undefined;
@@ -145,13 +145,14 @@ const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
           </button>
           {shouldRenderLabelAfter ? renderLabel() : null}
         </span>
-        {error ? (
+        {error && (
           <HelperText id={errorId} state="error">
             {error}
           </HelperText>
-        ) : helperText ? (
+        )}
+        {helperText && (
           <HelperText id={helperId}>{helperText}</HelperText>
-        ) : null}
+        )}
       </>
     );
   },

--- a/nextjs-app/shared/components/TextArea/TextArea.stories.tsx
+++ b/nextjs-app/shared/components/TextArea/TextArea.stories.tsx
@@ -92,7 +92,7 @@ WithError.tags = ["example"];
 WithError.parameters = {
   docs: {
     description: {
-      story: "error replaces the helper line, sets aria-invalid, and announces via role=alert.",
+      story: "error renders above the helper line, sets aria-invalid, and announces via role=alert.",
     },
   },
 };

--- a/nextjs-app/shared/components/TextArea/TextArea.test.tsx
+++ b/nextjs-app/shared/components/TextArea/TextArea.test.tsx
@@ -49,7 +49,7 @@ describe("TextArea", () => {
     expect(screen.getByText("Maximum 500 characters")).toBeInTheDocument();
   });
 
-  it("does not display helper text when error is present", () => {
+  it("displays helper text alongside the error", () => {
     render(
       <TextArea
         label="Description"
@@ -58,7 +58,14 @@ describe("TextArea", () => {
       />,
     );
     expect(screen.getByText("Required")).toBeInTheDocument();
-    expect(screen.queryByText("Helper text")).not.toBeInTheDocument();
+    expect(screen.getByText("Helper text")).toBeInTheDocument();
+    const textarea = screen.getByLabelText("Description");
+    expect(textarea.getAttribute("aria-describedby")).toContain(
+      screen.getByText("Required").id,
+    );
+    expect(textarea.getAttribute("aria-describedby")).toContain(
+      screen.getByText("Helper text").id,
+    );
   });
 
   it("disables textarea when disabled prop is true", () => {

--- a/nextjs-app/shared/components/TextArea/TextArea.tsx
+++ b/nextjs-app/shared/components/TextArea/TextArea.tsx
@@ -9,7 +9,7 @@ export interface TextAreaProps
   label: string;
   /** Value synced into the field; typing still works after it is set */
   value?: string;
-  /** Validation error message; replaces the helper line */
+  /** Validation error message; renders above the helper line */
   error?: string;
   /** Helper copy below the field */
   helperText?: string;
@@ -50,7 +50,7 @@ const TextArea: React.FC<TextAreaProps> = ({
 
   const hasError = !!error;
   const describedBy =
-    [hasError && errorId, helperText && !hasError && helperId]
+    [hasError && errorId, helperText && helperId]
       .filter(Boolean)
       .join(" ") || undefined;
 
@@ -141,7 +141,7 @@ const TextArea: React.FC<TextAreaProps> = ({
           {error}
         </HelperText>
       )}
-      {helperText && !hasError && (
+      {helperText && (
         <HelperText id={helperId}>{helperText}</HelperText>
       )}
     </div>

--- a/nextjs-app/shared/components/TextInput/TextInput.contract.json
+++ b/nextjs-app/shared/components/TextInput/TextInput.contract.json
@@ -213,7 +213,7 @@
     ],
     "dense": "labelled single-line field: text/number/email/tel/password/search, built-in email+phone validation, error/helperText, sm/md/lg; onValueChange(value); clearable ×-button (onClear); hideLabel",
     "usage": {
-        "description": "TextInput is the standard single-line field: label, control, helper and error text in one component. The email and tel types add built-in validation (typo suggestions for common email domains, libphonenumber formatting for phone numbers); error overrides the helper line and wires aria-invalid.",
+        "description": "TextInput is the standard single-line field: label, control, helper and error text in one component. The email and tel types add built-in validation (typo suggestions for common email domains, libphonenumber formatting for phone numbers); error renders above the helper line and wires aria-invalid.",
         "bestPractices": [
             {
                 "guidance": true,

--- a/nextjs-app/shared/components/TextInput/TextInput.stories.tsx
+++ b/nextjs-app/shared/components/TextInput/TextInput.stories.tsx
@@ -115,7 +115,7 @@ InputWithError.parameters = {
   docs: {
     description: {
       story:
-        "error replaces the helper line, sets aria-invalid, and announces via role=alert.",
+        "error renders above the helper line, sets aria-invalid, and announces via role=alert.",
     },
   },
 };

--- a/nextjs-app/shared/components/TextInput/TextInput.tsx
+++ b/nextjs-app/shared/components/TextInput/TextInput.tsx
@@ -37,7 +37,7 @@ export interface TextInputProps
   // EXISTING PROPS
   /** Controlled value; an initial "" is treated as absent (uncontrolled), later changes always sync in */
   value?: string | number;
-  /** Validation error message; replaces the helper line and sets aria-invalid */
+  /** Validation error message; renders above the helper line and sets aria-invalid */
   error?: string;
   /** Helper copy below the field */
   helperText?: string;
@@ -110,10 +110,10 @@ const TextInput: React.FC<TextInputProps> = ({
   const hasError = !!(error || phoneError || emailError);
   const errorMessage = error || phoneError || emailError;
 
-  // Compute aria-describedby - link to error or helper text
+  // Compute aria-describedby - link to error and helper text
   const describedBy = [
     hasError && errorId,
-    helperText && !hasError && helperId,
+    helperText && helperId,
   ].filter(Boolean).join(' ') || undefined;
 
   useEffect(() => {
@@ -241,7 +241,7 @@ const TextInput: React.FC<TextInputProps> = ({
           {errorMessage}
         </HelperText>
       )}
-      {helperText && !hasError && (
+      {helperText && (
         <HelperText id={helperId}>{helperText}</HelperText>
       )}
     </div>

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-11T10:52:16.007Z",
+  "generatedAt": "2026-07-11T15:32:58.173Z",
   "summary": {
     "componentCount": 164,
     "statusCounts": {
@@ -30292,7 +30292,7 @@
         ],
         "dense": "labelled single-line field: text/number/email/tel/password/search, built-in email+phone validation, error/helperText, sm/md/lg; onValueChange(value); clearable ×-button (onClear); hideLabel",
         "usage": {
-          "description": "TextInput is the standard single-line field: label, control, helper and error text in one component. The email and tel types add built-in validation (typo suggestions for common email domains, libphonenumber formatting for phone numbers); error overrides the helper line and wires aria-invalid.",
+          "description": "TextInput is the standard single-line field: label, control, helper and error text in one component. The email and tel types add built-in validation (typo suggestions for common email domains, libphonenumber formatting for phone numbers); error renders above the helper line and wires aria-invalid.",
           "bestPractices": [
             {
               "guidance": true,

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -4102,8 +4102,8 @@
         },
         {
           "story": "WithError",
-          "description": "error replaces the helper line, colors the control, and sets aria-invalid on the trigger.",
-          "source": "export const WithError: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: {\n      description: {\n        story:\n          \"error replaces the helper line, colors the control, and sets aria-invalid on the trigger.\",\n      },\n    },\n  },\n  render: () => <ComboboxDemo required error=\"Pick a timeline to continue.\" />,\n};"
+          "description": "error renders above the helper line, colors the control, and sets aria-invalid on the trigger.",
+          "source": "export const WithError: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: {\n      description: {\n        story:\n          \"error renders above the helper line, colors the control, and sets aria-invalid on the trigger.\",\n      },\n    },\n  },\n  render: () => <ComboboxDemo required error=\"Pick a timeline to continue.\" />,\n};"
         },
         {
           "story": "Disabled",
@@ -5906,8 +5906,8 @@
         },
         {
           "story": "SizeRejection",
-          "description": "Rejection state: an oversized pick is dropped, the input resets, and sizeErrorMessage replaces the helper until the next pick.",
-          "source": "export const SizeRejection = Template.bind({});\nSizeRejection.args = {\n  ...Default.args,\n  maxSizeInBytes: 10,\n  sizeErrorMessage: \"File exceeds the 10 byte demo limit.\",\n};\nSizeRejection.tags = [\"example\"];\nSizeRejection.parameters = {\n  docs: {\n    description: {\n      story:\n        \"Rejection state: an oversized pick is dropped, the input resets, and sizeErrorMessage replaces the helper until the next pick.\",\n    },\n  },\n};\nSizeRejection.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement);\n  const hiddenInput =\n    canvasElement.querySelector<HTMLInputElement>(\"input[type='file']\");\n  if (!hiddenInput) throw new Error(\"hidden file input not found\");\n\n  const bigFile = new File([\"x\".repeat(64)], \"too-big.pdf\", {\n    type: \"application/pdf\",\n  });\n  await userEvent.upload(hiddenInput, bigFile);\n\n  await waitFor(() =>\n    expect(\n      canvas.getByText(/exceeds the 10 byte demo limit/i),\n    ).toBeInTheDocument(),\n  );\n  const summary = canvas.getByRole(\"textbox\") as HTMLInputElement;\n  expect(summary.value).not.toMatch(/too-big\\.pdf/);\n};"
+          "description": "Rejection state: an oversized pick is dropped, the input resets, and sizeErrorMessage renders above the helper until the next pick.",
+          "source": "export const SizeRejection = Template.bind({});\nSizeRejection.args = {\n  ...Default.args,\n  maxSizeInBytes: 10,\n  sizeErrorMessage: \"File exceeds the 10 byte demo limit.\",\n};\nSizeRejection.tags = [\"example\"];\nSizeRejection.parameters = {\n  docs: {\n    description: {\n      story:\n        \"Rejection state: an oversized pick is dropped, the input resets, and sizeErrorMessage renders above the helper until the next pick.\",\n    },\n  },\n};\nSizeRejection.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement);\n  const hiddenInput =\n    canvasElement.querySelector<HTMLInputElement>(\"input[type='file']\");\n  if (!hiddenInput) throw new Error(\"hidden file input not found\");\n\n  const bigFile = new File([\"x\".repeat(64)], \"too-big.pdf\", {\n    type: \"application/pdf\",\n  });\n  await userEvent.upload(hiddenInput, bigFile);\n\n  await waitFor(() =>\n    expect(\n      canvas.getByText(/exceeds the 10 byte demo limit/i),\n    ).toBeInTheDocument(),\n  );\n  const summary = canvas.getByRole(\"textbox\") as HTMLInputElement;\n  expect(summary.value).not.toMatch(/too-big\\.pdf/);\n};"
         },
         {
           "story": "Editorial",
@@ -10555,8 +10555,8 @@
         },
         {
           "story": "WithError",
-          "description": "error replaces the helper line, sets aria-invalid, and links to the input via aria-describedby. Validate on submit with isValidPhoneNumber.",
-          "source": "export const WithError = Template.bind({});\nWithError.args = {\n  label: \"storyPhoneInputLabel\",\n  placeholder: \"storyPhoneInputPlaceholder\",\n  error: \"storyPhoneInputError\",\n};\nWithError.tags = [\"example\"];\nWithError.parameters = {\n  docs: {\n    description: {\n      story:\n        \"error replaces the helper line, sets aria-invalid, and links to the input via aria-describedby. Validate on submit with isValidPhoneNumber.\",\n    },\n  },\n};\nWithError.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement);\n  await canvas.findByText(\n    /invalid phone number|virheellinen puhelinnumero|ogiltigt telefonnummer/i,\n  );\n};"
+          "description": "error renders above the helper line, sets aria-invalid, and links to the input via aria-describedby. Validate on submit with isValidPhoneNumber.",
+          "source": "export const WithError = Template.bind({});\nWithError.args = {\n  label: \"storyPhoneInputLabel\",\n  placeholder: \"storyPhoneInputPlaceholder\",\n  error: \"storyPhoneInputError\",\n};\nWithError.tags = [\"example\"];\nWithError.parameters = {\n  docs: {\n    description: {\n      story:\n        \"error renders above the helper line, sets aria-invalid, and links to the input via aria-describedby. Validate on submit with isValidPhoneNumber.\",\n    },\n  },\n};\nWithError.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement);\n  await canvas.findByText(\n    /invalid phone number|virheellinen puhelinnumero|ogiltigt telefonnummer/i,\n  );\n};"
         },
         {
           "story": "CountryDefault",
@@ -11811,8 +11811,8 @@
         },
         {
           "story": "WithError",
-          "description": "error replaces the helper line, sets aria-invalid, and announces via role=alert.",
-          "source": "export const WithError = Template.bind({});\nWithError.args = {\n  label: \"storySelectLabel\",\n  options: [\n    { value: \"option1\", label: \"storyCheckboxOption1\" },\n    { value: \"option2\", label: \"storyCheckboxOption2\" },\n    { value: \"option3\", label: \"storyCheckboxOption3\" },\n  ],\n  value: \"option1\",\n  error: \"storySelectErrorRequired\",\n};\n\nWithError.tags = [\"example\"];\nWithError.parameters = {\n  docs: {\n    description: {\n      story: \"error replaces the helper line, sets aria-invalid, and announces via role=alert.\",\n    },\n  },\n};"
+          "description": "error renders above the helper line, sets aria-invalid, and announces via role=alert.",
+          "source": "export const WithError = Template.bind({});\nWithError.args = {\n  label: \"storySelectLabel\",\n  options: [\n    { value: \"option1\", label: \"storyCheckboxOption1\" },\n    { value: \"option2\", label: \"storyCheckboxOption2\" },\n    { value: \"option3\", label: \"storyCheckboxOption3\" },\n  ],\n  value: \"option1\",\n  error: \"storySelectErrorRequired\",\n};\n\nWithError.tags = [\"example\"];\nWithError.parameters = {\n  docs: {\n    description: {\n      story: \"error renders above the helper line, sets aria-invalid, and announces via role=alert.\",\n    },\n  },\n};"
         }
       ]
     },
@@ -13734,8 +13734,8 @@
         },
         {
           "story": "WithError",
-          "description": "The control owns its error: it replaces the helper line, sets aria-invalid, and announces via role=alert. Useful when an immediate toggle fails server-side.",
-          "source": "export const WithError: Story = {\n  tags: [\"example\"],\n  parameters: {\n    docs: {\n      description: {\n        story:\n          \"The control owns its error: it replaces the helper line, sets aria-invalid, and announces via role=alert. Useful when an immediate toggle fails server-side.\",\n      },\n    },\n  },\n  args: {\n    label: \"Email notifications\",\n    error: \"Could not update the setting. Try again.\",\n  },\n  render: (args) => <ControlledTemplate {...args} />,\n};"
+          "description": "The control owns its error: it renders above the helper line, sets aria-invalid, and announces via role=alert. Useful when an immediate toggle fails server-side.",
+          "source": "export const WithError: Story = {\n  tags: [\"example\"],\n  parameters: {\n    docs: {\n      description: {\n        story:\n          \"The control owns its error: it renders above the helper line, sets aria-invalid, and announces via role=alert. Useful when an immediate toggle fails server-side.\",\n      },\n    },\n  },\n  args: {\n    label: \"Email notifications\",\n    error: \"Could not update the setting. Try again.\",\n  },\n  render: (args) => <ControlledTemplate {...args} />,\n};"
         }
       ]
     },
@@ -14322,8 +14322,8 @@
         },
         {
           "story": "WithError",
-          "description": "error replaces the helper line, sets aria-invalid, and announces via role=alert.",
-          "source": "export const WithError = Template.bind({});\nWithError.args = {\n  label: \"storyTextAreaErrorLabel\",\n  placeholder: \"storyTextAreaPlaceholder\",\n  error: \"storyTextAreaErrorText\",\n  rows: 4,\n};\n\nWithError.tags = [\"example\"];\nWithError.parameters = {\n  docs: {\n    description: {\n      story: \"error replaces the helper line, sets aria-invalid, and announces via role=alert.\",\n    },\n  },\n};"
+          "description": "error renders above the helper line, sets aria-invalid, and announces via role=alert.",
+          "source": "export const WithError = Template.bind({});\nWithError.args = {\n  label: \"storyTextAreaErrorLabel\",\n  placeholder: \"storyTextAreaPlaceholder\",\n  error: \"storyTextAreaErrorText\",\n  rows: 4,\n};\n\nWithError.tags = [\"example\"];\nWithError.parameters = {\n  docs: {\n    description: {\n      story: \"error renders above the helper line, sets aria-invalid, and announces via role=alert.\",\n    },\n  },\n};"
         },
         {
           "story": "AnimatedResize",
@@ -14469,7 +14469,7 @@
         "use TextInput for multi-line text. Use **TextArea**, which"
       ],
       "usage": {
-        "description": "TextInput is the standard single-line field: label, control, helper and error text in one component. The email and tel types add built-in validation (typo suggestions for common email domains, libphonenumber formatting for phone numbers); error overrides the helper line and wires aria-invalid.",
+        "description": "TextInput is the standard single-line field: label, control, helper and error text in one component. The email and tel types add built-in validation (typo suggestions for common email domains, libphonenumber formatting for phone numbers); error renders above the helper line and wires aria-invalid.",
         "bestPractices": [
           {
             "guidance": true,
@@ -14533,8 +14533,8 @@
         },
         {
           "story": "InputWithError",
-          "description": "error replaces the helper line, sets aria-invalid, and announces via role=alert.",
-          "source": "export const InputWithError = Template.bind({});\nInputWithError.args = {\n  label: \"storyInputErrorLabel\",\n  type: \"text\",\n  placeholder: \"storyInputTextPlaceholder\",\n  error: \"storyInputErrorText\",\n};\n\nInputWithError.tags = [\"example\"];\nInputWithError.parameters = {\n  docs: {\n    description: {\n      story:\n        \"error replaces the helper line, sets aria-invalid, and announces via role=alert.\",\n    },\n  },\n};"
+          "description": "error renders above the helper line, sets aria-invalid, and announces via role=alert.",
+          "source": "export const InputWithError = Template.bind({});\nInputWithError.args = {\n  label: \"storyInputErrorLabel\",\n  type: \"text\",\n  placeholder: \"storyInputTextPlaceholder\",\n  error: \"storyInputErrorText\",\n};\n\nInputWithError.tags = [\"example\"];\nInputWithError.parameters = {\n  docs: {\n    description: {\n      story:\n        \"error renders above the helper line, sets aria-invalid, and announces via role=alert.\",\n    },\n  },\n};"
         }
       ]
     },


### PR DESCRIPTION
## Summary
Owner ruling: helperText is an always-on feature; error is additive, not a replacement.

- **All field components render both**: TextInput, TextArea, Select, PhoneInput, Combobox, MultiCombobox, Checkbox, Switch, FileUpload previously hid the helper line while `error` was set; now error renders above helper and `aria-describedby` references both ids. Fixes FileUpload's dangling describedby reference to the unrendered helper node. RadioGroup already rendered both; its contradictory JSDoc is fixed.
- **HelperText stacking**: adjacent helper lines (error + helper) now sit 4px apart as one block via `.helperText + .helperText` and an `@supports`-guarded `:has()` rule (NavMenuList idiom), instead of paragraph margins splitting them ~24px apart.
- JSDoc, story autodocs prose, TextInput contract prose, and tests updated; agent manifest regenerated.

No captured a11y snapshot changes: no captured story statically sets both props (verified story-by-story).

## Verification (local, CI is quota-dead)
- typecheck ✓, lint ✓ (2 pre-existing ToastStack warnings), lint:css baseline ✓, rhythmguard 0 new drift ✓
- npm test on final tree: 285 files, 2255 tests ✓
- npm run build on final tree: exit 0 ✓ (earlier overlapping-build lock resolved; rebuilt solo)
- check:contract-props ✓, check:consumers ✓, build:tokens ✓
- Live Storybook: TextInput error+helper both rendered and wired (describedby "error helper"), gap 24px → 5px

🤖 Generated with [Claude Code](https://claude.com/claude-code)