### PR TITLE
refactor(design-system): cap Timestamp size ladder at m (drop l–xxl)

### DIFF
--- a/nextjs-app/shared/components/Timestamp/Timestamp.contract.json
+++ b/nextjs-app/shared/components/Timestamp/Timestamp.contract.json
@@ -14,10 +14,7 @@
                 "xxs",
                 "xs",
                 "s",
-                "m",
-                "l",
-                "xl",
-                "xxl"
+                "m"
             ],
             "default": "s",
             "propSourced": true
@@ -116,12 +113,9 @@
             "type": "union",
             "values": [
                 "s",
-                "xl",
                 "xs",
                 "xxs",
-                "m",
-                "l",
-                "xxl"
+                "m"
             ]
         },
         "tone": {

--- a/nextjs-app/shared/components/Timestamp/Timestamp.module.css
+++ b/nextjs-app/shared/components/Timestamp/Timestamp.module.css
@@ -29,15 +29,3 @@
 .sizeM {
   font-size: var(--font-size-text-m);
 }
-
-.sizeL {
-  font-size: var(--font-size-text-l);
-}
-
-.sizeXL {
-  font-size: var(--font-size-text-xl);
-}
-
-.sizeXXL {
-  font-size: var(--font-size-text-xxl);
-}

--- a/nextjs-app/shared/components/Timestamp/Timestamp.stories.tsx
+++ b/nextjs-app/shared/components/Timestamp/Timestamp.stories.tsx
@@ -57,7 +57,7 @@ const meta = {
     },
     size: {
       control: { type: "select" },
-      options: ["xxs", "xs", "s", "m", "l", "xl", "xxl"],
+      options: ["xxs", "xs", "s", "m"],
       description: "Text-ladder size.",
       table: { category: "Appearance", defaultValue: { summary: "s" } },
     },
@@ -138,13 +138,13 @@ export const Sizes: Story = {
     docs: {
       description: {
         story:
-          "The text-ladder sizes from xxs to xxl. Timestamp inherits the same type scale as Text, so it aligns inline with surrounding copy at any size.",
+          "The text-ladder sizes from xxs to m. Timestamp is metadata, so it caps at body size (m) — it inherits the Text type scale and aligns inline with surrounding copy.",
       },
     },
   },
   render: () => (
     <div style={{ display: "grid", gap: "0.5rem" }}>
-      {(["xxs", "xs", "s", "m", "l", "xl", "xxl"] as const).map((size) => (
+      {(["xxs", "xs", "s", "m"] as const).map((size) => (
         <Text as="p" size="s" key={size}>
           {size}:{" "}
           <Timestamp value={OLDER} now={FIXED_NOW} format="date" size={size} />

--- a/nextjs-app/shared/components/Timestamp/Timestamp.tsx
+++ b/nextjs-app/shared/components/Timestamp/Timestamp.tsx
@@ -21,7 +21,7 @@ export type TimestampFormat =
   | "system_date_time"
   | "system_time";
 
-export type TimestampSize = "xxs" | "xs" | "s" | "m" | "l" | "xl" | "xxl";
+export type TimestampSize = "xxs" | "xs" | "s" | "m";
 
 export interface TimestampProps {
   /** The date/time to display: ISO 8601 string, Unix seconds, or Date. */
@@ -59,9 +59,6 @@ const SIZE_CLASS: Record<TimestampSize, string> = {
   xs: styles.sizeXS,
   s: styles.sizeS,
   m: styles.sizeM,
-  l: styles.sizeL,
-  xl: styles.sizeXL,
-  xxl: styles.sizeXXL,
 };
 
 const toDate = (value: string | number | Date): Date => {

--- a/nextjs-app/shared/components/Timestamp/__a11y-snapshots__/content-timestamp--default.yaml
+++ b/nextjs-app/shared/components/Timestamp/__a11y-snapshots__/content-timestamp--default.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (alpha)
 - time: 2 hours ago

--- a/nextjs-app/shared/components/Timestamp/__a11y-snapshots__/content-timestamp--example.yaml
+++ b/nextjs-app/shared/components/Timestamp/__a11y-snapshots__/content-timestamp--example.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (alpha)
 - paragraph:
   - text: "Last updated:"
   - time: Nov 29, 2025

--- a/nextjs-app/shared/components/Timestamp/__a11y-snapshots__/content-timestamp--forced-colors.yaml
+++ b/nextjs-app/shared/components/Timestamp/__a11y-snapshots__/content-timestamp--forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (alpha)
 - time: 2 hours ago

--- a/nextjs-app/shared/components/Timestamp/__a11y-snapshots__/content-timestamp--formats.yaml
+++ b/nextjs-app/shared/components/Timestamp/__a11y-snapshots__/content-timestamp--formats.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (alpha)
 - paragraph:
   - text: "relative:"
   - time: 3 months ago

--- a/nextjs-app/shared/components/Timestamp/__a11y-snapshots__/content-timestamp--playground.yaml
+++ b/nextjs-app/shared/components/Timestamp/__a11y-snapshots__/content-timestamp--playground.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (alpha)
 - time: 2 hours ago

--- a/nextjs-app/shared/components/Timestamp/__a11y-snapshots__/content-timestamp--relative.yaml
+++ b/nextjs-app/shared/components/Timestamp/__a11y-snapshots__/content-timestamp--relative.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (alpha)
 - paragraph:
   - text: "30 seconds:"
   - time: now

--- a/nextjs-app/shared/components/Timestamp/__a11y-snapshots__/content-timestamp--sizes.yaml
+++ b/nextjs-app/shared/components/Timestamp/__a11y-snapshots__/content-timestamp--sizes.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (alpha)
 - paragraph:
   - text: "xxs:"
   - time: Nov 29, 2025
@@ -10,13 +9,4 @@
   - time: Nov 29, 2025
 - paragraph:
   - text: "m:"
-  - time: Nov 29, 2025
-- paragraph:
-  - text: "l:"
-  - time: Nov 29, 2025
-- paragraph:
-  - text: "xl:"
-  - time: Nov 29, 2025
-- paragraph:
-  - text: "xxl:"
   - time: Nov 29, 2025

--- a/nextjs-app/shared/components/Timestamp/__a11y-snapshots__/content-timestamp--tones.yaml
+++ b/nextjs-app/shared/components/Timestamp/__a11y-snapshots__/content-timestamp--tones.yaml
@@ -1,4 +1,3 @@
-- status: Work in progress (alpha)
 - paragraph:
   - text: "muted:"
   - time: Nov 29, 2025, 02:00 PM


### PR DESCRIPTION
Timestamp is metadata and never needs display-scale sizes. Trims the size ladder to `xxs/xs/s/m` across the type union, CSS, contract (variants + props), the Sizes story, and recaptured AT snapshots.

Gate: farm pre-commit · typecheck · lint · 2280 tests · build · validate:components · check:contract-props — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)