### PR TITLE
refactor(patterns): consume published DS components from @digitaltableteur/react

### DIFF
--- a/nextjs-app/shared/foundations/dist/component-usage.json
+++ b/nextjs-app/shared/foundations/dist/component-usage.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-11T20:03:54.265Z",
+  "generatedAt": "2026-07-11T20:10:27.197Z",
   "components": [
     {
       "name": "__templates__",
@@ -606,7 +606,7 @@
         "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
         "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx"
       ],
-      "packageImportCount": 9,
+      "packageImportCount": 14,
       "packageImporters": [
         "app/blog/NextBlogNav.tsx",
         "app/error.tsx",
@@ -616,11 +616,15 @@
         "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullEnPage.tsx",
         "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullFiPage.tsx",
         "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullSvPage.tsx",
-        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx"
+        "nextjs-app/shared/components/pages/Pseo/PseoLeafPage.tsx",
+        "nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx",
+        "nextjs-app/shared/patterns/Hero/Hero.tsx",
+        "nextjs-app/shared/patterns/HighlightSection/HighlightSection.tsx",
+        "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
+        "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx"
       ],
       "prodPageCount": 12,
       "prodPages": [
-        "app/blog/[slug]/BlogArticleMdxBody.tsx",
         "app/blog/[slug]/BlogArticleShare.tsx",
         "app/blog/[slug]/page.tsx",
         "app/blog/[slug]/ServerArticleContent.tsx",
@@ -631,7 +635,8 @@
         "app/tools/email-signature/EmailSignatureContent.tsx",
         "app/tools/email-signature/page.tsx",
         "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
-        "nextjs-app/shared/components/pages/AboutPage/index.ts"
+        "nextjs-app/shared/components/pages/AboutPage/index.ts",
+        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx"
       ]
     },
     {
@@ -804,22 +809,14 @@
         "nextjs-app/shared/components/index.ts",
         "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx"
       ],
-      "packageImportCount": 1,
+      "packageImportCount": 2,
       "packageImporters": [
-        "app/dev/code-window/page.tsx"
-      ],
-      "prodPageCount": 10,
-      "prodPages": [
-        "app/blog/[slug]/BlogArticleMdxBody.tsx",
-        "app/blog/[slug]/page.tsx",
-        "app/blog/[slug]/ServerArticleContent.tsx",
-        "app/blog/[slug]/ServerArticleMain.tsx",
         "app/dev/code-window/page.tsx",
-        "nextjs-app/shared/components/pages/Blog/BlogArticlePage.tsx",
-        "nextjs-app/shared/components/pages/Blog/index.ts",
-        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
-        "nextjs-app/shared/patterns/ArticlePageTemplate/index.ts",
-        "nextjs-app/shared/patterns/index.ts"
+        "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx"
+      ],
+      "prodPageCount": 1,
+      "prodPages": [
+        "app/dev/code-window/page.tsx"
       ]
     },
     {
@@ -1584,8 +1581,10 @@
         "nextjs-app/shared/components/index.ts",
         "nextjs-app/shared/patterns/Footer/Footer.tsx"
       ],
-      "packageImportCount": 0,
-      "packageImporters": [],
+      "packageImportCount": 1,
+      "packageImporters": [
+        "nextjs-app/shared/patterns/Footer/Footer.tsx"
+      ],
       "prodPageCount": 1,
       "prodPages": [
         "nextjs-app/shared/patterns/Footer/Footer.tsx"
@@ -1836,7 +1835,7 @@
         "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx",
         "nextjs-app/shared/utils/semanticIcons.tsx"
       ],
-      "packageImportCount": 7,
+      "packageImportCount": 10,
       "packageImporters": [
         "app/blog/NextBlogNav.tsx",
         "app/error.tsx",
@@ -1844,7 +1843,10 @@
         "app/work/NextWorkNav.tsx",
         "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullEnPage.tsx",
         "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullFiPage.tsx",
-        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullSvPage.tsx"
+        "nextjs-app/shared/components/pages/CookiePolicy/CookiePolicyFullSvPage.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/Footer/Footer.tsx",
+        "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx"
       ],
       "prodPageCount": 12,
       "prodPages": [
@@ -2066,11 +2068,12 @@
         "nextjs-app/shared/patterns/Footer/Footer.tsx",
         "nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx"
       ],
