### PR TITLE
fix(design-system): count @digitaltableteur/react imports in consumer scan

### DIFF
--- a/nextjs-app/shared/components/Button/Button.contract.json
+++ b/nextjs-app/shared/components/Button/Button.contract.json
@@ -115,6 +115,11 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ClientArticleShell.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "app/blog/[slug]/page.tsx",
             "since": "2026-06-04"
         },
@@ -130,6 +135,11 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/NextBlogNav.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "app/dev/code-window/page.tsx",
             "since": "2026-06-04"
         },
@@ -140,27 +150,17 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/error.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "app/layout.tsx",
             "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/tools/email-signature/EmailSignatureContent.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/tools/email-signature/page.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/AboutPage/index.ts",
+            "path": "app/not-found.tsx",
             "since": "2026-06-04"
         }
     ],

--- a/nextjs-app/shared/components/Icon/Icon.contract.json
+++ b/nextjs-app/shared/components/Icon/Icon.contract.json
@@ -1,268 +1,268 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-  "name": "Icon",
-  "tier": "atom",
-  "group": "display",
-  "status": "stable",
-  "description": "Phosphor icon wrapper with size, weight, and motion affordances.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1176-1658",
-  "radixPrimitive": null,
-  "element": "span",
-  "variants": {
-    "size": {
-      "values": [
-        "2xs",
-        "xs",
-        "sm",
-        "md",
-        "lg",
-        "xl",
-        "2xl"
-      ],
-      "default": "md"
-    }
-  },
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [
-      "decorative icons use aria-hidden",
-      "meaningful icons require aria-label"
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "name": "Icon",
+    "tier": "atom",
+    "group": "display",
+    "status": "stable",
+    "description": "Phosphor icon wrapper with size, weight, and motion affordances.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1176-1658",
+    "radixPrimitive": null,
+    "element": "span",
+    "variants": {
+        "size": {
+            "values": [
+                "2xs",
+                "xs",
+                "sm",
+                "md",
+                "lg",
+                "xl",
+                "2xl"
+            ],
+            "default": "md"
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "2026-05-26 code review 2026-07-10 — Figma component built (Atoms, node 1176-1658, parity-audit batch B2a): contract axes as variants with DT variable bindings.",
-    "forcedColorsVerified": true,
-    "axeTestExempt": "Display-only glyph wrapper",
-    "accessibilityTreeVerified": true,
-    "realBrowserForcedColorsVerified": true
-  },
-  "tokens": {
-    "colors": [
-      "--color-error",
-      "--color-info",
-      "--color-primary",
-      "--color-success",
-      "--color-warning"
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [
+            "decorative icons use aria-hidden",
+            "meaningful icons require aria-label"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-05-26 code review 2026-07-10 — Figma component built (Atoms, node 1176-1658, parity-audit batch B2a): contract axes as variants with DT variable bindings.",
+        "forcedColorsVerified": true,
+        "axeTestExempt": "Display-only glyph wrapper",
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true
+    },
+    "tokens": {
+        "colors": [
+            "--color-error",
+            "--color-info",
+            "--color-primary",
+            "--color-success",
+            "--color-warning"
+        ],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/BlogArticleMdxBody.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/BlogArticleShare.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ClientArticleShell.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ServerArticleContent.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/[slug]/ServerArticleMain.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/blog/NextBlogNav.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/dev/code-window/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/dev/tailwind-test/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/error.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/layout.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/lib/siteStructure.ts",
+            "since": "2026-06-04"
+        }
     ],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "consumers": [
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "app/blog/[slug]/BlogArticleMdxBody.tsx",
-      "since": "2026-06-04"
+    "schemaVersion": 2,
+    "displayName": "Icon",
+    "props": {
+        "name": {
+            "optional": false,
+            "type": "string"
+        },
+        "weight": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "thin",
+                "light",
+                "regular",
+                "bold",
+                "fill",
+                "duotone"
+            ]
+        },
+        "legacyStyle": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "thin",
+                "light",
+                "regular",
+                "duotone",
+                "solid",
+                "brands"
+            ]
+        },
+        "size": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "sm",
+                "md",
+                "lg",
+                "xl",
+                "2xs",
+                "xs",
+                "2xl"
+            ]
+        },
+        "color": {
+            "optional": true,
+            "type": "string"
+        },
+        "rotate": {
+            "optional": true,
+            "type": "0 | 90 | 180 | 270"
+        },
+        "flip": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "horizontal",
+                "vertical",
+                "both"
+            ]
+        },
+        "spin": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "pulse": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "mirrored": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "ariaLabel": {
+            "optional": true,
+            "type": "string"
+        },
+        "decorative": {
+            "optional": true,
+            "type": "boolean"
+        }
     },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "app/blog/[slug]/BlogArticleShare.tsx",
