### PR TITLE
feat(react): publish 0.1.10 — NavLink current-page default cursor

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.10 - 2026-07-12
+
+- `NavLink`: the active same-path current-page indicator (rendered as `<span aria-current="page">` since 0.1.9) now uses `cursor: default` instead of the browser's text/I-beam default over its label. It is a non-interactive location marker, so the arrow cursor is correct — not `pointer` (nothing to follow) or `not-allowed` (which would overstate a current location as a blocked action). The real `<a>` (inactive/other links) keeps its native pointer. No API change; runtime public API unchanged (113 exports).
+- Verified by the full local gate (typecheck, lint, 2292 tests, build) plus check:react-package, check:react-public-api, and check:react-public-surface (0 alpha).
+
 ## 0.1.9 - 2026-07-12
 
 - Fixes the `CodeSnippet` expand control's `aria-controls`: it previously read `codeRef.current?.id`, which is `undefined` on first render (the ref is not attached yet) and empty thereafter (the `<code>` had no `id`), so the "Show more"/"Show less" toggle referenced nothing. The `<code>` element now carries a stable `useId()`-based `id` and the control points at it (SSR/hydration-safe). Regression-tested.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/react",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": false,
   "description": "React components and host adapters for the Digitaltableteur design system.",
   "type": "module",

--- a/packages/react/public-api.manifest.json
+++ b/packages/react/public-api.manifest.json
@@ -1,6 +1,6 @@
 {
   "packageName": "@digitaltableteur/react",
-  "packageVersion": "0.1.9",
+  "packageVersion": "0.1.10",
   "packageExports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
Publishes `@digitaltableteur/react@0.1.10`, shipping the #1132 NavLink fix to the registry.

- The active same-path current-page indicator (a non-interactive `<span aria-current="page">` since 0.1.9) now uses `cursor: default` instead of the browser's text/I-beam default over its label. Not `pointer` (nothing to follow) or `not-allowed` (overstates a current location as blocked). The real `<a>` keeps its native pointer.
- No API change; runtime public API unchanged (113 exports).

Only package-source change since 0.1.9. Verified: typecheck, lint, 2292 tests, build, check:react-package, check:react-public-api, check:react-public-surface (0 alpha); preflight passes all pre-publish gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the current-page navigation indicator: active links now display the standard default cursor over their label.
  - Inactive navigation links continue to display the pointer cursor.

- **Documentation**
  - Added release notes for version 0.1.10.

- **Release**
  - Published React package version 0.1.10 with no runtime API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->