### PR TITLE
fix(tokens): disabled field contrast — legible greys in all four themes

### DIFF
--- a/nextjs-app/shared/foundations/token-catalog.json
+++ b/nextjs-app/shared/foundations/token-catalog.json
@@ -1,6 +1,6 @@
 {
   "source": "nextjs-app/shared/styles/variables.css",
-  "generatedAt": "2026-07-09T23:20:08.148Z",
+  "generatedAt": "2026-07-11T16:31:25.521Z",
   "tokenCount": 184,
   "usageCoverage": 150,
   "themes": [
@@ -667,14 +667,14 @@
         },
         {
           "name": "--color-disabled-bg",
-          "value": "#e0e0e0",
+          "value": "#e8e8e8",
           "usage": "Color token (disabled-bg).",
           "category": "color",
           "subgroup": "Greyscale & borders"
         },
         {
           "name": "--color-disabled-bg-light",
-          "value": "#d8d8d8",
+          "value": "#efefef",
           "usage": "Color token (disabled-bg-light).",
           "category": "color",
           "subgroup": "Greyscale & borders"

--- a/nextjs-app/shared/foundations/tokens/production/color.json
+++ b/nextjs-app/shared/foundations/tokens/production/color.json
@@ -166,7 +166,7 @@
     "disabled": {
       "bg": {
         "DEFAULT": {
-          "$value": "#e0e0e0",
+          "$value": "#e8e8e8",
           "$description": "Color token (disabled-bg).",
           "$type": "color",
           "$extensions": {
@@ -178,7 +178,7 @@
           }
         },
         "light": {
-          "$value": "#d8d8d8",
+          "$value": "#efefef",
           "$description": "Color token (disabled-bg-light).",
           "$type": "color",
           "$extensions": {

--- a/nextjs-app/shared/styles/variables.css
+++ b/nextjs-app/shared/styles/variables.css
@@ -130,8 +130,8 @@
   --color-muted-light: #909090;
   --color-border: #c0c0c0;
   --color-border-light: #ccc;
-  --color-disabled-bg: #e0e0e0;
-  --color-disabled-bg-light: #d8d8d8;
+  --color-disabled-bg: #e8e8e8; /* 3.01:1 with --color-disabled-placeholder */
+  --color-disabled-bg-light: #efefef; /* 3.21:1 with --color-disabled-placeholder */
   --color-disabled-placeholder: #858585;
   --color-gray-medium: #666;
   --color-light-bg: #f9f9f9;
@@ -387,7 +387,7 @@
   --color-border-light: #444;
   --color-disabled-bg: #23272a;
   --color-disabled-bg-light: #23272a;
-  --color-disabled-placeholder: #555;
+  --color-disabled-placeholder: #767676; /* 3.31:1 on #23272a; #555 was 2.02:1 */
   --color-gray-medium: #888;
   --color-light-bg: #23272a;
   --accent-pink: #f205c5;
@@ -454,8 +454,8 @@
   --color-border: #333;
   --color-border-light: #444;
   --color-disabled-bg: #313131;
-  --color-disabled-bg-light: #7b7b7b;
-  --color-disabled-placeholder: #555;
+  --color-disabled-bg-light: #313131; /* #7b7b7b midtone was 1.76:1 with any gray text */
+  --color-disabled-placeholder: #9e9e9e; /* 4.86:1 on #313131; #555 was 1.74:1 */
   --color-gray-medium: #888;
   --color-light-bg: #101010;
   --accent-pink: #fff;
@@ -565,9 +565,9 @@
   --color-muted-light: #555;
   --color-border: #333;
   --color-border-light: #444;
-  --color-disabled-bg: #313131;
-  --color-disabled-bg-light: #7b7b7b;
-  --color-disabled-placeholder: #555;
+  --color-disabled-bg: #e8e8e8; /* dark-on-light HC theme: near-black fields were illegible */
+  --color-disabled-bg-light: #efefef;
+  --color-disabled-placeholder: #6b6b6b; /* 4.63:1 on #efefef, 4.35:1 on #e8e8e8 */
   --color-gray-medium: #888;
   --color-light-bg: #f1f1f1;
   --accent-pink: #000;


### PR DESCRIPTION
## Summary
Owner report: disabled inputs visibly fail contrast checks. Root-caused at token level; disabled controls are WCAG-1.4.3-exempt so `check:contrast` never covered these pairs.

| Theme | Before | After |
|---|---|---|
| Light | 2.59:1 | bg-light `#efefef` (3.21:1), bg `#e8e8e8` (3.01:1), text unchanged |
| Dark | 2.02:1 | placeholder `#767676` (3.31:1 on `#23272a`) |
| HC Black | 1.74:1 | `#9e9e9e` on `#313131` (4.86:1); `#7b7b7b` midtone field removed |
| HC White | 1.76:1 | `#6b6b6b` on `#efefef`/`#e8e8e8` (4.63/4.35:1); near-black fields removed |

Also un-inverts light-theme naming (`-bg-light` is now actually lighter than `-bg`). forced-colors GrayText/Canvas untouched. DTCG catalog + production color tokens regenerated.

Note: published `@digitaltableteur/tokens-css` now trails source until next publish.

## Verification (local, CI is quota-dead)
- Ratios computed with WCAG relative-luminance script; live Storybook computed-style checks in all four themes
- check:contrast ✓, npm test ✓ (TEST_OK), build ✓ (BUILD_OK), check:contract-props ✓, check:consumers ✓
- Pre-commit hooks: typecheck, lint, lint:css baseline, rhythmguard, contrast ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)