### PR TITLE
feat(design-system): SelectableCard full package + promote to beta

### DIFF
--- a/nextjs-app/shared/components/SelectableCard/SelectableCard.contract.json
+++ b/nextjs-app/shared/components/SelectableCard/SelectableCard.contract.json
@@ -1,18 +1,23 @@
 {
-    "$schema": "../../../scripts/design-system/contract.schema.json",
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
     "name": "SelectableCard",
     "tier": "molecule",
     "group": "form",
-    "status": "alpha",
+    "status": "beta",
     "description": "A Card that is one selectable option; grouped into single (radio) or multiple (checkbox) sets via SelectableCardGroup.",
-    "figma": null,
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1288-2114",
     "radixPrimitive": null,
     "element": "label",
     "variants": {},
     "slots": [],
     "asChild": false,
     "subParts": [],
-    "requiredStories": ["Default", "Playground", "Example", "ForcedColors"],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
     "a11y": {
         "keyboard": [
             "Tab moves focus into the group",
@@ -25,8 +30,9 @@
             "Error announces via role=alert and sets aria-invalid on the group"
         ],
         "reducedMotion": true,
-        "reviewed": false,
-        "forcedColorsVerified": false
+        "reviewed": true,
+        "reviewedNote": "2026-07-12 — alpha→beta: code-level a11y review. SelectableCardGroup renders a fieldset with a legend for the accessible name; each SelectableCard is a label wrapping a visually-hidden native radio (single) or checkbox (multiple) input, so keyboard, focus and form submission come from the platform. Error announces via role=alert and sets aria-invalid on the group. Selected/disabled states mirror to data-attributes for CSS + tests. Motion respects prefers-reduced-motion. Axe asserted in the colocated a11y test; forced-colors + light/dark verified on a non-6010 Storybook.",
+        "forcedColorsVerified": true
     },
     "tokens": {
         "colors": [
@@ -43,5 +49,38 @@
             "--space-internal-24"
         ]
     },
-    "lightDarkVerified": false
+    "lightDarkVerified": true,
+    "props": {
+        "value": {
+            "optional": false,
+            "type": "string"
+        },
+        "disabled": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "selected": {
+            "optional": true,
+            "type": "boolean"
+        },
+        "onSelectedChange": {
+            "optional": true,
+            "type": "(selected: boolean) => void"
+        }
+    },
+    "forbiddenUse": [
+        "nest interactive controls (buttons, links) inside a SelectableCard; the whole card is a label wrapping the input, so nested controls steal the click. Use a plain Card for action cards.",
+        "use it for navigation; selecting must not commit or route on click."
+    ],
+    "keywords": [
+        "selectable card",
+        "card radio",
+        "card checkbox",
+        "choice card",
+        "option card",
+        "card group"
+    ],
+    "dense": "Card as one selectable option; grouped via SelectableCardGroup into single (radio) or multiple (checkbox) sets; whole card is a label over a hidden native input; controlled or uncontrolled.",
+    "schemaVersion": 2,
+    "displayName": "SelectableCard"
 }

--- a/nextjs-app/shared/components/SelectableCard/SelectableCard.spec.md
+++ b/nextjs-app/shared/components/SelectableCard/SelectableCard.spec.md
@@ -17,8 +17,7 @@ is one option in it.
 ## Do / don't
 - Do: write the legend as the question; keep each card's title short and scannable.
 - Do: use `type="single"` for an exclusive choice, `type="multiple"` for add-ons.
-- Don't: nest interactive controls (buttons, links) inside a SelectableCard — the
-  label already owns the click. Use a plain Card for action cards.
+- Don't: nest interactive controls (buttons, links) inside a SelectableCard; the whole card is a label wrapping the input, so nested controls steal the click. Use a plain Card for action cards.
 - Don't: use it for navigation; selecting must not commit or route on click.
 
 ## Design notes

--- a/nextjs-app/shared/components/SelectableCard/SelectableCard.stories.tsx
+++ b/nextjs-app/shared/components/SelectableCard/SelectableCard.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
+import { expect, userEvent, within } from "storybook/test";
 import { SelectableCard, SelectableCardGroup } from "./SelectableCard";
 import contract from "./SelectableCard.contract.json";
 
@@ -13,7 +14,7 @@ const meta = {
     docs: { description: { component: contract.description } },
   },
   // Custom MDX docs page exists; do not also enable autodocs.
