### PR TITLE
refactor(pages): consume published DS components from @digitaltableteur/react

### DIFF
--- a/nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx
+++ b/nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx
@@ -3,13 +3,8 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-import { Container } from "@dt/Container";
-import Link from "@dt/Link";
-import List from "@dt/List";
-import { Section } from "@dt/Section";
-import Text from "@dt/Text";
+import { Container, Link, List, Section, Text, Title } from "@digitaltableteur/react";
 import Timestamp from "@dt/Timestamp";
-import Title from "@dt/Title";
 import styles from "../AiUsagePage/AiUsagePage.module.css";
 
 const delimiter = ": ";

--- a/nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx
+++ b/nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx
@@ -3,12 +3,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-import { Container } from "@dt/Container";
-import Link from "@dt/Link";
-import List from "@dt/List";
-import { Section } from "@dt/Section";
-import Text from "@dt/Text";
-import Title from "@dt/Title";
+import { Container, Link, List, Section, Text, Title } from "@digitaltableteur/react";
 import styles from "./AiUsagePage.module.css";
 
 const delimiter = ": ";

--- a/nextjs-app/shared/components/pages/Blog/AuthorPage.tsx
+++ b/nextjs-app/shared/components/pages/Blog/AuthorPage.tsx
@@ -5,8 +5,7 @@ import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 
 import AuthorBio from "@dt/AuthorBio/AuthorBio";
-import Button from "@dt/Button";
-import Title from "@dt/Title";
+import { Button, Title } from "@digitaltableteur/react";
 
 import { getAuthorBySlug } from "../../../data/authors";
 import PageLayout from "../../../patterns/PageLayout/PageLayout";

--- a/nextjs-app/shared/components/pages/Colophon/ColophonPage.tsx
+++ b/nextjs-app/shared/components/pages/Colophon/ColophonPage.tsx
@@ -3,8 +3,7 @@
 import Link from "next/link";
 import React from "react";
 
-import Text from "@dt/Text";
-import Title from "@dt/Title";
+import { Text, Title } from "@digitaltableteur/react";
 
 import styles from "./colophon.module.css";
 

--- a/nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullEnPage.tsx
+++ b/nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullEnPage.tsx
@@ -3,9 +3,7 @@
 import React from "react";
 import Link from "next/link";
 
