### PR TITLE
feat(design-system): build Tooltip Figma component + extend figma-links guardrail to beta

### DIFF
--- a/nextjs-app/shared/components/Tooltip/Tooltip.contract.json
+++ b/nextjs-app/shared/components/Tooltip/Tooltip.contract.json
@@ -5,7 +5,7 @@
     "group": "overlay",
     "status": "beta",
     "description": "Radix tooltip primitive set (Provider, Trigger, Content) for icon hints.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-tooltip",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1298-2106",
     "radixPrimitive": "@radix-ui/react-tooltip",
     "element": "div",
     "variants": {},

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-12T10:23:43.479Z",
+  "generatedAt": "2026-07-12T10:31:59.836Z",
   "summary": {
     "componentCount": 165,
     "statusCounts": {
@@ -32563,7 +32563,7 @@
         "group": "overlay",
         "status": "beta",
         "description": "Radix tooltip primitive set (Provider, Trigger, Content) for icon hints.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-tooltip",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1298-2106",
         "radixPrimitive": "@radix-ui/react-tooltip",
         "element": "div",
         "variants": {},

--- a/scripts/design-system/check-figma-links.mjs
+++ b/scripts/design-system/check-figma-links.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
- * Figma-link ratchet: a stable contract's `figma` must resolve to a REAL Figma
- * component, and the debt count can only go DOWN.
+ * Figma-link ratchet: a beta or stable contract's `figma` must resolve to a
+ * REAL Figma component, and the debt count can only go DOWN. (validate-
+ * components.ts requires a figma URL for both tiers, so both are guarded.)
  *
  * "Resolves to a real component" means BOTH:
  *   1. the URL carries a numeric node id (`node-id=<digits>-<digits>`), not a
@@ -54,16 +55,21 @@ const walk = (dir) => {
 walk(join(ROOT, "nextjs-app", "shared", "components"));
 walk(join(ROOT, "nextjs-app", "shared", "patterns"));
 
-/** name -> reason, for every stable contract whose figma does not resolve. */
+// validate-components.ts requires a figma URL for BOTH beta and stable, so both
+// tiers are guardrailed here — a beta placeholder (e.g. Tooltip -> dt-tooltip)
+// is the same class of gap as a stable one.
+const GUARDED = new Set(["beta", "stable"]);
+
+/** "name (status): reason", for every guarded contract whose figma doesn't resolve. */
 const unresolved = [];
 for (const file of contractFiles) {
   const contract = JSON.parse(readFileSync(file, "utf8"));
-  if (contract.status !== "stable") continue;
+  if (!GUARDED.has(contract.status)) continue;
   const nodeId = nodeIdOf(contract.figma);
   if (nodeId === null) {
-    unresolved.push(`${contract.name} (placeholder link)`);
+    unresolved.push(`${contract.name} [${contract.status}] (placeholder link)`);
   } else if (!knownComponentIds.has(nodeId)) {
-    unresolved.push(`${contract.name} (node ${nodeId} is not a known DS component)`);
+    unresolved.push(`${contract.name} [${contract.status}] (node ${nodeId} is not a known DS component)`);
   }
 }
 
@@ -73,10 +79,10 @@ const count = unresolved.length;
 
 if (count > ceiling) {
   console.error(
-    `✖ figma-links ratchet: ${count} stable contracts do not resolve to a real Figma component (ceiling ${ceiling}).`,
+    `✖ figma-links ratchet: ${count} beta/stable contracts do not resolve to a real Figma component (ceiling ${ceiling}).`,
   );
   console.error(
-    `  A stable contract needs a real COMPONENT/COMPONENT_SET node (build it, then add it to figma-component-index.json — see docs/design-system/figma-parity-audit.md).`,
+    `  A beta/stable contract needs a real COMPONENT/COMPONENT_SET node (build it, then add it to figma-component-index.json — see docs/design-system/figma-parity-audit.md).`,
   );
   console.error(`  Unresolved:\n    ${unresolved.sort().join("\n    ")}`);
   process.exit(1);
@@ -93,5 +99,5 @@ if (count < ceiling) {
 }
 
 console.log(
-  `✓ figma-links ratchet: ${count}/${ceiling} stable contracts without a real Figma component (can only decrease)`,
+  `✓ figma-links ratchet: ${count}/${ceiling} beta/stable contracts without a real Figma component (can only decrease)`,
 );

--- a/scripts/design-system/figma-component-index.json
+++ b/scripts/design-system/figma-component-index.json
@@ -406,6 +406,11 @@
       "name": "Timestamp",
       "type": "COMPONENT",
       "page": "Atoms"
+    },
+    "1298-2106": {
+      "name": "Tooltip",
+      "type": "COMPONENT",
+      "page": "Atoms"
     }
   }
 }

--- a/scripts/design-system/figma-links.baseline.json
+++ b/scripts/design-system/figma-links.baseline.json
@@ -1,4 +1,4 @@
 {
-  "stablePlaceholderCeiling": 36,
-  "note": "Ratchet for stable contracts whose figma link does not resolve to a real component in figma-component-index.json (placeholder dt-* links, deleted nodes, or non-component nodes like a Specimens section). Lower this in the PR that wires a real component. Raised 37->39 on 2026-07-12 when check:figma-links began verifying node existence/type, which surfaced Timestamp (Specimens section) and ContactInquiryPanel (deleted node 664-33). See docs/design-system/figma-parity-audit.md"
+  "stablePlaceholderCeiling": 67,
+  "note": "Ratchet for BETA and STABLE contracts whose figma link does not resolve to a real component in figma-component-index.json (validate requires a figma URL for both tiers). Raised to 67 on 2026-07-12 when the check was extended to cover beta (was stable-only at 36); beta added 31 placeholders incl. Tooltip. Lower this in the PR that wires a real component. See docs/design-system/figma-parity-audit.md"
 }


### PR DESCRIPTION
Tooltip was beta with a dt-tooltip placeholder, and the guardrail only checked *stable* contracts, so it slipped through despite validate requiring a figma URL for beta too.

**Changes**
- Built the real **Tooltip** component (node 1298-2106) — dark --color-primary popover + pointer, Feedback section — and wired its contract.
- Extended check:figma-links to guard **both beta and stable** (the tiers validate requires figma for). This surfaced **32 beta placeholders**; Tooltip is now fixed, 31 remain.
- Ratchet reseeded 36 -> 67 (36 stable + 31 beta) to reflect the true debt; still decreasing-only, negative-tested both directions.

**Policy note:** several remaining beta placeholders are non-visual (ThemeProvider, FadeIn, Spacer, WipBadge, Center, AspectRatio) and may warrant a figma exemption or alpha-demotion rather than a component build — worth a decision before building those.

**Local gate:** typecheck, lint, lint:css, test, build all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)