### PR TITLE
fix(NavLink): default cursor on the current-page indicator

### DIFF
--- a/nextjs-app/shared/components/NavLink/NavLink.tsx
+++ b/nextjs-app/shared/components/NavLink/NavLink.tsx
@@ -52,8 +52,12 @@ export function NavLink({
   );
 
   if (isActive && isSamePath) {
+    // The current-page item is a non-interactive location indicator, not a
+    // link: cursor-default (arrow) — never pointer (nothing to follow), text
+    // (the <span>'s default over its label; implies selectable prose), or
+    // not-allowed (overstates it as a blocked/disabled action).
     return (
-      <span className={linkClassName} aria-current="page">
+      <span className={cn(linkClassName, "cursor-default")} aria-current="page">
         {children}
       </span>
     );


### PR DESCRIPTION
The active same-path NavLink renders as a non-interactive `<span aria-current="page">`. Without an explicit cursor it showed the text/I-beam cursor (the span's default over its label), wrongly implying selectable prose.

`cursor-default` (arrow) is the correct signal for a current-location indicator: never `pointer` (nothing to follow) or `not-allowed` (overstates a current location as a blocked/disabled action). Matches Pagination's current-page treatment; applied to the span only, so the real `<a>` keeps its native pointer.

Not published — batches into the next react version bump per owner decision.

Verified: typecheck, lint, 2292 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Active navigation items are now clearly presented as non-interactive indicators.
  * Improved cursor behavior prevents users from treating the current page link as clickable.
  * Accessibility labeling for the current page remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->