### PR TITLE
fix(design-system): align ComplianceCard default height with resize ceiling

### DIFF
--- a/nextjs-app/shared/components/ComplianceCard/ComplianceCard.test.tsx
+++ b/nextjs-app/shared/components/ComplianceCard/ComplianceCard.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, test, expect, vi } from "vitest";
 import axe from "axe-core";
 import ComplianceCard from "@dt/ComplianceCard";
@@ -158,6 +158,25 @@ describe("ComplianceCard", () => {
       expect(resizeHandle).toHaveAttribute("aria-valuenow", "100");
       expect(resizeHandle).toHaveAttribute("aria-valuemin", "0");
       expect(resizeHandle).toHaveAttribute("aria-valuemax", "100");
+    });
+
+    test("reports aria-valuenow across the true resize range", () => {
+      render(<ComplianceCard title="Test" rules={mockRules} />);
+      const resizeHandle = screen.getByRole("separator", {
+        name: "complianceCard.resizeHandle",
+      });
+      const wrapper = resizeHandle.parentElement as HTMLElement;
+      wrapper.getBoundingClientRect = () =>
+        ({ top: 0, left: 0 }) as DOMRect;
+
+      // Drag the handle down to the minimum height (200px). A collapsed
+      // table must report the aria-valuemin of 0, not 25% (the pre-fix
+      // formula divided by the max height and floored at min/max = 25).
+      fireEvent.mouseDown(resizeHandle);
+      fireEvent.mouseMove(document, { clientY: 200, clientX: 600 });
+      fireEvent.mouseUp(document);
+
+      expect(resizeHandle).toHaveAttribute("aria-valuenow", "0");
     });
 
     test("uses grid layout for rules", () => {

--- a/nextjs-app/shared/components/ComplianceCard/ComplianceCard.tsx
+++ b/nextjs-app/shared/components/ComplianceCard/ComplianceCard.tsx
@@ -36,6 +36,15 @@ const STATUS_COLOR_MAP: Record<ComplianceStatus, string> = {
   fail: "var(--color-error)",
 };
 
+// Resize bounds. Keep in sync with min/max-height and min/max-width in
+// ComplianceCard.module.css. Defaults MUST stay within these ranges.
+const TABLE_MIN_HEIGHT = 200;
+const TABLE_MAX_HEIGHT = 800;
+const TABLE_MIN_WIDTH = 400;
+const TABLE_MAX_WIDTH = 1200;
+const TABLE_DEFAULT_HEIGHT = TABLE_MAX_HEIGHT;
+const TABLE_DEFAULT_WIDTH = 800;
+
 /**
  * ComplianceCard component.
  */
@@ -58,8 +67,8 @@ export const ComplianceCard: React.FC<ComplianceCardProps> = ({
       day: "numeric",
     });
   }, [lastReviewed]);
-  const [tableHeight, setTableHeight] = useState<number>(900);
-  const [tableWidth, setTableWidth] = useState<number>(800);
+  const [tableHeight, setTableHeight] = useState<number>(TABLE_DEFAULT_HEIGHT);
+  const [tableWidth, setTableWidth] = useState<number>(TABLE_DEFAULT_WIDTH);
   const tableWrapperRef = useRef<HTMLDivElement>(null);
   const isResizing = useRef(false);
 
@@ -77,10 +86,10 @@ export const ComplianceCard: React.FC<ComplianceCardProps> = ({
     const newHeight = e.clientY - rect.top;
     const newWidth = e.clientX - rect.left;
 
-    if (newHeight >= 200 && newHeight <= 800) {
+    if (newHeight >= TABLE_MIN_HEIGHT && newHeight <= TABLE_MAX_HEIGHT) {
       setTableHeight(newHeight);
     }
-    if (newWidth >= 400 && newWidth <= 1200) {
+    if (newWidth >= TABLE_MIN_WIDTH && newWidth <= TABLE_MAX_WIDTH) {
       setTableWidth(newWidth);
     }
   }, []);
@@ -165,7 +174,11 @@ export const ComplianceCard: React.FC<ComplianceCardProps> = ({
           role="separator"
           aria-orientation="vertical"
           aria-label={t("complianceCard.resizeHandle")}
-          aria-valuenow={Math.min(100, Math.round((tableHeight / 800) * 100))}
+          aria-valuenow={Math.round(
+            ((tableHeight - TABLE_MIN_HEIGHT) /
+              (TABLE_MAX_HEIGHT - TABLE_MIN_HEIGHT)) *
+              100,
+          )}
           aria-valuemin={0}
           aria-valuemax={100}
           tabIndex={0}


### PR DESCRIPTION
## Problem
The ComplianceCard resize table defaulted to `900px` while both the JS drag clamp and the CSS `max-height` cap at `800px`. Consequences:
- The `900` state value never matched the rendered box — the browser clamped it to 800 via `max-height`, so state and DOM disagreed from mount.
- It drove `aria-valuenow` to an invalid `113` (> `aria-valuemax` of 100). The previous PR band-aided this with `Math.min(100, …)`; this removes the cause.

The root defect was three uncoordinated magic numbers: the `900` default, the `800` drag ceiling, and the `800` aria divisor.

## Fix
- Extract resize bounds into named constants (`TABLE_MIN/MAX_HEIGHT`, `TABLE_MIN/MAX_WIDTH`, defaults) kept in sync with the CSS min/max, so a default can no longer drift out of range.
- Default height = the `800px` ceiling. **Zero visual change** — the card already rendered at 800px due to `max-height`.
- Compute `aria-valuenow` across the true `[min, max]` range, so a collapsed table (200px) now reports the `aria-valuemin` of `0` instead of the pre-fix `25%`.

## Tests
Added a resize-to-minimum test locking the range-based aria semantics (fails against the old `/800` formula, which reported 25% at the floor).

## Local verification (all exit 0)
- `npm run typecheck`, `npm run lint` (2 pre-existing warnings, 0 errors)
- `npm test` — 2278 tests
- `npm run build`
- pre-push farm gate: contrast AA, stylelint baseline, rhythmguard 0 new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ComplianceCard table resizing to consistently respect minimum, maximum, and default dimensions.
  * Corrected resize handle accessibility values so they accurately reflect the table’s position within its allowed height range, including when collapsed to the minimum.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->