-      "since": "2026-06-04"
+    "forbiddenUse": [
+        "pass both `ariaLabel` and `decorative`. The component prefers",
+        "import a Phosphor component directly from `@phosphor-icons/react`"
+    ],
+    "composesWith": [
+        "Button",
+        "Title",
+        "ComplianceCard",
+        "CodeSnippet",
+        "Text",
+        "HelperText"
+    ],
+    "keywords": [
+        "icon",
+        "phosphor",
+        "glyph",
+        "decorative",
+        "aria-label",
+        "spin",
+        "status",
+        "arrow",
+        "caret",
+        "check",
+        "close"
+    ],
+    "dense": "Phosphor icon wrapper; name by PascalCase or slug (FontAwesome aliases kept), 2xs-2xl size ladder, weight, rotate/flip/spin/pulse, decorative by default, ariaLabel switches to role=img",
+    "usage": {
+        "description": "Icon wraps the Phosphor icon set with the project's size ladder, motion affordances, and accessibility defaults. It accepts a Phosphor name (PascalCase like ShareNetwork or a slug like share-network) and stays decorative (aria-hidden) unless you pass ariaLabel, which switches it to role=img with an accessible name. Legacy FontAwesome-style names are aliased so older call sites keep working.",
+        "bestPractices": [
+            {
+                "guidance": true,
+                "description": "Keep icons decorative (no ariaLabel) inside labelled controls; the control's own label is the accessible name."
+            },
+            {
+                "guidance": true,
+                "description": "Pass ariaLabel when the icon is the only content of an interactive element, so the control has a name."
+            },
+            {
+                "guidance": true,
+                "description": "Use spin for loading and pulse for ambient activity; both stop under prefers-reduced-motion."
+            },
+            {
+                "guidance": true,
+                "description": "Pair semantic status icons with visible text; the icon reinforces, the text carries the meaning."
+            },
+            {
+                "guidance": false,
+                "description": "Do not build icon-only buttons from a bare Icon; use Button with icon and accessibleName so focus, hit target and keyboard activation are owned by the right component."
+            },
+            {
+                "guidance": false,
+                "description": "Do not pass both ariaLabel and decorative; they are mutually exclusive and ariaLabel wins."
+            },
+            {
+                "guidance": false,
+                "description": "Do not force brand marks through Icon; anything outside the Phosphor catalogue goes through the image pipeline."
+            }
+        ]
     },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "app/blog/[slug]/page.tsx",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "app/blog/[slug]/ServerArticleContent.tsx",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "app/blog/[slug]/ServerArticleMain.tsx",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "app/dev/code-window/page.tsx",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "app/dev/tailwind-test/page.tsx",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "app/layout.tsx",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "app/lib/siteStructure.ts",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "app/tools/email-signature/EmailSignatureContent.tsx",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "app/tools/email-signature/page.tsx",
