### PR TITLE
feat(design-system): link FilterChip to its new Figma component

### DIFF
--- a/nextjs-app/shared/components/FilterChip/FilterChip.contract.json
+++ b/nextjs-app/shared/components/FilterChip/FilterChip.contract.json
@@ -5,7 +5,7 @@
     "group": "controls",
     "status": "alpha",
     "description": "Single-select filter toggle chip: a button[aria-pressed] with pill, underline, and minimal treatments.",
-    "figma": null,
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1249-1954",
     "radixPrimitive": null,
     "element": "button",
     "variants": {


### PR DESCRIPTION
FilterChip had no Figma component, and `BlogCategoryFilter` ([node 1035:110](https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1035-110)) was hand-built from bespoke pills rather than dogfooding it.

- Built the **FilterChip component set** in Figma ([1249:1954](https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1249-1954)) — Pill / Underline / Minimal × Pressed, with a `Label` text property, matching the code API.
- Rebuilt **BlogCategoryFilter** from 5 FilterChip instances (visually identical: All Posts pressed + 4 unpressed categories).
- Records the component node in the FilterChip contract.

Gate: validate:components · check:contract-props · typecheck — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)