### PR TITLE
chore(app): consume @digitaltableteur/react@0.1.9 from the registry

### DIFF
--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.8
+  - definition: 0.1.9
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.8
+  - definition: 0.1.9
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.8
+  - definition: 0.1.9
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.8
+  - definition: 0.1.9
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.8
+  - definition: 0.1.9
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.8
+  - definition: 0.1.9
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.8
+  - definition: 0.1.9
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.8
+  - definition: 0.1.9
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.8
+  - definition: 0.1.9
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.8
+  - definition: 0.1.9
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.8
+  - definition: 0.1.9
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.8
+  - definition: 0.1.9
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ai-sdk/openai": "^3.0.71",
         "@ai-sdk/react": "^3.0.207",
         "@calcom/embed-react": "^1.5.3",
-        "@digitaltableteur/react": "^0.1.8",
+        "@digitaltableteur/react": "^0.1.9",
         "@digitaltableteur/tokens": "^0.1.1",
         "@digitaltableteur/tokens-css": "^0.1.2",
         "@emailjs/browser": "^4.4.1",
@@ -3429,9 +3429,9 @@
       "license": "MIT"
     },
     "node_modules/@digitaltableteur/react": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.8.tgz",
-      "integrity": "sha512-6NYlagICpiUBZ3yg28efGqUVnhr5ZAdvs8wtFW7Lr14gCZ7TfqZRlhQRfICAZ8MmXgIH/JmsDqfwprndz0MeOg==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.9.tgz",
+      "integrity": "sha512-WOiEWBVAkjV2lNgCmcFjcaYZn6osH6a51NZp6P5CHJIgmcrIi1F9A17B0rB7wbixWxiwlmij2X6zMIH+P3h4oA==",
       "license": "UNLICENSED",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "@ai-sdk/openai": "^3.0.71",
     "@ai-sdk/react": "^3.0.207",
     "@calcom/embed-react": "^1.5.3",
-    "@digitaltableteur/react": "^0.1.8",
+    "@digitaltableteur/react": "^0.1.9",
     "@digitaltableteur/tokens": "^0.1.1",
     "@digitaltableteur/tokens-css": "^0.1.2",
     "@emailjs/browser": "^4.4.1",


### PR DESCRIPTION
Post-publish consume of `@digitaltableteur/react@0.1.9` (published this session in #1130 — CodeSnippet aria-controls fix, NavLink current-page, new type exports).

- Root app now depends on `^0.1.9`; lockfile resolves the registry tarball.
- Re-trues AboutPageContent a11y-tree snapshots' react colophon `0.1.8 → 0.1.9` (12 files, one `definition` line each; tokens `0.1.1`/`0.1.2` unchanged).

Verified locally: typecheck, lint, 2292 tests, build, check:react-registry-install, check:package-registry-resolution, check:package-registry-status, check:storybook-registry-package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)