### PR TITLE
feat(design-system): CommandPalette full package + promote to beta

### DIFF
--- a/nextjs-app/shared/components/CommandPalette/CommandPalette.contract.json
+++ b/nextjs-app/shared/components/CommandPalette/CommandPalette.contract.json
@@ -3,16 +3,21 @@
     "name": "CommandPalette",
     "tier": "organism",
     "group": "navigation",
-    "status": "alpha",
+    "status": "beta",
     "description": "Modal, keyboard-driven command launcher: a search input filters a listbox of commands (matched on label + keywords); Arrow keys move the active option, Enter runs it, Escape closes. Focus is trapped and background scroll locked while open.",
-    "figma": null,
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1285-2113",
     "radixPrimitive": null,
     "element": "div",
     "variants": {},
     "slots": [],
     "asChild": false,
     "subParts": [],
-    "requiredStories": ["Default", "Playground", "Example", "ForcedColors"],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
     "a11y": {
         "keyboard": [
             "Arrow Down / Up move the active option (wrapping)",
@@ -26,8 +31,9 @@
             "Each command is role=option with aria-selected reflecting the active item"
         ],
         "reducedMotion": true,
-        "reviewed": false,
-        "forcedColorsVerified": false
+        "reviewed": true,
+        "reviewedNote": "2026-07-12 — alpha→beta: code-level a11y review. Overlay dialog is role=dialog aria-modal with an accessible label; the search input is role=combobox with aria-expanded, aria-controls and aria-activedescendant onto the role=listbox; each command is role=option with aria-selected reflecting the active item. Focus is trapped (useFocusTrap) and background scroll locked (useScrollLock) while open; Arrow Up/Down wrap the active option, Enter runs it and closes, Escape closes, overlay mousedown closes. User-facing strings are props so the component carries no i18n dependency. Axe asserted in unit test; forced-colors + light/dark verified on a non-6010 Storybook. Known limitation: virtualization is not implemented, so very long command lists render in full.",
+        "forcedColorsVerified": true
     },
     "tokens": {
         "colors": [
@@ -49,5 +55,54 @@
             "--font-size-text-m"
         ]
     },
-    "lightDarkVerified": false
+    "lightDarkVerified": true,
+    "props": {
+        "open": {
+            "optional": false,
+            "type": "boolean"
+        },
+        "onClose": {
+            "optional": false,
+            "type": "() => void"
+        },
+        "items": {
+            "optional": false,
+            "type": "CommandPaletteItem[]"
+        },
+        "label": {
+            "optional": true,
+            "type": "string"
+        },
+        "placeholder": {
+            "optional": true,
+            "type": "string"
+        },
+        "emptyText": {
+            "optional": true,
+            "type": "string"
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "nest submenus or put long forms inside it; it is a launcher, not a menu system or a modal form",
+        "hardcode user-facing copy; pass `label`, `placeholder`, and `emptyText` so the host owns i18n"
+    ],
+    "keywords": [
+        "command palette",
+        "command launcher",
+        "cmdk",
+        "quick actions",
+        "spotlight",
+        "fuzzy search"
+    ],
+    "dense": "Modal keyboard-driven command launcher: role=dialog with a combobox filtering a role=listbox on label+keywords; Arrow moves active option, Enter runs, Escape closes; focus trapped, scroll locked.",
+    "usage": {
+        "description": "CommandPalette is a modal, keyboard-first launcher: a search input filters a listbox of commands matched on label and keywords, Arrow keys move the active option, Enter runs it, Escape closes. It is controlled (open + onClose) and portal-rendered with focus trapped and background scroll locked while open. Reach for it as a power-user shortcut surface (go-to navigation, quick actions), not as a replacement for primary navigation or a container for forms. All user-facing strings are props so the host owns i18n."
+    },
+    "composesWith": [],
+    "schemaVersion": 2,
+    "displayName": "CommandPalette"
 }

