### PR TITLE
feat(react): publish 0.1.8 — alpha-wave runtime exports + type-only surface alignment

### DIFF
--- a/nextjs-app/shared/components/Badge/index.ts
+++ b/nextjs-app/shared/components/Badge/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Badge";
+export type { BadgeProps, BadgeSize, BadgeTone, BadgeVariant } from "./Badge";

--- a/nextjs-app/shared/components/Button/index.ts
+++ b/nextjs-app/shared/components/Button/index.ts
@@ -2,6 +2,9 @@ export { default } from "./Button";
 export type {
   ButtonAsButton,
   ButtonAsLink,
+  ButtonSize,
   ButtonProps,
   ButtonSurface,
+  ButtonTone,
+  ButtonVariant,
 } from "./Button";

--- a/nextjs-app/shared/components/Checkbox/Checkbox.test.tsx
+++ b/nextjs-app/shared/components/Checkbox/Checkbox.test.tsx
@@ -53,4 +53,24 @@ describe("Checkbox", () => {
     );
     expect(screen.getByLabelText("Disabled")).toBeDisabled();
   });
+
+  it("associates error and helper text through aria-describedby", () => {
+    render(
+      <Checkbox
+        id="terms"
+        label="Terms"
+        checked={false}
+        onCheckedChange={() => {}}
+        error="Required"
+        helperText="Accept before continuing"
+      />,
+    );
+
+    const checkbox = screen.getByLabelText("Terms");
+    expect(checkbox).toHaveAttribute("aria-invalid", "true");
+    expect(checkbox).toHaveAttribute(
+      "aria-describedby",
+      "terms-error terms-helper",
+    );
+  });
 });

--- a/nextjs-app/shared/components/Checkbox/index.ts
+++ b/nextjs-app/shared/components/Checkbox/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Checkbox";
+export type { CheckboxProps } from "./Checkbox";

--- a/nextjs-app/shared/components/FileUpload/FileUpload.test.tsx
+++ b/nextjs-app/shared/components/FileUpload/FileUpload.test.tsx
@@ -32,6 +32,23 @@ describe("FileUpload", () => {
     expect(screen.getByRole("button", { name: /choose file/i })).toBeInTheDocument();
   });
 
