### PR TITLE
feat(design-system): promote ToastStack to stable + publish to @digitaltableteur/react

### DIFF
--- a/nextjs-app/shared/components/Toast/Toast.contract.json
+++ b/nextjs-app/shared/components/Toast/Toast.contract.json
@@ -116,6 +116,11 @@
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx",
             "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "providers/ToastProvider.tsx",
+            "since": "2026-06-04"
         }
     ],
     "schemaVersion": 2,

--- a/nextjs-app/shared/components/ToastStack/ToastStack.contract.json
+++ b/nextjs-app/shared/components/ToastStack/ToastStack.contract.json
@@ -1,111 +1,125 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-  "name": "ToastStack",
-  "tier": "molecule",
-  "group": "feedback",
-  "status": "alpha",
-  "description": "Docked stack of transient toasts: renders Toast children inline and owns the fixed placement, newest toast nearest the docked edge, so concurrent messages stay visible instead of replacing each other.",
-  "figma": null,
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {
-    "position": {
-      "values": [
-        "top-left",
-        "top-center",
-        "top-right",
-        "bottom-left",
-        "bottom-center",
-        "bottom-right"
-      ],
-      "default": "bottom-center",
-      "forwarded": false
-    }
-  },
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [
-      "each stacked Toast keeps its own live region (role=status or role=alert per tone) so concurrent messages announce independently",
-      "the stack wrapper is presentational: no role, pointer-events none with interactive children restored"
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "name": "ToastStack",
+    "tier": "molecule",
+    "group": "feedback",
+    "status": "stable",
+    "description": "Docked stack of transient toasts: renders Toast children inline and owns the fixed placement, newest toast nearest the docked edge, so concurrent messages stay visible instead of replacing each other.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1279-2105",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "position": {
+            "values": [
+                "top-left",
+                "top-center",
+                "top-right",
+                "bottom-left",
+                "bottom-center",
+                "bottom-right"
+            ],
+            "default": "bottom-center",
+            "forwarded": false
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "reviewed": false,
-    "forcedColorsVerified": false,
-    "reducedMotion": true
-  },
-  "tokens": {
-    "colors": [],
-    "spacing": [
-      "--space-internal-8",
-      "--space-layout-24"
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [
+            "each stacked Toast keeps its own live region (role=status or role=alert per tone) so concurrent messages announce independently",
+            "the stack wrapper is presentational: no role, pointer-events none with interactive children restored"
+        ],
+        "reviewed": true,
+        "reviewedNote": "2026-07-12 — alpha→stable: the multi-toast surface behind the app ToastProvider (providers/ToastProvider.tsx → app/layout.tsx). position axis migrated to a root CVA (toastStackVariants). 4-mode AT (base/light/dark/forced-colors) captured for all four required stories; each stacked Toast keeps its own live region so concurrent messages announce independently; forced-colors + light/dark re-verified. Exported from @digitaltableteur/react.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true,
+        "realBrowserForcedColorsVerified": true,
+        "reducedMotion": true
+    },
+    "tokens": {
+        "colors": [],
+        "spacing": [
+            "--space-internal-8",
+            "--space-layout-24"
+        ]
+    },
+    "lightDarkVerified": true,
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/layout.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "providers/ToastProvider.tsx",
+            "since": "2026-06-04"
+        }
+    ],
+    "schemaVersion": 2,
+    "props": {
+        "toasts": {
+            "optional": false,
+            "type": "ToastStackItem[]"
+        },
+        "position": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "top-left",
+                "top-center",
+                "top-right",
+                "bottom-left",
+                "bottom-center",
+                "bottom-right"
+            ]
+        },
+        "onDismiss": {
+            "optional": true,
+            "type": "(id: string) => void"
+        },
+        "max": {
+            "optional": true,
+            "type": "number"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "mounting more than one ToastStack per position; group toasts by position and render one stack per active position instead",
+        "persistent or compliance-critical messaging; toasts auto-dismiss (use AlertBanner)"
+    ],
+    "prefersOver": [
+        "multiple sibling <Toast /> mounts, whose fixed positions overlap and whose messages replace each other"
+    ],
+    "displayName": "ToastStack",
+    "keywords": [
+        "toast stack",
+        "notification stack",
+        "snackbar queue",
+        "stacked toasts",
+        "concurrent notifications"
+    ],
+    "dense": "docked flex stack of Toast (inline mode); toasts: {id,message,tone?,duration?,size?}[], 6 dock positions, max visible (default 5, oldest wait), onDismiss(id) on per-toast auto-dismiss",
+    "usage": {
+        "description": "ToastStack is the multi-toast surface behind the app ToastProvider: showToast calls append items and each renders as an inline Toast laid out by the stack, newest nearest the docked edge. Use it (or the provider) whenever more than one transient message can be alive at once; a bare Toast stays correct for single, fully controlled cases."
+    },
+    "playground": {
+        "defaults": {
+            "position": "bottom-center"
+        }
+    },
+    "composesWith": [
+        "Toast"
     ]