-import Button from "@dt/Button";
-import Icon from "@dt/Icon";
-import Title from "@dt/Title";
+import { Button, Icon, Title } from "@digitaltableteur/react";
 import styles from "./CookiePolicy.module.css";
 
 export function CookiePolicyFullEnPage({

--- a/nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullFiPage.tsx
+++ b/nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullFiPage.tsx
@@ -3,9 +3,7 @@
 import React from "react";
 import Link from "next/link";
 
-import Button from "@dt/Button";
-import Icon from "@dt/Icon";
-import Title from "@dt/Title";
+import { Button, Icon, Title } from "@digitaltableteur/react";
 import styles from "./CookiePolicy.module.css";
 
 export function CookiePolicyFullFiPage({

--- a/nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullSvPage.tsx
+++ b/nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullSvPage.tsx
@@ -3,9 +3,7 @@
 import React from "react";
 import Link from "next/link";
 
-import Button from "@dt/Button";
-import Icon from "@dt/Icon";
-import Title from "@dt/Title";
+import { Button, Icon, Title } from "@digitaltableteur/react";
 import styles from "./CookiePolicy.module.css";
 
 export function CookiePolicyFullSvPage({

--- a/nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyPage.tsx
+++ b/nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyPage.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
 
-import Title from "@dt/Title";
+import { Title } from "@digitaltableteur/react";
 
 import styles from "./CookiePolicy.module.css";
 

--- a/nextjs-app/shared/components/pages/ImprintPage/ImprintPage.tsx
+++ b/nextjs-app/shared/components/pages/ImprintPage/ImprintPage.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-import Title from "@dt/Title";
+import { Title } from "@digitaltableteur/react";
 import styles from "./ImprintPage.module.css";
 
 export function ImprintPage() {

--- a/nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx
+++ b/nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx
@@ -3,13 +3,15 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-import { Container } from "@dt/Container";
-import Link from "@dt/Link";
-import List from "@dt/List";
+import {
+  Container,
+  Link,
+  List,
+  Section,
+  Text,
+  Title,
+} from "@digitaltableteur/react";
 import Timestamp from "@dt/Timestamp";
-import { Section } from "@dt/Section";
-import Text from "@dt/Text";
-import Title from "@dt/Title";
 import styles from "../AiUsagePage/AiUsagePage.module.css";
 
 const renderContactLinks = (text: string, email: string, phone?: string) => {

--- a/nextjs-app/shared/components/pages/Pseo/PseoClusterBadges.tsx
+++ b/nextjs-app/shared/components/pages/Pseo/PseoClusterBadges.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 
-import Badge from "@dt/Badge";
+import { Badge } from "@digitaltableteur/react";
 
 type ClusterBadgesProps = {
   serviceHref: string;

--- a/nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx
+++ b/nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx
@@ -3,10 +3,8 @@ import type { PseoCatalog, PseoLeafPage } from "@/lib/pseo/types";
 import { getStackDisplayName } from "@/lib/pseo/display";
 
 import PageLayout from "../../../patterns/PageLayout/PageLayout";
-import Card from "@dt/Card";
+import { Card, Text, Title } from "@digitaltableteur/react";
 import NextLink from "next/link";
-import Text from "@dt/Text";
-import Title from "@dt/Title";
 import styles from "./PseoIndexPage.module.css";
 
 export function PseoIndexPage({

--- a/nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx
+++ b/nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx
@@ -5,11 +5,7 @@ import type {
   PseoRelatedLinkCopy,
 } from "@/lib/pseo/types";
 
-import Breadcrumb from "@dt/Breadcrumb";
-import Button from "@dt/Button";
-import Card from "@dt/Card";
-import Text from "@dt/Text";
-import Title from "@dt/Title";
+import { Breadcrumb, Button, Card, Text, Title } from "@digitaltableteur/react";
 import MarkdownMessage from "@dt/MarkdownMessage";
 import PageLayout from "../../../patterns/PageLayout/PageLayout";
 import { PseoClusterBadges } from "./PseoClusterBadges";

--- a/nextjs-app/shared/components/pages/Pseo/PseoPillarMetaBadgeLinks.tsx
+++ b/nextjs-app/shared/components/pages/Pseo/PseoPillarMetaBadgeLinks.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 
-import Badge from "@dt/Badge";
+import { Badge } from "@digitaltableteur/react";
 
 export type PseoMetaBadgeLink = {
   href: string;

--- a/nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx
+++ b/nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx
@@ -1,9 +1,7 @@
 import type { PseoCatalogItem, PseoLeafPage } from "@/lib/pseo/types";
 
 import PageLayout from "../../../patterns/PageLayout/PageLayout";
-import Card from "@dt/Card";
-import Text from "@dt/Text";
-import Title from "@dt/Title";
+import { Card, Text, Title } from "@digitaltableteur/react";
 import { PseoPillarMetaBadgeLinks } from "./PseoPillarMetaBadgeLinks";
 import styles from "./PseoPillarPage.module.css";
 

--- a/nextjs-app/shared/components/pages/SitemapPage/SitemapPage.tsx
+++ b/nextjs-app/shared/components/pages/SitemapPage/SitemapPage.tsx
@@ -4,8 +4,7 @@ import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import SiteTree from "@dt/SiteTree";
-import Text from "@dt/Text";
-import Title from "@dt/Title";
+import { Text, Title } from "@digitaltableteur/react";
 import { buildSiteTree } from "@/app/lib/siteStructure";
 
 import styles from "./SitemapPage.module.css";

--- a/nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import React from "react";
-import Title from "@dt/Title";
-import Text from "@dt/Text";
+import { Text, Title } from "@digitaltableteur/react";
 import ProcessBlock from "../../../../patterns/ProcessBlock";
 import StoryBlock from "../../../../patterns/StoryBlock";
 import GridBlock from "../../../../patterns/GridBlock";

--- a/nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx
@@ -2,8 +2,7 @@
 
 import React from "react";
 import Image from "next/image";
-import Text from "@dt/Text";
-import Title from "@dt/Title";
+import { Text, Title } from "@digitaltableteur/react";
 import ProcessBlock from "../../../../patterns/ProcessBlock";
 import StoryBlock from "../../../../patterns/StoryBlock";
 import GridBlock from "../../../../patterns/GridBlock";

--- a/nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx
@@ -2,8 +2,7 @@
 
 import React from "react";
 import Image from "next/image";
-import Text from "@dt/Text";
-import Title from "@dt/Title";
+import { Text, Title } from "@digitaltableteur/react";
 import ProcessBlock from "../../../../patterns/ProcessBlock";
 import StoryBlock from "../../../../patterns/StoryBlock";
 import { ProjectDetailLayout } from "../../../../patterns/ProjectDetailLayout";

--- a/nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import Text from "@dt/Text";
+import { Text } from "@digitaltableteur/react";
 import ProcessBlock from "../../../../patterns/ProcessBlock";
 import TeamBlock from "../../../../patterns/TeamBlock";
 import StoryBlock from "../../../../patterns/StoryBlock";

--- a/nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx
@@ -2,10 +2,8 @@
 
 import React, { useState, useCallback } from "react";
 
-import Badge from "@dt/Badge";
-import FlexBox from "@dt/FlexBox";
+import { Badge, FlexBox, Title } from "@digitaltableteur/react";
 import { ProjectDetailLayout } from "../../../../patterns/ProjectDetailLayout";
-import Title from "@dt/Title";
 import WorkNav from "@dt/WorkNav";
 import styles from "./illustrations.module.css";
 

--- a/nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import Text from "@dt/Text";
+import { Text } from "@digitaltableteur/react";
 import StoryBlock from "../../../../patterns/StoryBlock";
 import GridBlock from "../../../../patterns/GridBlock";
 import { ProjectDetailLayout } from "../../../../patterns/ProjectDetailLayout";

--- a/nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import React from "react";
-import Title from "@dt/Title";
-import Text from "@dt/Text";
+import { Text, Title } from "@digitaltableteur/react";
 import { Mermaid } from "../../../Mermaid";
 import StoryBlock from "../../../../patterns/StoryBlock";
 import GridBlock from "../../../../patterns/GridBlock";

--- a/nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import React from "react";
-import Title from "@dt/Title";
-import Text from "@dt/Text";
+import { Text, Title } from "@digitaltableteur/react";
 import ProcessBlock from "../../../../patterns/ProcessBlock";
 import StoryBlock from "../../../../patterns/StoryBlock";
 import GridBlock from "../../../../patterns/GridBlock";

--- a/nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx
@@ -2,9 +2,7 @@
 
 import React from "react";
 import Image from "next/image";
-import Text from "@dt/Text";
-import Title from "@dt/Title";
-import Gallery from "@dt/Gallery";
+import { Gallery, Text, Title } from "@digitaltableteur/react";
 import ProcessBlock from "../../../../patterns/ProcessBlock";
 import StoryBlock from "../../../../patterns/StoryBlock";
 import { ProjectDetailLayout } from "../../../../patterns/ProjectDetailLayout";

--- a/nextjs-app/shared/components/pages/Work/ProjectSpine/ProjectSpinePage.tsx
+++ b/nextjs-app/shared/components/pages/Work/ProjectSpine/ProjectSpinePage.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import React from "react";
-import Title from "@dt/Title";
-import Text from "@dt/Text";
+import { Text, Title } from "@digitaltableteur/react";
 import ProcessBlock from "../../../../patterns/ProcessBlock";
 import StoryBlock from "../../../../patterns/StoryBlock";
 import GridBlock from "../../../../patterns/GridBlock";

--- a/nextjs-app/shared/components/pages/Work/RawView/RawViewPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/RawView/RawViewPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import Text from "@dt/Text";
+import { Text } from "@digitaltableteur/react";
 import StoryBlock from "../../../../patterns/StoryBlock";
 import GridBlock from "../../../../patterns/GridBlock";
 import ProcessBlock from "../../../../patterns/ProcessBlock";

--- a/nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import React from "react";
-import Title from "@dt/Title";
-import Text from "@dt/Text";
-import CodeSnippet from "@dt/CodeSnippet";
+import { CodeSnippet, Text, Title } from "@digitaltableteur/react";
 import ProcessBlock from "../../../../patterns/ProcessBlock";
 import StoryBlock from "../../../../patterns/StoryBlock";
 import GridBlock from "../../../../patterns/GridBlock";

--- a/nextjs-app/shared/components/pages/Work/SapBuildApps/SapBuildAppsPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/SapBuildApps/SapBuildAppsPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import Text from "@dt/Text";
+import { Text } from "@digitaltableteur/react";
 import ProcessBlock from "../../../../patterns/ProcessBlock";
 import StoryBlock from "../../../../patterns/StoryBlock";
 import GridBlock from "../../../../patterns/GridBlock";

--- a/nextjs-app/shared/components/pages/Work/Tulli/TulliPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/Tulli/TulliPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import Text from "@dt/Text";
+import { Text } from "@digitaltableteur/react";
 import StoryBlock from "../../../../patterns/StoryBlock";
 import GridBlock from "../../../../patterns/GridBlock";
 import { ProjectDetailLayout } from "../../../../patterns/ProjectDetailLayout";

--- a/nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import React from "react";
-import Text from "@dt/Text";
-import Title from "@dt/Title";
+import { Text, Title } from "@digitaltableteur/react";
 import { Mermaid } from "../../../Mermaid";
 import ProcessBlock from "../../../../patterns/ProcessBlock";
 import StoryBlock from "../../../../patterns/StoryBlock";

--- a/nextjs-app/shared/foundations/dist/component-usage.json
+++ b/nextjs-app/shared/foundations/dist/component-usage.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-11T18:07:01.188Z",
+  "generatedAt": "2026-07-11T20:03:54.265Z",
   "components": [
     {
       "name": "__templates__",
@@ -397,9 +397,13 @@
         "nextjs-app/shared/components/pages/Pseo/PseoPillarMetaBadgeLinks.tsx",
         "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx"
       ],
-      "packageImportCount": 0,
-      "packageImporters": [],
-      "prodPageCount": 12,
+      "packageImportCount": 3,
+      "packageImporters": [
+        "nextjs-app/shared/components/pages/Pseo/PseoClusterBadges.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoPillarMetaBadgeLinks.tsx",
+        "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx"
+      ],
+      "prodPageCount": 10,
       "prodPages": [
         "app/dev/tailwind-test/page.tsx",
         "app/layout.tsx",
@@ -409,8 +413,6 @@
         "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
         "nextjs-app/shared/components/pages/Pseo/PseoPillarMetaBadgeLinks.tsx",
         "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx",
-        "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
-        "nextjs-app/shared/components/pages/Work/Illustrations/index.ts",
         "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
         "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
       ]
@@ -543,12 +545,12 @@
         "nextjs-app/shared/components/index.ts",
         "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx"
       ],
-      "packageImportCount": 0,
-      "packageImporters": [],
-      "prodPageCount": 1,
-      "prodPages": [
+      "packageImportCount": 1,
+      "packageImporters": [
         "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx"
-      ]
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
     },
     {
       "name": "Button",
@@ -604,12 +606,17 @@
         "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
         "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx"
       ],
-      "packageImportCount": 4,
+      "packageImportCount": 9,
       "packageImporters": [
         "app/blog/NextBlogNav.tsx",
         "app/error.tsx",
         "app/not-found.tsx",
-        "app/work/NextWorkNav.tsx"
+        "app/work/NextWorkNav.tsx",
+        "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullEnPage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullFiPage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullSvPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx"
       ],
       "prodPageCount": 12,
       "prodPages": [
@@ -654,14 +661,14 @@
         "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
         "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx"
       ],
-      "packageImportCount": 0,
-      "packageImporters": [],
-      "prodPageCount": 3,
-      "prodPages": [
+      "packageImportCount": 3,
+      "packageImporters": [
         "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
         "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
         "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx"
-      ]
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
     },
     {
       "name": "CategoryFilter",
@@ -823,8 +830,10 @@
       "directImporters": [
         "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx"
       ],
-      "packageImportCount": 0,
-      "packageImporters": [],
+      "packageImportCount": 1,
+      "packageImporters": [
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx"
+      ],
       "prodPageCount": 2,
       "prodPages": [
         "nextjs-app/shared/components/pages/Work/Rhythmguard/index.ts",
@@ -1044,9 +1053,12 @@
         "nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.tsx",
         "nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.tsx"
       ],
-      "packageImportCount": 1,
+      "packageImportCount": 4,
       "packageImporters": [
-        "app/dev/code-window/page.tsx"
+        "app/dev/code-window/page.tsx",
+        "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
+        "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+        "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx"
       ],
       "prodPageCount": 12,
       "prodPages": [
@@ -1469,13 +1481,12 @@
         "nextjs-app/shared/components/index.ts",
         "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx"
       ],
-      "packageImportCount": 0,
-      "packageImporters": [],
-      "prodPageCount": 2,
-      "prodPages": [
-        "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
-        "nextjs-app/shared/components/pages/Work/Illustrations/index.ts"
-      ]
+      "packageImportCount": 1,
+      "packageImporters": [
+        "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
     },
     {
       "name": "Footer",
@@ -1530,8 +1541,10 @@
         "nextjs-app/shared/components/index.ts",
         "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx"
       ],
-      "packageImportCount": 0,
-      "packageImporters": [],
+      "packageImportCount": 1,
+      "packageImporters": [
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx"
+      ],
       "prodPageCount": 2,
       "prodPages": [
         "nextjs-app/shared/components/pages/Work/NewThingsCo/index.ts",
@@ -1823,12 +1836,15 @@
         "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx",
         "nextjs-app/shared/utils/semanticIcons.tsx"
       ],
-      "packageImportCount": 4,
+      "packageImportCount": 7,
       "packageImporters": [
         "app/blog/NextBlogNav.tsx",
         "app/error.tsx",
         "app/not-found.tsx",
-        "app/work/NextWorkNav.tsx"
+        "app/work/NextWorkNav.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullEnPage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullFiPage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullSvPage.tsx"
       ],
       "prodPageCount": 12,
       "prodPages": [
@@ -2050,8 +2066,12 @@
         "nextjs-app/shared/patterns/Footer/Footer.tsx",
         "nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx"
       ],
-      "packageImportCount": 0,
-      "packageImporters": [],
+      "packageImportCount": 3,
+      "packageImporters": [
+        "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
+        "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+        "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx"
+      ],
       "prodPageCount": 12,
       "prodPages": [
         "app/blog/[slug]/BlogArticleMdxBody.tsx",
@@ -2061,11 +2081,11 @@
         "app/dev/tailwind-test/page.tsx",
         "app/layout.tsx",
         "app/lib/siteStructure.ts",
-        "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
-        "nextjs-app/shared/components/pages/AccessibilityPage/index.ts",
-        "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
-        "nextjs-app/shared/components/pages/AiUsagePage/index.ts",
-        "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx"
+        "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+        "nextjs-app/shared/components/pages/SitemapPage/index.ts"
       ]
     },
     {
@@ -2092,22 +2112,26 @@
         "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx",
         "nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.tsx"
       ],
-      "packageImportCount": 0,
-      "packageImporters": [],
+      "packageImportCount": 3,
+      "packageImporters": [
+        "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
+        "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+        "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx"
+      ],
       "prodPageCount": 12,
       "prodPages": [
-        "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
-        "nextjs-app/shared/components/pages/AccessibilityPage/index.ts",
-        "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
-        "nextjs-app/shared/components/pages/AiUsagePage/index.ts",
-        "nextjs-app/shared/components/pages/PrivacyPolicyPage/index.ts",
-        "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
         "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
         "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts",
         "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
         "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/index.ts",
         "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
-        "nextjs-app/shared/components/pages/Work/GarageJunction/index.ts"
+        "nextjs-app/shared/components/pages/Work/GarageJunction/index.ts",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/index.ts",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/index.ts",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx",
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/index.ts",
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx"
       ]
     },
     {
@@ -2262,11 +2286,11 @@
         "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
         "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
         "nextjs-app/shared/components/pages/Blog/index.ts",
-        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
         "nextjs-app/shared/components/pages/Work/Rhythmguard/index.ts",
         "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx",
         "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
-        "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts"
+        "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
       ]
     },
     {
@@ -3093,8 +3117,12 @@
         "nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.tsx",
         "nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.tsx"
       ],
-      "packageImportCount": 0,
-      "packageImporters": [],
+      "packageImportCount": 3,
+      "packageImporters": [
+        "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
+        "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+        "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx"
+      ],
       "prodPageCount": 12,
       "prodPages": [
         "app/blog/[slug]/BlogArticleMdxBody.tsx",
@@ -3103,12 +3131,12 @@
         "app/blog/[slug]/ServerArticleMain.tsx",
         "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
         "nextjs-app/shared/components/pages/AboutPage/index.ts",
-        "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
-        "nextjs-app/shared/components/pages/AccessibilityPage/index.ts",
-        "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
-        "nextjs-app/shared/components/pages/AiUsagePage/index.ts",
         "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
-        "nextjs-app/shared/components/pages/Blog/BlogPage.tsx"
+        "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
+        "nextjs-app/shared/components/pages/Home/HomePage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/index.ts"
       ]
     },
     {
@@ -3349,12 +3377,8 @@
       ],
       "packageImportCount": 0,
       "packageImporters": [],
-      "prodPageCount": 3,
-      "prodPages": [
-        "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
-        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
-        "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx"
-      ]
+      "prodPageCount": 0,
+      "prodPages": []
     },
     {
       "name": "SkillsGrid",
@@ -3538,7 +3562,7 @@
       ],
       "packageImportCount": 0,
       "packageImporters": [],
-      "prodPageCount": 12,
+      "prodPageCount": 10,
       "prodPages": [
         "app/dev/tailwind-test/page.tsx",
         "app/layout.tsx",
@@ -3548,8 +3572,6 @@
         "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
         "nextjs-app/shared/components/pages/Pseo/PseoPillarMetaBadgeLinks.tsx",
         "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx",
-        "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
-        "nextjs-app/shared/components/pages/Work/Illustrations/index.ts",
         "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
         "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
       ]
@@ -3781,9 +3803,31 @@
         "nextjs-app/shared/patterns/StoryBlock/StoryBlock.tsx",
         "nextjs-app/shared/patterns/TeamBlock/TeamBlock.tsx"
       ],
-      "packageImportCount": 1,
+      "packageImportCount": 23,
       "packageImporters": [
-        "app/dev/code-window/page.tsx"
+        "app/dev/code-window/page.tsx",
+        "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
+        "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+        "nextjs-app/shared/components/pages/Colophon/ColophonPage.tsx",
+        "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx",
+        "nextjs-app/shared/components/pages/SitemapPage/SitemapPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Intrum/IntrumPage.tsx",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx",
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx",
+        "nextjs-app/shared/components/pages/Work/ProjectSpine/ProjectSpinePage.tsx",
+        "nextjs-app/shared/components/pages/Work/RawView/RawViewPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx",
+        "nextjs-app/shared/components/pages/Work/SapBuildApps/SapBuildAppsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Tulli/TulliPage.tsx",
+        "nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx"
       ],
       "prodPageCount": 12,
       "prodPages": [
@@ -3797,8 +3841,8 @@
         "app/layout.tsx",
         "app/tools/email-signature/EmailSignatureContent.tsx",
         "app/tools/email-signature/page.tsx",
-        "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
-        "nextjs-app/shared/components/pages/AccessibilityPage/index.ts"
+        "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx"
       ]
     },
     {
@@ -3955,9 +3999,33 @@
         "nextjs-app/shared/patterns/StoryBlock/StoryBlock.tsx",
         "nextjs-app/shared/patterns/TeamBlock/TeamBlock.tsx"
       ],
-      "packageImportCount": 1,
+      "packageImportCount": 25,
       "packageImporters": [
-        "app/dev/code-window/page.tsx"
+        "app/dev/code-window/page.tsx",
+        "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
+        "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
+        "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
+        "nextjs-app/shared/components/pages/Colophon/ColophonPage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullEnPage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullFiPage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullSvPage.tsx",
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyPage.tsx",
+        "nextjs-app/shared/components/pages/ImprintPage/ImprintPage.tsx",
+        "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+        "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx",
+        "nextjs-app/shared/components/pages/SitemapPage/SitemapPage.tsx",
+        "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
+        "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/FinnishTransportAgencyPage.tsx",
+        "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
+        "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+        "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx",
+        "nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx",
+        "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx",
+        "nextjs-app/shared/components/pages/Work/ProjectSpine/ProjectSpinePage.tsx",
+        "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx",
+        "nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx"
       ],
       "prodPageCount": 12,
       "prodPages": [
@@ -3972,7 +4040,7 @@
         "app/tools/email-signature/page.tsx",
         "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
         "nextjs-app/shared/components/pages/AboutPage/index.ts",
-        "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx"
+        "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx"
       ]
     },
     {


### PR DESCRIPTION
Flip page-shell imports of already-published components from local `@dt/*` paths to the `@digitaltableteur/react` registry package.

The app now consumes **14 components from npm** across **31 page shells** (~71 import sites): Title, Text, Button, Icon, Badge, Card, Container, Link, List, Section, Breadcrumb, FlexBox, Gallery, CodeSnippet.

- **No publish needed** — these already ship in 0.1.7.
- Components not yet in the package (Timestamp, WorkNav, MarkdownMessage, SiteTree, ImagePlaceholder, and app-specific surfaces) stay on `@dt/` until a later export+publish batch.
- **Behavior-neutral** — same components, registry import path.

## Consumption metric: 6 → 15 of 207

## Gate (all exit 0)
typecheck · lint (2 pre-existing warnings) · 2278 tests · build · pre-commit farm gate (contrast, stylelint baseline, rhythmguard 0 new findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized shared interface components across informational, policy, portfolio, and listing pages.
  * Page content, layout, rendering, and behavior remain unchanged.
  * Improves consistency of the application’s visual component usage without introducing user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->