### PR TITLE
feat(design-system): SegmentedControl full package + promote to beta

### DIFF
--- a/nextjs-app/shared/components/SegmentedControl/SegmentedControl.contract.json
+++ b/nextjs-app/shared/components/SegmentedControl/SegmentedControl.contract.json
@@ -3,22 +3,30 @@
     "name": "SegmentedControl",
     "tier": "molecule",
     "group": "form",
-    "status": "alpha",
+    "status": "beta",
     "description": "Single-select segmented control: a compact row of mutually exclusive options with one visibly selected, as a radiogroup with roving-tabindex arrow-key navigation.",
-    "figma": null,
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1281-2108",
     "radixPrimitive": null,
     "element": "div",
     "variants": {
         "size": {
-            "values": ["sm", "md", "lg"],
-            "default": "md",
-            "propSourced": true
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "default": "md"
         }
     },
     "slots": [],
     "asChild": false,
     "subParts": [],
-    "requiredStories": ["Default", "Playground", "Example", "ForcedColors"],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
     "a11y": {
         "keyboard": [
             "Tab moves focus to the selected segment (roving tabindex)",
@@ -31,8 +39,9 @@
             "Disabled segments are skipped by keyboard navigation"
         ],
         "reducedMotion": true,
-        "reviewed": false,
-        "forcedColorsVerified": false
+        "reviewed": true,
+        "reviewedNote": "2026-07-12 — alpha→beta: code-level a11y review. Container is role=radiogroup with a required aria-label; each segment is role=radio with aria-checked reflecting selection. Roving tabindex keeps exactly one segment tabbable (the selection, else the first enabled); Arrow keys move selection wrapping and skip disabled segments; Home/End jump to first/last enabled. Selection shown by a raised neutral surface (not brand fill) so it reads across light/dark; forced-colors maps the selected segment to a Highlight outline. Motion respects prefers-reduced-motion. Axe asserted in unit test; forced-colors + light/dark verified on a non-6010 Storybook.",
+        "forcedColorsVerified": true
     },
     "tokens": {
         "colors": [
@@ -55,5 +64,60 @@
             "--font-size-text-m"
         ]
     },
-    "lightDarkVerified": false
+    "lightDarkVerified": true,
+    "props": {
+        "items": {
+            "optional": false,
+            "type": "SegmentedControlItem[]"
+        },
+        "value": {
+            "optional": false,
+            "type": "string"
+        },
+        "onValueChange": {
+            "optional": false,
+            "type": "(value: string) => void"
+        },
+        "size": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ]
+        },
+        "ariaLabel": {
+            "optional": false,
+            "type": "string"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "use it for actions or navigation that commits/routes — use `ButtonGroup`",
+        "overflow it; if the options do not fit on one line, use `Select`."
+    ],
+    "keywords": [
+        "segmented control",
+        "toggle group",
+        "single select",
+        "view switcher",
+        "radiogroup",
+        "mode switch"
+    ],
+    "dense": "Single-select segmented control (role=radiogroup): 2-5 short options, one visibly selected; sm/md/lg; controlled value + onValueChange; roving-tabindex arrow-key nav skipping disabled segments.",
+    "usage": {
+        "description": "SegmentedControl is the single-select counterpart to ButtonGroup: a compact row of mutually exclusive options with one visibly selected, for switching a small closed set of views or modes inline without opening a menu (list/grid, day/week/month). It is controlled — value + onValueChange own the selection. Keep it to 2-5 short segments; if the options do not fit on one line, use Select. Selecting must only change the bound value, never commit or route."
+    },
+    "playground": {
+        "defaults": {
+            "size": "md"
+        }
+    },
+    "composesWith": [],
+    "schemaVersion": 2,
+    "displayName": "SegmentedControl"
 }

