### PR TITLE
feat(guardrails): gate disabled-token contrast at the DS dim-but-legible bar

### DIFF
--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-11T16:19:26.524Z",
+  "generatedAt": "2026-07-11T16:39:31.734Z",
   "summary": {
     "componentCount": 165,
     "statusCounts": {
@@ -53,7 +53,7 @@
         "label": "High contrast (white)"
       }
     ],
-    "contrastPairCount": 9
+    "contrastPairCount": 11
   },
   "catalogCoverage": {
     "description": "Catalog completeness across the codebase. componentCount above is the catalog count; this block reveals how much of the codebase that catalog actually represents.",

--- a/nextjs-app/shared/foundations/token-catalog.json
+++ b/nextjs-app/shared/foundations/token-catalog.json
@@ -1,6 +1,6 @@
 {
   "source": "nextjs-app/shared/styles/variables.css",
-  "generatedAt": "2026-07-11T16:31:25.521Z",
+  "generatedAt": "2026-07-11T16:39:46.044Z",
   "tokenCount": 184,
   "usageCoverage": 150,
   "themes": [
@@ -88,6 +88,30 @@
       "bg": "--color-warning",
       "label": "Warning text on warning",
       "largeText": false
+    },
+    {
+      "id": "disabled-text-on-disabled-bg",
+      "fg": "--color-disabled-placeholder",
+      "bg": "--color-disabled-bg",
+      "label": "Disabled text on disabled fill",
+      "minRatioByTheme": {
+        "light": 3,
+        "dark": 3,
+        "hcb": 4.3,
+        "hcw": 4.3
+      }
+    },
+    {
+      "id": "disabled-text-on-disabled-bg-light",
+      "fg": "--color-disabled-placeholder",
+      "bg": "--color-disabled-bg-light",
+      "label": "Disabled text on disabled field",
+      "minRatioByTheme": {
+        "light": 3,
+        "dark": 3,
+        "hcb": 4.3,
+        "hcw": 4.3
+      }
     }
   ],
   "contrastByTheme": {
@@ -208,6 +232,42 @@
         "ratio": 10.86,
         "level": "AAA",
         "pass": true
+      },
+      {
+        "id": "disabled-text-on-disabled-bg",
+        "fg": "--color-disabled-placeholder",
+        "bg": "--color-disabled-bg",
+        "label": "Disabled text on disabled fill",
+        "minRatioByTheme": {
+          "light": 3,
+          "dark": 3,
+          "hcb": 4.3,
+          "hcw": 4.3
+        },
+        "themeId": "light",
+        "fgRaw": "#858585",
+        "bgRaw": "#e8e8e8",
+        "ratio": 3.01,
+        "level": "DS ≥3:1",
+        "pass": true
+      },
+      {
+        "id": "disabled-text-on-disabled-bg-light",
+        "fg": "--color-disabled-placeholder",
+        "bg": "--color-disabled-bg-light",
+        "label": "Disabled text on disabled field",
+        "minRatioByTheme": {
+          "light": 3,
+          "dark": 3,
+          "hcb": 4.3,
+          "hcw": 4.3
+        },
+        "themeId": "light",
+        "fgRaw": "#858585",
+        "bgRaw": "#efefef",
+        "ratio": 3.21,
+        "level": "DS ≥3:1",
+        "pass": true
       }
     ],
     "dark": [
@@ -326,6 +386,42 @@
         "bgRaw": "#ffb366",
         "ratio": 9.89,
         "level": "AAA",
+        "pass": true
+      },
+      {
+        "id": "disabled-text-on-disabled-bg",
+        "fg": "--color-disabled-placeholder",
+        "bg": "--color-disabled-bg",
+        "label": "Disabled text on disabled fill",
+        "minRatioByTheme": {
+          "light": 3,
+          "dark": 3,
+          "hcb": 4.3,
+          "hcw": 4.3
+        },
+        "themeId": "dark",
+        "fgRaw": "#767676",
+        "bgRaw": "#23272a",
+        "ratio": 3.31,
+        "level": "DS ≥3:1",
+        "pass": true
+      },
+      {
+        "id": "disabled-text-on-disabled-bg-light",
+        "fg": "--color-disabled-placeholder",
+        "bg": "--color-disabled-bg-light",
+        "label": "Disabled text on disabled field",
+        "minRatioByTheme": {
+          "light": 3,
+          "dark": 3,
+          "hcb": 4.3,
+          "hcw": 4.3
+        },
+        "themeId": "dark",
+        "fgRaw": "#767676",
+        "bgRaw": "#23272a",
+        "ratio": 3.31,
+        "level": "DS ≥3:1",
         "pass": true
       }
     ],
@@ -446,6 +542,42 @@
         "ratio": 21,
         "level": "AAA",
         "pass": true
