### PR TITLE
feat(design-system): nav-cluster prop-type exports; TableOfContents DS scaffold + disclosure ARIA

### DIFF
--- a/nextjs-app/shared/components/Breadcrumb/index.ts
+++ b/nextjs-app/shared/components/Breadcrumb/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Breadcrumb";
+export type { BreadcrumbItem, BreadcrumbProps } from "./Breadcrumb";

--- a/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.test.tsx
+++ b/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.test.tsx
@@ -44,6 +44,29 @@ describe("LanguageSwitcher", () => {
     expect(screen.getByText("SV")).toBeVisible();
   });
 
+  it("pins trigger aria-current, aria-expanded, and aria-controls", async () => {
+    renderSwitcher("en");
+    const user = userEvent.setup();
+    const trigger = screen.getByRole("button", { name: /english/i });
+    const controlsId = trigger.getAttribute("aria-controls");
+
+    expect(trigger).toHaveAttribute("aria-current", "true");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(controlsId).toBeTruthy();
+    expect(document.getElementById(controlsId as string)).toHaveTextContent(
+      /show language options/i,
+    );
+
+    await user.click(trigger);
+
+    expect(trigger).toHaveAttribute("aria-current", "true");
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(trigger).toHaveAttribute("aria-controls", controlsId);
+    expect(document.getElementById(controlsId as string)).toHaveTextContent(
+      /hide language options/i,
+    );
+  });
+
   // Backs the audit:controls effect exemptions for the open-tray class props:
   // both exist in the DOM only while the tray is expanded.
   it("applies openTriggerClassName and floatedButtonClassName while open", async () => {

--- a/nextjs-app/shared/components/NavMenuList/NavMenuList.test.tsx
+++ b/nextjs-app/shared/components/NavMenuList/NavMenuList.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import NavMenuList, { NavMenuItem } from "@dt/NavMenuList";
 import {
   NavigationProvider,
@@ -14,7 +15,10 @@ const items: NavMenuItem[] = [
 ];
 
 describe("NavMenuList", () => {
-  const renderNav = (pathname: string) => {
+  const renderNav = (
+    pathname: string,
+    props: Partial<React.ComponentProps<typeof NavMenuList>> = {},
+  ) => {
     const runtime: NavigationRuntime = {
       pathname,
       searchParams: new URLSearchParams(),
@@ -23,7 +27,7 @@ describe("NavMenuList", () => {
     };
     return render(
       <NavigationProvider runtime={runtime}>
-        <NavMenuList items={items} />
+        <NavMenuList items={items} {...props} />
       </NavigationProvider>,
     );
   };
@@ -47,5 +51,16 @@ describe("NavMenuList", () => {
       "aria-current",
       "page",
     );
+  });
+
+  it("calls onNavigate when a link is activated", async () => {
+    const onNavigate = vi.fn((event?: { preventDefault: () => void }) =>
+      event?.preventDefault(),
+    );
+    renderNav("/", { onNavigate });
+
+    await userEvent.click(screen.getByRole("link", { name: "Work" }));
+
+    expect(onNavigate).toHaveBeenCalledTimes(1);
   });
 });

--- a/nextjs-app/shared/components/NavMenuList/index.ts
+++ b/nextjs-app/shared/components/NavMenuList/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./NavMenuList";
+export type { NavMenuItem, NavMenuListProps } from "./NavMenuList";

--- a/nextjs-app/shared/components/SiteTree/SiteTree.test.tsx
+++ b/nextjs-app/shared/components/SiteTree/SiteTree.test.tsx
@@ -61,4 +61,28 @@ describe("SiteTree", () => {
     const homeLink = screen.getByRole("link", { name: "Home" });
     expect(homeLink.closest("details")?.open).toBe(true);
   });
+
+  it("keeps branch index links outside summary to avoid nested-interactive markup", () => {
+    render(
+      <SiteTree
+        nodes={[
+          {
+            id: "docs",
+            label: "Docs",
+            href: "/docs",
+            indexLabel: "Docs overview",
+            defaultExpanded: true,
+            children: [{ id: "api", label: "API", href: "/docs/api" }],
+          },
+        ]}
+      />,
+    );
+
+    const summary = screen.getByText("Docs").closest("summary");
+    expect(summary?.querySelector("a")).toBeNull();
+
+    const branchIndexLink = screen.getByRole("link", { name: "Docs overview" });
+    expect(branchIndexLink).toHaveAttribute("href", "/docs");
+    expect(branchIndexLink.closest("summary")).toBeNull();
+  });
 });

--- a/nextjs-app/shared/components/SocialShare/index.ts
+++ b/nextjs-app/shared/components/SocialShare/index.ts
@@ -1,2 +1,7 @@
 export { SocialShare } from "./SocialShare";
 export { SocialShare as default } from "./SocialShare";
+export type {
+  SocialShareChannel,
+  SocialShareProps,
+  SocialShareVariant,
+} from "./SocialShare";

--- a/nextjs-app/shared/components/TableOfContents/TableOfContents.contract.json
+++ b/nextjs-app/shared/components/TableOfContents/TableOfContents.contract.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+  "schemaVersion": 2,
+  "name": "TableOfContents",
+  "tier": "molecule",
+  "group": "navigation",
+  "status": "alpha",
+  "description": "In-article table of contents for h2/h3 sections, with mobile disclosure and active-section indication.",
+  "figma": null,
+  "radixPrimitive": null,
+  "element": "nav",
+  "variants": {},
+  "slots": [],
+  "asChild": false,
+  "subParts": [],
+  "requiredStories": [
+    "Default",
+    "Playground",
+    "Example",
+    "ForcedColors"
+  ],
+  "a11y": {
+    "keyboard": [
+      "Tab reaches the disclosure trigger and each heading button.",
+      "Enter / Space toggles the mobile disclosure and activates heading buttons."
+    ],
+    "ariaRequirements": [
+      "nav landmark with a localized aria-label",
+      "mobile trigger exposes aria-expanded and aria-controls",
+      "active heading button exposes aria-current='location'"
+    ],
+    "reducedMotion": true,
+    "reviewed": false,
+    "forcedColorsVerified": false
+  },
+  "tokens": {
+    "colors": [],
+    "spacing": []
+  },
+  "lightDarkVerified": false,
+  "props": {
+    "items": {
+      "optional": false,
+      "type": "TOCItem[]"
+    },
+    "activeId": {
+      "optional": true,
+      "type": "string | null"
+    },
+    "sticky": {
+      "optional": true,
+      "type": "boolean"
+    },
+    "onItemClick": {
+      "optional": true,
+      "type": "(id: string) => void"
+    },
+    "className": {
+      "optional": true,
+      "type": "string"
+    }
+  },
+  "forbiddenUse": [
+    "Use for global site navigation — use NavMenuList or SiteTree instead.",
+    "Pass heading levels outside h2/h3 without updating the TOCItem contract."
+  ],
+  "composesWith": [
+    "ArticleContent",
+    "ArticlePageTemplate",
+    "ReadingProgress"
+  ],
+  "displayName": "TableOfContents",
+  "keywords": [
+    "toc",
+    "table of contents",
+    "article navigation",
+    "headings",
+    "active section"
+  ],
+  "dense": "Article table of contents for h2/h3 headings; mobile disclosure; activeId marks aria-current=location; onItemClick or built-in smooth scroll.",
+  "usage": {
+    "description": "Use TableOfContents in article layouts when the page exposes multiple h2/h3 sections. Pass extracted heading items and activeId from useTableOfContents; pass onItemClick when the parent owns scroll behavior."
+  }
+}

--- a/nextjs-app/shared/components/TableOfContents/TableOfContents.spec.md
+++ b/nextjs-app/shared/components/TableOfContents/TableOfContents.spec.md
@@ -1,0 +1,37 @@
+# TableOfContents
+
+## Intent
+
+Render an in-article navigation list for h2/h3 headings so readers can scan and
+jump between sections without leaving the article context.
+
+## Interaction contract
+
+- Keyboard: Tab reaches the mobile disclosure trigger and every heading button.
+- Pointer: The trigger expands/collapses the mobile list; heading buttons jump to
+  the matching section.
+- Screen readers: The root is a `nav` landmark labelled "Table of Contents";
+  the active heading exposes `aria-current="location"`.
+
+## API
+
+| Prop | Type | Notes |
+| --- | --- | --- |
+| `items` | `TOCItem[]` | Ordered h2/h3 headings. |
+| `activeId` | `string | null` | Heading id currently in view. |
+| `sticky` | `boolean` | Enables tablet-and-up sticky positioning. |
+| `onItemClick` | `(id: string) => void` | Parent-owned scroll handler. |
+| `className` | `string` | Optional root classes. |
+
+## Do / don't
+
+- Do: Pair with `useTableOfContents` in article templates.
+- Do: Keep item text identical to the rendered heading text.
+- Don't: Use for primary site navigation.
+- Don't: Pass arbitrary nesting levels without expanding `TOCItem`.
+
+## Design notes
+
+- Uses existing article typography and Tailwind token utilities.
+- Figma: not linked yet; keep the contract alpha until forced-colors and AT
+  verification are captured.

--- a/nextjs-app/shared/components/TableOfContents/TableOfContents.stories.tsx
+++ b/nextjs-app/shared/components/TableOfContents/TableOfContents.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState, type ComponentProps } from "react";
+import { expect, userEvent, within } from "storybook/test";
+
+import { TableOfContents, type TOCItem } from "./TableOfContents";
+import contract from "./TableOfContents.contract.json";
+
+const items: TOCItem[] = [
+  { id: "overview", text: "Overview", level: 2 },
+  { id: "setup", text: "Setup", level: 3 },
+  { id: "api", text: "API", level: 2 },
+  { id: "limits", text: "Known limits", level: 3 },
+];
+
+function Demo(args: ComponentProps<typeof TableOfContents>) {
+  const [activeId, setActiveId] = useState(args.activeId ?? "overview");
+  return (
+    <TableOfContents
+      {...args}
+      activeId={activeId}
+      onItemClick={(id) => {
+        setActiveId(id);
+        args.onItemClick?.(id);
+      }}
+    />
+  );
+}
+
+const meta = {
+  title: "Navigation/TableOfContents",
+  component: TableOfContents,
+  tags: ["alpha", "autodocs"],
+  parameters: {
+    layout: "padded",
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+    docs: { description: { component: contract.description } },
+  },
+  args: {
+    items,
+    activeId: "overview",
+    sticky: false,
+  },
+} satisfies Meta<typeof TableOfContents>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Playground: Story = {
+  render: (args) => <Demo {...args} />,
+};
+
+Playground.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  const api = canvas.getByRole("button", { name: "API" });
+  await userEvent.click(api);
+  await expect(api).toHaveAttribute("aria-current", "location");
+};
+
+export const Example: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => <Demo items={items} activeId="setup" sticky />,
+};
+
+export const ForcedColors: Story = {
+  globals: { forcedColors: "active" },
+  args: {
+    items,
+    activeId: "api",
+  },
+};

