### PR TITLE
fix(forms): unify disabled styling — controls visibly disable, value text mutes

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-07-11T14:43:55.471Z",
+  "createdAt": "2026-07-11T16:07:14.660Z",
   "directory": "nextjs-app/shared",
   "findings": [
     {
@@ -3485,8 +3485,8 @@
     {
       "column": 22,
       "file": "nextjs-app/shared/components/PhoneInput/PhoneInput.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/PhoneInput/PhoneInput.module.css\u001f61\u001f22\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 61,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/PhoneInput/PhoneInput.module.css\u001f79\u001f22\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 79,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -3495,8 +3495,8 @@
     {
       "column": 19,
       "file": "nextjs-app/shared/components/PhoneInput/PhoneInput.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/PhoneInput/PhoneInput.module.css\u001f62\u001f19\u001f0.25rem\u001fUnexpected raw scale value \"0.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 62,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/PhoneInput/PhoneInput.module.css\u001f80\u001f19\u001f0.25rem\u001fUnexpected raw scale value \"0.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 80,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -3505,8 +3505,8 @@
     {
       "column": 27,
       "file": "nextjs-app/shared/components/PhoneInput/PhoneInput.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/PhoneInput/PhoneInput.module.css\u001f62\u001f27\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 62,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/PhoneInput/PhoneInput.module.css\u001f80\u001f27\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 80,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -3515,8 +3515,8 @@
     {
       "column": 17,
       "file": "nextjs-app/shared/components/PhoneInput/PhoneInput.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/PhoneInput/PhoneInput.module.css\u001f71\u001f17\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 71,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/PhoneInput/PhoneInput.module.css\u001f89\u001f17\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 89,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -4335,8 +4335,8 @@
     {
       "column": 23,
       "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f119\u001f23\u001f2.5rem\u001fUnexpected off-scale value \"2.5rem\". Use scale values (nearest: 32px or 32px). (rhythmguard/use-scale)",
-      "line": 119,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f120\u001f23\u001f2.5rem\u001fUnexpected off-scale value \"2.5rem\". Use scale values (nearest: 32px or 32px). (rhythmguard/use-scale)",
+      "line": 120,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"2.5rem\". Use scale values (nearest: 32px or 32px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -4345,8 +4345,8 @@
     {
       "column": 11,
       "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f158\u001f11\u001f-1px\u001fUnexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "line": 158,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f159\u001f11\u001f-1px\u001fUnexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 159,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"-1px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -4425,8 +4425,8 @@
     {
       "column": 17,
       "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f100\u001f17\u001f1.5rem\u001fUnexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 100,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f101\u001f17\u001f1.5rem\u001fUnexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 101,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"1.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -4435,8 +4435,8 @@
     {
       "column": 23,
       "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f119\u001f23\u001f2.5rem\u001fUnexpected raw scale value \"2.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 119,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f120\u001f23\u001f2.5rem\u001fUnexpected raw scale value \"2.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 120,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"2.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -4445,8 +4445,8 @@
     {
       "column": 21,
       "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f135\u001f21\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 135,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f136\u001f21\u001f0.5rem\u001fUnexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 136,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -4455,8 +4455,8 @@
     {
       "column": 11,
       "file": "nextjs-app/shared/components/TextInput/TextInput.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f158\u001f11\u001f-1px\u001fUnexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 158,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/TextInput/TextInput.module.css\u001f159\u001f11\u001f-1px\u001fUnexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 159,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",

--- a/nextjs-app/shared/components/Combobox/ComboboxField.module.css
+++ b/nextjs-app/shared/components/Combobox/ComboboxField.module.css
@@ -233,9 +233,20 @@
 /* Dedicated-token disabled surface (no opacity), matching the text inputs. The
    border/background live on the parent .wrapper, so mute it when it holds a
    disabled control. */
+
 .wrapper:has(.disabled) {
   border-color: var(--color-primary-disabled);
   background: var(--color-disabled-bg-light);
+}
+
+.wrapper:has(.disabled) .triggerLabel,
+.wrapper:has(.disabled) .triggerPlaceholder {
+  color: var(--color-disabled-placeholder);
+}
+
+.field:has(.disabled) .label {
+  color: var(--color-muted-light);
+  cursor: not-allowed;
 }
 
 @keyframes dropdown-enter {

--- a/nextjs-app/shared/components/MultiCombobox/MultiCombobox.module.css
+++ b/nextjs-app/shared/components/MultiCombobox/MultiCombobox.module.css
@@ -52,7 +52,13 @@
 }
 
 .input:disabled {
+  color: var(--color-disabled-placeholder);
   cursor: not-allowed;
+}
+
+.input:disabled::placeholder {
+  color: var(--color-disabled-placeholder);
+  opacity: 1;
 }
 
 .badgeWrap {
@@ -69,4 +75,8 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+}
+
+.control:has(.input:disabled) .badgeLabel {
+  color: var(--color-disabled-placeholder);
 }

--- a/nextjs-app/shared/components/PhoneInput/PhoneInput.module.css
+++ b/nextjs-app/shared/components/PhoneInput/PhoneInput.module.css
@@ -56,6 +56,24 @@
   font-style: italic;
 }
 
+/* Dedicated-token disabled surface (no opacity), matching the text inputs */
+
+.phone-input:has(:global(.PhoneInputInput):disabled) {
+  border-color: var(--color-primary-disabled);
+  background-color: var(--color-disabled-bg-light);
+  cursor: not-allowed;
+}
+
+.phone-input :global(.PhoneInputInput):disabled {
+  color: var(--color-disabled-placeholder);
+  cursor: not-allowed;
+}
+
+.phone-input :global(.PhoneInputInput):disabled::placeholder {
+  color: var(--color-disabled-placeholder);
+  opacity: 1;
+}
+
 .phone-input :global(.PhoneInputCountry) {
   display: flex;
   margin-inline-end: 0.5rem;

--- a/nextjs-app/shared/components/Select/Select.module.css
+++ b/nextjs-app/shared/components/Select/Select.module.css
@@ -68,8 +68,9 @@
 }
 
 .select:disabled {
-  background-color: var(--color-disabled-bg);
-  color: var(--color-muted);
+  border-color: var(--color-primary-disabled);
+  background-color: var(--color-disabled-bg-light);
+  color: var(--color-disabled-placeholder);
   cursor: not-allowed;
 }
 

--- a/nextjs-app/shared/components/Select/Select.tsx
+++ b/nextjs-app/shared/components/Select/Select.tsx
@@ -109,7 +109,11 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
 
     return (
       <div className={styles.container}>
-        {label && <Label htmlFor={selectId}>{label}</Label>}
+        {label && (
+          <Label htmlFor={selectId} disabled={disabled}>
+            {label}
+          </Label>
+        )}
         <div className={styles.wrapper}>
           <select
             id={selectId}

--- a/nextjs-app/shared/components/TextArea/TextArea.module.css
+++ b/nextjs-app/shared/components/TextArea/TextArea.module.css
@@ -68,6 +68,7 @@
 .input:disabled {
   border-color: var(--color-primary-disabled);
   background-color: var(--color-disabled-bg-light);
+  color: var(--color-disabled-placeholder);
   cursor: not-allowed;
 }
 

--- a/nextjs-app/shared/components/TextInput/TextInput.module.css
+++ b/nextjs-app/shared/components/TextInput/TextInput.module.css
@@ -88,6 +88,7 @@
 .input:disabled {
   border-color: var(--color-primary-disabled);
   background-color: var(--color-disabled-bg-light);
+  color: var(--color-disabled-placeholder);
   cursor: not-allowed;
 }
 

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -1,6 +1,6 @@
 {
   "generatedBy": "npm run lint:css:update",
-  "warningCount": 444,
+  "warningCount": 443,
   "warnings": [
     {
       "id": "app/blog/NextBlogNav.module.css::7::3::order/properties-order::Expected \"margin-inline\" to come before \"max-width\" (order/properties-order)",
@@ -460,15 +460,6 @@
       "rule": "no-descending-specificity",
       "severity": "warning",
       "text": "Expected selector \".pre\" to come before selector \".single .pre\", at line 47 (no-descending-specificity)"
-    },
-    {
-      "id": "nextjs-app/shared/components/Combobox/ComboboxField.module.css::236::1::rule-empty-line-before::Expected empty line before rule (rule-empty-line-before)",
-      "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 236,
-      "column": 1,
-      "rule": "rule-empty-line-before",
-      "severity": "warning",
-      "text": "Expected empty line before rule (rule-empty-line-before)"
     },
     {
       "id": "nextjs-app/shared/components/ComplianceCard/ComplianceCard.module.css::135::22::declaration-no-important::Disallowed !important (declaration-no-important)",


### PR DESCRIPTION
## Summary
Owner-directed unification, verified against Astryx (measured live: control wrapper opacity .5), Carbon (disabled field text = $text-disabled; they treated our exact bug as a defect in carbon#2028), and Material 3 (38% on-surface for all parts).

One canonical disabled recipe for every text-value control: surface `--color-disabled-bg-light` + border `--color-primary-disabled`, value text/placeholder/chips `--color-disabled-placeholder`, dimmed label, `cursor: not-allowed`.

- **TextInput / TextArea**: value text was full-strength while disabled; now muted.
- **Select**: bg aligned to `-bg-light`, text to `--color-disabled-placeholder`, disabled border added; Label now receives `disabled` (previously never dimmed).
- **PhoneInput**: had zero disabled styling; full recipe added.
- **Combobox / MultiCombobox**: trigger label, typed query, chips, placeholder now mute; field label dims via `.field:has(.disabled)`.
- Stylelint baseline 444→443 (fixed pre-existing warning); rhythmguard baseline rewritten for pure line shifts (new 10 = resolved 10, identical pre-existing values, attribution verified).

Extends the 2026-07-07 disabled-unification canon (#956-#961) to value text; aria trees unchanged (color-only + Label prop), so no AT snapshot recaptures.

## Verification (local, CI is quota-dead)
- Live Storybook computed-style checks on all six controls: value text rgb(133,133,133) on rgb(216,216,216) surface, labels rgb(144,144,144) + not-allowed
- npm test ✓ (TEST_OK), build ✓ (BUILD_OK), check:contract-props ✓, check:consumers ✓
- Pre-commit: typecheck, lint, lint:css baseline, rhythmguard, contrast ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)