-  tags: ["!autodocs"],
+  tags: ["beta", "!autodocs"],
   argTypes: {
     value: {
       control: "text",
@@ -55,6 +56,7 @@ type Story = StoryObj<typeof meta>;
 
 /** A standalone card toggles as a controlled checkbox-style option. */
 export const Default: Story = {
+  tags: ["beta-matrix"],
   globals: { forcedColors: "none" },
   render: (args) => {
     const [on, setOn] = useState(Boolean(args.selected));
@@ -68,15 +70,27 @@ export const Default: Story = {
       </div>
     );
   },
+  // Drives the toggle via the native input. Two clicks net to zero (on then off)
+  // so the settled selection is unchanged and the captured AT snapshot is stable.
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole("checkbox");
+    await userEvent.click(input);
+    await expect(input).toBeChecked();
+    await userEvent.click(input);
+    await expect(input).not.toBeChecked();
+  },
 };
 
 export const Playground: Story = {
+  tags: ["beta-matrix"],
   globals: { forcedColors: "none" },
   render: Default.render,
 };
 
 /** Single-select set: an exclusive radio group rendered as cards. */
 export const Example: Story = {
+  tags: ["beta-matrix"],
   parameters: { controls: { disable: true } },
   render: () => {
     const [plan, setPlan] = useState("team");
@@ -174,6 +188,7 @@ export const WithError: Story = {
 };
 
 export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
   parameters: {
     controls: { disable: true },

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--default.dark.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--default.dark.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- checkbox "Starter For solo work — 1 seat, community support."
+- heading "Starter" [level=3]
+- paragraph: For solo work — 1 seat, community support.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--default.forced-colors.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- checkbox "Starter For solo work — 1 seat, community support."
+- heading "Starter" [level=3]
+- paragraph: For solo work — 1 seat, community support.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--default.light.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--default.light.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- checkbox "Starter For solo work — 1 seat, community support."
+- heading "Starter" [level=3]
+- paragraph: For solo work — 1 seat, community support.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--default.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--default.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- checkbox "Starter For solo work — 1 seat, community support."
+- heading "Starter" [level=3]
+- paragraph: For solo work — 1 seat, community support.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--disabled.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--disabled.yaml
@@ -1,0 +1,15 @@
+- status: Work in progress (beta)
+- group "Whole group disabled":
+  - text: Whole group disabled
+  - radio "Option A Selected but disabled." [checked] [disabled]
+  - heading "Option A" [level=3]
+  - paragraph: Selected but disabled.
+  - radio "Option B" [disabled]
+  - heading "Option B" [level=3]
+- group "One option disabled":
+  - text: One option disabled
+  - radio "Available" [checked]
+  - heading "Available" [level=3]
+  - radio "Unavailable Out of stock." [disabled]
+  - heading "Unavailable" [level=3]
+  - paragraph: Out of stock.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--example.dark.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--example.dark.yaml
@@ -1,0 +1,12 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter 1 seat, community support."
+  - heading "Starter" [level=3]
+  - paragraph: 1 seat, community support.
+  - radio "Team Up to 10 seats, priority support." [checked]
+  - heading "Team" [level=3]
+  - paragraph: Up to 10 seats, priority support.
+  - radio "Scale Unlimited seats, SLA."
+  - heading "Scale" [level=3]
+  - paragraph: Unlimited seats, SLA.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--example.forced-colors.yaml
@@ -1,0 +1,12 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter 1 seat, community support."
+  - heading "Starter" [level=3]
+  - paragraph: 1 seat, community support.
+  - radio "Team Up to 10 seats, priority support." [checked]
+  - heading "Team" [level=3]
+  - paragraph: Up to 10 seats, priority support.
+  - radio "Scale Unlimited seats, SLA."
+  - heading "Scale" [level=3]
+  - paragraph: Unlimited seats, SLA.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--example.light.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--example.light.yaml
@@ -1,0 +1,12 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter 1 seat, community support."
+  - heading "Starter" [level=3]
+  - paragraph: 1 seat, community support.
+  - radio "Team Up to 10 seats, priority support." [checked]
+  - heading "Team" [level=3]
+  - paragraph: Up to 10 seats, priority support.
+  - radio "Scale Unlimited seats, SLA."
+  - heading "Scale" [level=3]
+  - paragraph: Unlimited seats, SLA.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--example.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--example.yaml
@@ -1,0 +1,12 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter 1 seat, community support."
+  - heading "Starter" [level=3]
+  - paragraph: 1 seat, community support.
+  - radio "Team Up to 10 seats, priority support." [checked]
+  - heading "Team" [level=3]
+  - paragraph: Up to 10 seats, priority support.
+  - radio "Scale Unlimited seats, SLA."
+  - heading "Scale" [level=3]
+  - paragraph: Unlimited seats, SLA.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--forced-colors.dark.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter 1 seat."
+  - heading "Starter" [level=3]
+  - paragraph: 1 seat.
+  - radio "Team Up to 10 seats." [checked]
+  - heading "Team" [level=3]
+  - paragraph: Up to 10 seats.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--forced-colors.forced-colors.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter 1 seat."
+  - heading "Starter" [level=3]
+  - paragraph: 1 seat.
+  - radio "Team Up to 10 seats." [checked]
+  - heading "Team" [level=3]
+  - paragraph: Up to 10 seats.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--forced-colors.light.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter 1 seat."
+  - heading "Starter" [level=3]
+  - paragraph: 1 seat.
+  - radio "Team Up to 10 seats." [checked]
+  - heading "Team" [level=3]
+  - paragraph: Up to 10 seats.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--forced-colors.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--forced-colors.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter 1 seat."
+  - heading "Starter" [level=3]
+  - paragraph: 1 seat.
+  - radio "Team Up to 10 seats." [checked]
+  - heading "Team" [level=3]
+  - paragraph: Up to 10 seats.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--horizontal.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--horizontal.yaml
@@ -1,0 +1,9 @@
+- status: Work in progress (beta)
+- group "T-shirt size":
+  - text: T-shirt size
+  - radio "S"
+  - heading "S" [level=3]
+  - radio "M" [checked]
+  - heading "M" [level=3]
+  - radio "L"
+  - heading "L" [level=3]

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--multi-select.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--multi-select.yaml
@@ -1,0 +1,13 @@
+- status: Work in progress (beta)
+- group "Add-ons":
+  - text: Add-ons
+  - checkbox "Analytics Usage dashboards." [checked]
+  - heading "Analytics" [level=3]
+  - paragraph: Usage dashboards.
+  - checkbox "Audit log Exportable event history."
+  - heading "Audit log" [level=3]
+  - paragraph: Exportable event history.
+  - checkbox "SSO SAML / OIDC single sign-on."
+  - heading "SSO" [level=3]
+  - paragraph: SAML / OIDC single sign-on.
+  - paragraph: Pick any that apply.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--playground.dark.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--playground.dark.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- checkbox "Starter For solo work — 1 seat, community support."
+- heading "Starter" [level=3]
+- paragraph: For solo work — 1 seat, community support.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--playground.forced-colors.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- checkbox "Starter For solo work — 1 seat, community support."
+- heading "Starter" [level=3]
+- paragraph: For solo work — 1 seat, community support.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--playground.light.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--playground.light.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- checkbox "Starter For solo work — 1 seat, community support."
+- heading "Starter" [level=3]
+- paragraph: For solo work — 1 seat, community support.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--playground.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--playground.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (beta)
+- checkbox "Starter For solo work — 1 seat, community support."
+- heading "Starter" [level=3]
+- paragraph: For solo work — 1 seat, community support.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--with-error.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecard--with-error.yaml
@@ -1,0 +1,12 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter 1 seat."
+  - heading "Starter" [level=3]
+  - paragraph: 1 seat.
+  - radio "Team Up to 10 seats."
+  - heading "Team" [level=3]
+  - paragraph: Up to 10 seats.
+  - alert:
+    - img
+    - text: Select a plan to continue.

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-12T08:25:46.352Z",
+  "generatedAt": "2026-07-12T08:40:42.306Z",
   "summary": {
     "componentCount": 165,
     "statusCounts": {
-      "beta": 50,
+      "beta": 51,
       "stable": 92,
-      "alpha": 22,
+      "alpha": 21,
       "deprecated": 1
     },
     "honestBetaDocDebt": 0,
@@ -107,9 +107,9 @@
     },
     "statusMix": {
       "digitaltableteur": {
-        "beta": 50,
+        "beta": 51,
         "stable": 92,
-        "alpha": 22,
+        "alpha": 21,
         "deprecated": 1
       },
       "dsharp": {
@@ -24905,13 +24905,13 @@
     {
       "name": "SelectableCard",
       "contract": {
-        "$schema": "../../../scripts/design-system/contract.schema.json",
+        "$schema": "../../../scripts/design-system/contract.schema.v2.json",
         "name": "SelectableCard",
         "tier": "molecule",
         "group": "form",
-        "status": "alpha",
+        "status": "beta",
         "description": "A Card that is one selectable option; grouped into single (radio) or multiple (checkbox) sets via SelectableCardGroup.",
-        "figma": null,
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1288-2114",
         "radixPrimitive": null,
         "element": "label",
         "variants": {},
@@ -24936,8 +24936,9 @@
             "Error announces via role=alert and sets aria-invalid on the group"
           ],
           "reducedMotion": true,
-          "reviewed": false,
-          "forcedColorsVerified": false
+          "reviewed": true,
+          "reviewedNote": "2026-07-12 — alpha→beta: code-level a11y review. SelectableCardGroup renders a fieldset with a legend for the accessible name; each SelectableCard is a label wrapping a visually-hidden native radio (single) or checkbox (multiple) input, so keyboard, focus and form submission come from the platform. Error announces via role=alert and sets aria-invalid on the group. Selected/disabled states mirror to data-attributes for CSS + tests. Motion respects prefers-reduced-motion. Axe asserted in the colocated a11y test; forced-colors + light/dark verified on a non-6010 Storybook.",
+          "forcedColorsVerified": true
         },
         "tokens": {
           "colors": [
@@ -24954,9 +24955,42 @@
             "--space-internal-24"
           ]
         },
-        "lightDarkVerified": false
+        "lightDarkVerified": true,
+        "props": {
+          "value": {
+            "optional": false,
+            "type": "string"
+          },
+          "disabled": {
+            "optional": true,
+            "type": "boolean"
+          },
+          "selected": {
+            "optional": true,
+            "type": "boolean"
+          },
+          "onSelectedChange": {
+            "optional": true,
+            "type": "(selected: boolean) => void"
+          }
+        },
+        "forbiddenUse": [
+          "nest interactive controls (buttons, links) inside a SelectableCard; the whole card is a label wrapping the input, so nested controls steal the click. Use a plain Card for action cards.",
+          "use it for navigation; selecting must not commit or route on click."
+        ],
+        "keywords": [
+          "selectable card",
+          "card radio",
+          "card checkbox",
+          "choice card",
+          "option card",
+          "card group"
+        ],
+        "dense": "Card as one selectable option; grouped via SelectableCardGroup into single (radio) or multiple (checkbox) sets; whole card is a label over a hidden native input; controlled or uncontrolled.",
+        "schemaVersion": 2,
+        "displayName": "SelectableCard"
       },
-      "spec": "# SelectableCard\n\n## Intent\nTurn a Card into a selectable option so a set of rich choices (plan pickers,\nonboarding options, add-ons, settings tiles) reads as cards rather than bare\nradios or checkboxes. `SelectableCardGroup` owns the selection; `SelectableCard`\nis one option in it.\n\n## Interaction contract\n- Keyboard: Tab moves focus into the group; Arrow keys move within a single-select\n  set (native radio behavior); Space toggles the focused option.\n- Pointer: the whole card is the hit area — clicking anywhere toggles the option.\n- Screen readers: the group is a fieldset announced by its legend; each option is\n  a native radio (single) or checkbox (multiple) whose accessible name is the\n  card content; errors announce via role=alert and set aria-invalid on the group.\n\n## Do / don't\n- Do: write the legend as the question; keep each card's title short and scannable.\n- Do: use `type=\"single\"` for an exclusive choice, `type=\"multiple\"` for add-ons.\n- Don't: nest interactive controls (buttons, links) inside a SelectableCard — the\n  label already owns the click. Use a plain Card for action cards.\n- Don't: use it for navigation; selecting must not commit or route on click.\n\n## Design notes\n- Tokens: `--color-primary` (selected ring + indicator), `--color-focus-ring`\n  (focus), `--color-border` / `--color-border-light` (rest/hover), `--color-surface`;\n  spacing from `--space-internal-*`. No hardcoded colors.\n- The selected state is shown by a ring on the surface plus an indicator (radio\n  dot / checkbox check) drawn in `--color-primary`, with a forced-colors mapping\n  to `Highlight`.\n- Figma: TODO (parity build; no Figma node yet).\n\n## Promotion notes\nParity build (Astryx `SelectableCard`). Ships at alpha with the WIP badge. Do not\npromote past alpha/beta without a documented production consumer, AT snapshots,\nand forced-colors + light/dark verification.\n",
+      "spec": "# SelectableCard\n\n## Intent\nTurn a Card into a selectable option so a set of rich choices (plan pickers,\nonboarding options, add-ons, settings tiles) reads as cards rather than bare\nradios or checkboxes. `SelectableCardGroup` owns the selection; `SelectableCard`\nis one option in it.\n\n## Interaction contract\n- Keyboard: Tab moves focus into the group; Arrow keys move within a single-select\n  set (native radio behavior); Space toggles the focused option.\n- Pointer: the whole card is the hit area — clicking anywhere toggles the option.\n- Screen readers: the group is a fieldset announced by its legend; each option is\n  a native radio (single) or checkbox (multiple) whose accessible name is the\n  card content; errors announce via role=alert and set aria-invalid on the group.\n\n## Do / don't\n- Do: write the legend as the question; keep each card's title short and scannable.\n- Do: use `type=\"single\"` for an exclusive choice, `type=\"multiple\"` for add-ons.\n- Don't: nest interactive controls (buttons, links) inside a SelectableCard; the whole card is a label wrapping the input, so nested controls steal the click. Use a plain Card for action cards.\n- Don't: use it for navigation; selecting must not commit or route on click.\n\n## Design notes\n- Tokens: `--color-primary` (selected ring + indicator), `--color-focus-ring`\n  (focus), `--color-border` / `--color-border-light` (rest/hover), `--color-surface`;\n  spacing from `--space-internal-*`. No hardcoded colors.\n- The selected state is shown by a ring on the surface plus an indicator (radio\n  dot / checkbox check) drawn in `--color-primary`, with a forced-colors mapping\n  to `Highlight`.\n- Figma: TODO (parity build; no Figma node yet).\n\n## Promotion notes\nParity build (Astryx `SelectableCard`). Ships at alpha with the WIP badge. Do not\npromote past alpha/beta without a documented production consumer, AT snapshots,\nand forced-colors + light/dark verification.\n",
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/SelectableCard",
@@ -24995,7 +25029,7 @@
           "use `type=\"single\"` for an exclusive choice, `type=\"multiple\"` for add-ons."
         ],
         "avoidWhen": [
-          "nest interactive controls (buttons, links) inside a SelectableCard — the",
+          "nest interactive controls (buttons, links) inside a SelectableCard; the whole card is a label wrapping the input, so nested controls steal the click. Use a plain Card for action cards.",
           "use it for navigation; selecting must not commit or route on click."
         ],
         "requiredA11y": [
@@ -25009,7 +25043,7 @@
           "Space toggles the focused option"
         ],
         "compositionRules": [
-          "nest interactive controls (buttons, links) inside a SelectableCard — the"
+          "nest interactive controls (buttons, links) inside a SelectableCard; the whole card is a label wrapping the input, so nested controls steal the click. Use a plain Card for action cards."
         ],
         "canonicalExamples": [
           "Default",
@@ -25019,7 +25053,7 @@
         ],
         "replacementFor": [],
         "forbiddenUse": [
-          "nest interactive controls (buttons, links) inside a SelectableCard — the",
+          "nest interactive controls (buttons, links) inside a SelectableCard; the whole card is a label wrapping the input, so nested controls steal the click. Use a plain Card for action cards.",
           "use it for navigation; selecting must not commit or route on click."
         ],
         "composesWith": [],

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-12T08:04:34.941Z",
+  "generatedAt": "2026-07-12T08:37:41.480Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -7687,7 +7687,7 @@
         "use `type=\"single\"` for an exclusive choice, `type=\"multiple\"` for add-ons."
       ],
       "avoidWhen": [
-        "nest interactive controls (buttons, links) inside a SelectableCard — the",
+        "nest interactive controls (buttons, links) inside a SelectableCard; the whole card is a label wrapping the input, so nested controls steal the click. Use a plain Card for action cards.",
         "use it for navigation; selecting must not commit or route on click."
       ],
       "requiredA11y": [
@@ -7701,7 +7701,7 @@
         "Space toggles the focused option"
       ],
       "compositionRules": [
-        "nest interactive controls (buttons, links) inside a SelectableCard — the"
+        "nest interactive controls (buttons, links) inside a SelectableCard; the whole card is a label wrapping the input, so nested controls steal the click. Use a plain Card for action cards."
       ],
       "canonicalExamples": [
         "Default",
@@ -7711,7 +7711,7 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "nest interactive controls (buttons, links) inside a SelectableCard — the",
+        "nest interactive controls (buttons, links) inside a SelectableCard; the whole card is a label wrapping the input, so nested controls steal the click. Use a plain Card for action cards.",
         "use it for navigation; selecting must not commit or route on click."
       ],
       "composesWith": [],

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -12029,16 +12029,59 @@
       "name": "SelectableCard",
       "group": "form",
       "tier": 2,
-      "status": "alpha",
+      "status": "beta",
       "description": "A Card that is one selectable option; grouped into single (radio) or multiple (checkbox) sets via SelectableCardGroup.",
-      "dense": "",
-      "keywords": [],
+      "dense": "Card as one selectable option; grouped via SelectableCardGroup into single (radio) or multiple (checkbox) sets; whole card is a label over a hidden native input; controlled or uncontrolled.",
+      "keywords": [
+        "selectable card",
+        "card radio",
+        "card checkbox",
+        "choice card",
+        "option card",
+        "card group"
+      ],
       "importLine": "import { SelectableCard } from \"@dt/SelectableCard\";",
-      "keyProps": [],
-      "props": {},
+      "keyProps": [
+        {
+          "name": "value",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "disabled",
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "selected",
+          "type": "boolean",
+          "required": false
+        }
+      ],
+      "props": {
+        "value": {
+          "optional": false,
+          "type": "string"
+        },
+        "disabled": {
+          "optional": true,
+          "type": "boolean"
+        },
+        "selected": {
+          "optional": true,
+          "type": "boolean"
+        },
+        "onSelectedChange": {
+          "optional": true,
+          "type": "(selected: boolean) => void"
+        }
+      },
       "composesWith": [],
       "prefersOver": [],
-      "forbiddenUse": [],
+      "forbiddenUse": [
+        "nest interactive controls (buttons, links) inside a SelectableCard; the whole card is a label wrapping the input, so nested controls steal the click. Use a plain Card for action cards.",
+        "use it for navigation; selecting must not commit or route on click."
+      ],
       "usage": null,
       "tokens": {
         "colors": [

--- a/packages/react/public-api.manifest.json
+++ b/packages/react/public-api.manifest.json
@@ -83,6 +83,8 @@
     "Section",
     "SegmentedControl",
     "Select",
+    "SelectableCard",
+    "SelectableCardGroup",
     "SelectOption",
     "Skeleton",
     "SkipLink",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -175,6 +175,13 @@ export type {
 } from "../../../nextjs-app/shared/components/Select/Select";
 export { default as SelectOption } from "../../../nextjs-app/shared/components/Select/SelectOption";
 export {
+  SelectableCard,
+  SelectableCardGroup,
+  type SelectableCardGroupProps,
+  type SelectableCardProps,
+  type SelectableCardSelectionType,
+} from "../../../nextjs-app/shared/components/SelectableCard/SelectableCard";
+export {
   SkipLink,
   type SkipLinkProps,
 } from "../../../nextjs-app/shared/components/SkipLink";


### PR DESCRIPTION
Card as one selectable option, grouped by SelectableCardGroup into single (radio) or multiple (checkbox) sets; the whole card is a label over a hidden native input. Full-package alpha->beta.

**Changes**
- Migrated the contract to schemaVersion 2, synced props, a11y.reviewed + note, forcedColors + lightDark verified, added keywords/dense.
- Fixed the spec Do/don%27t bullet so the machine-synced forbiddenUse renders as clean complete prose (was truncated at a line break, with an em-dash).
- Kept the existing Carbon-style MDX (all required headings present).
- Fleshed the stories: beta tag, beta-matrix on required stories, a net-zero toggle play (drives the native input without perturbing the AT snapshot).
- Built the Figma component (node 1288-2114) in the Forms section with bound surface/primary/border/text fills.
- Exported SelectableCard + SelectableCardGroup + types (manifest 111->113).

No genuine production consumer yet, so it lands at **beta**.

**Local gate:** typecheck, lint, lint:css, test, build all exit 0. Compare gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)