-      "since": "2026-06-04"
-    },
-    {
-      "repo": "digitaltableteur/digitaltableteur",
-      "path": "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
-      "since": "2026-06-04"
+    "playground": {
+        "defaults": {
+            "name": "share-network",
+            "size": "lg"
+        }
     }
-  ],
-  "schemaVersion": 2,
-  "displayName": "Icon",
-  "props": {
-    "name": {
-      "optional": false,
-      "type": "string"
-    },
-    "weight": {
-      "optional": true,
-      "type": "union",
-      "values": [
-        "thin",
-        "light",
-        "regular",
-        "bold",
-        "fill",
-        "duotone"
-      ]
-    },
-    "legacyStyle": {
-      "optional": true,
-      "type": "union",
-      "values": [
-        "thin",
-        "light",
-        "regular",
-        "duotone",
-        "solid",
-        "brands"
-      ]
-    },
-    "size": {
-      "optional": true,
-      "type": "union",
-      "values": [
-        "sm",
-        "md",
-        "lg",
-        "xl",
-        "2xs",
-        "xs",
-        "2xl"
-      ]
-    },
-    "color": {
-      "optional": true,
-      "type": "string"
-    },
-    "rotate": {
-      "optional": true,
-      "type": "0 | 90 | 180 | 270"
-    },
-    "flip": {
-      "optional": true,
-      "type": "union",
-      "values": [
-        "horizontal",
-        "vertical",
-        "both"
-      ]
-    },
-    "spin": {
-      "optional": true,
-      "type": "boolean"
-    },
-    "pulse": {
-      "optional": true,
-      "type": "boolean"
-    },
-    "mirrored": {
-      "optional": true,
-      "type": "boolean"
-    },
-    "ariaLabel": {
-      "optional": true,
-      "type": "string"
-    },
-    "decorative": {
-      "optional": true,
-      "type": "boolean"
-    }
-  },
-  "forbiddenUse": [
-    "pass both `ariaLabel` and `decorative`. The component prefers",
-    "import a Phosphor component directly from `@phosphor-icons/react`"
-  ],
-  "composesWith": [
-    "Button",
-    "Title",
-    "ComplianceCard",
-    "CodeSnippet",
-    "Text",
-    "HelperText"
-  ],
-  "keywords": [
-    "icon",
-    "phosphor",
-    "glyph",
-    "decorative",
-    "aria-label",
-    "spin",
-    "status",
-    "arrow",
-    "caret",
-    "check",
-    "close"
-  ],
-  "dense": "Phosphor icon wrapper; name by PascalCase or slug (FontAwesome aliases kept), 2xs-2xl size ladder, weight, rotate/flip/spin/pulse, decorative by default, ariaLabel switches to role=img",
-  "usage": {
-    "description": "Icon wraps the Phosphor icon set with the project's size ladder, motion affordances, and accessibility defaults. It accepts a Phosphor name (PascalCase like ShareNetwork or a slug like share-network) and stays decorative (aria-hidden) unless you pass ariaLabel, which switches it to role=img with an accessible name. Legacy FontAwesome-style names are aliased so older call sites keep working.",
-    "bestPractices": [
-      {
-        "guidance": true,
-        "description": "Keep icons decorative (no ariaLabel) inside labelled controls; the control's own label is the accessible name."
-      },
-      {
-        "guidance": true,
-        "description": "Pass ariaLabel when the icon is the only content of an interactive element, so the control has a name."
-      },
-      {
-        "guidance": true,
-        "description": "Use spin for loading and pulse for ambient activity; both stop under prefers-reduced-motion."
-      },
-      {
-        "guidance": true,
-        "description": "Pair semantic status icons with visible text; the icon reinforces, the text carries the meaning."
-      },
-      {
-        "guidance": false,
-        "description": "Do not build icon-only buttons from a bare Icon; use Button with icon and accessibleName so focus, hit target and keyboard activation are owned by the right component."
-      },
-      {
-        "guidance": false,
-        "description": "Do not pass both ariaLabel and decorative; they are mutually exclusive and ariaLabel wins."
-      },
-      {
-        "guidance": false,
-        "description": "Do not force brand marks through Icon; anything outside the Phosphor catalogue goes through the image pipeline."
-      }
-    ]
-  },
-  "playground": {
-    "defaults": {
-      "name": "share-network",
-      "size": "lg"
-    }
-  }
 }

