### PR TITLE
feat(design-system): add named neutral tone to Toast (language/theme toasts)

### DIFF
--- a/app/components/LanguageNotice/LanguageNotice.test.tsx
+++ b/app/components/LanguageNotice/LanguageNotice.test.tsx
@@ -52,7 +52,7 @@ describe("LanguageNotice", () => {
     await waitFor(() => {
       expect(showToast).toHaveBeenCalledWith(
         "Tämä sisältö on saatavilla vain englanniksi.",
-        { duration: 5000 },
+        { tone: "neutral", duration: 5000 },
       );
     });
   });

--- a/app/components/LanguageNotice/LanguageNotice.tsx
+++ b/app/components/LanguageNotice/LanguageNotice.tsx
@@ -50,7 +50,7 @@ export function LanguageNotice({
     if (announcedKeyRef.current === announcementKey) return;
 
     announcedKeyRef.current = announcementKey;
-    showToast(message, { duration: 5000 });
+    showToast(message, { tone: "neutral", duration: 5000 });
   }, [contentLanguage, getResourceBundle, resolvedLanguage, showToast]);
 
   return null;

--- a/nextjs-app/shared/components/Toast/Toast.contract.json
+++ b/nextjs-app/shared/components/Toast/Toast.contract.json
@@ -21,12 +21,13 @@
         },
         "tone": {
             "values": [
+                "neutral",
                 "success",
                 "error",
                 "warning",
                 "info"
             ],
-            "default": "info",
+            "default": "neutral",
             "forwarded": true
         },
         "position": {
@@ -133,6 +134,7 @@
             "optional": true,
             "type": "union",
             "values": [
+                "neutral",
                 "info",
                 "success",
                 "warning",

--- a/nextjs-app/shared/components/Toast/Toast.stories.tsx
+++ b/nextjs-app/shared/components/Toast/Toast.stories.tsx
@@ -66,13 +66,14 @@ export const Tones: Story = {
     docs: {
       description: {
         story:
-          "One toast, four tones. The filled icon carries the meaning alongside color; error and warning announce assertively (role=alert), success and info stay polite.",
+          "One toast, five tones. Neutral is the plain acknowledgement (no icon, no accent) used for language/theme changes; the four semantic tones add a filled icon that carries the meaning alongside color. Error and warning announce assertively (role=alert); neutral, success, and info stay polite.",
       },
     },
   },
   render: function TonesStory() {
     const [tone, setTone] = useState<ToastTone | null>(null);
     const messages: Record<ToastTone, string> = {
+      neutral: "Language changed to English.",
       success: "Operation completed successfully.",
       error: "An error occurred. Please try again.",
       warning: "Your session will expire soon.",

--- a/nextjs-app/shared/components/Toast/Toast.tsx
+++ b/nextjs-app/shared/components/Toast/Toast.tsx
@@ -2,10 +2,12 @@ import { forwardRef, useEffect, type ReactNode } from "react";
 import styles from "./Toast.module.css";
 import { CheckCircle, Warning, XCircle, Info } from "@phosphor-icons/react";
 
-export type ToastTone = "success" | "error" | "warning" | "info";
+export type ToastTone = "neutral" | "success" | "error" | "warning" | "info";
 
-// Direct Phosphor icons for color-independent meaning (WCAG 1.4.1).
-const toneIcons: Record<ToastTone, ReactNode> = {
+// Direct Phosphor icons for color-independent meaning (WCAG 1.4.1). Neutral
+// carries no icon and no accent colour — it is the plain acknowledgement toast
+// (e.g. "Language changed", "Theme set to dark").
+const toneIcons: Record<Exclude<ToastTone, "neutral">, ReactNode> = {
   success: <CheckCircle weight="fill" aria-hidden="true" />,
   error: <XCircle weight="fill" aria-hidden="true" />,
   warning: <Warning weight="fill" aria-hidden="true" />,
@@ -23,7 +25,7 @@ export type ToastPosition =
 export interface ToastProps {
   /** Controls visibility. */
   open?: boolean;
-  /** Semantic colour. */
+  /** Semantic colour. @default "neutral" */
   tone?: ToastTone;
   /** Position on screen. @default "bottom-center" */
   position?: ToastPosition;
@@ -49,7 +51,7 @@ export interface ToastProps {
  * AnimatePresence mount/unmount, which would defeat the live region.
  */
 const Toast = forwardRef<HTMLDivElement, ToastProps>(function Toast(
-  { open, tone, position = "bottom-center", size = "md", message, duration = 3000, onClose, inline },
+  { open, tone = "neutral", position = "bottom-center", size = "md", message, duration = 3000, onClose, inline },
   ref,
 ) {
   useEffect(() => {
@@ -66,7 +68,7 @@ const Toast = forwardRef<HTMLDivElement, ToastProps>(function Toast(
   // Error/warning interrupt (assertive); everything else is a polite status.
   const isAssertive = tone === "error" || tone === "warning";
 
-  const toneIcon = tone ? toneIcons[tone] : null;
+  const toneIcon = tone === "neutral" ? null : toneIcons[tone];
 
   return (
     <div
@@ -74,7 +76,7 @@ const Toast = forwardRef<HTMLDivElement, ToastProps>(function Toast(
       className={[
         styles.toast,
         styles[`toast--${size}`],
-        tone ? styles[`toast--${tone}`] : "",
+        tone === "neutral" ? "" : styles[`toast--${tone}`],
         inline ? styles["toast--inline"] : styles[`toast--${position}`],
         !isVisible ? styles["toast--hidden"] : "",
       ]

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-12T08:54:38.481Z",
+  "generatedAt": "2026-07-12T10:01:45.807Z",
   "summary": {
     "componentCount": 165,
     "statusCounts": {
@@ -31887,12 +31887,13 @@
           },
           "tone": {
             "values": [
+              "neutral",
               "success",
               "error",
               "warning",
               "info"
             ],
-            "default": "info",
+            "default": "neutral",
             "forwarded": true
           },
           "position": {
@@ -31999,6 +32000,7 @@
             "optional": true,
             "type": "union",
             "values": [
+              "neutral",
               "info",
               "success",
               "warning",
@@ -32204,7 +32206,8 @@
               "info",
               "success",
               "warning",
-              "error"
+              "error",
+              "neutral"
             ]
           },
           "position": {
@@ -32251,7 +32254,8 @@
               "info",
               "success",
               "warning",
-              "error"
+              "error",
+              "neutral"
             ],
             "default": "info"
           },

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-12T08:37:41.480Z",
+  "generatedAt": "2026-07-12T10:01:45.548Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -9871,7 +9871,8 @@
             "info",
             "success",
             "warning",
-            "error"
+            "error",
+            "neutral"
           ]
         },
         "position": {
@@ -9918,7 +9919,8 @@
             "info",
             "success",
             "warning",
-            "error"
+            "error",
+            "neutral"
           ],
           "default": "info"
         },

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -15248,7 +15248,7 @@
         },
         {
           "name": "tone",
-          "type": "info | success | warning | error",
+          "type": "neutral | info | success | warning | error",
           "required": false
         },
         {
@@ -15281,6 +15281,7 @@
           "optional": true,
           "type": "union",
           "values": [
+            "neutral",
             "info",
             "success",
             "warning",
@@ -15399,8 +15400,8 @@
       "examples": [
         {
           "story": "Tones",
-          "description": "One toast, four tones. The filled icon carries the meaning alongside color; error and warning announce assertively (role=alert), success and info stay polite.",
-          "source": "export const Tones: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: {\n      description: {\n        story:\n          \"One toast, four tones. The filled icon carries the meaning alongside color; error and warning announce assertively (role=alert), success and info stay polite.\",\n      },\n    },\n  },\n  render: function TonesStory() {\n    const [tone, setTone] = useState<ToastTone | null>(null);\n    const messages: Record<ToastTone, string> = {\n      success: \"Operation completed successfully.\",\n      error: \"An error occurred. Please try again.\",\n      warning: \"Your session will expire soon.\",\n      info: \"New features available.\",\n    };\n    return (\n      <>\n        {(Object.keys(messages) as ToastTone[]).map((t) => (\n          <Button\n            key={t}\n            variant=\"secondary\"\n            size=\"sm\"\n            onClick={() => setTone(t)}\n          >\n            {t}\n          </Button>\n        ))}\n        <Toast\n          message={tone ? messages[tone] : \"\"}\n          open={tone !== null}\n          tone={tone ?? undefined}\n          onClose={() => setTone(null)}\n        />\n      </>\n    );\n  },\n};\n\n/** Six placements; the toast is position: fixed so it anchors to the viewport. */"
+          "description": "One toast, five tones. Neutral is the plain acknowledgement (no icon, no accent) used for language/theme changes; the four semantic tones add a filled icon that carries the meaning alongside color. Error and warning announce assertively (role=alert); neutral, success, and info stay polite.",
+          "source": "export const Tones: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: {\n      description: {\n        story:\n          \"One toast, five tones. Neutral is the plain acknowledgement (no icon, no accent) used for language/theme changes; the four semantic tones add a filled icon that carries the meaning alongside color. Error and warning announce assertively (role=alert); neutral, success, and info stay polite.\",\n      },\n    },\n  },\n  render: function TonesStory() {\n    const [tone, setTone] = useState<ToastTone | null>(null);\n    const messages: Record<ToastTone, string> = {\n      neutral: \"Language changed to English.\",\n      success: \"Operation completed successfully.\",\n      error: \"An error occurred. Please try again.\",\n      warning: \"Your session will expire soon.\",\n      info: \"New features available.\",\n    };\n    return (\n      <>\n        {(Object.keys(messages) as ToastTone[]).map((t) => (\n          <Button\n            key={t}\n            variant=\"secondary\"\n            size=\"sm\"\n            onClick={() => setTone(t)}\n          >\n            {t}\n          </Button>\n        ))}\n        <Toast\n          message={tone ? messages[tone] : \"\"}\n          open={tone !== null}\n          tone={tone ?? undefined}\n          onClose={() => setTone(null)}\n        />\n      </>\n    );\n  },\n};\n\n/** Six placements; the toast is position: fixed so it anchors to the viewport. */"
         },
         {
           "story": "Placement",

--- a/nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx
+++ b/nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx
@@ -129,7 +129,7 @@ export function SiteHeader({
     }
     const nextTheme = cycleTheme() as Theme;
     const label = t(themeNames[nextTheme], nextTheme);
-    showToast(t("themeChanged", { theme: label }), 3000);
+    showToast(t("themeChanged", { theme: label }), { tone: "neutral", duration: 3000 });
   };
 
   const handleLanguageChange = (code: string) => {
@@ -151,7 +151,7 @@ export function SiteHeader({
         lng: code,
         language: label,
       }),
-      3000,
+      { tone: "neutral", duration: 3000 },
     );
   };
 

--- a/providers/ToastProvider.tsx
+++ b/providers/ToastProvider.tsx
@@ -8,7 +8,10 @@ import React, {
   useRef,
   useState,
 } from "react";
-import type { ToastTone, ToastPosition } from "@digitaltableteur/react";
+// Import the tone/position types from local source (not the published barrel):
+// the neutral tone is added locally here and ships to the package on the next
+// republish; until then the barrel's .d.ts lags the local ToastTone.
+import type { ToastTone, ToastPosition } from "@dt/Toast";
 import ToastStack, { type ToastStackItem } from "@dt/ToastStack";
 import { ToastRuntimeProvider } from "../nextjs-app/shared/lib/toast";
 


### PR DESCRIPTION
Language and theme changes trigger the plain, tone-less Toast, but it was an implicit undocumented state (tone omitted) and the contract claimed a misleading tone default of info. This makes it first-class.

**Changes**
- ToastTone gains **neutral** (now the default). Rendering is unchanged: base --color-primary surface, no icon, role=status polite.
- The three call sites (LanguageNotice, SiteHeader theme + language change) now pass tone: neutral explicitly.
- Contract tone values/default updated; the Tones story documents all five tones.
- Figma Toast set gained Tone=neutral x sm/md/lg (no icon, color/primary background).
- providers/ToastProvider imports ToastTone/ToastPosition from local @dt/Toast (the published barrel .d.ts lags until the next republish).

AT snapshots are unchanged (neutral is accessibility-tree-identical to the prior no-tone default).

**Local gate:** typecheck, lint, lint:css, test, build all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a neutral toast tone without semantic coloring or an icon.
  * Neutral is now the default toast style.
  * Theme and language change notifications use the neutral tone.

* **Documentation**
  * Updated toast examples to showcase the new neutral tone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->