### PR TITLE
chore(work): consume CategoryFilter, Container, Section from the registry

### DIFF
--- a/nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx
@@ -2,10 +2,8 @@
 
 import React, { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Container } from "../../../../components/Container";
-import { Section } from "../../../../components/Section";
+import { CategoryFilter, Container, Section } from "@digitaltableteur/react";
 import { WorkHero } from "../../../../patterns/WorkHero";
-import { CategoryFilter } from "../../../../components/CategoryFilter";
 import { WorkGrid } from "../../../../components/WorkGrid";
 import { FadeIn } from "../../../../components/animations/FadeIn";
 import {


### PR DESCRIPTION
WorkIndexPage flip: three published components move from relative imports to `@digitaltableteur/react`. CategoryFilter gains its first registry consumer (metric 18→19). Verified: typecheck, tests, resolution guard, live /work interaction check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)