--- a/nextjs-app/shared/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/nextjs-app/shared/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import React, { useState } from "react";
+import { expect, userEvent, within } from "storybook/test";
 import SegmentedControl, {
   type SegmentedControlItem,
   type SegmentedControlProps,
@@ -15,11 +16,43 @@ const items: SegmentedControlItem[] = [
 const meta = {
   title: "Navigation/SegmentedControl",
   component: SegmentedControl,
-  tags: ["alpha", "!autodocs"],
+  tags: ["beta", "!autodocs"],
   parameters: {
     layout: "centered",
     a11y: { test: "error" },
     contractStatus: contract.status,
+  },
+  argTypes: {
+    items: {
+      control: { type: "object" },
+      description: "Segments to render, in order. Each: { value, label, disabled? }.",
+      table: { category: "Content", type: { summary: "SegmentedControlItem[]" } },
+    },
+    value: {
+      control: "text",
+      description: "Currently selected value (controlled).",
+      table: { category: "Behavior" },
+    },
+    onValueChange: {
+      description: "Called with the new value when a segment is selected.",
+      table: { category: "Behavior", type: { summary: "(value: string) => void" } },
+    },
+    size: {
+      control: { type: "radio" },
+      options: ["sm", "md", "lg"],
+      description: "Size token.",
+      table: { category: "Appearance", defaultValue: { summary: "md" } },
+    },
+    ariaLabel: {
+      control: "text",
+      description: "Accessible name for the group (required; announced by screen readers).",
+      table: { category: "Accessibility" },
+    },
+    className: {
+      control: "text",
+      description: "Additional CSS class names.",
+      table: { category: "Appearance" },
+    },
   },
   args: { items, value: "list", size: "md", ariaLabel: "View" },
 } satisfies Meta<typeof SegmentedControl>;
@@ -33,14 +66,29 @@ const Controlled = (args: SegmentedControlProps) => {
 };
 
 export const Default: Story = {
+  tags: ["beta-matrix"],
   render: (args) => <Controlled {...args} />,
+  // Exercises pointer + roving-tabindex arrow navigation. The moves net to zero
+  // (re-select the already-selected segment, then ArrowRight/ArrowLeft round-trip)
+  // so the settled selection is unchanged and the captured AT snapshot is stable.
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const list = canvas.getByRole("radio", { name: "List" });
+    await userEvent.click(list);
+    await expect(list).toBeChecked();
+    list.focus();
+    await userEvent.keyboard("{ArrowRight}{ArrowLeft}");
+    await expect(list).toBeChecked();
+  },
 };
 
 export const Playground: Story = {
+  tags: ["beta-matrix"],
   render: (args) => <Controlled {...args} />,
 };
 
 export const Example: Story = {
+  tags: ["beta-matrix"],
   parameters: { controls: { disable: true } },
   render: () => {
     const withDisabled: SegmentedControlItem[] = [
@@ -53,6 +101,7 @@ export const Example: Story = {
 };
 
 export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
   parameters: { a11y: { disable: true, test: "off" } },
   render: (args) => <Controlled {...args} />,

--- a/nextjs-app/shared/components/SegmentedControl/SegmentedControl.tsx
+++ b/nextjs-app/shared/components/SegmentedControl/SegmentedControl.tsx
@@ -1,8 +1,20 @@
 "use client";
 
 import React, { useRef } from "react";
+import { cva } from "class-variance-authority";
 import { cn } from "../../lib/cn";
 import styles from "./SegmentedControl.module.css";
+
+export const segmentedControlVariants = cva(styles.root, {
+  variants: {
+    size: {
+      sm: styles.sm,
+      md: styles.md,
+      lg: styles.lg,
+    },
+  },
+  defaultVariants: { size: "md" },
+});
 
 export interface SegmentedControlItem {
   /** Stable value emitted on selection. */
@@ -84,7 +96,7 @@ export const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedContro
         ref={ref}
         role="radiogroup"
         aria-label={ariaLabel}
-        className={cn(styles.root, styles[size], className)}
+        className={cn(segmentedControlVariants({ size }), className)}
       >
         {items.map((item, i) => {
           const selected = item.value === value;

--- a/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--default.dark.yaml
+++ b/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--default.dark.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- radiogroup "View":
+  - radio "List" [checked]
+  - radio "Grid"
+  - radio "Board"

--- a/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--default.forced-colors.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- radiogroup "View":
+  - radio "List" [checked]
+  - radio "Grid"
+  - radio "Board"

--- a/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--default.light.yaml
+++ b/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--default.light.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- radiogroup "View":
+  - radio "List" [checked]
+  - radio "Grid"
+  - radio "Board"

--- a/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--default.yaml
+++ b/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--default.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- radiogroup "View":
+  - radio "List" [checked]
+  - radio "Grid"
+  - radio "Board"

--- a/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--example.dark.yaml
+++ b/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--example.dark.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- radiogroup "Range":
+  - radio "Day" [checked]
+  - radio "Week"
+  - radio "Month" [disabled]

--- a/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--example.forced-colors.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- radiogroup "Range":
+  - radio "Day" [checked]
+  - radio "Week"
+  - radio "Month" [disabled]

--- a/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--example.light.yaml
+++ b/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--example.light.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- radiogroup "Range":
+  - radio "Day" [checked]
+  - radio "Week"
+  - radio "Month" [disabled]

--- a/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--example.yaml
+++ b/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--example.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- radiogroup "Range":
+  - radio "Day" [checked]
+  - radio "Week"
+  - radio "Month" [disabled]

--- a/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--forced-colors.dark.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- radiogroup "View":
+  - radio "List" [checked]
+  - radio "Grid"
+  - radio "Board"

--- a/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--forced-colors.forced-colors.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- radiogroup "View":
+  - radio "List" [checked]
+  - radio "Grid"
+  - radio "Board"

--- a/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--forced-colors.light.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- radiogroup "View":
+  - radio "List" [checked]
+  - radio "Grid"
+  - radio "Board"

--- a/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--forced-colors.yaml
+++ b/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--forced-colors.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- radiogroup "View":
+  - radio "List" [checked]
+  - radio "Grid"
+  - radio "Board"

--- a/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--playground.dark.yaml
+++ b/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--playground.dark.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- radiogroup "View":
+  - radio "List" [checked]
+  - radio "Grid"
+  - radio "Board"

--- a/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--playground.forced-colors.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- radiogroup "View":
+  - radio "List" [checked]
+  - radio "Grid"
+  - radio "Board"

--- a/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--playground.light.yaml
+++ b/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--playground.light.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- radiogroup "View":
+  - radio "List" [checked]
+  - radio "Grid"
+  - radio "Board"

--- a/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--playground.yaml
+++ b/nextjs-app/shared/components/SegmentedControl/__a11y-snapshots__/navigation-segmentedcontrol--playground.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- radiogroup "View":
+  - radio "List" [checked]
+  - radio "Grid"
+  - radio "Board"

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-12T07:52:15.578Z",
+  "generatedAt": "2026-07-12T08:12:17.996Z",
   "summary": {
     "componentCount": 165,
     "statusCounts": {
-      "beta": 48,
+      "beta": 49,
       "stable": 92,
-      "alpha": 24,
+      "alpha": 23,
       "deprecated": 1
     },
     "honestBetaDocDebt": 0,
@@ -107,9 +107,9 @@
     },
     "statusMix": {
       "digitaltableteur": {
-        "beta": 48,
+        "beta": 49,
         "stable": 92,
-        "alpha": 24,
+        "alpha": 23,
         "deprecated": 1
       },
       "dsharp": {
@@ -24286,9 +24286,9 @@
         "name": "SegmentedControl",
         "tier": "molecule",
         "group": "form",
-        "status": "alpha",
+        "status": "beta",
         "description": "Single-select segmented control: a compact row of mutually exclusive options with one visibly selected, as a radiogroup with roving-tabindex arrow-key navigation.",
-        "figma": null,
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1281-2108",
         "radixPrimitive": null,
         "element": "div",
         "variants": {
@@ -24298,8 +24298,7 @@
               "md",
               "lg"
             ],
-            "default": "md",
-            "propSourced": true
+            "default": "md"
           }
         },
         "slots": [],
@@ -24323,8 +24322,9 @@
             "Disabled segments are skipped by keyboard navigation"
           ],
           "reducedMotion": true,
-          "reviewed": false,
-          "forcedColorsVerified": false
+          "reviewed": true,
+          "reviewedNote": "2026-07-12 — alpha→beta: code-level a11y review. Container is role=radiogroup with a required aria-label; each segment is role=radio with aria-checked reflecting selection. Roving tabindex keeps exactly one segment tabbable (the selection, else the first enabled); Arrow keys move selection wrapping and skip disabled segments; Home/End jump to first/last enabled. Selection shown by a raised neutral surface (not brand fill) so it reads across light/dark; forced-colors maps the selected segment to a Highlight outline. Motion respects prefers-reduced-motion. Axe asserted in unit test; forced-colors + light/dark verified on a non-6010 Storybook.",
+          "forcedColorsVerified": true
         },
         "tokens": {
           "colors": [
@@ -24347,7 +24347,62 @@
             "--font-size-text-m"
           ]
         },
-        "lightDarkVerified": false
+        "lightDarkVerified": true,
+        "props": {
+          "items": {
+            "optional": false,
+            "type": "SegmentedControlItem[]"
+          },
+          "value": {
+            "optional": false,
+            "type": "string"
+          },
+          "onValueChange": {
+            "optional": false,
+            "type": "(value: string) => void"
+          },
+          "size": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "sm",
+              "md",
+              "lg"
+            ]
+          },
+          "ariaLabel": {
+            "optional": false,
+            "type": "string"
+          },
+          "className": {
+            "optional": true,
+            "type": "string"
+          }
+        },
+        "forbiddenUse": [
+          "use it for actions or navigation that commits/routes — use `ButtonGroup`",
+          "overflow it; if the options do not fit on one line, use `Select`."
+        ],
+        "keywords": [
+          "segmented control",
+          "toggle group",
+          "single select",
+          "view switcher",
+          "radiogroup",
+          "mode switch"
+        ],
+        "dense": "Single-select segmented control (role=radiogroup): 2-5 short options, one visibly selected; sm/md/lg; controlled value + onValueChange; roving-tabindex arrow-key nav skipping disabled segments.",
+        "usage": {
+          "description": "SegmentedControl is the single-select counterpart to ButtonGroup: a compact row of mutually exclusive options with one visibly selected, for switching a small closed set of views or modes inline without opening a menu (list/grid, day/week/month). It is controlled — value + onValueChange own the selection. Keep it to 2-5 short segments; if the options do not fit on one line, use Select. Selecting must only change the bound value, never commit or route."
+        },
+        "playground": {
+          "defaults": {
+            "size": "md"
+          }
+        },
+        "composesWith": [],
+        "schemaVersion": 2,
+        "displayName": "SegmentedControl"
       },
       "spec": "# SegmentedControl\n\n## Intent\nA compact row of mutually exclusive options with one visibly selected, for\nswitching a small closed set of views or modes (e.g. list/grid, day/week/month)\ninline without opening a menu. It is the single-select counterpart to\n`ButtonGroup`, which is a non-exclusive row of actions.\n\n## Interaction contract\n- Keyboard: Tab moves focus to the selected segment (roving tabindex — exactly one\n  segment is tabbable); Arrow Left/Up and Right/Down move selection to the\n  previous/next enabled segment, wrapping; Home/End jump to the first/last enabled\n  segment. Disabled segments are skipped.\n- Pointer: clicking a segment selects it.\n- Controlled only: `value` + `onValueChange` own the selection; the component\n  holds no selection state.\n- Screen readers: the container is `role=radiogroup` with a required `ariaLabel`;\n  each segment is `role=radio` with `aria-checked` reflecting selection.\n\n## Do / don't\n- Do: keep to 2–5 short segments; it is a glance-and-switch control, not a menu.\n- Do: give a meaningful `ariaLabel` naming what is being switched.\n- Don't: use it for actions or navigation that commits/routes — use `ButtonGroup`\n  or links. Selecting must only change the bound value.\n- Don't: overflow it; if the options do not fit on one line, use `Select`.\n\n## Design notes\n- Tokens: track fill from `--color-muted`; segment text `--color-muted` →\n  `--color-text` (hover/selected); selected surface `--color-surface` with a\n  subtle shadow; focus via `--focus-ring-*`; spacing/radius from `--space-internal-*`\n  / `--radius-*`. No hardcoded colors.\n- Selection is shown by a raised neutral surface, not a brand fill, so it reads\n  consistently across light/dark; forced-colors maps the selected segment to a\n  `Highlight` outline. Motion respects `prefers-reduced-motion`.\n- Figma: TODO (parity build; no Figma node yet).\n\n## Promotion notes\nParity build (Astryx `Segmented Control`). Ships at alpha with the WIP badge. Do\nnot promote past alpha/beta without a documented production consumer, AT\nsnapshots, and forced-colors + light/dark verification.\n",
       "documentationDebt": false,
@@ -24407,11 +24462,20 @@
               "md",
               "lg"
             ],
-            "default": "sm"
+            "default": "md"
           }
         },