-      "packageImportCount": 3,
+      "packageImportCount": 4,
       "packageImporters": [
         "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
         "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
-        "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx"
+        "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
+        "nextjs-app/shared/patterns/Footer/Footer.tsx"
       ],
       "prodPageCount": 12,
       "prodPages": [
@@ -2112,11 +2115,13 @@
         "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx",
         "nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.tsx"
       ],
-      "packageImportCount": 3,
+      "packageImportCount": 5,
       "packageImporters": [
         "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
         "nextjs-app/shared/components/pages/AiUsagePage/AiUsagePage.tsx",
-        "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx"
+        "nextjs-app/shared/components/pages/PrivacyPolicyPage/PrivacyPolicyPage.tsx",
+        "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx",
+        "nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.tsx"
       ],
       "prodPageCount": 12,
       "prodPages": [
@@ -2684,17 +2689,12 @@
         "nextjs-app/shared/components/index.ts",
         "nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx"
       ],
-      "packageImportCount": 0,
-      "packageImporters": [],
-      "prodPageCount": 6,
-      "prodPages": [
-        "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
-        "nextjs-app/shared/components/pages/ContactPage/index.ts",
-        "nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx",
-        "nextjs-app/shared/patterns/ContactInquiryPanel/index.ts",
-        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
-        "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts"
-      ]
+      "packageImportCount": 1,
+      "packageImporters": [
+        "nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx"
+      ],
+      "prodPageCount": 0,
+      "prodPages": []
     },
     {
       "name": "ProjectCard",
@@ -3803,7 +3803,7 @@
         "nextjs-app/shared/patterns/StoryBlock/StoryBlock.tsx",
         "nextjs-app/shared/patterns/TeamBlock/TeamBlock.tsx"
       ],
-      "packageImportCount": 23,
+      "packageImportCount": 33,
       "packageImporters": [
         "app/dev/code-window/page.tsx",
         "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
@@ -3827,7 +3827,17 @@
         "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx",
         "nextjs-app/shared/components/pages/Work/SapBuildApps/SapBuildAppsPage.tsx",
         "nextjs-app/shared/components/pages/Work/Tulli/TulliPage.tsx",
-        "nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx"
+        "nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/GridBlock/GridBlock.tsx",
+        "nextjs-app/shared/patterns/Hero/Hero.tsx",
+        "nextjs-app/shared/patterns/HighlightSection/HighlightSection.tsx",
+        "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx",
+        "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx",
+        "nextjs-app/shared/patterns/ProofBlock/ProofBlock.tsx",
+        "nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.tsx",
+        "nextjs-app/shared/patterns/StoryBlock/StoryBlock.tsx",
+        "nextjs-app/shared/patterns/TeamBlock/TeamBlock.tsx"
       ],
       "prodPageCount": 12,
       "prodPages": [
@@ -3999,7 +4009,7 @@
         "nextjs-app/shared/patterns/StoryBlock/StoryBlock.tsx",
         "nextjs-app/shared/patterns/TeamBlock/TeamBlock.tsx"
       ],
