### PR TITLE
chore(deps): consume @digitaltableteur/react@0.1.7 from registry

### DIFF
--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.6
+  - definition: 0.1.7
   - term: tokens
-  - definition: 0.1.0
+  - definition: 0.1.1
   - term: tokens-css
-  - definition: 0.1.0
+  - definition: 0.1.2
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.6
+  - definition: 0.1.7
   - term: tokens
-  - definition: 0.1.0
+  - definition: 0.1.1
   - term: tokens-css
-  - definition: 0.1.0
+  - definition: 0.1.2
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.6
+  - definition: 0.1.7
   - term: tokens
-  - definition: 0.1.0
+  - definition: 0.1.1
   - term: tokens-css
-  - definition: 0.1.0
+  - definition: 0.1.2
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.6
+  - definition: 0.1.7
   - term: tokens
-  - definition: 0.1.0
+  - definition: 0.1.1
   - term: tokens-css
-  - definition: 0.1.0
+  - definition: 0.1.2
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.6
+  - definition: 0.1.7
   - term: tokens
-  - definition: 0.1.0
+  - definition: 0.1.1
   - term: tokens-css
-  - definition: 0.1.0
+  - definition: 0.1.2
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.6
+  - definition: 0.1.7
   - term: tokens
-  - definition: 0.1.0
+  - definition: 0.1.1
   - term: tokens-css
-  - definition: 0.1.0
+  - definition: 0.1.2
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.6
+  - definition: 0.1.7
   - term: tokens
-  - definition: 0.1.0
+  - definition: 0.1.1
   - term: tokens-css
-  - definition: 0.1.0
+  - definition: 0.1.2
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.6
+  - definition: 0.1.7
   - term: tokens
-  - definition: 0.1.0
+  - definition: 0.1.1
   - term: tokens-css
-  - definition: 0.1.0
+  - definition: 0.1.2
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.6
+  - definition: 0.1.7
   - term: tokens
-  - definition: 0.1.0
+  - definition: 0.1.1
   - term: tokens-css
-  - definition: 0.1.0
+  - definition: 0.1.2
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.6
+  - definition: 0.1.7
   - term: tokens
-  - definition: 0.1.0
+  - definition: 0.1.1
   - term: tokens-css
-  - definition: 0.1.0
+  - definition: 0.1.2
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.6
+  - definition: 0.1.7
   - term: tokens
-  - definition: 0.1.0
+  - definition: 0.1.1
   - term: tokens-css
-  - definition: 0.1.0
+  - definition: 0.1.2
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.6
+  - definition: 0.1.7
   - term: tokens
-  - definition: 0.1.0
+  - definition: 0.1.1
   - term: tokens-css
-  - definition: 0.1.0
+  - definition: 0.1.2
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ai-sdk/openai": "^3.0.71",
         "@ai-sdk/react": "^3.0.207",
         "@calcom/embed-react": "^1.5.3",
-        "@digitaltableteur/react": "^0.1.6",
+        "@digitaltableteur/react": "^0.1.7",
         "@digitaltableteur/tokens": "^0.1.1",
         "@digitaltableteur/tokens-css": "^0.1.2",
         "@emailjs/browser": "^4.4.1",
@@ -3429,9 +3429,9 @@
       "license": "MIT"
     },
     "node_modules/@digitaltableteur/react": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.6.tgz",
-      "integrity": "sha512-XNPUN8+IsXqJA1IUqEmtsII0T0tOoc1tApW77UejnIGCrvv7lRM8a3Krc8TzU/Tk3UEv3oIcHmV7VmuVDrdmSA==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.7.tgz",
+      "integrity": "sha512-YUj85SXbF+Uqrv92osAvNbcr2HgHLRMb0lhsFmMyoTYnmKEk7e2+2dY6JEEYz9h/mR8Vra+JvdwN22oDpg58NQ==",
       "license": "UNLICENSED",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "@ai-sdk/openai": "^3.0.71",
     "@ai-sdk/react": "^3.0.207",
     "@calcom/embed-react": "^1.5.3",
-    "@digitaltableteur/react": "^0.1.6",
+    "@digitaltableteur/react": "^0.1.7",
     "@digitaltableteur/tokens": "^0.1.1",
     "@digitaltableteur/tokens-css": "^0.1.2",
     "@emailjs/browser": "^4.4.1",


### PR DESCRIPTION
## Summary
Consume step for react 0.1.7 (published via ds-publish.yml run 29162557169). The app now renders this week's forms work from the registry package: helper+error render-both with HelperText stacking (#1094), disabled unification (#1096), combobox dangling-IDREF fix (#1093), type-export alignment (#1093/#1095/#1097).

- Lockfile + version range.
- AboutPageContent AT yamls recaptured via runner (base/light/dark, scoped): exactly 12 files × 3 `definition:` version lines (react 0.1.7, tokens 0.1.1, tokens-css 0.1.2), zero strays. Note: the tokens definition lines had been stale at 0.1.0 — token consumes DO touch these yamls now; memory rule updated.

## Verification (local, CI is quota-dead)
- Installed dist verified (14 disabled-placeholder refs in shipped CSS vs 1 in 0.1.6; HelperText stacking rule present)
- check:react-registry-install ✓ (0.1.7, 106 exports, runtime+types), check:package-registry-resolution ✓, check:storybook-registry-package ✓
- typecheck ✓, npm test ✓ (TEST_OK), build ✓ (BUILD_OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)