### PR TITLE
feat(design-system): strengthen check:figma-links to verify node existence + type

### DIFF
--- a/scripts/design-system/check-figma-links.mjs
+++ b/scripts/design-system/check-figma-links.mjs
@@ -1,26 +1,47 @@
 #!/usr/bin/env node
 /**
- * Figma-link ratchet: stable contracts must not gain placeholder Figma links.
+ * Figma-link ratchet: a stable contract's `figma` must resolve to a REAL Figma
+ * component, and the debt count can only go DOWN.
  *
- * A "placeholder" is any contract `figma` value without a real numeric node id
- * (node-id=<digits>-<digits>). The committed ceiling in figma-links.baseline.json
- * can only go DOWN — lower it in the same PR that wires real nodes. The backfill
- * plan lives in docs/design-system/figma-parity-audit.md.
+ * "Resolves to a real component" means BOTH:
+ *   1. the URL carries a numeric node id (`node-id=<digits>-<digits>`), not a
+ *      `dt-<name>` placeholder; AND
+ *   2. that node id is present in figma-component-index.json — the committed
+ *      set of real COMPONENT / COMPONENT_SET node ids in the DT-Site-stuff file.
  *
- * This is a static check: it cannot detect numeric links whose node was later
- * deleted in Figma (those are caught by the audit's live scan).
+ * Rule (2) is what catches links that point at a numeric node which is NOT a
+ * component — e.g. a Section full of loose "Specimens" frames (Timestamp), a
+ * deleted node, or a stray group. The plain URL-presence check in
+ * validate-components.ts cannot see that; this can, because the index
+ * (figma-component-index.json) is enumerated from the live Figma file via the
+ * Figma MCP (findAllWithCriteria over COMPONENT/COMPONENT_SET on the Atoms /
+ * Organisms / Patterns pages) and committed.
+ *
+ * Regenerate the index whenever DS components are added/moved (re-run the MCP
+ * enumeration and rewrite the file), then this check (and the ratchet) reflects
+ * the true state. Lower the ceiling in figma-links.baseline.json in the same PR
+ * that wires a real component.
  */
 import { readFileSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
-const BASELINE_PATH = join(
-  dirname(fileURLToPath(import.meta.url)),
-  "figma-links.baseline.json",
-);
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(HERE, "..", "..");
+const BASELINE_PATH = join(HERE, "figma-links.baseline.json");
+const INDEX_PATH = join(HERE, "figma-component-index.json");
 
-const REAL_NODE = /node-id=\d+[-:]\d+/;
+const REAL_NODE = /node-id=(\d+)[-:](\d+)/;
+
+const index = JSON.parse(readFileSync(INDEX_PATH, "utf8"));
+const knownComponentIds = new Set(Object.keys(index.components));
+
+/** Extract the node id from a figma URL, normalised to dash form, or null. */
+function nodeIdOf(figma) {
+  if (typeof figma !== "string") return null;
+  const m = figma.match(REAL_NODE);
+  return m ? `${m[1]}-${m[2]}` : null;
+}
 
 const contractFiles = [];
 const walk = (dir) => {
@@ -33,27 +54,31 @@ const walk = (dir) => {
 walk(join(ROOT, "nextjs-app", "shared", "components"));
 walk(join(ROOT, "nextjs-app", "shared", "patterns"));
 
-const stablePlaceholders = [];
+/** name -> reason, for every stable contract whose figma does not resolve. */
+const unresolved = [];
 for (const file of contractFiles) {
   const contract = JSON.parse(readFileSync(file, "utf8"));
   if (contract.status !== "stable") continue;
-  if (typeof contract.figma !== "string" || !REAL_NODE.test(contract.figma)) {
-    stablePlaceholders.push(contract.name);
+  const nodeId = nodeIdOf(contract.figma);
+  if (nodeId === null) {
+    unresolved.push(`${contract.name} (placeholder link)`);
+  } else if (!knownComponentIds.has(nodeId)) {
+    unresolved.push(`${contract.name} (node ${nodeId} is not a known DS component)`);
   }
 }
 
 const baseline = JSON.parse(readFileSync(BASELINE_PATH, "utf8"));
 const ceiling = baseline.stablePlaceholderCeiling;
-const count = stablePlaceholders.length;
+const count = unresolved.length;
 
 if (count > ceiling) {
   console.error(
-    `✖ figma-links ratchet: ${count} stable contracts have placeholder Figma links (ceiling ${ceiling}).`,
+    `✖ figma-links ratchet: ${count} stable contracts do not resolve to a real Figma component (ceiling ${ceiling}).`,
   );
   console.error(
-    `  New stable contracts need a real numeric Figma node (build it first — see docs/design-system/figma-parity-audit.md).`,
+    `  A stable contract needs a real COMPONENT/COMPONENT_SET node (build it, then add it to figma-component-index.json — see docs/design-system/figma-parity-audit.md).`,
   );
-  console.error(`  Placeholders: ${stablePlaceholders.sort().join(", ")}`);
+  console.error(`  Unresolved:\n    ${unresolved.sort().join("\n    ")}`);
   process.exit(1);
 }
 
@@ -68,5 +93,5 @@ if (count < ceiling) {
 }
 
 console.log(
-  `✓ figma-links ratchet: ${count}/${ceiling} stable contracts with placeholder Figma links (can only decrease)`,
+  `✓ figma-links ratchet: ${count}/${ceiling} stable contracts without a real Figma component (can only decrease)`,
 );

--- a/scripts/design-system/figma-component-index.json
+++ b/scripts/design-system/figma-component-index.json
@@ -1,0 +1,396 @@
+{
+  "$comment": "Index of real Figma COMPONENT/COMPONENT_SET node-ids in DT-Site-stuff, keyed by node-id (dash form). Regenerate via scripts/design-system/audit-figma-components.mjs when components are added/moved. A beta/stable contract's figma link MUST resolve to a node-id in this index (check:figma-links).",
+  "fileKey": "PC2UPdYwm8qGt6ZTg0AakF",
+  "components": {
+    "371-30": {
+      "name": "Link",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "492-1578": {
+      "name": "DonnyAvatar",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "543-2510": {
+      "name": "Storybook banner",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "1177-1644": {
+      "name": "SkipLink",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "1176-1676": {
+      "name": "Stack",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1176-1698": {
+      "name": "FlexBox",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1177-1654": {
+      "name": "Grid",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "1178-1654": {
+      "name": "Container",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1178-1712": {
+      "name": "Section",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "480-1588": {
+      "name": "Logo",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "516-3098": {
+      "name": "nav",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "516-3146": {
+      "name": "NavLink",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "368-6": {
+      "name": "Divider",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "371-31": {
+      "name": "VisuallyHidden",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "406-1569": {
+      "name": "Button",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1012-176": {
+      "name": "ButtonGroup",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1194-1733": {
+      "name": "IconButton",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1015-180": {
+      "name": "Menu",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "1052-2084": {
+      "name": "SplitButton",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1249-1954": {
+      "name": "FilterChip",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "369-8": {
+      "name": "Avatar",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1010-147": {
+      "name": "AvatarGroup",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "400-1249": {
+      "name": "Badge",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1164-257": {
+      "name": "CodeBlockWindow",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "1161-2809": {
+      "name": "CodeSnippet",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1014-192": {
+      "name": "EmptyState",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1176-1658": {
+      "name": "Icon",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1005-1638": {
+      "name": "Kbd",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "370-19": {
+      "name": "Text",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "370-12": {
+      "name": "Title",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "372-14": {
+      "name": "Checkbox",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "383-24": {
+      "name": "CheckboxGroup",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "384-26": {
+      "name": "FileUpload",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "1288-2114": {
+      "name": "SelectableCard",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "371-6": {
+      "name": "Label",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "371-17": {
+      "name": "HelperText",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1290-2104": {
+      "name": "GroupLabel",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "372-27": {
+      "name": "Radio",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "383-23": {
+      "name": "Select",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "373-14": {
+      "name": "Switch",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1227-2963": {
+      "name": "RadioGroup",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "374-10": {
+      "name": "TextInput",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "374-17": {
+      "name": "TextArea",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "393-35": {
+      "name": "Toast",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1279-2105": {
+      "name": "ToastStack",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "394-41": {
+      "name": "AlertBanner",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1222-2927": {
+      "name": "Modal",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "369-15": {
+      "name": "Progress",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1177-1652": {
+      "name": "Skeleton",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1004-1677": {
+      "name": "StatusDot",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "368-16": {
+      "name": "Spinner",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1281-2108": {
+      "name": "SegmentedControl",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "1285-2113": {
+      "name": "CommandPalette",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "381-31": {
+      "name": "Breadcrumb",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "949-1774": {
+      "name": "Component 1",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "949-1791": {
+      "name": "Component 2",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "1151-2835": {
+      "name": "Badge/Card",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "1211-2930": {
+      "name": "Tabs",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1223-2915": {
+      "name": "Accordion",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "377-26": {
+      "name": "Card",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "470-2": {
+      "name": "ContactForm",
+      "type": "COMPONENT",
+      "page": "Organisms"
+    },
+    "471-21": {
+      "name": "NewsletterWaitlist",
+      "type": "COMPONENT",
+      "page": "Organisms"
+    },
+    "473-25": {
+      "name": "ChatWidget",
+      "type": "COMPONENT",
+      "page": "Organisms"
+    },
+    "1027-2672": {
+      "name": "WorkNav",
+      "type": "COMPONENT",
+      "page": "Organisms"
+    },
+    "1028-89": {
+      "name": "ProjectNav",
+      "type": "COMPONENT",
+      "page": "Organisms"
+    },
+    "1029-101": {
+      "name": "BlogNav",
+      "type": "COMPONENT",
+      "page": "Organisms"
+    },
+    "1031-109": {
+      "name": "ProjectCard",
+      "type": "COMPONENT",
+      "page": "Organisms"
+    },
+    "1032-110": {
+      "name": "ProjectGallery",
+      "type": "COMPONENT",
+      "page": "Organisms"
+    },
+    "1033-110": {
+      "name": "WorkGrid",
+      "type": "COMPONENT",
+      "page": "Organisms"
+    },
+    "1034-110": {
+      "name": "BlogGrid",
+      "type": "COMPONENT",
+      "page": "Organisms"
+    },
+    "1035-110": {
+      "name": "BlogCategoryFilter",
+      "type": "COMPONENT",
+      "page": "Organisms"
+    },
+    "1036-109": {
+      "name": "BlogMediaImage",
+      "type": "COMPONENT",
+      "page": "Organisms"
+    },
+    "1037-110": {
+      "name": "ArticleContent",
+      "type": "COMPONENT",
+      "page": "Organisms"
+    },
+    "1043-110": {
+      "name": "ArticleShareSection",
+      "type": "COMPONENT",
+      "page": "Organisms"
+    },
+    "476-2": {
+      "name": "SiteHeader",
+      "type": "COMPONENT",
+      "page": "Patterns"
+    },
+    "477-6": {
+      "name": "SiteFooter",
+      "type": "COMPONENT",
+      "page": "Patterns"
+    },
+    "502-20": {
+      "name": "CTASection",
+      "type": "COMPONENT",
+      "page": "Patterns"
+    },
+    "503-20": {
+      "name": "NewsBulletin",
+      "type": "COMPONENT",
+      "page": "Patterns"
+    }
+  }
+}

--- a/scripts/design-system/figma-links.baseline.json
+++ b/scripts/design-system/figma-links.baseline.json
@@ -1,4 +1,4 @@
 {
-  "stablePlaceholderCeiling": 37,
-  "note": "Ratchet: lower this in the PR that wires real Figma nodes; see docs/design-system/figma-parity-audit.md"
+  "stablePlaceholderCeiling": 39,
+  "note": "Ratchet for stable contracts whose figma link does not resolve to a real component in figma-component-index.json (placeholder dt-* links, deleted nodes, or non-component nodes like a Specimens section). Lower this in the PR that wires a real component. Raised 37->39 on 2026-07-12 when check:figma-links began verifying node existence/type, which surfaced Timestamp (Specimens section) and ContactInquiryPanel (deleted node 664-33). See docs/design-system/figma-parity-audit.md"
 }


### PR DESCRIPTION
The old guardrail only checked that a stable contract 'figma' value was a non-null URL with a numeric node-id, so a link pointing at a deleted node or a non-component (a Section of loose Specimens frames) passed. This is why several stable components effectively had no real Figma component.

**Changes**
- Adds a committed figma-component-index.json: 78 real COMPONENT/COMPONENT_SET node-ids enumerated from the Atoms/Organisms/Patterns pages via the Figma MCP.
- check:figma-links now requires each stable contract node-id to be present in that index (not just numeric).
- Surfaced two problems the old check missed: **Timestamp** (node 1245-1732 is a Specimens section, not a component) and **ContactInquiryPanel** (node 664-33 was deleted).
- Ratchet ceiling raised 37->39 to reflect the true debt; it can only decrease as real components are built.
- Negative-tested both ratchet directions (fails on regression and on an un-tightened drop).

Next: the build phase drives the 39 to 0 (List, Combobox, Timestamp, then down the list).

**Local gate:** typecheck, lint, lint:css, test, build all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)