-        "cvaVariants": {},
-        "variantsFnName": null,
+        "cvaVariants": {
+          "size": {
+            "values": [
+              "sm",
+              "md",
+              "lg"
+            ],
+            "default": "md"
+          }
+        },
+        "variantsFnName": "segmentedControlVariants",
         "useWhen": [
           "keep to 2–5 short segments; it is a glance-and-switch control, not a menu.",
           "give a meaningful `ariaLabel` naming what is being switched."

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-12T07:41:35.141Z",
+  "generatedAt": "2026-07-12T08:04:34.941Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -7508,11 +7508,20 @@
             "md",
             "lg"
           ],
-          "default": "sm"
+          "default": "md"
         }
       },
-      "cvaVariants": {},
-      "variantsFnName": null,
+      "cvaVariants": {
+        "size": {
+          "values": [
+            "sm",
+            "md",
+            "lg"
+          ],
+          "default": "md"
+        }
+      },
+      "variantsFnName": "segmentedControlVariants",
       "useWhen": [
         "keep to 2–5 short segments; it is a glance-and-switch control, not a menu.",
         "give a meaningful `ariaLabel` naming what is being switched."

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -11683,17 +11683,85 @@
       "name": "SegmentedControl",
       "group": "form",
       "tier": 2,
-      "status": "alpha",
+      "status": "beta",
       "description": "Single-select segmented control: a compact row of mutually exclusive options with one visibly selected, as a radiogroup with roving-tabindex arrow-key navigation.",
-      "dense": "",
-      "keywords": [],
+      "dense": "Single-select segmented control (role=radiogroup): 2-5 short options, one visibly selected; sm/md/lg; controlled value + onValueChange; roving-tabindex arrow-key nav skipping disabled segments.",
+      "keywords": [
+        "segmented control",
+        "toggle group",
+        "single select",
+        "view switcher",
+        "radiogroup",
+        "mode switch"
+      ],
       "importLine": "import { SegmentedControl } from \"@dt/SegmentedControl\";",
-      "keyProps": [],
-      "props": {},
+      "keyProps": [
+        {
+          "name": "items",
+          "type": "SegmentedControlItem[]",
+          "required": true
+        },
+        {
+          "name": "value",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "ariaLabel",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "size",
+          "type": "sm | md | lg",
+          "required": false
+        },
+        {
+          "name": "className",
+          "type": "string",
+          "required": false
+        }
+      ],
+      "props": {
+        "items": {
+          "optional": false,
+          "type": "SegmentedControlItem[]"
+        },
+        "value": {
+          "optional": false,
+          "type": "string"
+        },
+        "onValueChange": {
+          "optional": false,
+          "type": "(value: string) => void"
+        },
+        "size": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "sm",
+            "md",
+            "lg"
+          ]
+        },
+        "ariaLabel": {
+          "optional": false,
+          "type": "string"
+        },
+        "className": {
+          "optional": true,
+          "type": "string"
+        }
+      },
       "composesWith": [],
       "prefersOver": [],