-      "packageImportCount": 25,
+      "packageImportCount": 34,
       "packageImporters": [
         "app/dev/code-window/page.tsx",
         "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
@@ -4025,7 +4035,16 @@
         "nextjs-app/shared/components/pages/Work/NewThingsCo/NewThingsCoPage.tsx",
         "nextjs-app/shared/components/pages/Work/ProjectSpine/ProjectSpinePage.tsx",
         "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx",
-        "nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx"
+        "nextjs-app/shared/components/pages/Work/VertaaUX/VertaaUXPage.tsx",
+        "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
+        "nextjs-app/shared/patterns/Hero/Hero.tsx",
+        "nextjs-app/shared/patterns/HighlightSection/HighlightSection.tsx",
+        "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx",
+        "nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx",
+        "nextjs-app/shared/patterns/ProofBlock/ProofBlock.tsx",
+        "nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.tsx",
+        "nextjs-app/shared/patterns/StoryBlock/StoryBlock.tsx",
+        "nextjs-app/shared/patterns/TeamBlock/TeamBlock.tsx"
       ],
       "prodPageCount": 12,
       "prodPages": [

--- a/nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx
+++ b/nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx
@@ -15,7 +15,7 @@ import type { BlogPostEntry } from "../../data/blogPosts";
 
 // MDX component imports preserved from original
 import AuthorBio from "@dt/AuthorBio/AuthorBio";
-import CodeBlockWindow from "@dt/CodeBlockWindow";
+import { CodeBlockWindow } from "@digitaltableteur/react";
 import { DashLeadList } from "@dt/DashLeadList";
 import { MdxImage } from "../../components/MdxImage";
 import { cn } from "../../lib/cn";

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/ContactInquiryPanel.tsx
@@ -11,9 +11,8 @@ import {
   type ReactNode,
 } from "react";
 import { useLocalization } from "../../lib/translation";
-import Button from "@dt/Button";
+import { Button, Progress } from "@digitaltableteur/react";
 import DonnyBookingEmbed from "@dt/DonnyBookingEmbed";
-import Progress from "@dt/Progress";
 import Tabs, { getTabPanelProps, type TabItem } from "@dt/Tabs";
 import {
   resolveSiteBookingConfig,

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx
@@ -6,9 +6,7 @@ import { useTranslate } from "../../lib/translation";
 import { motion, AnimatePresence } from "framer-motion";
 import { useHydrationSafeMotion } from "../../hooks/useHydrationSafeMotion";
 import { cn } from "../../lib/cn";
-import Text from "@dt/Text";
-import Title from "@dt/Title";
-import Icon from "@dt/Icon";
+import { Icon, Text, Title } from "@digitaltableteur/react";
 import {
   ContactInquiryPanel,
   type ContactInquiryMode,

--- a/nextjs-app/shared/patterns/Footer/Footer.tsx
+++ b/nextjs-app/shared/patterns/Footer/Footer.tsx
@@ -5,10 +5,8 @@ export interface FooterProps {
 }
 
 import styles from "./Footer.module.css";
-import Grid from "@dt/Grid";
-import Link from "@dt/Link";
+import { Grid, Icon, Link } from "@digitaltableteur/react";
 import { useTranslate } from "../../lib/translation";
-import Icon from "@dt/Icon";
 
 /**
  * Footer component.

--- a/nextjs-app/shared/patterns/GridBlock/GridBlock.tsx
+++ b/nextjs-app/shared/patterns/GridBlock/GridBlock.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import Image from "next/image";
 import PageLayout from "../PageLayout/PageLayout";
-import Text from "@dt/Text";
+import { Text } from "@digitaltableteur/react";
 import styles from "./GridBlock.module.css";
 
 /**

--- a/nextjs-app/shared/patterns/Hero/Hero.tsx
+++ b/nextjs-app/shared/patterns/Hero/Hero.tsx
@@ -3,9 +3,7 @@
 import React from "react";
 import Image from "next/image";
 import PageLayout from "../PageLayout/PageLayout";
-import Title from "@dt/Title";
-import Text from "@dt/Text";
-import Button from "@dt/Button";
+import { Button, Text, Title } from "@digitaltableteur/react";
 import styles from "./Hero.module.css";
 
 export interface HeroProps {

--- a/nextjs-app/shared/patterns/HighlightSection/HighlightSection.tsx
+++ b/nextjs-app/shared/patterns/HighlightSection/HighlightSection.tsx
@@ -2,9 +2,7 @@
 
 import React from "react";
 import { useTranslate } from "../../lib/translation";
-import Title from "@dt/Title";
-import Text from "@dt/Text";
-import Button from "@dt/Button";
+import { Button, Text, Title } from "@digitaltableteur/react";
 import type { ButtonProps } from "@dt/Button";
 import styles from "./HighlightSection.module.css";
 

--- a/nextjs-app/shared/patterns/HomeHero/HomeHero.tsx
+++ b/nextjs-app/shared/patterns/HomeHero/HomeHero.tsx
@@ -10,7 +10,7 @@ import { FadeIn } from "../../components/animations/FadeIn";
 import { ScrollIndicator } from "../../components/ScrollIndicator";
 import { Container } from "../../components/Container";
 import { Stack } from "../../components/Stack";
-import Button from "@dt/Button";
+import { Button } from "@digitaltableteur/react";
 import { cn } from "../../lib/cn";
 
 function pickRandomIndex(length: number): number {

--- a/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx
+++ b/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx
@@ -4,10 +4,7 @@ import Image from "next/image";
 import { useId, useState } from "react";
 import { useTranslate } from "../../lib/translation";
 import { cn } from "../../lib/cn";
-import Button from "@dt/Button";
-import Icon from "@dt/Icon";
-import Text from "@dt/Text";
-import Title from "@dt/Title";
+import { Button, Icon, Text, Title } from "@digitaltableteur/react";
 import styles from "./PricingPageContent.module.css";
 
 const PRICING_HERO_IMAGE = "/images/pricing/dsharp3-hero.png";

--- a/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx
+++ b/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx
@@ -2,9 +2,7 @@
 
 import React from "react";
 import PageLayout from "../PageLayout/PageLayout";
-import Title from "@dt/Title";
-import Text from "@dt/Text";
-import List from "@dt/List";
+import { List, Text, Title } from "@digitaltableteur/react";
 import styles from "./ProcessBlock.module.css";
 
 /**

--- a/nextjs-app/shared/patterns/ProofBlock/ProofBlock.tsx
+++ b/nextjs-app/shared/patterns/ProofBlock/ProofBlock.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import PageLayout from "../PageLayout";
-import Title from "@dt/Title";
-import Text from "@dt/Text";
+import { Text, Title } from "@digitaltableteur/react";
 import styles from "./ProofBlock.module.css";
 
 export type ProofMetric = {

--- a/nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.tsx
+++ b/nextjs-app/shared/patterns/ServicesBlock/ServicesBlock.tsx
@@ -2,9 +2,7 @@
 
 import React from "react";
 import PageLayout from "../PageLayout/PageLayout";
-import Title from "@dt/Title";
-import Text from "@dt/Text";
-import List from "@dt/List";
+import { List, Text, Title } from "@digitaltableteur/react";
 import styles from "./ServicesBlock.module.css";
 
 export interface ServiceItem {

--- a/nextjs-app/shared/patterns/StoryBlock/StoryBlock.tsx
+++ b/nextjs-app/shared/patterns/StoryBlock/StoryBlock.tsx
@@ -3,8 +3,7 @@
 import React from "react";
 import Image from "next/image";
 import PageLayout from "../PageLayout/PageLayout";
-import Title from "@dt/Title";
-import Text from "@dt/Text";
+import { Text, Title } from "@digitaltableteur/react";
 import styles from "./StoryBlock.module.css";
 
 /**

--- a/nextjs-app/shared/patterns/TeamBlock/TeamBlock.tsx
+++ b/nextjs-app/shared/patterns/TeamBlock/TeamBlock.tsx
@@ -3,8 +3,7 @@
 import React from "react";
 import Image from "next/image";
 import PageLayout from "../PageLayout/PageLayout";
-import Title from "@dt/Title";
-import Text from "@dt/Text";
+import { Text, Title } from "@digitaltableteur/react";
 import styles from "./TeamBlock.module.css";
 
 /**


### PR DESCRIPTION
Flip pattern imports of already-published components to `@digitaltableteur/react` across 14 patterns (~33 sites). `ArticleLayout` (itself a package export) keeps local imports.

Consumption metric: **15 → 17 of 207**. No publish needed; behavior-neutral.

Gate: typecheck · lint · 2278 tests · build · farm pre-commit — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)