+      },
+      {
+        "id": "disabled-text-on-disabled-bg",
+        "fg": "--color-disabled-placeholder",
+        "bg": "--color-disabled-bg",
+        "label": "Disabled text on disabled fill",
+        "minRatioByTheme": {
+          "light": 3,
+          "dark": 3,
+          "hcb": 4.3,
+          "hcw": 4.3
+        },
+        "themeId": "hcb",
+        "fgRaw": "#9e9e9e",
+        "bgRaw": "#313131",
+        "ratio": 4.86,
+        "level": "DS ≥4.3:1",
+        "pass": true
+      },
+      {
+        "id": "disabled-text-on-disabled-bg-light",
+        "fg": "--color-disabled-placeholder",
+        "bg": "--color-disabled-bg-light",
+        "label": "Disabled text on disabled field",
+        "minRatioByTheme": {
+          "light": 3,
+          "dark": 3,
+          "hcb": 4.3,
+          "hcw": 4.3
+        },
+        "themeId": "hcb",
+        "fgRaw": "#9e9e9e",
+        "bgRaw": "#313131",
+        "ratio": 4.86,
+        "level": "DS ≥4.3:1",
+        "pass": true
       }
     ],
     "hcw": [
@@ -564,6 +696,42 @@
         "bgRaw": "#000",
         "ratio": 21,
         "level": "AAA",
+        "pass": true
+      },
+      {
+        "id": "disabled-text-on-disabled-bg",
+        "fg": "--color-disabled-placeholder",
+        "bg": "--color-disabled-bg",
+        "label": "Disabled text on disabled fill",
+        "minRatioByTheme": {
+          "light": 3,
+          "dark": 3,
+          "hcb": 4.3,
+          "hcw": 4.3
+        },
+        "themeId": "hcw",
+        "fgRaw": "#6b6b6b",
+        "bgRaw": "#e8e8e8",
+        "ratio": 4.35,
+        "level": "DS ≥4.3:1",
+        "pass": true
+      },
+      {
+        "id": "disabled-text-on-disabled-bg-light",
+        "fg": "--color-disabled-placeholder",
+        "bg": "--color-disabled-bg-light",
+        "label": "Disabled text on disabled field",
+        "minRatioByTheme": {
+          "light": 3,
+          "dark": 3,
+          "hcb": 4.3,
+          "hcw": 4.3
+        },
+        "themeId": "hcw",
+        "fgRaw": "#6b6b6b",
+        "bgRaw": "#efefef",
+        "ratio": 4.63,
+        "level": "DS ≥4.3:1",
         "pass": true
       }
     ]

--- a/scripts/design-system/contrast-utils.mjs
+++ b/scripts/design-system/contrast-utils.mjs
@@ -59,4 +59,10 @@ export const SEMANTIC_CONTRAST_PAIRS = [
   { id: "error-on-canvas", fg: "--color-error", bg: "--main-body-background-color", label: "Error on canvas", largeText: false },
   { id: "error-text-on-error-bg", fg: "--color-error-text", bg: "--color-error-bg", label: "Error text on error surface", largeText: false },
   { id: "warning-text-on-warning", fg: "--color-warning-text", bg: "--color-warning", label: "Warning text on warning", largeText: false },
+  // Disabled controls are WCAG-1.4.3-exempt, so these two enforce the DS's own
+  // dim-but-legible bar instead of AA: 3:1 on the normal themes, 4.3:1 on the
+  // high-contrast themes. Guards against the silent 1.7-2.6:1 regressions
+  // fixed in #1099.
+  { id: "disabled-text-on-disabled-bg", fg: "--color-disabled-placeholder", bg: "--color-disabled-bg", label: "Disabled text on disabled fill", minRatioByTheme: { light: 3, dark: 3, hcb: 4.3, hcw: 4.3 } },
+  { id: "disabled-text-on-disabled-bg-light", fg: "--color-disabled-placeholder", bg: "--color-disabled-bg-light", label: "Disabled text on disabled field", minRatioByTheme: { light: 3, dark: 3, hcb: 4.3, hcw: 4.3 } },
 ];

--- a/scripts/design-system/extract-variables-catalog.mjs
+++ b/scripts/design-system/extract-variables-catalog.mjs
@@ -164,7 +164,15 @@ function auditContrast(themeMap, themeId) {
       return { ...pair, themeId, fgRaw, bgRaw, ratio: null, level: "N/A", pass: null };
     }
     const ratio = contrastRatio(fgRgb, bgRgb);
-    const level = wcagLevel(ratio, pair.largeText);
+    // Pairs with a DS-defined minimum (e.g. disabled tokens, WCAG-exempt)
+    // grade against that per-theme bar instead of the AA/AAA ladder.
+    const minRatio = pair.minRatioByTheme?.[themeId];
+    const level =
+      minRatio != null
+        ? ratio >= minRatio
+          ? `DS ≥${minRatio}:1`
+          : "Fail"
+        : wcagLevel(ratio, pair.largeText);
     const pass = level !== "Fail";
     return { ...pair, themeId, fgRaw, bgRaw, ratio: Math.round(ratio * 100) / 100, level, pass };
   });


### PR DESCRIPTION
## Summary
Follow-up to #1099. Disabled controls are WCAG-1.4.3-exempt, so `check:contrast` never covered the disabled token family — which is how 1.7-2.6:1 pairs shipped silently across all four themes.

- Two new pairs: `--color-disabled-placeholder` on `--color-disabled-bg` and `--color-disabled-bg-light`, graded against a **DS-defined per-theme minimum** instead of the AA ladder: 3:1 light/dark, 4.3:1 HC — set just under current values (3.01/3.21/3.31/4.86/4.35/4.63) so they ratchet.
- Mechanism: `SEMANTIC_CONTRAST_PAIRS` entries may carry `minRatioByTheme`; `auditContrast` grades those as `DS ≥N:1` / `Fail`. forced-colors stays unaudited (system GrayText/Canvas).
- **Negative-tested**: regressing the light placeholder to `#a5a5a5` makes `check:contrast` exit 1 with two FAIL rows (2.01/2.14); restoring returns it green.

## Verification (local, CI is quota-dead)
- check:contrast ✓ with all 8 new theme-pair rows passing; negative test above
- typecheck ✓, npm test ✓ (TEST_OK), build ✓ (BUILD_OK), check:contract-props ✓, check:consumers ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)