--- a/nextjs-app/shared/components/TableOfContents/TableOfContents.test.tsx
+++ b/nextjs-app/shared/components/TableOfContents/TableOfContents.test.tsx
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe, toHaveNoViolations } from "jest-axe";
+
+import { TableOfContents, type TOCItem } from "./TableOfContents";
+
+expect.extend(toHaveNoViolations);
+
+vi.mock("../../lib/translation", () => ({
+  useTranslate: () => (_key: string, fallback?: string) => fallback ?? _key,
+}));
+
+const items: TOCItem[] = [
+  { id: "intro", text: "Introduction", level: 2 },
+  { id: "setup", text: "Setup", level: 3 },
+  { id: "api", text: "API", level: 2 },
+];
+
+describe("TableOfContents", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders nothing for an empty item list", () => {
+    const { container } = render(<TableOfContents items={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a labelled navigation landmark", () => {
+    render(<TableOfContents items={items} activeId="setup" />);
+
+    expect(
+      screen.getByRole("navigation", { name: "Table of Contents" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Setup" })).toHaveAttribute(
+      "aria-current",
+      "location",
+    );
+  });
+
+  it("pins mobile disclosure aria-expanded and aria-controls", async () => {
+    render(<TableOfContents items={items} />);
+    const user = userEvent.setup();
+    const toggle = screen.getByRole("button", { name: "Table of Contents" });
+    const controlsId = toggle.getAttribute("aria-controls");
+
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(controlsId).toBeTruthy();
+    expect(document.getElementById(controlsId as string)).toBeInTheDocument();
+
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(toggle).toHaveAttribute("aria-controls", controlsId);
+  });
+
+  it("calls onItemClick with the selected heading id and collapses", async () => {
+    const onItemClick = vi.fn();
+    render(<TableOfContents items={items} onItemClick={onItemClick} />);
+    const user = userEvent.setup();
+    const toggle = screen.getByRole("button", { name: "Table of Contents" });
+
+    await user.click(toggle);
+    await user.click(screen.getByRole("button", { name: "API" }));
+
+    expect(onItemClick).toHaveBeenCalledTimes(1);
+    expect(onItemClick).toHaveBeenCalledWith("api");
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("scrolls to the matching heading when no callback is supplied", async () => {
+    const scrollIntoView = vi.fn();
+    const heading = document.createElement("h2");
+    heading.id = "api";
+    heading.scrollIntoView = scrollIntoView;
+    document.body.appendChild(heading);
+
+    render(<TableOfContents items={items} />);
+    await userEvent.click(screen.getByRole("button", { name: "API" }));
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "start",
+    });
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(
+      <TableOfContents items={items} activeId="intro" />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/TableOfContents/TableOfContents.tsx
+++ b/nextjs-app/shared/components/TableOfContents/TableOfContents.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useState } from "react";
 import { useTranslate } from "../../lib/translation";
 import { ChevronDown } from "lucide-react";
 import { cn } from "../../lib/cn";
@@ -45,6 +45,7 @@ export function TableOfContents({
 }: TableOfContentsProps) {
   const t = useTranslate();
   const [isExpanded, setIsExpanded] = useState(false);
+  const listId = useId();
 
   // Don't render if no items
   if (!items || items.length === 0) {
@@ -70,7 +71,7 @@ export function TableOfContents({
       className={cn(
         "w-full",
         sticky && "tablet:sticky tablet:top-24",
-        className
+        className,
       )}
     >
       {/* Mobile toggle button */}
@@ -81,26 +82,28 @@ export function TableOfContents({
           "flex items-center justify-between w-full",
           "tablet:hidden",
           "p-4 bg-muted rounded-lg",
-          "text-sm font-body font-medium text-foreground"
+          "text-sm font-body font-medium text-foreground",
         )}
         aria-expanded={isExpanded}
+        aria-controls={listId}
       >
         <span>{t("articleTOCTitle", "Table of Contents")}</span>
         <ChevronDown
           className={cn(
             "w-4 h-4 transition-transform",
-            isExpanded && "rotate-180"
+            isExpanded && "rotate-180",
           )}
         />
       </button>
 
       {/* TOC list */}
       <div
+        id={listId}
         className={cn(
           // Mobile: collapsible
           "tablet:block",
           isExpanded ? "block" : "hidden",
-          "mt-2 tablet:mt-0"
+          "mt-2 tablet:mt-0",
         )}
       >
         {/* Title (desktop only) */}
@@ -129,8 +132,9 @@ export function TableOfContents({
                     // Active state
                     isActive
                       ? "text-foreground font-medium bg-muted/50 tablet:bg-transparent tablet:border-l-2 tablet:border-primary tablet:pl-3"
-                      : "text-muted-foreground hover:text-foreground"
+                      : "text-muted-foreground hover:text-foreground",
                   )}
+                  aria-current={isActive ? "location" : undefined}
                 >
                   {item.text}
                 </button>

--- a/nextjs-app/shared/components/index.ts
+++ b/nextjs-app/shared/components/index.ts
@@ -84,6 +84,7 @@ export type {
 } from "./Menu";
 export { default as MCPActionButton } from "./MCPActionButton/MCPActionButton";
 export { default as NavMenuList } from "./NavMenuList/NavMenuList";
+export type { NavMenuItem, NavMenuListProps } from "./NavMenuList";
 export { default as MarkdownMessage } from "./MarkdownMessage/MarkdownMessage";
 export { default as Modal } from "./Modal/Modal";
 export type { ModalProps, ModalSeverity } from "./Modal/Modal";
@@ -108,6 +109,11 @@ export { SkillsGrid, type SkillsGridProps, type Skill } from "./SkillsGrid";
 export { default as StudioMap } from "./StudioMap/StudioMap";
 export { default as Switch } from "./Switch/Switch";
 export { SocialShare } from "./SocialShare/SocialShare";
+export type {
+  SocialShareChannel,
+  SocialShareProps,
+  SocialShareVariant,
+} from "./SocialShare";
 export { default as Tabs, getTabPanelProps } from "./Tabs";
 export type { TabItem, TabsProps } from "./Tabs";
 export { default as Testimonial } from "./Testimonial/Testimonial";

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,16 +1,16 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-11T15:32:58.173Z",
+  "generatedAt": "2026-07-11T16:19:26.524Z",
   "summary": {
-    "componentCount": 164,
+    "componentCount": 165,
     "statusCounts": {
       "beta": 48,
       "stable": 89,
-      "alpha": 26,
+      "alpha": 27,
       "deprecated": 1
     },
     "honestBetaDocDebt": 0,
-    "catalogCompletenessPercent": 87.7,
+    "catalogCompletenessPercent": 88.2,
     "codebaseComponentCount": 187,
     "usageCoveragePercent": 93.3,
     "componentsWithProductionUsage": 49,
@@ -58,40 +58,40 @@
   "catalogCoverage": {
     "description": "Catalog completeness across the codebase. componentCount above is the catalog count; this block reveals how much of the codebase that catalog actually represents.",
     "totalComponentsInCodebase": 187,
-    "inCatalog": 164,
-    "outOfCatalog": 23,
-    "catalogCompletenessPercent": 87.7,
+    "inCatalog": 165,
+    "outOfCatalog": 22,
+    "catalogCompletenessPercent": 88.2,
     "artifactCoverage": {
-      "stories": 148,
-      "tests": 147,
+      "stories": 149,
+      "tests": 148,
       "mdx": 6,
-      "spec": 164
+      "spec": 165
     },
     "outOfCatalogByBucket": {
       "catalog-gap": 0,
       "page-pattern": 0,
       "enhanced-fork": 4,
-      "exempt": 19
+      "exempt": 18
     },
     "regenerate": "node scripts/design-system/audit-catalog-coverage.mjs (run with --json for machine-readable output)"
   },
   "usageCoverage": {
     "description": "Auto-detected import evidence from app/** and nextjs-app/**. Separate from contract.consumers[], which remains the stable-promotion gate for shipping-product proof.",
-    "catalogedComponents": 164,
-    "withAnyUsage": 153,
+    "catalogedComponents": 165,
+    "withAnyUsage": 154,
     "withProductionUsage": 49,
-    "uniqueImportedComponents": 153,
-    "totalEvidenceRows": 868,
+    "uniqueImportedComponents": 154,
+    "totalEvidenceRows": 871,
     "aliasImportFiles": 485,
-    "relativeImportFiles": 391,
+    "relativeImportFiles": 396,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
   },
   "relationshipGraph": {
     "description": "Merged static composesWith policy + co-import evidence (see generate-relationship-graph.mjs).",
-    "generatedAt": "2026-07-11T09:36:34.646Z",
+    "generatedAt": "2026-07-11T16:19:24.393Z",
     "coImportMinFiles": 3,
-    "nodesWithComposesWith": 87,
+    "nodesWithComposesWith": 88,
     "regenerate": "npm run build:relationship-graph or npm run build:tokens",
     "path": "nextjs-app/shared/foundations/dist/relationship-graph.json"
   },
@@ -102,14 +102,14 @@
   "dsharpParity": {
     "description": "Comparison against DSharp as of 2026-05-26. Breadth is close, maturity is not. This block walks back the earlier parity overclaim.",
     "contractCount": {
-      "digitaltableteur": 164,
+      "digitaltableteur": 165,
       "dsharp": 112
     },
     "statusMix": {
       "digitaltableteur": {
         "beta": 48,
         "stable": 89,
-        "alpha": 26,
+        "alpha": 27,
         "deprecated": 1
       },
       "dsharp": {
@@ -28858,6 +28858,192 @@
         "composesWith": [],
         "prefersOver": [],
         "declaredPropCount": 10
+      }
+    },
+    {
+      "name": "TableOfContents",
+      "contract": {
+        "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+        "schemaVersion": 2,
+        "name": "TableOfContents",
+        "tier": "molecule",
+        "group": "navigation",
+        "status": "alpha",
+        "description": "In-article table of contents for h2/h3 sections, with mobile disclosure and active-section indication.",
+        "figma": null,
+        "radixPrimitive": null,
+        "element": "nav",
+        "variants": {},
+        "slots": [],
+        "asChild": false,
+        "subParts": [],
+        "requiredStories": [
+          "Default",
+          "Playground",
+          "Example",
+          "ForcedColors"
+        ],
+        "a11y": {
+          "keyboard": [
+            "Tab reaches the disclosure trigger and each heading button.",
+            "Enter / Space toggles the mobile disclosure and activates heading buttons."
+          ],
+          "ariaRequirements": [
+            "nav landmark with a localized aria-label",
+            "mobile trigger exposes aria-expanded and aria-controls",
+            "active heading button exposes aria-current='location'"
+          ],
+          "reducedMotion": true,
+          "reviewed": false,
+          "forcedColorsVerified": false
+        },
+        "tokens": {
+          "colors": [],
+          "spacing": []
+        },
+        "lightDarkVerified": false,
+        "props": {
+          "items": {
+            "optional": false,
+            "type": "TOCItem[]"
+          },
+          "activeId": {
+            "optional": true,
+            "type": "string | null"
+          },
+          "sticky": {
+            "optional": true,
+            "type": "boolean"
+          },
+          "onItemClick": {
+            "optional": true,
+            "type": "(id: string) => void"
+          },
+          "className": {
+            "optional": true,
+            "type": "string"
+          }
+        },
+        "forbiddenUse": [
+          "Use for global site navigation — use NavMenuList or SiteTree instead.",
+          "Pass heading levels outside h2/h3 without updating the TOCItem contract."
+        ],
+        "composesWith": [
+          "ArticleContent",
+          "ArticlePageTemplate",
+          "ReadingProgress"
+        ],
+        "displayName": "TableOfContents",
+        "keywords": [
+          "toc",
+          "table of contents",
+          "article navigation",
+          "headings",
+          "active section"
+        ],
+        "dense": "Article table of contents for h2/h3 headings; mobile disclosure; activeId marks aria-current=location; onItemClick or built-in smooth scroll.",
+        "usage": {
+          "description": "Use TableOfContents in article layouts when the page exposes multiple h2/h3 sections. Pass extracted heading items and activeId from useTableOfContents; pass onItemClick when the parent owns scroll behavior."
+        }
+      },
+      "spec": "# TableOfContents\n\n## Intent\n\nRender an in-article navigation list for h2/h3 headings so readers can scan and\njump between sections without leaving the article context.\n\n## Interaction contract\n\n- Keyboard: Tab reaches the mobile disclosure trigger and every heading button.\n- Pointer: The trigger expands/collapses the mobile list; heading buttons jump to\n  the matching section.\n- Screen readers: The root is a `nav` landmark labelled \"Table of Contents\";\n  the active heading exposes `aria-current=\"location\"`.\n\n## API\n\n| Prop | Type | Notes |\n| --- | --- | --- |\n| `items` | `TOCItem[]` | Ordered h2/h3 headings. |\n| `activeId` | `string | null` | Heading id currently in view. |\n| `sticky` | `boolean` | Enables tablet-and-up sticky positioning. |\n| `onItemClick` | `(id: string) => void` | Parent-owned scroll handler. |\n| `className` | `string` | Optional root classes. |\n\n## Do / don't\n\n- Do: Pair with `useTableOfContents` in article templates.\n- Do: Keep item text identical to the rendered heading text.\n- Don't: Use for primary site navigation.\n- Don't: Pass arbitrary nesting levels without expanding `TOCItem`.\n\n## Design notes\n\n- Uses existing article typography and Tailwind token utilities.\n- Figma: not linked yet; keep the contract alpha until forced-colors and AT\n  verification are captured.\n",
+      "documentationDebt": false,
+      "usage": {
+        "publicImport": "@dt/TableOfContents",
+        "importCount": 3,
+        "productionImportCount": 0,
+        "patternImportCount": 1,
+        "componentImportCount": 1,
+        "evidence": [
+          {
+            "path": "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
+            "importKind": "relative",
+            "importPath": "../../components/TableOfContents",
+            "context": "pattern"
+          },
+          {
+            "path": "nextjs-app/shared/components/index.ts",
+            "importKind": "relative",
+            "importPath": "./TableOfContents",
+            "context": "component"
+          },
+          {
+            "path": "nextjs-app/shared/hooks/useTableOfContents.ts",
+            "importKind": "relative",
+            "importPath": "../components/TableOfContents",
+            "context": "other"
+          }
+        ]
+      },
+      "agent": {
+        "preferredImport": "@dt/TableOfContents",
+        "intent": "Render an in-article navigation list for h2/h3 headings so readers can scan and jump between sections without leaving the article context.",
+        "props": {
+          "items": {
+            "optional": false,
+            "type": "TOCItem[]"
+          },
+          "activeId": {
+            "optional": true,
+            "type": "string | null"
+          },
+          "sticky": {
+            "optional": true,
+            "type": "boolean"
+          },
+          "onItemClick": {
+            "optional": true,
+            "type": "(id: string) => void"
+          },
+          "className": {
+            "optional": true,
+            "type": "string"
+          }
+        },
+        "variants": {},
+        "cvaVariants": {},
+        "variantsFnName": null,
+        "useWhen": [
+          "Pair with `useTableOfContents` in article templates.",
+          "Keep item text identical to the rendered heading text."
+        ],
+        "avoidWhen": [
+          "Use for primary site navigation.",
+          "Pass arbitrary nesting levels without expanding `TOCItem`."
+        ],
+        "requiredA11y": [
+          "nav landmark with a localized aria-label",
+          "mobile trigger exposes aria-expanded and aria-controls",
+          "active heading button exposes aria-current='location'"
+        ],
+        "keyboard": [
+          "Tab reaches the disclosure trigger and each heading button.",
+          "Enter / Space toggles the mobile disclosure and activates heading buttons."
+        ],
+        "compositionRules": [
+          "Pass arbitrary nesting levels without expanding `TOCItem`."
+        ],
+        "canonicalExamples": [
+          "Default",
+          "Playground",
+          "Example",
+          "ForcedColors"
+        ],
+        "replacementFor": [],
+        "forbiddenUse": [
+          "Use for primary site navigation.",
+          "Pass arbitrary nesting levels without expanding `TOCItem`."
+        ],
+        "composesWith": [
+          "AuthorBio",
+          "CodeBlockWindow",
+          "DashLeadList",
+          "ArticleContent",
+          "EnhancedAuthorCard",
+          "ArticleShareSection"
+        ],
+        "prefersOver": [],
+        "declaredPropCount": 5
       }
     },
     {

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -13739,6 +13739,84 @@
         }
       ]
     },
+    "TableOfContents": {
+      "name": "TableOfContents",
+      "group": "navigation",
+      "tier": 2,
+      "status": "alpha",
+      "description": "In-article table of contents for h2/h3 sections, with mobile disclosure and active-section indication.",
+      "dense": "Article table of contents for h2/h3 headings; mobile disclosure; activeId marks aria-current=location; onItemClick or built-in smooth scroll.",
+      "keywords": [
+        "toc",
+        "table of contents",
+        "article navigation",
+        "headings",
+        "active section"
+      ],
+      "importLine": "import { TableOfContents } from \"@dt/TableOfContents\";",
+      "keyProps": [
+        {
+          "name": "items",
+          "type": "TOCItem[]",
+          "required": true
+        },
+        {
+          "name": "activeId",
+          "type": "string | null",
+          "required": false
+        },
+        {
+          "name": "sticky",
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "className",
+          "type": "string",
+          "required": false
+        }
+      ],
+      "props": {
+        "items": {
+          "optional": false,
+          "type": "TOCItem[]"
+        },
+        "activeId": {
+          "optional": true,
+          "type": "string | null"
+        },
+        "sticky": {
+          "optional": true,
+          "type": "boolean"
+        },
+        "onItemClick": {
+          "optional": true,
+          "type": "(id: string) => void"
+        },
+        "className": {
+          "optional": true,
+          "type": "string"
+        }
+      },
+      "composesWith": [
+        "ArticleContent",
+        "ArticlePageTemplate",
+        "ReadingProgress"
+      ],
+      "prefersOver": [],
+      "forbiddenUse": [
+        "Use for global site navigation — use NavMenuList or SiteTree instead.",
+        "Pass heading levels outside h2/h3 without updating the TOCItem contract."
+      ],
+      "usage": {
+        "description": "Use TableOfContents in article layouts when the page exposes multiple h2/h3 sections. Pass extracted heading items and activeId from useTableOfContents; pass onItemClick when the parent owns scroll behavior."
+      },
+      "tokens": {
+        "colors": [],
+        "spacing": []
+      },
+      "examples": []
+    },
     "Tabs": {
       "name": "Tabs",
       "group": "navigation",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -122,6 +122,10 @@ export {
   type NavLinkProps,
 } from "../../../nextjs-app/shared/components/NavLink";
 export { default as NavMenuList } from "../../../nextjs-app/shared/components/NavMenuList/NavMenuList";
+export type {
+  NavMenuItem,
+  NavMenuListProps,
+} from "../../../nextjs-app/shared/components/NavMenuList";
 export {
   Pagination,
   type PaginationProps,


### PR DESCRIPTION
## Summary
Vetted Codex batch 3 (nav cluster). No tampering this round; two review corrections applied before commit.

- Type-only exports for Breadcrumb, NavMenuList, SocialShare across barrels, shared root, and `@digitaltableteur/react` (runtime API unchanged at 106 exports).
- New tests: NavMenuList.onNavigate, SiteTree nested-interactive safety, LanguageSwitcher ARIA state.
- **TableOfContents** gains full DS shape: contract (alpha, navigation group), spec, stories (Default/Playground+play/Example/ForcedColors), tests incl. axe; source adds `aria-controls` on the mobile disclosure and `aria-current="location"` on the active heading. (Component is in the pre-existing Tailwind cohort; not converted here.)
- **Review corrections**: story title `Article/*` → `Navigation/*` (use-based taxonomy rule; `Article` was an invented one-off group), JSX indentation fix.
- Agent manifest regenerated: catalog 164 → 165, 0 doc-debt.

## Verification (local, CI is quota-dead)
- npm test ✓ (TEST_OK), build ✓ (BUILD_OK), check:contract-props ✓, check:consumers ✓, check:react-package 106 exports ✓, validate:components ✓, check:contract-drift --strict ✓
- Live Storybook: story renders under Navigation, nav landmark labelled, aria-current on active item, aria-controls resolves
- Pre-commit hooks: typecheck, lint, lint:css baseline, rhythmguard 0 new drift, contrast ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a fully documented and tested Table of Contents component with mobile disclosure, sticky mode, active-section indication, smooth scrolling, and accessibility support.
  - Improved accessibility relationships for collapsible navigation and language controls.

- **Bug Fixes**
  - Prevented nested interactive elements in site tree navigation.

- **Documentation**
  - Added Table of Contents usage specifications, contracts, and Storybook examples.

- **Tests**
  - Expanded coverage for navigation interactions, accessibility attributes, and Table of Contents behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->