### PR TITLE
feat(design-system): chat/select/content type exports + semantic a11y tests

### DIFF
--- a/nextjs-app/shared/components/ChatWidget/ChatWidget.focus.test.tsx
+++ b/nextjs-app/shared/components/ChatWidget/ChatWidget.focus.test.tsx
@@ -10,6 +10,7 @@ describe("ChatWidget focus behavior", () => {
     const { getByRole, findByLabelText } = render(<ChatWidget />);
     const toggle = getByRole("button", { name: /chat with donny/i });
     fireEvent.click(toggle);
+    expect(getByRole("dialog")).toHaveAttribute("aria-modal", "false");
     const textarea = await findByLabelText(/ask donny a question/i);
     await waitFor(() => expect(textarea).toHaveFocus());
   });

--- a/nextjs-app/shared/components/ChatWidget/index.ts
+++ b/nextjs-app/shared/components/ChatWidget/index.ts
@@ -30,4 +30,7 @@ export {
   extractLastToolActivity,
   resolveToolAvatarState,
 } from "./chatAvatarState";
-export type { ChatErrorMessages } from "./ChatWidget";
+export type {
+  ChatErrorMessages,
+  ChatWidgetProps,
+} from "./ChatWidget";

--- a/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.test.tsx
+++ b/nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow.test.tsx
@@ -75,7 +75,9 @@ describe("CodeBlockWindow", () => {
     await user.click(button);
 
     await waitFor(() => {
-      expect(screen.getByText("Copied")).toBeInTheDocument();
+      const status = screen.getByRole("status");
+      expect(status).toHaveTextContent("Copied");
+      expect(status).toHaveAttribute("aria-live", "polite");
     });
   });
 

--- a/nextjs-app/shared/components/GroupLabel/index.ts
+++ b/nextjs-app/shared/components/GroupLabel/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./GroupLabel";
+export type { GroupLabelProps } from "./GroupLabel";

