### PR TITLE
chore(app): consume @digitaltableteur/react@0.1.8 from the registry

### DIFF
--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.7
+  - definition: 0.1.8
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.7
+  - definition: 0.1.8
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.7
+  - definition: 0.1.8
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.7
+  - definition: 0.1.8
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.7
+  - definition: 0.1.8
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.7
+  - definition: 0.1.8
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.7
+  - definition: 0.1.8
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.7
+  - definition: 0.1.8
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.7
+  - definition: 0.1.8
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.7
+  - definition: 0.1.8
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.7
+  - definition: 0.1.8
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.7
+  - definition: 0.1.8
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ai-sdk/openai": "^3.0.71",
         "@ai-sdk/react": "^3.0.207",
         "@calcom/embed-react": "^1.5.3",
-        "@digitaltableteur/react": "^0.1.7",
+        "@digitaltableteur/react": "^0.1.8",
         "@digitaltableteur/tokens": "^0.1.1",
         "@digitaltableteur/tokens-css": "^0.1.2",
         "@emailjs/browser": "^4.4.1",
@@ -3429,9 +3429,9 @@
       "license": "MIT"
     },
     "node_modules/@digitaltableteur/react": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.7.tgz",
-      "integrity": "sha512-YUj85SXbF+Uqrv92osAvNbcr2HgHLRMb0lhsFmMyoTYnmKEk7e2+2dY6JEEYz9h/mR8Vra+JvdwN22oDpg58NQ==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.8.tgz",
+      "integrity": "sha512-6NYlagICpiUBZ3yg28efGqUVnhr5ZAdvs8wtFW7Lr14gCZ7TfqZRlhQRfICAZ8MmXgIH/JmsDqfwprndz0MeOg==",
       "license": "UNLICENSED",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "@ai-sdk/openai": "^3.0.71",
     "@ai-sdk/react": "^3.0.207",
     "@calcom/embed-react": "^1.5.3",
-    "@digitaltableteur/react": "^0.1.7",
+    "@digitaltableteur/react": "^0.1.8",
     "@digitaltableteur/tokens": "^0.1.1",
     "@digitaltableteur/tokens-css": "^0.1.2",
     "@emailjs/browser": "^4.4.1",

--- a/providers/ToastProvider.tsx
+++ b/providers/ToastProvider.tsx
@@ -8,19 +8,12 @@ import React, {
   useRef,
   useState,
 } from "react";
-// Import Toast tone/position types and the ToastStack component from local
-// source (relative path, not the published barrel): the #1124 neutral tone is
-// added locally and ships to the package with this 0.1.8 republish, but until
-// that version is consumed the registry barrel's .d.ts lags the local ToastTone
-// (LanguageNotice passes tone:"neutral"). Flip both to "@digitaltableteur/react"
-// after the 0.1.8 consume; classified in check:package-registry-resolution.
-import type {
-  ToastTone,
-  ToastPosition,
-} from "../nextjs-app/shared/components/Toast/Toast";
-import ToastStack, {
+import {
+  ToastStack,
+  type ToastTone,
+  type ToastPosition,
   type ToastStackItem,
-} from "../nextjs-app/shared/components/ToastStack/ToastStack";
+} from "@digitaltableteur/react";
 import { ToastRuntimeProvider } from "../nextjs-app/shared/lib/toast";
 
 export interface ShowToastOptions {

--- a/scripts/design-system/check-package-registry-resolution.mjs
+++ b/scripts/design-system/check-package-registry-resolution.mjs
@@ -88,14 +88,6 @@ const ALLOWED_LOCAL_SHARED_IMPORTS = new Map([
     "toast runtime is LOCAL end-to-end (ToastStack + LanguageNotice read this instance); dual-provide if a package component ever calls useToast",
   ],
   [
-    "providers/ToastProvider.tsx :: ../nextjs-app/shared/components/Toast/Toast",
-    "ToastTone/ToastPosition: local source leads the published barrel until 0.1.8 ships the #1124 neutral tone (LanguageNotice passes tone:'neutral'); flip to @digitaltableteur/react after the 0.1.8 consume",
-  ],
-  [
-    "providers/ToastProvider.tsx :: ../nextjs-app/shared/components/ToastStack/ToastStack",
-    "ToastStack + ToastStackItem: presentational stack rides the same local source until the 0.1.8 consume ships it to the registry barrel; flip to @digitaltableteur/react then",
-  ],
-  [
     "app/components/LanguageNotice/LanguageNotice.tsx :: @/nextjs-app/shared/lib/toast",
     "reads the LOCAL toast instance mounted by providers/ToastProvider",
   ],


### PR DESCRIPTION
Post-publish consume of `@digitaltableteur/react@0.1.8` (published this session in #1128).

- Root app now depends on `^0.1.8`; lockfile resolves the registry tarball.
- Flips `ToastProvider` Toast/ToastStack imports from local source to `@digitaltableteur/react` (barrel now carries the #1124 neutral tone + ToastStack export) and removes the two temporary `ALLOWED_LOCAL_SHARED_IMPORTS` classifications.
- Re-trues AboutPageContent a11y-tree snapshots' react colophon `0.1.7 → 0.1.8` (12 files, one `definition` line each, zero strays; tokens `0.1.1`/`0.1.2` unchanged).

Verified locally (CI quota-dead): typecheck, lint, 2284 tests, build, check:react-registry-install, check:package-registry-resolution (16 classified, 0 pending), check:package-registry-status (0.1.8 published), check:storybook-registry-package, check:published-tokens-freshness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)