+  it("pins editorial required and validation ARIA wiring", () => {
+    renderComponent({
+      appearance: "editorial",
+      error: "Upload is required",
+      required: true,
+    });
+
+    const trigger = screen.getByRole("button", { name: /attachment/i });
+    const error = screen.getByText("Upload is required");
+    const helper = screen.getByText("Max 5 MB");
+
+    expect(trigger).toHaveAttribute("aria-invalid", "true");
+    expect(trigger).toHaveAttribute("aria-required", "true");
+    expect(trigger.getAttribute("aria-describedby")).toContain(error.id);
+    expect(trigger.getAttribute("aria-describedby")).toContain(helper.id);
+  });
+
   it("calls onFileChange when file is selected", () => {
     const handleChange = vi.fn();
     const { container } = renderComponent({ onFileChange: handleChange });

--- a/nextjs-app/shared/components/Gallery/index.ts
+++ b/nextjs-app/shared/components/Gallery/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Gallery";
+export type { GalleryProps } from "./Gallery";

--- a/nextjs-app/shared/components/HelperText/index.ts
+++ b/nextjs-app/shared/components/HelperText/index.ts
@@ -1,2 +1,2 @@
 export { default } from "./HelperText";
-export type { HelperTextProps } from "./HelperText";
+export type { HelperTextProps, HelperTextState } from "./HelperText";

--- a/nextjs-app/shared/components/Label/index.ts
+++ b/nextjs-app/shared/components/Label/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Label";
+export type { LabelProps } from "./Label";

--- a/nextjs-app/shared/components/Radio/Radio.test.tsx
+++ b/nextjs-app/shared/components/Radio/Radio.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
 import Radio from "./Radio";
 
 describe("Radio", () => {
@@ -13,5 +13,21 @@ describe("Radio", () => {
   it("preselects via defaultChecked on the uncontrolled path", () => {
     render(<Radio name="n" value="v" label="Opt" defaultChecked />);
     expect(screen.getByRole("radio")).toBeChecked();
+  });
+
+  it("calls onCheckedChange with the selected state", () => {
+    const onCheckedChange = vi.fn();
+    render(
+      <Radio
+        name="n"
+        value="v"
+        label="Opt"
+        checked={false}
+        onCheckedChange={onCheckedChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("radio"));
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
   });
 });

--- a/nextjs-app/shared/components/Switch/Switch.test.tsx
+++ b/nextjs-app/shared/components/Switch/Switch.test.tsx
@@ -110,4 +110,23 @@ describe("Switch", () => {
     expect(toggle).toHaveAttribute("aria-busy", "true");
     expect(toggle).toHaveAttribute("data-loading", "true");
   });
+
+  it("associates error and helper text through aria-describedby", () => {
+    render(
+      <Switch
+        id="email-alerts"
+        checked={false}
+        label="Email alerts"
+        error="Required"
+        helperText="Used for service updates"
+      />,
+    );
+
+    const toggle = screen.getByRole("switch", { name: "Email alerts" });
+    expect(toggle).toHaveAttribute("aria-invalid", "true");
+    expect(toggle).toHaveAttribute(
+      "aria-describedby",
+      "email-alerts-error email-alerts-helper",
+    );
+  });
 });

--- a/nextjs-app/shared/components/Title/index.ts
+++ b/nextjs-app/shared/components/Title/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Title";
+export type { TitleProps } from "./Title";

--- a/nextjs-app/shared/components/index.ts
+++ b/nextjs-app/shared/components/index.ts
@@ -3,10 +3,13 @@ export { default as ArticleCard } from "./ArticleCard/ArticleCard";
 export { default as Author } from "./Author/Author";
 export { default as AuthorBio } from "./AuthorBio/AuthorBio";
 export { default as Avatar } from "./Avatar/Avatar";
+export type { AvatarMenuItem, AvatarProps, AvatarSize } from "./Avatar";
 export { default as AvatarGroup } from "./AvatarGroup/AvatarGroup";
+export type { AvatarGroupProps, AvatarGroupSize } from "./AvatarGroup";
 export { default as AlertBanner } from "./AlertBanner/AlertBanner";
 export type { AlertBannerProps } from "./AlertBanner/AlertBanner";
 export { default as Badge } from "./Badge/Badge";
+export type { BadgeProps, BadgeSize, BadgeTone, BadgeVariant } from "./Badge";
 export { default as Breadcrumb } from "./Breadcrumb/Breadcrumb";
 export type {
   BreadcrumbItem,
@@ -16,13 +19,24 @@ export { default as Button } from "./Button/Button";
 export type {
   ButtonAsButton,
   ButtonAsLink,
+  ButtonSize,
   ButtonProps,
   ButtonSurface,
+  ButtonTone,
+  ButtonVariant,
 } from "./Button/Button";
 export { default as ButtonGroup } from "./ButtonGroup/ButtonGroup";
 export type { ButtonGroupProps } from "./ButtonGroup/ButtonGroup";
 export { default as Card } from "./Card/Card";
+export type {
+  CardDescriptionProps,
+  CardPadding,
+  CardProps,
+  CardTitleProps,
+  CardVariant,
+} from "./Card";
 export { default as Checkbox } from "./Checkbox/Checkbox";
+export type { CheckboxProps } from "./Checkbox";
 export { default as CheckboxGroup } from "./CheckboxGroup/CheckboxGroup";
 export type { CheckboxGroupProps } from "./CheckboxGroup/CheckboxGroup";
 export { default as ChunkErrorBoundary } from "./ChunkErrorBoundary/ChunkErrorBoundary";
@@ -59,11 +73,14 @@ export { default as FlexBox } from "./FlexBox/FlexBox";
 export { default as FileUpload } from "./FileUpload/FileUpload";
 export type { FileUploadProps } from "./FileUpload/FileUpload";
 export { default as Gallery } from "./Gallery/Gallery";
+export type { GalleryProps } from "./Gallery";
 export { default as Grid } from "./Grid/Grid";
 export { default as GroupLabel } from "./GroupLabel/GroupLabel";
 export { default as Icon } from "./Icon/Icon";
+export type { IconProps } from "./Icon";
 export { default as HelsinkiClock } from "./HelsinkiClock/HelsinkiClock";
 export { default as Kbd } from "./Kbd/Kbd";
+export type { KbdProps, KbdSize } from "./Kbd";
 export { default as StatusDot } from "./StatusDot/StatusDot";
 export type {
   StatusDotProps,
@@ -73,6 +90,7 @@ export type {
 export { default as TextInput } from "./TextInput/TextInput";
 export type { TextInputProps } from "./TextInput/TextInput";
 export { default as Label } from "./Label/Label";
+export type { LabelProps } from "./Label";
 export { default as Link } from "./Link/Link";
 export { default as List } from "./List/List";
 export { default as MacWindowFrame } from "./MacWindowFrame/MacWindowFrame";
@@ -121,6 +139,7 @@ export type { SkeletonProps } from "./Skeleton";
 export { SkillsGrid, type SkillsGridProps, type Skill } from "./SkillsGrid";
 export { default as StudioMap } from "./StudioMap/StudioMap";
 export { default as Switch } from "./Switch/Switch";
+export type { SwitchProps } from "./Switch";
 export { SocialShare } from "./SocialShare/SocialShare";
 export type {
   SocialShareChannel,
@@ -134,6 +153,7 @@ export { default as Text } from "./Text/Text";
 export { ThemeProvider, useTheme } from "./ThemeProvider/ThemeProvider";
 export type { Theme, ThemeProviderProps } from "./ThemeProvider/ThemeProvider";
 export { default as Title } from "./Title/Title";
+export type { TitleProps } from "./Title";
 export { default as Toast } from "./Toast/Toast";
 export type { ToastPosition, ToastProps, ToastTone } from "./Toast/Toast";
 export { default as TransformingActionInput } from "./TransformingActionInput/TransformingActionInput";

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-12T10:31:59.836Z",
+  "generatedAt": "2026-07-12T11:40:32.358Z",
   "summary": {
     "componentCount": 165,
     "statusCounts": {
@@ -83,7 +83,7 @@
     "uniqueImportedComponents": 154,
     "totalEvidenceRows": 763,
     "aliasImportFiles": 377,
-    "relativeImportFiles": 401,
+    "relativeImportFiles": 412,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
   },

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.8 - 2026-07-12
+
+- Batch publish of the alpha-wave promotions merged since 0.1.7. Seven new runtime exports enter the package surface: `CommandPalette`, `FilterChip`, `SegmentedControl`, `SelectableCard`, `SelectableCardGroup`, `SplitButton`, `ToastStack` (with their prop types). Runtime public API now lists 113 exports (was 106).
+- Type-only export alignment across the curated surface: `Avatar` (incl. `AvatarMenuItem`/`AvatarSize`), `AvatarGroup`, `Badge` (`BadgeSize`/`BadgeTone`/`BadgeVariant`), `Card` (`CardProps`/`CardVariant`/`CardPadding`/`CardTitleProps`/`CardDescriptionProps`), `Checkbox`, `Gallery`, `HelperText` (adds `HelperTextState`), `Icon`, `Kbd` (`KbdSize`), `Label`, `Switch`, `Title`, and `Button` (`ButtonSize`/`ButtonTone`/`ButtonVariant`). Mixed `export { X, type Y }` statements split into separate `export type { … }` blocks so the public-surface guard classifies them correctly. No runtime behavior change from these.
+- `ArticleLayout` is intentionally not exported in this release: it is `status: alpha` and the public surface enforces a zero-alpha ceiling. It returns at beta once its full promotion surface (stories, verified forced-colors/light-dark, a11y review, docs) lands.
+- Verified by the full local gate (typecheck, lint, 2284 tests, build) plus check:react-package, check:react-public-api, and check:react-public-surface (0 alpha).
+
 ## 0.1.7 - 2026-07-11
 
 - Forms semantics unification (#1094, owner ruling): `helperText` is always-on across all field components — TextInput, TextArea, Select, PhoneInput, Combobox, MultiCombobox, Checkbox, Switch, FileUpload now render `error` above the helper instead of replacing it, with `aria-describedby` referencing both ids. Consecutive HelperText lines stack 4px apart as one block.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/react",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": false,
   "description": "React components and host adapters for the Digitaltableteur design system.",
   "type": "module",

--- a/packages/react/public-api.manifest.json
+++ b/packages/react/public-api.manifest.json
@@ -1,6 +1,6 @@
 {
   "packageName": "@digitaltableteur/react",
-  "packageVersion": "0.1.7",
+  "packageVersion": "0.1.8",
   "packageExports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -11,7 +11,6 @@
   "runtimeExports": [
     "AlertBanner",
     "AnimationRuntimeProvider",
-    "ArticleLayout",
     "Avatar",
     "AvatarGroup",
     "Badge",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,8 +1,23 @@
 export { default as AlertBanner } from "../../../nextjs-app/shared/components/AlertBanner/AlertBanner";
 export type { AlertBannerProps } from "../../../nextjs-app/shared/components/AlertBanner/AlertBanner";
 export { default as Avatar } from "../../../nextjs-app/shared/components/Avatar/Avatar";
+export type {
+  AvatarMenuItem,
+  AvatarProps,
+  AvatarSize,
+} from "../../../nextjs-app/shared/components/Avatar";
 export { default as AvatarGroup } from "../../../nextjs-app/shared/components/AvatarGroup/AvatarGroup";
+export type {
+  AvatarGroupProps,
+  AvatarGroupSize,
+} from "../../../nextjs-app/shared/components/AvatarGroup";
 export { default as Badge } from "../../../nextjs-app/shared/components/Badge/Badge";
+export type {
+  BadgeProps,
+  BadgeSize,
+  BadgeTone,
+  BadgeVariant,
+} from "../../../nextjs-app/shared/components/Badge";
 export { default as Breadcrumb } from "../../../nextjs-app/shared/components/Breadcrumb/Breadcrumb";
 export type {
   BreadcrumbItem,
@@ -12,18 +27,29 @@ export { default as Button } from "../../../nextjs-app/shared/components/Button/
 export type {
   ButtonAsButton,
   ButtonAsLink,
+  ButtonSize,
   ButtonProps,
   ButtonSurface,
+  ButtonTone,
+  ButtonVariant,
 } from "../../../nextjs-app/shared/components/Button/Button";
 export { default as ButtonGroup } from "../../../nextjs-app/shared/components/ButtonGroup/ButtonGroup";
 export type { ButtonGroupProps } from "../../../nextjs-app/shared/components/ButtonGroup/ButtonGroup";
 export { default as Card } from "../../../nextjs-app/shared/components/Card/Card";
+export type {
+  CardDescriptionProps,
+  CardPadding,
+  CardProps,
+  CardTitleProps,
+  CardVariant,
+} from "../../../nextjs-app/shared/components/Card";
 export {
   CategoryFilter,
   type CategoryFilterProps,
   type CategoryOption,
 } from "../../../nextjs-app/shared/components/CategoryFilter";
 export { default as Checkbox } from "../../../nextjs-app/shared/components/Checkbox/Checkbox";
+export type { CheckboxProps } from "../../../nextjs-app/shared/components/Checkbox";
 export { default as CheckboxGroup } from "../../../nextjs-app/shared/components/CheckboxGroup/CheckboxGroup";
 export type { CheckboxGroupProps } from "../../../nextjs-app/shared/components/CheckboxGroup/CheckboxGroup";
 export { default as CodeBlockWindow } from "../../../nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow";
@@ -40,10 +66,10 @@ export {
   optionsFromSelectChildren,
   splitPlaceholderOption,
 } from "../../../nextjs-app/shared/components/Combobox";
-export {
-  CommandPalette,
-  type CommandPaletteItem,
-  type CommandPaletteProps,
+export { CommandPalette } from "../../../nextjs-app/shared/components/CommandPalette/CommandPalette";
+export type {
+  CommandPaletteItem,
+  CommandPaletteProps,
 } from "../../../nextjs-app/shared/components/CommandPalette/CommandPalette";
 export { Container, type ContainerProps } from "../../../nextjs-app/shared/components/Container";
 export { default as CookieConsent } from "../../../nextjs-app/shared/components/CookieConsent/CookieConsent";
@@ -78,26 +104,31 @@ export {
 export { default as FlexBox } from "../../../nextjs-app/shared/components/FlexBox/FlexBox";
 export { default as FileUpload } from "../../../nextjs-app/shared/components/FileUpload/FileUpload";
 export type { FileUploadProps } from "../../../nextjs-app/shared/components/FileUpload/FileUpload";
-export {
-  FilterChip,
-  type FilterChipProps,
-} from "../../../nextjs-app/shared/components/FilterChip";
+export { FilterChip } from "../../../nextjs-app/shared/components/FilterChip";
+export type { FilterChipProps } from "../../../nextjs-app/shared/components/FilterChip";
 export {
   FormField,
   type FormFieldProps,
 } from "../../../nextjs-app/shared/components/FormField";
 export { default as Gallery } from "../../../nextjs-app/shared/components/Gallery/Gallery";
+export type { GalleryProps } from "../../../nextjs-app/shared/components/Gallery";
 export { default as Grid } from "../../../nextjs-app/shared/components/Grid/Grid";
 export { default as GroupLabel } from "../../../nextjs-app/shared/components/GroupLabel/GroupLabel";
 export { default as HelperText } from "../../../nextjs-app/shared/components/HelperText/HelperText";
-export type { HelperTextProps } from "../../../nextjs-app/shared/components/HelperText/HelperText";
+export type {
+  HelperTextProps,
+  HelperTextState,
+} from "../../../nextjs-app/shared/components/HelperText";
 export { default as Icon } from "../../../nextjs-app/shared/components/Icon/Icon";
+export type { IconProps } from "../../../nextjs-app/shared/components/Icon";
 export {
   IconButton,
   type IconButtonProps,
 } from "../../../nextjs-app/shared/components/IconButton";
 export { default as Kbd } from "../../../nextjs-app/shared/components/Kbd/Kbd";
 export { default as Label } from "../../../nextjs-app/shared/components/Label/Label";
+export type { KbdProps, KbdSize } from "../../../nextjs-app/shared/components/Kbd";
+export type { LabelProps } from "../../../nextjs-app/shared/components/Label";
 export {
   LanguageSwitcher,
   type LanguageSwitcherOption,
@@ -163,10 +194,10 @@ export {
   Section,
   type SectionProps,
 } from "../../../nextjs-app/shared/components/Section";
-export {
-  default as SegmentedControl,
-  type SegmentedControlItem,
-  type SegmentedControlProps,
+export { default as SegmentedControl } from "../../../nextjs-app/shared/components/SegmentedControl/SegmentedControl";
+export type {
+  SegmentedControlItem,
+  SegmentedControlProps,
 } from "../../../nextjs-app/shared/components/SegmentedControl/SegmentedControl";
 export { default as Select } from "../../../nextjs-app/shared/components/Select/Select";
 export type {
@@ -177,9 +208,11 @@ export { default as SelectOption } from "../../../nextjs-app/shared/components/S
 export {
   SelectableCard,
   SelectableCardGroup,
-  type SelectableCardGroupProps,
-  type SelectableCardProps,
-  type SelectableCardSelectionType,
+} from "../../../nextjs-app/shared/components/SelectableCard/SelectableCard";
+export type {
+  SelectableCardGroupProps,
+  SelectableCardProps,
+  SelectableCardSelectionType,
 } from "../../../nextjs-app/shared/components/SelectableCard/SelectableCard";
 export {
   SkipLink,
@@ -191,10 +224,10 @@ export {
   Spinner,
   type SpinnerProps,
 } from "../../../nextjs-app/shared/components/Spinner";
-export {
-  default as SplitButton,
-  type SplitButtonOption,
-  type SplitButtonProps,
+export { default as SplitButton } from "../../../nextjs-app/shared/components/SplitButton/SplitButton";
+export type {
+  SplitButtonOption,
+  SplitButtonProps,
 } from "../../../nextjs-app/shared/components/SplitButton/SplitButton";
 export {
   Stack,
@@ -207,6 +240,7 @@ export type {
   StatusDotTone,
 } from "../../../nextjs-app/shared/components/StatusDot";
 export { default as Switch } from "../../../nextjs-app/shared/components/Switch/Switch";
+export type { SwitchProps } from "../../../nextjs-app/shared/components/Switch";
 export { default as Tabs, getTabPanelProps } from "../../../nextjs-app/shared/components/Tabs";
 export type { TabItem, TabsProps } from "../../../nextjs-app/shared/components/Tabs";
 export { default as Text } from "../../../nextjs-app/shared/components/Text/Text";
@@ -225,16 +259,17 @@ export type {
   ThemeProviderProps,
 } from "../../../nextjs-app/shared/components/ThemeProvider/ThemeProvider";
 export { default as Title } from "../../../nextjs-app/shared/components/Title/Title";
+export type { TitleProps } from "../../../nextjs-app/shared/components/Title";
 export { default as Toast } from "../../../nextjs-app/shared/components/Toast/Toast";
 export type {
   ToastPosition,
   ToastProps,
   ToastTone,
 } from "../../../nextjs-app/shared/components/Toast/Toast";
-export {
-  default as ToastStack,
-  type ToastStackItem,
-  type ToastStackProps,
+export { default as ToastStack } from "../../../nextjs-app/shared/components/ToastStack/ToastStack";
+export type {
+  ToastStackItem,
+  ToastStackProps,
 } from "../../../nextjs-app/shared/components/ToastStack/ToastStack";
 export {
   ValueCard,
@@ -305,12 +340,3 @@ export {
   type ScrollOverflowState,
 } from "../../../nextjs-app/shared/hooks/useOverflow";
 export { useScrollLock } from "../../../nextjs-app/shared/hooks/useScrollLock";
-
-// ── Patterns ──────────────────────────────────────────────────────────────
-// Composite, page-level building blocks. First pattern exported from the
-// registry, establishing the pattern rung of the full-consumption mandate
-// (atoms → molecules → patterns → pages).
-export {
-  ArticleLayout,
-  type ArticleLayoutProps,
-} from "../../../nextjs-app/shared/patterns/ArticleLayout/ArticleLayout";

--- a/providers/ToastProvider.tsx
+++ b/providers/ToastProvider.tsx
@@ -8,11 +8,19 @@ import React, {
   useRef,
   useState,
 } from "react";
-// Import the tone/position types from local source (not the published barrel):
-// the neutral tone is added locally here and ships to the package on the next
-// republish; until then the barrel's .d.ts lags the local ToastTone.
-import type { ToastTone, ToastPosition } from "@dt/Toast";
-import ToastStack, { type ToastStackItem } from "@dt/ToastStack";
+// Import Toast tone/position types and the ToastStack component from local
+// source (relative path, not the published barrel): the #1124 neutral tone is
+// added locally and ships to the package with this 0.1.8 republish, but until
+// that version is consumed the registry barrel's .d.ts lags the local ToastTone
+// (LanguageNotice passes tone:"neutral"). Flip both to "@digitaltableteur/react"
+// after the 0.1.8 consume; classified in check:package-registry-resolution.
+import type {
+  ToastTone,
+  ToastPosition,
+} from "../nextjs-app/shared/components/Toast/Toast";
+import ToastStack, {
+  type ToastStackItem,
+} from "../nextjs-app/shared/components/ToastStack/ToastStack";
 import { ToastRuntimeProvider } from "../nextjs-app/shared/lib/toast";
 
 export interface ShowToastOptions {

--- a/scripts/design-system/astryx-roadmap.state.json
+++ b/scripts/design-system/astryx-roadmap.state.json
@@ -325,6 +325,7 @@
       "ScrollOverflowState",
       "SectionProps",
       "SelectOption",
+      "SelectableCardGroup",
       "SkipLinkProps",
       "SpinnerProps",
       "StackProps",

--- a/scripts/design-system/check-package-registry-resolution.mjs
+++ b/scripts/design-system/check-package-registry-resolution.mjs
@@ -88,6 +88,14 @@ const ALLOWED_LOCAL_SHARED_IMPORTS = new Map([
     "toast runtime is LOCAL end-to-end (ToastStack + LanguageNotice read this instance); dual-provide if a package component ever calls useToast",
   ],
   [
+    "providers/ToastProvider.tsx :: ../nextjs-app/shared/components/Toast/Toast",
+    "ToastTone/ToastPosition: local source leads the published barrel until 0.1.8 ships the #1124 neutral tone (LanguageNotice passes tone:'neutral'); flip to @digitaltableteur/react after the 0.1.8 consume",
+  ],
+  [
+    "providers/ToastProvider.tsx :: ../nextjs-app/shared/components/ToastStack/ToastStack",
+    "ToastStack + ToastStackItem: presentational stack rides the same local source until the 0.1.8 consume ships it to the registry barrel; flip to @digitaltableteur/react then",
+  ],
+  [
     "app/components/LanguageNotice/LanguageNotice.tsx :: @/nextjs-app/shared/lib/toast",
     "reads the LOCAL toast instance mounted by providers/ToastProvider",
   ],


### PR DESCRIPTION
## What

Batch-publishes `@digitaltableteur/react@0.1.8` and aligns the type surface.

- **7 new runtime exports** (promotions merged since 0.1.7, never published): `CommandPalette`, `FilterChip`, `SegmentedControl`, `SelectableCard`, `SelectableCardGroup`, `SplitButton`, `ToastStack` (with prop types). Runtime API: 106 → 113.
- **Type-only export alignment** across the curated surface (Avatar, AvatarGroup, Badge, Card, Checkbox, Gallery, HelperText+`HelperTextState`, Icon, Kbd, Label, Switch, Title, Button `Size`/`Tone`/`Variant`). Mixed `export { X, type Y }` statements split into separate `export type {}` blocks so the public-surface guard classifies them.
- **Removes alpha `ArticleLayout`** from the package surface. It is `status: alpha` and breaches the zero-alpha public-surface ceiling — a latent red on `main` since #1108. It has zero consumers; returns at beta once its full promotion surface (stories, verified forced-colors/light-dark, a11y review, docs) lands.
- **ToastProvider consumption prep**: `@dt/`-alias imports of published symbols must resolve from the registry package. `ToastProvider` still needs local Toast source because its `ToastTone` leads the 0.1.7 barrel (the #1124 neutral tone ships in *this* 0.1.8 republish; `LanguageNotice` passes `tone:"neutral"`). Converted the two alias imports to relative-source imports and classified them in `ALLOWED_LOCAL_SHARED_IMPORTS`, to be flipped to `@digitaltableteur/react` after the 0.1.8 consume.
- Adds `aria-describedby`/`aria-invalid` regression tests (Checkbox, Switch, FileUpload editorial) and Radio `onCheckedChange` coverage.

Origin: Codex/AlphaEvolve sweep, reviewed and validated. No repo tampering (settings/hooks clean vs HEAD).

## Verification (local — CI is quota-dead)

- `typecheck` ✓, `lint` ✓ (0 errors, 2 pre-existing ToastStack warnings), `npm test` ✓ (2284 tests), `build` ✓
- `check:react-package` (113 exports), `check:react-public-api`, `check:react-public-surface` (0 alpha), `check:contract-props`, `check:contract-drift --strict`, `check:consumers`, `check:package-registry-resolution`, `check:astryx-roadmap`, `build:tokens` all ✓
- `check:react-publish-preflight` passes every pre-publish gate (only the post-publish registry-status E404 remains, expected until 0.1.8 is live)

Follow-up after publish + consume: flip ToastProvider to the registry barrel and remove the temporary classifications; promote ArticleLayout to beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the React package to version 0.1.8.
  - Added several UI components, including command palettes, filter chips, segmented controls, selectable cards, split buttons, and toast stacks.
  - Expanded publicly available component type definitions for improved developer support.

- **Bug Fixes**
  - Improved accessibility validation for checkbox, switch, file upload, and related form controls.
  - Added coverage for controlled radio-button interactions.

- **Documentation**
  - Updated release documentation and public API listings to reflect the latest package surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->