--- a/nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.test.tsx
+++ b/nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.test.tsx
@@ -4,10 +4,11 @@ import MarkdownMessage from "@dt/MarkdownMessage";
 
 describe("MarkdownMessage", () => {
   it("renders fallback when content empty", () => {
-    render(
+    const { container } = render(
       <MarkdownMessage content="" fallback="Loading…" data-role="assistant" />,
     );
     expect(screen.getByText("Loading…")).toBeInTheDocument();
+    expect(container.firstElementChild).toHaveAttribute("aria-live", "polite");
   });
 
   it("renders basic markdown (heading, list, code)", () => {

--- a/nextjs-app/shared/components/NextLayout/index.ts
+++ b/nextjs-app/shared/components/NextLayout/index.ts
@@ -1,1 +1,2 @@
 export { NextLayout } from "./NextLayout";
+export type { NextLayoutProps } from "./NextLayout";

--- a/nextjs-app/shared/components/Select/Select.test.tsx
+++ b/nextjs-app/shared/components/Select/Select.test.tsx
@@ -68,4 +68,26 @@ describe("Select", () => {
       onChange.mock.invocationCallOrder[0],
     );
   });
+
+  it("associates error and helper text with the invalid control", () => {
+    render(
+      <Select
+        label="Test Select"
+        options={options}
+        error="Choose a valid option"
+        helperText="This choice affects the result"
+        aria-describedby="external-description"
+      />,
+    );
+
+    const select = screen.getByRole("combobox");
+    const error = screen.getByText("Choose a valid option");
+    const helper = screen.getByText("This choice affects the result");
+    const describedBy = select.getAttribute("aria-describedby")?.split(" ");
+
+    expect(select).toHaveAttribute("aria-invalid", "true");
+    expect(describedBy).toEqual(
+      expect.arrayContaining([error.id, helper.id, "external-description"]),
+    );
+  });
 });

--- a/nextjs-app/shared/components/ThemeProvider/index.ts
+++ b/nextjs-app/shared/components/ThemeProvider/index.ts
@@ -1,3 +1,3 @@
 export { ThemeProvider, useTheme } from "./ThemeProvider";
 export { ThemeProvider as default } from "./ThemeProvider";
-export type { Theme } from "./ThemeProvider";
+export type { Theme, ThemeProviderProps } from "./ThemeProvider";

--- a/nextjs-app/shared/components/index.ts
+++ b/nextjs-app/shared/components/index.ts
@@ -53,13 +53,24 @@ export type {
 } from "./ComplianceCard";
 export { default as ContactForm } from "./ContactForm/ContactForm";
 export { default as ChatWidget } from "./ChatWidget/ChatWidget";
+export type {
+  ChatErrorMessages,
+  ChatWidgetProps,
+} from "./ChatWidget/ChatWidget";
 export { default as ChatHeader } from "./ChatWidget/ChatHeader";
+export type { ChatHeaderProps } from "./ChatWidget/ChatHeader";
 export { default as ChatMessages } from "./ChatWidget/ChatMessages";
+export type { ChatMessagesProps } from "./ChatWidget/ChatMessages";
 export { default as ChatComposer } from "./ChatWidget/ChatComposer";
+export type {
+  ChatComposerHandle,
+  ChatComposerProps,
+} from "./ChatWidget/ChatComposer";
 export { default as ChatToggle } from "./ChatWidget/ChatToggle";
 export { default as CookieConsent } from "./CookieConsent/CookieConsent";
 export type { CookieConsentProps } from "./CookieConsent";
 export { default as CodeBlockWindow } from "./CodeBlockWindow/CodeBlockWindow";
+export type { CodeBlockWindowProps } from "./CodeBlockWindow/CodeBlockWindow";
 export { Container, type ContainerProps } from "./Container";
 export {
   DonnyAvatar,
@@ -78,6 +89,7 @@ export type { GalleryProps } from "./Gallery";
 export { default as Grid } from "./Grid/Grid";
 export type { GridProps } from "./Grid/Grid";
 export { default as GroupLabel } from "./GroupLabel/GroupLabel";
+export type { GroupLabelProps } from "./GroupLabel/GroupLabel";
 export { default as Icon } from "./Icon/Icon";
 export type { IconProps } from "./Icon";
 export { default as HelsinkiClock } from "./HelsinkiClock/HelsinkiClock";
@@ -122,9 +134,11 @@ export type { MCPActionButtonProps } from "./MCPActionButton";
 export { default as NavMenuList } from "./NavMenuList/NavMenuList";
 export type { NavMenuItem, NavMenuListProps } from "./NavMenuList";
 export { default as MarkdownMessage } from "./MarkdownMessage/MarkdownMessage";
+export type { MarkdownMessageProps } from "./MarkdownMessage/MarkdownMessage";
 export { default as Modal } from "./Modal/Modal";
 export type { ModalProps, ModalSeverity } from "./Modal/Modal";
 export { NextLayout } from "./NextLayout";
+export type { NextLayoutProps } from "./NextLayout";
 export { default as OpenHours } from "./OpenHours/OpenHours";
 export { default as PersonCard } from "./PersonCard/PersonCard";
 export { default as PhoneInput } from "./PhoneInput/PhoneInput";
@@ -136,6 +150,7 @@ export {
   type SegmentedControlItem,
 } from "./SegmentedControl";
 export { default as Select } from "./Select/Select";
+export type { SelectOptionItem, SelectProps } from "./Select/Select";
 export { default as SelectOption } from "./Select/SelectOption";
 export { default as ServicesGrid } from "./ServicesGrid/ServicesGrid";
 export { default as SiteTree } from "./SiteTree";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -53,6 +53,7 @@ export type { CheckboxProps } from "../../../nextjs-app/shared/components/Checkb
 export { default as CheckboxGroup } from "../../../nextjs-app/shared/components/CheckboxGroup/CheckboxGroup";
 export type { CheckboxGroupProps } from "../../../nextjs-app/shared/components/CheckboxGroup/CheckboxGroup";
 export { default as CodeBlockWindow } from "../../../nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow";
+export type { CodeBlockWindowProps } from "../../../nextjs-app/shared/components/CodeBlockWindow/CodeBlockWindow";
 export { default as CodeSnippet } from "../../../nextjs-app/shared/components/CodeSnippet/CodeSnippet";
 export type {
   CodeSnippetProps,
@@ -116,6 +117,7 @@ export type { GalleryProps } from "../../../nextjs-app/shared/components/Gallery
 export { default as Grid } from "../../../nextjs-app/shared/components/Grid/Grid";
 export type { GridProps } from "../../../nextjs-app/shared/components/Grid/Grid";
 export { default as GroupLabel } from "../../../nextjs-app/shared/components/GroupLabel/GroupLabel";
+export type { GroupLabelProps } from "../../../nextjs-app/shared/components/GroupLabel/GroupLabel";
 export { default as HelperText } from "../../../nextjs-app/shared/components/HelperText/HelperText";
 export type {
   HelperTextProps,


### PR DESCRIPTION
Codex/AlphaEvolve batch, reviewed and verified.

- Type-only exports: `GroupLabelProps` + `CodeBlockWindowProps` reach the react package (both are package-territory runtime exports already); ChatWidget family, `MarkdownMessageProps`, `NextLayoutProps`, `ThemeProviderProps`, `SelectProps`/`SelectOptionItem` stay DS-barrel-only — app/product surfaces remain outside the curated package boundary. **Runtime API unchanged (113).**
- Semantic tests: ChatWidget dialog `aria-modal=false`, CodeBlockWindow copy feedback `role=status`+`aria-live=polite`, MarkdownMessage fallback `aria-live`, Select merged `aria-describedby` (error + helper + external id) with `aria-invalid`.
- No contract/manifest changes; no repo tampering (settings/excludes clean).

Verified locally (CI quota-dead): typecheck, lint (2 pre-existing ToastStack warnings), 2295 tests, build, check:react-package, check:react-public-api, check:react-public-surface (0 alpha).

Not published: types-only package delta, batches into 0.1.11 with #1135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)