--- a/nextjs-app/shared/components/CommandPalette/CommandPalette.stories.tsx
+++ b/nextjs-app/shared/components/CommandPalette/CommandPalette.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import React, { useState } from "react";
+import { expect, userEvent, within } from "storybook/test";
 import {
   CommandPalette,
   type CommandPaletteItem,
@@ -18,11 +19,47 @@ const commands: CommandPaletteItem[] = [
 const meta = {
   title: "Navigation/CommandPalette",
   component: CommandPalette,
-  tags: ["alpha", "!autodocs"],
+  tags: ["beta", "!autodocs"],
   parameters: {
     layout: "fullscreen",
     a11y: { test: "error" },
     contractStatus: contract.status,
+  },
+  argTypes: {
+    open: {
+      control: "boolean",
+      description: "Whether the palette is open (controlled).",
+      table: { category: "Behavior" },
+    },
+    onClose: {
+      description: "Called to request close (Escape, overlay click, or after a selection).",
+      table: { category: "Behavior", type: { summary: "() => void" } },
+    },
+    items: {
+      control: { type: "object" },
+      description: "Commands to show, in order. Each: { id, label, onSelect, keywords?, icon? }.",
+      table: { category: "Content", type: { summary: "CommandPaletteItem[]" } },
+    },
+    label: {
+      control: "text",
+      description: "Accessible name for the dialog + listbox.",
+      table: { category: "Accessibility", defaultValue: { summary: "Command palette" } },
+    },
+    placeholder: {
+      control: "text",
+      description: "Search input placeholder.",
+      table: { category: "Content", defaultValue: { summary: "Search commands…" } },
+    },
+    emptyText: {
+      control: "text",
+      description: "Shown when nothing matches.",
+      table: { category: "Content", defaultValue: { summary: "No results" } },
+    },
+    className: {
+      control: "text",
+      description: "Additional CSS class names for the dialog.",
+      table: { category: "Appearance" },
+    },
   },
   args: { open: true, items: commands, label: "Command palette" },
 } satisfies Meta<typeof CommandPalette>;
@@ -43,14 +80,27 @@ const Harness = (args: CommandPaletteProps) => {
 };
 
 export const Default: Story = {
+  tags: ["beta-matrix"],
   render: (args) => <Harness {...args} />,
+  // The palette renders in a portal (document.body), so this drives the combobox
+  // and roving active-option there and leaves the dialog open (axe validates the
+  // open state). The canvas snapshot is only the trigger button, unperturbed.
+  play: async () => {
+    const body = within(document.body);
+    const input = body.getByRole("combobox");
+    await userEvent.type(input, "blog");
+    await userEvent.keyboard("{ArrowDown}{ArrowUp}");
+    await expect(body.getByRole("dialog")).toBeInTheDocument();
+  },
 };
 
 export const Playground: Story = {
+  tags: ["beta-matrix"],
   render: (args) => <Harness {...args} />,
 };
 
 export const Example: Story = {
+  tags: ["beta-matrix"],
   parameters: { controls: { disable: true } },
   render: () => (
     <Harness open items={commands} label="Command palette" placeholder="Type a command…" onClose={() => {}} />
@@ -58,6 +108,7 @@ export const Example: Story = {
 };
 
 export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
   parameters: { a11y: { disable: true, test: "off" } },
   render: (args) => <Harness {...args} />,

--- a/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--default.dark.yaml
+++ b/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--default.dark.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- button "Open command palette"
+- dialog "Command palette":
+  - combobox "Search commands…" [expanded]: blog
+  - listbox "Command palette":
+    - option "Go to Blog" [selected]
+    - option "New blog post"

--- a/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--default.forced-colors.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- button "Open command palette"
+- dialog "Command palette":
+  - combobox "Search commands…" [expanded]: blog
+  - listbox "Command palette":
+    - option "Go to Blog" [selected]
+    - option "New blog post"

--- a/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--default.light.yaml
+++ b/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--default.light.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- button "Open command palette"
+- dialog "Command palette":
+  - combobox "Search commands…" [expanded]: blog
+  - listbox "Command palette":
+    - option "Go to Blog" [selected]
+    - option "New blog post"

--- a/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--default.yaml
+++ b/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--default.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (beta)
+- button "Open command palette"
+- dialog "Command palette":
+  - combobox "Search commands…" [expanded]: blog
+  - listbox "Command palette":
+    - option "Go to Blog" [selected]
+    - option "New blog post"

--- a/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--example.dark.yaml
+++ b/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--example.dark.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- button "Open command palette"
+- dialog "Command palette":
+  - combobox "Type a command…" [expanded]
+  - listbox "Command palette":
+    - option "Go to Home" [selected]
+    - option "Go to Blog"
+    - option "Go to Work"
+    - option "Go to Contact"
+    - option "New blog post"

--- a/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--example.forced-colors.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- button "Open command palette"
+- dialog "Command palette":
+  - combobox "Type a command…" [expanded]
+  - listbox "Command palette":
+    - option "Go to Home" [selected]
+    - option "Go to Blog"
+    - option "Go to Work"
+    - option "Go to Contact"
+    - option "New blog post"

--- a/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--example.light.yaml
+++ b/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--example.light.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- button "Open command palette"
+- dialog "Command palette":
+  - combobox "Type a command…" [expanded]
+  - listbox "Command palette":
+    - option "Go to Home" [selected]
+    - option "Go to Blog"
+    - option "Go to Work"
+    - option "Go to Contact"
+    - option "New blog post"

--- a/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--example.yaml
+++ b/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--example.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- button "Open command palette"
+- dialog "Command palette":
+  - combobox "Type a command…" [expanded]
+  - listbox "Command palette":
+    - option "Go to Home" [selected]
+    - option "Go to Blog"
+    - option "Go to Work"
+    - option "Go to Contact"
+    - option "New blog post"

--- a/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--forced-colors.dark.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- button "Open command palette"
+- dialog "Command palette":
+  - combobox "Search commands…" [expanded]
+  - listbox "Command palette":
+    - option "Go to Home" [selected]
+    - option "Go to Blog"
+    - option "Go to Work"
+    - option "Go to Contact"
+    - option "New blog post"

--- a/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--forced-colors.forced-colors.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- button "Open command palette"
+- dialog "Command palette":
+  - combobox "Search commands…" [expanded]
+  - listbox "Command palette":
+    - option "Go to Home" [selected]
+    - option "Go to Blog"
+    - option "Go to Work"
+    - option "Go to Contact"
+    - option "New blog post"

--- a/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--forced-colors.light.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- button "Open command palette"
+- dialog "Command palette":
+  - combobox "Search commands…" [expanded]
+  - listbox "Command palette":
+    - option "Go to Home" [selected]
+    - option "Go to Blog"
+    - option "Go to Work"
+    - option "Go to Contact"
+    - option "New blog post"

--- a/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--forced-colors.yaml
+++ b/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--forced-colors.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- button "Open command palette"
+- dialog "Command palette":
+  - combobox "Search commands…" [expanded]
+  - listbox "Command palette":
+    - option "Go to Home" [selected]
+    - option "Go to Blog"
+    - option "Go to Work"
+    - option "Go to Contact"
+    - option "New blog post"

--- a/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--playground.dark.yaml
+++ b/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--playground.dark.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- button "Open command palette"
+- dialog "Command palette":
+  - combobox "Search commands…" [expanded]
+  - listbox "Command palette":
+    - option "Go to Home" [selected]
+    - option "Go to Blog"
+    - option "Go to Work"
+    - option "Go to Contact"
+    - option "New blog post"

--- a/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--playground.forced-colors.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- button "Open command palette"
+- dialog "Command palette":
+  - combobox "Search commands…" [expanded]
+  - listbox "Command palette":
+    - option "Go to Home" [selected]
+    - option "Go to Blog"
+    - option "Go to Work"
+    - option "Go to Contact"
+    - option "New blog post"

--- a/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--playground.light.yaml
+++ b/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--playground.light.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- button "Open command palette"
+- dialog "Command palette":
+  - combobox "Search commands…" [expanded]
+  - listbox "Command palette":
+    - option "Go to Home" [selected]
+    - option "Go to Blog"
+    - option "Go to Work"
+    - option "Go to Contact"
+    - option "New blog post"

--- a/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--playground.yaml
+++ b/nextjs-app/shared/components/CommandPalette/__a11y-snapshots__/navigation-commandpalette--playground.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- button "Open command palette"
+- dialog "Command palette":
+  - combobox "Search commands…" [expanded]
+  - listbox "Command palette":
+    - option "Go to Home" [selected]
+    - option "Go to Blog"
+    - option "Go to Work"
+    - option "Go to Contact"
+    - option "New blog post"

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-12T08:12:17.996Z",
+  "generatedAt": "2026-07-12T08:25:46.352Z",
   "summary": {
     "componentCount": 165,
     "statusCounts": {
-      "beta": 49,
+      "beta": 50,
       "stable": 92,
-      "alpha": 23,
+      "alpha": 22,
       "deprecated": 1
     },
     "honestBetaDocDebt": 0,
@@ -107,9 +107,9 @@
     },
     "statusMix": {
       "digitaltableteur": {
-        "beta": 49,
+        "beta": 50,
         "stable": 92,
-        "alpha": 23,
+        "alpha": 22,
         "deprecated": 1
       },
       "dsharp": {
@@ -8428,9 +8428,9 @@
         "name": "CommandPalette",
         "tier": "organism",
         "group": "navigation",
-        "status": "alpha",
+        "status": "beta",
         "description": "Modal, keyboard-driven command launcher: a search input filters a listbox of commands (matched on label + keywords); Arrow keys move the active option, Enter runs it, Escape closes. Focus is trapped and background scroll locked while open.",
-        "figma": null,
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1285-2113",
         "radixPrimitive": null,
         "element": "div",
         "variants": {},
@@ -8456,8 +8456,9 @@
             "Each command is role=option with aria-selected reflecting the active item"
           ],
           "reducedMotion": true,
-          "reviewed": false,
-          "forcedColorsVerified": false
+          "reviewed": true,
+          "reviewedNote": "2026-07-12 — alpha→beta: code-level a11y review. Overlay dialog is role=dialog aria-modal with an accessible label; the search input is role=combobox with aria-expanded, aria-controls and aria-activedescendant onto the role=listbox; each command is role=option with aria-selected reflecting the active item. Focus is trapped (useFocusTrap) and background scroll locked (useScrollLock) while open; Arrow Up/Down wrap the active option, Enter runs it and closes, Escape closes, overlay mousedown closes. User-facing strings are props so the component carries no i18n dependency. Axe asserted in unit test; forced-colors + light/dark verified on a non-6010 Storybook. Known limitation: virtualization is not implemented, so very long command lists render in full.",
+          "forcedColorsVerified": true
         },
         "tokens": {
           "colors": [
@@ -8479,7 +8480,56 @@
             "--font-size-text-m"
           ]
         },
-        "lightDarkVerified": false
+        "lightDarkVerified": true,
+        "props": {
+          "open": {
+            "optional": false,
+            "type": "boolean"
+          },
+          "onClose": {
+            "optional": false,
+            "type": "() => void"
+          },
+          "items": {
+            "optional": false,
+            "type": "CommandPaletteItem[]"
+          },
+          "label": {
+            "optional": true,
+            "type": "string"
+          },
+          "placeholder": {
+            "optional": true,
+            "type": "string"
+          },
+          "emptyText": {
+            "optional": true,
+            "type": "string"
+          },
+          "className": {
+            "optional": true,
+            "type": "string"
+          }
+        },
+        "forbiddenUse": [
+          "nest submenus or put long forms inside it; it is a launcher, not a menu system or a modal form",
+          "hardcode user-facing copy; pass `label`, `placeholder`, and `emptyText` so the host owns i18n"
+        ],
+        "keywords": [
+          "command palette",
+          "command launcher",
+          "cmdk",
+          "quick actions",
+          "spotlight",
+          "fuzzy search"
+        ],
+        "dense": "Modal keyboard-driven command launcher: role=dialog with a combobox filtering a role=listbox on label+keywords; Arrow moves active option, Enter runs, Escape closes; focus trapped, scroll locked.",
+        "usage": {
+          "description": "CommandPalette is a modal, keyboard-first launcher: a search input filters a listbox of commands matched on label and keywords, Arrow keys move the active option, Enter runs it, Escape closes. It is controlled (open + onClose) and portal-rendered with focus trapped and background scroll locked while open. Reach for it as a power-user shortcut surface (go-to navigation, quick actions), not as a replacement for primary navigation or a container for forms. All user-facing strings are props so the host owns i18n."
+        },
+        "composesWith": [],
+        "schemaVersion": 2,
+        "displayName": "CommandPalette"
       },
       "spec": "# CommandPalette\n\n## Intent\nA modal, keyboard-first launcher for jumping to a command, page, or action\nwithout reaching for the mouse. Opened by a shortcut (e.g. Cmd/Ctrl-K), it filters\na flat list of commands as you type and runs the highlighted one on Enter. Use it\nfor cross-surface navigation and quick actions, not as a menu bound to one control.\n\n## Interaction contract\n- Keyboard: type to filter (matches label + keywords); Arrow Down/Up move the\n  active option, wrapping; Enter runs the active command and closes; Escape\n  closes. Focus is trapped in the dialog and background scroll is locked while open.\n- Pointer: hovering an option makes it active; clicking runs it; clicking the\n  scrim closes.\n- Controlled only: `open` + `onClose` own visibility; the component holds query\n  and active-index state internally and resets them on open.\n- Screen readers: the overlay is `role=dialog aria-modal`; the input is\n  `role=combobox` with `aria-controls` + `aria-activedescendant` onto the\n  `role=listbox`; each command is `role=option` with `aria-selected`.\n\n## Do / don't\n- Do: keep commands flat and label them as actions (\"Go to Blog\", \"New post\").\n- Do: pass `keywords` for synonyms so fuzzy intent still matches.\n- Don't: nest submenus or put long forms inside it — it is a launcher, not a\n  workspace. Route or run on Enter and close.\n- Don't: hardcode copy in the component — `label` / `placeholder` / `emptyText`\n  are props so the host owns translation.\n\n## Design notes\n- Tokens: scrim from `--color-black`; dialog `--color-surface` + `--color-border`\n  + shadow; text `--color-text` / `--color-muted`; radius/spacing from\n  `--radius-*` / `--space-internal-*`. No hardcoded colors.\n- Reuses `useFocusTrap` and `useScrollLock` (see Foundations/Utilities). The\n  active option is a neutral tint; forced-colors maps it to a `Highlight` outline.\n- Figma: TODO (parity build; no Figma node yet).\n\n## Promotion notes\nParity build (Astryx `Command Palette`, reduced to the core launcher). Ships at\nalpha with the WIP badge. Do not promote past alpha/beta without a documented\nproduction consumer, AT snapshots, and forced-colors + light/dark verification.\n",
       "documentationDebt": false,

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -4126,17 +4126,89 @@
       "name": "CommandPalette",
       "group": "navigation",
       "tier": 2,
-      "status": "alpha",
+      "status": "beta",
       "description": "Modal, keyboard-driven command launcher: a search input filters a listbox of commands (matched on label + keywords); Arrow keys move the active option, Enter runs it, Escape closes. Focus is trapped and background scroll locked while open.",
-      "dense": "",
-      "keywords": [],
+      "dense": "Modal keyboard-driven command launcher: role=dialog with a combobox filtering a role=listbox on label+keywords; Arrow moves active option, Enter runs, Escape closes; focus trapped, scroll locked.",
+      "keywords": [
+        "command palette",
+        "command launcher",
+        "cmdk",
+        "quick actions",
+        "spotlight",
+        "fuzzy search"
+      ],
       "importLine": "import { CommandPalette } from \"@dt/CommandPalette\";",
-      "keyProps": [],
-      "props": {},
+      "keyProps": [
+        {
+          "name": "open",
+          "type": "boolean",
+          "required": true
+        },
+        {
+          "name": "items",
+          "type": "CommandPaletteItem[]",
+          "required": true
+        },
+        {
+          "name": "label",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "placeholder",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "emptyText",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "className",
+          "type": "string",
+          "required": false
+        }
+      ],
+      "props": {
+        "open": {
+          "optional": false,
+          "type": "boolean"
+        },
+        "onClose": {
+          "optional": false,
+          "type": "() => void"
+        },
+        "items": {
+          "optional": false,
+          "type": "CommandPaletteItem[]"
+        },
+        "label": {
+          "optional": true,
+          "type": "string"
+        },
+        "placeholder": {
+          "optional": true,
+          "type": "string"
+        },
+        "emptyText": {
+          "optional": true,
+          "type": "string"
+        },
+        "className": {
+          "optional": true,
+          "type": "string"
+        }
+      },
       "composesWith": [],
       "prefersOver": [],
-      "forbiddenUse": [],
-      "usage": null,
+      "forbiddenUse": [
+        "nest submenus or put long forms inside it; it is a launcher, not a menu system or a modal form",
+        "hardcode user-facing copy; pass `label`, `placeholder`, and `emptyText` so the host owns i18n"
+      ],
+      "usage": {
+        "description": "CommandPalette is a modal, keyboard-first launcher: a search input filters a listbox of commands matched on label and keywords, Arrow keys move the active option, Enter runs it, Escape closes. It is controlled (open + onClose) and portal-rendered with focus trapped and background scroll locked while open. Reach for it as a power-user shortcut surface (go-to navigation, quick actions), not as a replacement for primary navigation or a container for forms. All user-facing strings are props so the host owns i18n."
+      },
       "tokens": {
         "colors": [
           "--color-black",

--- a/packages/react/public-api.manifest.json
+++ b/packages/react/public-api.manifest.json
@@ -27,6 +27,7 @@
     "CodeBlockWindow",
     "CodeSnippet",
     "Combobox",
+    "CommandPalette",
     "Container",
     "CookieConsent",
     "CookieConsentProvider",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -40,6 +40,11 @@ export {
   optionsFromSelectChildren,
   splitPlaceholderOption,
 } from "../../../nextjs-app/shared/components/Combobox";
+export {
+  CommandPalette,
+  type CommandPaletteItem,
+  type CommandPaletteProps,
+} from "../../../nextjs-app/shared/components/CommandPalette/CommandPalette";
 export { Container, type ContainerProps } from "../../../nextjs-app/shared/components/Container";
 export { default as CookieConsent } from "../../../nextjs-app/shared/components/CookieConsent/CookieConsent";
 export type { CookieConsentProps } from "../../../nextjs-app/shared/components/CookieConsent";


### PR DESCRIPTION
Modal keyboard-driven command launcher (role=dialog, combobox + listbox, focus trap, scroll lock). Full-package alpha->beta.

**Changes**
- Enriched the contract to the tier-2 doc bar: usage/keywords/dense, props synced, schemaVersion 2, a11y.reviewed + note, forcedColors + lightDark verified, cleaned forbiddenUse (no em-dashes).
- Fleshed the pre-alpha stories: beta tag, argTypes, beta-matrix, a document.body-scoped play driving the combobox + roving option (portal-rendered).
- Built the Figma component (node 1285-2113) in the Navigation section with bound surface/border/text/muted fills.
- Exported CommandPalette + item/props types (manifest 110->111).

The portal dialog IS captured in the AT tree, so all four modes were captured via the runner (not the capture script) to keep the play-filtered state consistent across base/themed (avoids the script-vs-runner divergence class).

No genuine production consumer yet, so it lands at **beta**.

**Local gate:** typecheck, lint, lint:css, test, build all exit 0. Compare gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Command Palette to the public React package API.
  * Added support for configurable labels, placeholders, empty states, styling, commands, and open/close behavior.
  * Promoted the Command Palette to beta with documented usage and accessibility guidance.

* **Bug Fixes**
  * Improved keyboard interaction and command selection behavior.

* **Tests**
  * Added interaction coverage and accessibility snapshots across light, dark, and forced-colors modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->