### PR TITLE
feat(react): export ArticleLayout — first pattern in the registry barrel

### DIFF
--- a/packages/react/public-api.manifest.json
+++ b/packages/react/public-api.manifest.json
@@ -1,6 +1,6 @@
 {
   "packageName": "@digitaltableteur/react",
-  "packageVersion": "0.1.5",
+  "packageVersion": "0.1.7",
   "packageExports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -11,6 +11,7 @@
   "runtimeExports": [
     "AlertBanner",
     "AnimationRuntimeProvider",
+    "ArticleLayout",
     "Avatar",
     "AvatarGroup",
     "Badge",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -274,3 +274,12 @@ export {
   type ScrollOverflowState,
 } from "../../../nextjs-app/shared/hooks/useOverflow";
 export { useScrollLock } from "../../../nextjs-app/shared/hooks/useScrollLock";
+
+// ── Patterns ──────────────────────────────────────────────────────────────
+// Composite, page-level building blocks. First pattern exported from the
+// registry, establishing the pattern rung of the full-consumption mandate
+// (atoms → molecules → patterns → pages).
+export {
+  ArticleLayout,
+  type ArticleLayoutProps,
+} from "../../../nextjs-app/shared/patterns/ArticleLayout/ArticleLayout";


### PR DESCRIPTION
## Summary
Establishes the **pattern rung** of the full-consumption mandate (atoms → molecules → patterns → pages). `ArticleLayout` is the first composite exported from `@digitaltableteur/react`. Export-only — no consumer flip; the app keeps its local import until a registry version shipping this export is published (batched later).

## Why ArticleLayout
It's the cleanest pattern to lead with: genuinely consumed at the app level (`app/blog/[slug]/ClientArticleShell.tsx`, a client file, so RSC-safe), and lean enough to bundle standalone (`react`, `lib/cn`, `ReadingProgress` — no `@/` or `next/` leakage).

## Pilot-proven locally (temporary file: link, reverted)
- Package build bundles it (JS + types), 2141 modules, no leakage
- App **typechecks and next build succeeds** with `ClientArticleShell` consuming `ArticleLayout` from the barrel
- Usage metric moves **6 → 7 of 207**
- Public API surface grows **106 → 107**; `public-api.manifest.json` updated

## Gate (all exit 0)
typecheck · lint (2 pre-existing warnings) · **2278 tests** · build · `check:react-public-api` (107 verified) · pre-commit farm gate (contrast, stylelint baseline, rhythmguard 0 new findings)

## Notes for the batch publish
- Registry stays `0.1.7` (106) until a future `0.1.8` publish ships this + other queued patterns, at which point the consumer flip + dep bump land together.
- `tsconfig.types.json` already emits pattern declarations (it excludes `components/pages/**`, not `patterns/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
