### PR TITLE
feat(design-system): build real Figma components for List, Combobox, Timestamp

### DIFF
--- a/nextjs-app/shared/components/Combobox/Combobox.contract.json
+++ b/nextjs-app/shared/components/Combobox/Combobox.contract.json
@@ -5,7 +5,7 @@
     "group": "form",
     "status": "stable",
     "description": "Single-select combobox with portaled dropdown, shared with MultiCombobox.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-combobox",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1297-3061",
     "radixPrimitive": null,
     "element": "button",
     "variants": {},

--- a/nextjs-app/shared/components/List/List.contract.json
+++ b/nextjs-app/shared/components/List/List.contract.json
@@ -5,7 +5,7 @@
     "group": "structure",
     "status": "stable",
     "description": "Typographic list (ul or ol) that renders `items` on the text ladder — size matches the surrounding Text voice, listStyleType styles or removes markers, and spacing owns the inter-item rhythm.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-list",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1297-2111",
     "radixPrimitive": null,
     "element": "ul",
     "variants": {

--- a/nextjs-app/shared/components/Timestamp/Timestamp.contract.json
+++ b/nextjs-app/shared/components/Timestamp/Timestamp.contract.json
@@ -5,7 +5,7 @@
     "group": "display",
     "status": "stable",
     "description": "Formats a date or time value into human-readable text: relative for recency, absolute for precision, or auto to switch between them. Modeled on the Astryx Timestamp reference.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1245-1732",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1297-3064",
     "radixPrimitive": null,
     "element": "time",
     "variants": {

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-12T10:01:45.807Z",
+  "generatedAt": "2026-07-12T10:23:43.479Z",
   "summary": {
     "componentCount": 165,
     "statusCounts": {
@@ -8076,7 +8076,7 @@
         "group": "form",
         "status": "stable",
         "description": "Single-select combobox with portaled dropdown, shared with MultiCombobox.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-combobox",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1297-3061",
         "radixPrimitive": null,
         "element": "button",
         "variants": {},
@@ -17065,7 +17065,7 @@
         "group": "structure",
         "status": "stable",
         "description": "Typographic list (ul or ol) that renders `items` on the text ladder — size matches the surrounding Text voice, listStyleType styles or removes markers, and spacing owns the inter-item rhythm.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-list",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1297-2111",
         "radixPrimitive": null,
         "element": "ul",
         "variants": {
@@ -31131,7 +31131,7 @@
         "group": "display",
         "status": "stable",
         "description": "Formats a date or time value into human-readable text: relative for recency, absolute for precision, or auto to switch between them. Modeled on the Astryx Timestamp reference.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1245-1732",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1297-3064",
         "radixPrimitive": null,
         "element": "time",
         "variants": {

--- a/scripts/design-system/figma-component-index.json
+++ b/scripts/design-system/figma-component-index.json
@@ -391,6 +391,21 @@
       "name": "NewsBulletin",
       "type": "COMPONENT",
       "page": "Patterns"
+    },
+    "1297-2111": {
+      "name": "List",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "1297-3061": {
+      "name": "Combobox",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "1297-3064": {
+      "name": "Timestamp",
+      "type": "COMPONENT",
+      "page": "Atoms"
     }
   }
 }

--- a/scripts/design-system/figma-links.baseline.json
+++ b/scripts/design-system/figma-links.baseline.json
@@ -1,4 +1,4 @@
 {
-  "stablePlaceholderCeiling": 39,
+  "stablePlaceholderCeiling": 36,
   "note": "Ratchet for stable contracts whose figma link does not resolve to a real component in figma-component-index.json (placeholder dt-* links, deleted nodes, or non-component nodes like a Specimens section). Lower this in the PR that wires a real component. Raised 37->39 on 2026-07-12 when check:figma-links began verifying node existence/type, which surfaced Timestamp (Specimens section) and ContactInquiryPanel (deleted node 664-33). See docs/design-system/figma-parity-audit.md"
 }


### PR DESCRIPTION
First build-phase batch closing the figma-links debt surfaced by #1125.

**Built real COMPONENTs:**
- **List** (node 1297-2111) — dash-marker list, Content section.
- **Combobox** (node 1297-3061) — input + open listbox, Forms section.
- **Timestamp** (node 1297-3064) — semantic time, placed in the Timestamp section beside the existing Specimens (which stay as a format reference). This replaces the loose Specimens-section link with a real component.

Wired each contract figma link to its node, added the three ids to figma-component-index.json, and lowered the ratchet 39->36. No AT recapture (the figma field is not in snapshots).

**Local gate:** typecheck, lint, lint:css, test, build all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)