-      "forbiddenUse": [],
-      "usage": null,
+      "forbiddenUse": [
+        "use it for actions or navigation that commits/routes — use `ButtonGroup`",
+        "overflow it; if the options do not fit on one line, use `Select`."
+      ],
+      "usage": {
+        "description": "SegmentedControl is the single-select counterpart to ButtonGroup: a compact row of mutually exclusive options with one visibly selected, for switching a small closed set of views or modes inline without opening a menu (list/grid, day/week/month). It is controlled — value + onValueChange own the selection. Keep it to 2-5 short segments; if the options do not fit on one line, use Select. Selecting must only change the bound value, never commit or route."
+      },
       "tokens": {
         "colors": [
           "--color-muted",

--- a/packages/react/public-api.manifest.json
+++ b/packages/react/public-api.manifest.json
@@ -80,6 +80,7 @@
     "ReadingProgress",
     "saveConsentState",
     "Section",
+    "SegmentedControl",
     "Select",
     "SelectOption",
     "Skeleton",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -158,6 +158,11 @@ export {
   Section,
   type SectionProps,
 } from "../../../nextjs-app/shared/components/Section";
+export {
+  default as SegmentedControl,
+  type SegmentedControlItem,
+  type SegmentedControlProps,
+} from "../../../nextjs-app/shared/components/SegmentedControl/SegmentedControl";
 export { default as Select } from "../../../nextjs-app/shared/components/Select/Select";
 export type {
   SelectOptionItem,


### PR DESCRIPTION
Single-select segmented control (radiogroup, roving-tabindex arrow nav). Full-package alpha->beta.

**Changes**
- Migrated the size axis to a root CVA (segmentedControlVariants).
- Enriched the contract to the beta doc bar: usage/keywords/dense/playground, props synced, schemaVersion 2, a11y.reviewed + reviewedNote, forcedColors + lightDark verified.
- Fleshed the pre-alpha stories: beta meta tag, argTypes, beta-matrix on required stories, a net-zero keyboard+pointer play (drives the control without perturbing the AT snapshot).
- Captured the 4-mode AT set for all four required stories.
- Built the Figma component (node 1281-2108) in the Navigation section; size is geometry-only so modelled as a documented property note.
- Exported SegmentedControl + item/props types (manifest 109->110).

No genuine production consumer yet, so it lands at **beta** (per the owner decision); stable awaits real usage.

**Local gate:** typecheck, lint, lint:css, test, build all exit 0. Story-runner compare passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)