### PR TITLE
feat(design-system): export interactive-primitive prop types; add focus/openchange tests

### DIFF
--- a/nextjs-app/shared/components/Accordion/index.ts
+++ b/nextjs-app/shared/components/Accordion/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Accordion";
+export type { AccordionItem, AccordionProps } from "./Accordion";

--- a/nextjs-app/shared/components/CommandPalette/CommandPalette.test.tsx
+++ b/nextjs-app/shared/components/CommandPalette/CommandPalette.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent, within } from "@testing-library/react";
+import { render, screen, fireEvent, within, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { axe, toHaveNoViolations } from "jest-axe";
 import { CommandPalette, type CommandPaletteItem } from "./CommandPalette";
@@ -70,6 +70,33 @@ describe("CommandPalette", () => {
     fireEvent.click(within(screen.getByRole("listbox")).getByText("Go to Work"));
     expect(items[2].onSelect).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("traps focus while open and restores prior focus when closed", async () => {
+    const main = document.createElement("main");
+    main.id = "main-content";
+    const before = document.createElement("button");
+    before.type = "button";
+    before.textContent = "Before";
+    main.appendChild(before);
+    document.body.appendChild(main);
+    before.focus();
+
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <CommandPalette open onClose={onClose} items={makeItems()} />,
+    );
+
+    await waitFor(() => expect(screen.getByRole("combobox")).toHaveFocus());
+    expect(main).toHaveAttribute("inert");
+
+    rerender(
+      <CommandPalette open={false} onClose={onClose} items={makeItems()} />,
+    );
+
+    expect(before).toHaveFocus();
+    expect(main).not.toHaveAttribute("inert");
+    main.remove();
   });
 
   it("has no axe violations", async () => {

--- a/nextjs-app/shared/components/Menu/Menu.test.tsx
+++ b/nextjs-app/shared/components/Menu/Menu.test.tsx
@@ -21,15 +21,17 @@ beforeAll(() => {
 
 function renderMenu({
   defaultOpen,
+  onOpenChange,
   onSelect,
   disabled,
 }: {
   defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
   onSelect?: () => void;
   disabled?: boolean;
 } = {}) {
   return render(
-    <Menu defaultOpen={defaultOpen}>
+    <Menu defaultOpen={defaultOpen} onOpenChange={onOpenChange}>
       <MenuTrigger asChild>
         <button type="button">Actions</button>
       </MenuTrigger>
@@ -67,6 +69,16 @@ describe("Menu", () => {
     renderMenu({ defaultOpen: true, onSelect });
     await user.click(screen.getByText("Edit"));
     expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onOpenChange with the next open state", async () => {
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+    renderMenu({ onOpenChange });
+
+    await user.click(screen.getByRole("button", { name: "Actions" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(true);
   });
 
   it("does not select a disabled item and marks it disabled", async () => {

--- a/nextjs-app/shared/components/SelectableCard/SelectableCard.test.tsx
+++ b/nextjs-app/shared/components/SelectableCard/SelectableCard.test.tsx
@@ -133,6 +133,30 @@ describe("SelectableCardGroup — error", () => {
     expect(screen.getByText("Pick one.")).toBeInTheDocument();
     expect(screen.getByRole("group")).toHaveAttribute("aria-invalid", "true");
   });
+
+  it("wires helper and error copy through aria-describedby", () => {
+    render(
+      <SelectableCardGroup
+        type="single"
+        legend="Plan"
+        name="plan"
+        helperText="Choose a plan."
+        error="Pick one."
+      >
+        <SelectableCard value="a" title="A" />
+      </SelectableCardGroup>,
+    );
+
+    const group = screen.getByRole("group", { name: "Plan" });
+    expect(group).toHaveAttribute(
+      "aria-describedby",
+      expect.stringContaining("plan-helper"),
+    );
+    expect(group).toHaveAttribute(
+      "aria-describedby",
+      expect.stringContaining("plan-error"),
+    );
+  });
 });
 
 describe("SelectableCard — standalone", () => {

--- a/nextjs-app/shared/components/Tooltip/Tooltip.test.tsx
+++ b/nextjs-app/shared/components/Tooltip/Tooltip.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { axe, toHaveNoViolations } from "jest-axe";
 import {
   Tooltip,
@@ -11,7 +11,10 @@ import {
 
 expect.extend(toHaveNoViolations);
 
-function renderTooltip(props?: { defaultOpen?: boolean }) {
+function renderTooltip(props?: {
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
   return render(
     <TooltipProvider delayDuration={0}>
       <Tooltip {...props}>
@@ -44,6 +47,17 @@ describe("Tooltip", () => {
     expect(trigger).toHaveFocus();
     await waitFor(() => expect(screen.getByRole("tooltip")).toBeVisible());
     expect(trigger).toHaveAttribute("aria-describedby");
+  });
+
+  it("calls onOpenChange when keyboard focus opens the tooltip", async () => {
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+    renderTooltip({ onOpenChange });
+
+    await user.tab();
+    await waitFor(() => expect(screen.getByRole("tooltip")).toBeVisible());
+
+    expect(onOpenChange).toHaveBeenCalledWith(true);
   });
 
   it("dismisses on Escape without moving focus", async () => {

--- a/nextjs-app/shared/components/Tooltip/index.ts
+++ b/nextjs-app/shared/components/Tooltip/index.ts
@@ -4,3 +4,4 @@ export {
   TooltipContent,
   TooltipProvider,
 } from "./Tooltip";
+export type { TooltipProps } from "./Tooltip";

--- a/nextjs-app/shared/components/index.ts
+++ b/nextjs-app/shared/components/index.ts
@@ -13,7 +13,14 @@ export type {
   BreadcrumbProps,
 } from "./Breadcrumb/Breadcrumb";
 export { default as Button } from "./Button/Button";
+export type {
+  ButtonAsButton,
+  ButtonAsLink,
+  ButtonProps,
+  ButtonSurface,
+} from "./Button/Button";
 export { default as ButtonGroup } from "./ButtonGroup/ButtonGroup";
+export type { ButtonGroupProps } from "./ButtonGroup/ButtonGroup";
 export { default as Card } from "./Card/Card";
 export { default as Checkbox } from "./Checkbox/Checkbox";
 export { default as CheckboxGroup } from "./CheckboxGroup/CheckboxGroup";
@@ -67,10 +74,19 @@ export {
   MenuSubTrigger,
   MenuSubContent,
 } from "./Menu";
+export type {
+  MenuItemProps,
+  MenuProps,
+  MenuRootProps,
+  MenuSubProps,
+  MenuSubTriggerProps,
+  MenuTriggerProps,
+} from "./Menu";
 export { default as MCPActionButton } from "./MCPActionButton/MCPActionButton";
 export { default as NavMenuList } from "./NavMenuList/NavMenuList";
 export { default as MarkdownMessage } from "./MarkdownMessage/MarkdownMessage";
 export { default as Modal } from "./Modal/Modal";
+export type { ModalProps, ModalSeverity } from "./Modal/Modal";
 export { NextLayout } from "./NextLayout";
 export { default as OpenHours } from "./OpenHours/OpenHours";
 export { default as PersonCard } from "./PersonCard/PersonCard";
@@ -100,7 +116,7 @@ export { ThemeProvider, useTheme } from "./ThemeProvider/ThemeProvider";
 export type { Theme, ThemeProviderProps } from "./ThemeProvider/ThemeProvider";
 export { default as Title } from "./Title/Title";
 export { default as Toast } from "./Toast/Toast";
-export type { ToastPosition, ToastTone } from "./Toast/Toast";
+export type { ToastPosition, ToastProps, ToastTone } from "./Toast/Toast";
 export { default as TransformingActionInput } from "./TransformingActionInput/TransformingActionInput";
 export { ValueCard, type ValueCardProps } from "./ValueCard";
 export { default as WorkNav } from "./WorkNav/WorkNav";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -9,7 +9,14 @@ export type {
   BreadcrumbProps,
 } from "../../../nextjs-app/shared/components/Breadcrumb/Breadcrumb";
 export { default as Button } from "../../../nextjs-app/shared/components/Button/Button";
+export type {
+  ButtonAsButton,
+  ButtonAsLink,
+  ButtonProps,
+  ButtonSurface,
+} from "../../../nextjs-app/shared/components/Button/Button";
 export { default as ButtonGroup } from "../../../nextjs-app/shared/components/ButtonGroup/ButtonGroup";
+export type { ButtonGroupProps } from "../../../nextjs-app/shared/components/ButtonGroup/ButtonGroup";
 export { default as Card } from "../../../nextjs-app/shared/components/Card/Card";
 export {
   CategoryFilter,
@@ -95,7 +102,16 @@ export {
   MenuSubTrigger,
   MenuSubContent,
 } from "../../../nextjs-app/shared/components/Menu";
+export type {
+  MenuItemProps,
+  MenuProps,
+  MenuRootProps,
+  MenuSubProps,
+  MenuSubTriggerProps,
+  MenuTriggerProps,
+} from "../../../nextjs-app/shared/components/Menu";
 export { default as Modal } from "../../../nextjs-app/shared/components/Modal/Modal";
+export type { ModalProps, ModalSeverity } from "../../../nextjs-app/shared/components/Modal/Modal";
 export {
   MultiCombobox,
   type MultiComboboxOption,
@@ -171,6 +187,7 @@ export { default as Title } from "../../../nextjs-app/shared/components/Title/Ti
 export { default as Toast } from "../../../nextjs-app/shared/components/Toast/Toast";
 export type {
   ToastPosition,
+  ToastProps,
   ToastTone,
 } from "../../../nextjs-app/shared/components/Toast/Toast";
 export {


### PR DESCRIPTION
## Summary
Vetted Codex interactive-primitives batch (reviewed diff, no tampering found this round).

- Type-only exports for Button (Props/AsButton/AsLink/Surface), ButtonGroup, Menu (6 prop types), Modal (Props/Severity), Toast (ToastProps) on shared root + @digitaltableteur/react; folder barrels for Accordion (Item/Props) and Tooltip (Props).
- New tests: CommandPalette focus trap + inert + focus restore, Menu onOpenChange, Tooltip onOpenChange (keyboard), SelectableCardGroup helper/error aria-describedby.

## Verification (local, CI is quota-dead)
- Focused vitest: 44 tests ✓; full npm test ✓ (TEST_OK marker); build ✓ (BUILD_OK marker)
- typecheck ✓, check:react-package: 106 runtime exports unchanged ✓
- Pre-commit hooks: contrast, stylelint baseline, rhythmguard 0 new drift, lint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)