--- a/scripts/design-system/consumers-lib.mjs
+++ b/scripts/design-system/consumers-lib.mjs
@@ -142,16 +142,18 @@ function parseDtComponents(content) {
 
 function parsePackageComponents(content) {
   const names = new Set();
+  // Anchor the brace group directly to the barrel `from` clause. `[^{}]*`
+  // cannot cross another import's braces, so a preceding `import { … } from
+  // "react"` no longer bleeds into this match (the old `[\s\S]*?` did, which
+  // silently dropped every barrel-consumed component to zero). An optional
+  // default binding and a whole-import `type ` prefix are tolerated.
   const re =
-    /\bimport\s+(type\s+)?([\s\S]*?)\s+from\s+["']@digitaltableteur\/react["']/g;
+    /\bimport\s+(?:[A-Za-z0-9_$]+\s*,\s*)?(type\s+)?\{([^{}]*)\}\s+from\s+["']@digitaltableteur\/react["']/g;
   let match;
   while ((match = re.exec(content)) !== null) {
     const isTypeOnly = Boolean(match[1]);
     if (isTypeOnly) continue;
-    const clause = match[2];
-    const named = clause.match(/\{([\s\S]*?)\}/);
-    if (!named) continue;
-    for (const raw of named[1].split(",")) {
+    for (const raw of match[2].split(",")) {
       const local = raw
         .trim()
         .replace(/^type\s+/, "")

--- a/scripts/design-system/consumers-lib.test.mjs
+++ b/scripts/design-system/consumers-lib.test.mjs
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { computeConsumersForComponent } from "./consumers-lib.mjs";
+
+// Regression guard for the barrel-import parser. The original regex used a
+// non-greedy `[\s\S]*?` between `import` and `from "@digitaltableteur/react"`,
+// which bled across a preceding `import { … } from "react"` and captured the
+// wrong brace group — silently dropping every barrel-consumed component to
+// zero consumers. That, in turn, made dogfooded components (consumed only via
+// the registry package) fail the stable "requires consumers" gate.
+describe("consumers-lib: barrel import parsing", () => {
+  it("counts a component imported from @digitaltableteur/react", () => {
+    // Progress is consumed only via the barrel (e.g. ContactInquiryPanel does
+    // `import { Button, Progress } from "@digitaltableteur/react"`), with a
+    // preceding React import in the same file — the exact shape that broke the
+    // old regex.
+    const consumers = computeConsumersForComponent("Progress");
+    expect(consumers.length).toBeGreaterThan(0);
+    expect(
+      consumers.some((c) => /ContactInquiryPanel|ContactPage/.test(c.path)),
+    ).toBe(true);
+  });
+
+  it("counts atoms consumed from the barrel across page shells", () => {
+    // Title/Text are barrel-consumed across many page shells after the atom
+    // consumption sweep; a barrel-blind parser would report zero.
+    expect(computeConsumersForComponent("Title").length).toBeGreaterThan(0);
+    expect(computeConsumersForComponent("Text").length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
The consumer scan's barrel-import regex used a non-greedy `[\s\S]*?` that bled across a preceding `import { … } from "react"` and captured the wrong braces — so **every component consumed only via the registry barrel scored zero consumers**. The atom-consumption sweeps (#1109/#1110) exposed this: moving consumers onto the barrel made stable components (Progress, Skeleton) read as unconsumed and fail the stable `requires-consumers` gate, even though e.g. `ContactInquiryPanel` imports `Progress` from the barrel.

**Fix:** anchor the brace group to the barrel `from` clause so it can't cross another import. Adds a regression test. `audit:consumers` re-sorts Button/Icon consumer lists now that barrel consumers count.

This also makes the consumption metric honest going forward — the mandate's whole point is barrel consumption, which the scan was blind to.

Gate: typecheck · lint · **2280 tests** · build · check:consumers · check:contract-props — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of components imported from the shared React library, preventing valid component usage from being overlooked.
  - Updated component usage records to more accurately reflect where buttons and icons are used across the application.
  - Resolved an issue that could incorrectly report components as having no consumers.

- **Tests**
  - Added regression coverage for shared component import detection across pages and application shells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->