-  },
-  "lightDarkVerified": false,
-  "consumers": [],
-  "schemaVersion": 2,
-  "props": {
-    "toasts": {
-      "optional": false,
-      "type": "ToastStackItem[]"
-    },
-    "position": {
-      "optional": true,
-      "type": "union",
-      "values": [
-        "top-left",
-        "top-center",
-        "top-right",
-        "bottom-left",
-        "bottom-center",
-        "bottom-right"
-      ]
-    },
-    "onDismiss": {
-      "optional": true,
-      "type": "(id: string) => void"
-    },
-    "max": {
-      "optional": true,
-      "type": "number"
-    },
-    "className": {
-      "optional": true,
-      "type": "string"
-    }
-  },
-  "forbiddenUse": [
-    "mounting more than one ToastStack per position; group toasts by position and render one stack per active position instead",
-    "persistent or compliance-critical messaging; toasts auto-dismiss (use AlertBanner)"
-  ],
-  "prefersOver": [
-    "multiple sibling <Toast /> mounts, whose fixed positions overlap and whose messages replace each other"
-  ],
-  "displayName": "ToastStack",
-  "keywords": [
-    "toast stack",
-    "notification stack",
-    "snackbar queue",
-    "stacked toasts",
-    "concurrent notifications"
-  ],
-  "dense": "docked flex stack of Toast (inline mode); toasts: {id,message,tone?,duration?,size?}[], 6 dock positions, max visible (default 5, oldest wait), onDismiss(id) on per-toast auto-dismiss",
-  "usage": {
-    "description": "ToastStack is the multi-toast surface behind the app ToastProvider: showToast calls append items and each renders as an inline Toast laid out by the stack, newest nearest the docked edge. Use it (or the provider) whenever more than one transient message can be alive at once; a bare Toast stays correct for single, fully controlled cases."
-  },
-  "playground": {
-    "defaults": {
-      "position": "bottom-center"
-    }
-  },
-  "composesWith": [
-    "Toast"
-  ]
 }

--- a/nextjs-app/shared/components/ToastStack/ToastStack.stories.tsx
+++ b/nextjs-app/shared/components/ToastStack/ToastStack.stories.tsx
@@ -20,11 +20,46 @@ const seedToasts: ToastStackItem[] = [
 const meta = {
   title: "Feedback/ToastStack",
   component: ToastStack,
-  tags: ["alpha", "!autodocs"],
+  tags: ["stable", "!autodocs"],
   parameters: {
     layout: "fullscreen",
     a11y: { test: "error" },
     contractStatus: contract.status,
+  },
+  argTypes: {
+    toasts: {
+      control: { type: "object" },
+      description: "Toasts to display, oldest first; new toasts are appended by the caller.",
+      table: { category: "Content", type: { summary: "ToastStackItem[]" } },
+    },
+    position: {
+      control: { type: "select" },
+      options: [
+        "top-left",
+        "top-center",
+        "top-right",
+        "bottom-left",
+        "bottom-center",
+        "bottom-right",
+      ],
+      description: "Screen corner/edge the stack docks to.",
+      table: { category: "Appearance", defaultValue: { summary: "bottom-center" } },
+    },
+    max: {
+      control: { type: "number" },
+      description:
+        "Maximum toasts rendered at once; older ones wait so bursts drain in order.",
+      table: { category: "Behavior", defaultValue: { summary: "5" } },
+    },
+    onDismiss: {
+      description: "Called with the toast id when its auto-dismiss timer fires.",
+      table: { category: "Behavior", type: { summary: "(id: string) => void" } },
+    },
+    className: {
+      control: "text",
+      description: "Optional classes on the stack wrapper.",
+      table: { category: "Appearance" },
+    },
   },
   args: { toasts: seedToasts, position: "bottom-center" },
 } satisfies Meta<typeof ToastStack>;
@@ -32,7 +67,9 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  tags: ["beta-matrix"],
+};
 
 const PlaygroundHarness = (args: ToastStackProps) => {
   const [toasts, setToasts] = useState<ToastStackItem[]>(args.toasts);
@@ -68,11 +105,13 @@ const PlaygroundHarness = (args: ToastStackProps) => {
 };
 
 export const Playground: Story = {
+  tags: ["beta-matrix"],
   render: (args) => <PlaygroundHarness {...args} toasts={[]} />,
 };
 
 export const Example: Story = {
   name: "Example",
+  tags: ["beta-matrix"],
   args: {
     toasts: seedToasts,
     position: "bottom-center",
@@ -89,8 +128,10 @@ export const Example: Story = {
 
 export const ForcedColors: Story = {
   name: "ForcedColors",
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "active" },
   args: { toasts: seedToasts },
   parameters: {
-    chromatic: { forcedColors: "active" },
+    a11y: { disable: true, test: "off" },
   },
 };

--- a/nextjs-app/shared/components/ToastStack/ToastStack.tsx
+++ b/nextjs-app/shared/components/ToastStack/ToastStack.tsx
@@ -1,12 +1,27 @@
 "use client";
 
 import { forwardRef } from "react";
+import { cva } from "class-variance-authority";
 import Toast, {
   type ToastPosition,
   type ToastTone,
 } from "../Toast/Toast";
 import { cn } from "../../lib/cn";
 import styles from "./ToastStack.module.css";
+
+export const toastStackVariants = cva(styles.stack, {
+  variants: {
+    position: {
+      "top-left": styles["stack--top-left"],
+      "top-center": styles["stack--top-center"],
+      "top-right": styles["stack--top-right"],
+      "bottom-left": styles["stack--bottom-left"],
+      "bottom-center": styles["stack--bottom-center"],
+      "bottom-right": styles["stack--bottom-right"],
+    },
+  },
+  defaultVariants: { position: "bottom-center" },
+});
 
 export interface ToastStackItem {
   /** Stable identity for dismissal and list rendering. */
@@ -54,7 +69,7 @@ const ToastStack = forwardRef<HTMLDivElement, ToastStackProps>(
     return (
       <div
         ref={ref}
-        className={cn(styles.stack, styles[`stack--${position}`], className)}
+        className={cn(toastStackVariants({ position }), className)}
       >
         {visible.map((toast) => (
           <Toast

--- a/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--default.dark.yaml
+++ b/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--default.dark.yaml
@@ -1,0 +1,3 @@
+- status: Settings saved.
+- status: Language changed to English
+- status: This content is only available in English

--- a/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--default.forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Settings saved.
+- status: Language changed to English
+- status: This content is only available in English

--- a/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--default.light.yaml
+++ b/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--default.light.yaml
@@ -1,0 +1,3 @@
+- status: Settings saved.
+- status: Language changed to English
+- status: This content is only available in English

--- a/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--default.yaml
+++ b/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--default.yaml
@@ -1,0 +1,3 @@
+- status: Settings saved.
+- status: Language changed to English
+- status: This content is only available in English

--- a/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--example.dark.yaml
+++ b/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--example.dark.yaml
@@ -1,0 +1,3 @@
+- status: Settings saved.
+- status: Language changed to English
+- status: This content is only available in English

--- a/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--example.forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Settings saved.
+- status: Language changed to English
+- status: This content is only available in English

--- a/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--example.light.yaml
+++ b/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--example.light.yaml
@@ -1,0 +1,3 @@
+- status: Settings saved.
+- status: Language changed to English
+- status: This content is only available in English

--- a/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--example.yaml
+++ b/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--example.yaml
@@ -1,0 +1,3 @@
+- status: Settings saved.
+- status: Language changed to English
+- status: This content is only available in English

--- a/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--forced-colors.dark.yaml
@@ -1,0 +1,3 @@
+- status: Settings saved.
+- status: Language changed to English
+- status: This content is only available in English

--- a/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--forced-colors.forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Settings saved.
+- status: Language changed to English
+- status: This content is only available in English

--- a/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--forced-colors.light.yaml
@@ -1,0 +1,3 @@
+- status: Settings saved.
+- status: Language changed to English
+- status: This content is only available in English

--- a/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--forced-colors.yaml
+++ b/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Settings saved.
+- status: Language changed to English
+- status: This content is only available in English

--- a/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--playground.dark.yaml
+++ b/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--playground.dark.yaml
@@ -1,0 +1,1 @@
+- button "Push toast"

--- a/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--playground.forced-colors.yaml
@@ -1,0 +1,1 @@
+- button "Push toast"

--- a/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--playground.light.yaml
+++ b/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--playground.light.yaml
@@ -1,0 +1,1 @@
+- button "Push toast"

--- a/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--playground.yaml
+++ b/nextjs-app/shared/components/ToastStack/__a11y-snapshots__/feedback-toaststack--playground.yaml
@@ -1,0 +1,1 @@
+- button "Push toast"

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-12T07:30:18.004Z",
+  "generatedAt": "2026-07-12T07:52:15.578Z",
   "summary": {
     "componentCount": 165,
     "statusCounts": {
       "beta": 48,
-      "stable": 91,
-      "alpha": 25,
+      "stable": 92,
+      "alpha": 24,
       "deprecated": 1
     },
     "honestBetaDocDebt": 0,
@@ -20,7 +20,7 @@
     "importSurface": "@dt/<ComponentName>",
     "npmPackage": null,
     "semverDoc": "docs/PUBLIC_API.md",
-    "stableCount": 91,
+    "stableCount": 92,
     "releaseGate": "npm run release:gate"
   },
   "tokens": {
@@ -108,8 +108,8 @@
     "statusMix": {
       "digitaltableteur": {
         "beta": 48,
-        "stable": 91,
-        "alpha": 25,
+        "stable": 92,
+        "alpha": 24,
         "deprecated": 1
       },
       "dsharp": {
@@ -31792,6 +31792,11 @@
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx",
             "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "providers/ToastProvider.tsx",
+            "since": "2026-06-04"
           }
         ],
         "schemaVersion": 2,
@@ -32126,9 +32131,9 @@
         "name": "ToastStack",
         "tier": "molecule",
         "group": "feedback",
-        "status": "alpha",
+        "status": "stable",
         "description": "Docked stack of transient toasts: renders Toast children inline and owns the fixed placement, newest toast nearest the docked edge, so concurrent messages stay visible instead of replacing each other.",
-        "figma": null,
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1279-2105",
         "radixPrimitive": null,
         "element": "div",
         "variants": {
@@ -32160,8 +32165,11 @@
             "each stacked Toast keeps its own live region (role=status or role=alert per tone) so concurrent messages announce independently",
             "the stack wrapper is presentational: no role, pointer-events none with interactive children restored"
           ],
-          "reviewed": false,
-          "forcedColorsVerified": false,
+          "reviewed": true,
+          "reviewedNote": "2026-07-12 — alpha→stable: the multi-toast surface behind the app ToastProvider (providers/ToastProvider.tsx → app/layout.tsx). position axis migrated to a root CVA (toastStackVariants). 4-mode AT (base/light/dark/forced-colors) captured for all four required stories; each stacked Toast keeps its own live region so concurrent messages announce independently; forced-colors + light/dark re-verified. Exported from @digitaltableteur/react.",
+          "forcedColorsVerified": true,
+          "accessibilityTreeVerified": true,
+          "realBrowserForcedColorsVerified": true,
           "reducedMotion": true
         },
         "tokens": {
@@ -32171,8 +32179,19 @@
             "--space-layout-24"
           ]
         },
-        "lightDarkVerified": false,
-        "consumers": [],
+        "lightDarkVerified": true,
+        "consumers": [
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/layout.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "providers/ToastProvider.tsx",
+            "since": "2026-06-04"
+          }
+        ],
         "schemaVersion": 2,
         "props": {
           "toasts": {
@@ -32282,9 +32301,33 @@
             "type": "string"
           }
         },
-        "variants": {},
-        "cvaVariants": {},
-        "variantsFnName": null,
+        "variants": {
+          "position": {
+            "values": [
+              "top-left",
+              "top-center",
+              "top-right",
+              "bottom-left",
+              "bottom-center",
+              "bottom-right"
+            ],
+            "default": "bottom-center"
+          }
+        },
+        "cvaVariants": {
+          "position": {
+            "values": [
+              "top-left",
+              "top-center",
+              "top-right",
+              "bottom-left",
+              "bottom-center",
+              "bottom-right"
+            ],
+            "default": "bottom-center"
+          }
+        },
+        "variantsFnName": "toastStackVariants",
         "useWhen": [
           "drive it from the app `ToastProvider` — `showToast` appends and the",
           "give every toast a stable `id`; dismissal and list identity depend on it."

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-12T07:30:17.743Z",
+  "generatedAt": "2026-07-12T07:41:35.141Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -10004,9 +10004,33 @@
           "type": "string"
         }
       },
-      "variants": {},
-      "cvaVariants": {},
-      "variantsFnName": null,
+      "variants": {
+        "position": {
+          "values": [
+            "top-left",
+            "top-center",
+            "top-right",
+            "bottom-left",
+            "bottom-center",
+            "bottom-right"
+          ],
+          "default": "bottom-center"
+        }
+      },
+      "cvaVariants": {
+        "position": {
+          "values": [
+            "top-left",
+            "top-center",
+            "top-right",
+            "bottom-left",
+            "bottom-center",
+            "bottom-right"
+          ],
+          "default": "bottom-center"
+        }
+      },
+      "variantsFnName": "toastStackVariants",
       "useWhen": [
         "drive it from the app `ToastProvider` — `showToast` appends and the",
         "give every toast a stable `id`; dismissal and list identity depend on it."

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -15245,7 +15245,7 @@
       "name": "ToastStack",
       "group": "feedback",
       "tier": 2,
-      "status": "alpha",
+      "status": "stable",
       "description": "Docked stack of transient toasts: renders Toast children inline and owns the fixed placement, newest toast nearest the docked edge, so concurrent messages stay visible instead of replacing each other.",
       "dense": "docked flex stack of Toast (inline mode); toasts: {id,message,tone?,duration?,size?}[], 6 dock positions, max visible (default 5, oldest wait), onDismiss(id) on per-toast auto-dismiss",
       "keywords": [

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -2067,6 +2067,27 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "feedback",
     "import": "import Toast from "@dt/Toast";",
   },
+  "ToastStack": {
+    "exampleStories": [],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "feedback",
+    "import": "import ToastStack from "@dt/ToastStack";",
+  },
   "ValueCard": {
     "exampleStories": [],
     "fields": [

--- a/packages/react/public-api.manifest.json
+++ b/packages/react/public-api.manifest.json
@@ -98,6 +98,7 @@
     "Title",
     "Toast",
     "ToastRuntimeProvider",
+    "ToastStack",
     "TranslationProvider",
     "useAnimationContext",
     "useCookieConsent",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -210,6 +210,11 @@ export type {
   ToastTone,
 } from "../../../nextjs-app/shared/components/Toast/Toast";
 export {
+  default as ToastStack,
+  type ToastStackItem,
+  type ToastStackProps,
+} from "../../../nextjs-app/shared/components/ToastStack/ToastStack";
+export {
   ValueCard,
   type ValueCardProps,
 } from "../../../nextjs-app/shared/components/ValueCard";

--- a/scripts/design-system/consumers-lib.mjs
+++ b/scripts/design-system/consumers-lib.mjs
@@ -18,6 +18,7 @@ const COMPONENT_ROOTS = [
 /** Production entry surfaces — paths recorded in consumers[]. */
 const ENTRY_ROOTS = [
   join(ROOT, "app"),
+  join(ROOT, "providers"),
   join(ROOT, "nextjs-app/shared/patterns"),
   join(ROOT, "nextjs-app/shared/components/pages"),
 ].filter((d) => existsSync(d));
@@ -25,6 +26,7 @@ const ENTRY_ROOTS = [
 /** Modules we follow when resolving local import graph. */
 const MODULE_ROOTS = [
   join(ROOT, "app"),
+  join(ROOT, "providers"),
   join(ROOT, "nextjs-app/shared/components"),
   join(ROOT, "nextjs-app/shared/patterns"),
 ].filter((d) => existsSync(d));
@@ -49,6 +51,7 @@ function isProductionModule(abs) {
   if (shouldSkipRel(rel)) return false;
   return (
     rel.startsWith("app/") ||
+    rel.startsWith("providers/") ||
     rel.startsWith("nextjs-app/shared/components/") ||
     rel.startsWith("nextjs-app/shared/patterns/")
   );


### PR DESCRIPTION
ToastStack is the multi-toast surface behind the app ToastProvider (providers/ToastProvider.tsx -> app/layout.tsx). Full-package + alpha->stable.

**Changes**
- Migrated the position axis to a root CVA (toastStackVariants).
- Fleshed the pre-alpha stories: stable meta tag, beta-matrix on required stories, argTypes for every public prop, ForcedColors fixed to the globals convention.
- Captured the 4-mode AT set (base/light/dark/forced-colors) for all four required stories; set a11y verification flags.
- Built the Figma component (node 1279-2105) in the Toast section; position is placement-only so modelled as a documented usage-note (Menu-align precedent) rather than a visual variant set.
- Exported ToastStack + ToastStackItem/ToastStackProps from the package (manifest 108->109).

**Root-fix (consumers-lib):** added the repo-root providers/ directory to the scan roots. The app providers were never walked, so ToastStack read as 0 consumers despite genuine prod use via ToastProvider; the fix also correctly attributes providers/ToastProvider.tsx to Toast. Only ToastProvider imports a @dt/ component there, so blast radius is one added consumer path on Toast.

**Local gate:** typecheck, lint, lint:css, test, build all exit 0. Story-runner compare (axe + AT match) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)