### PR TITLE
feat(react): publish 0.1.11 — pattern rung (PageLayout, ProcessBlock) + accumulated type exports

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.11 - 2026-07-13
+
+- Re-establishes the pattern rung: `PageLayout` and `ProcessBlock` are the first composite patterns exported from the package (runtime public API 113 → 115, both stable contracts, zero-alpha surface ceiling holds). ProcessBlock's own imports move off the published barrel onto package-internal source per the same-module-instance rule.
+- Type-only export alignment accumulated since 0.1.10: `TextProps`, `LinkProps`, `ListProps`, `GridProps`, `FlexBoxProps`, `CodeBlockWindowProps`, `GroupLabelProps` now ship in the d.ts.
+- Accessibility regression coverage added across Divider (semantic `aria-orientation`), ImagePlaceholder (decorative icon hidden), CodeBlockWindow (copy feedback as `role=status` live region), Select (merged `aria-describedby` with external ids), MarkdownMessage (fallback announcement), and ChatWidget dialog modality (DS-internal).
+- Verified by the full local gate (typecheck, lint, 2295 tests, build) plus check:react-package, check:react-public-api, check:react-public-surface (0 alpha), and check:astryx-roadmap (no next/* imports in package source).
+
 ## 0.1.10 - 2026-07-12
 
 - `NavLink`: the active same-path current-page indicator (rendered as `<span aria-current="page">` since 0.1.9) now uses `cursor: default` instead of the browser's text/I-beam default over its label. It is a non-interactive location marker, so the arrow cursor is correct — not `pointer` (nothing to follow) or `not-allowed` (which would overstate a current location as a blocked action). The real `<a>` (inactive/other links) keeps its native pointer. No API change; runtime public API unchanged (113 exports).

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/react",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": false,
   "description": "React components and host adapters for the Digitaltableteur design system.",
   "type": "module",

--- a/packages/react/public-api.manifest.json
+++ b/packages/react/public-api.manifest.json
@@ -1,6 +1,6 @@
 {
   "packageName": "@digitaltableteur/react",
-  "packageVersion": "0.1.10",
+  "packageVersion": "0.1.11",
   "packageExports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
Version bump for the 0.1.11 release: #1138 pattern exports (runtime 113→115), #1135/#1136 type-only alignment, a11y regression coverage. Preflight passes all pre-publish gates (post-publish registry-status E404 expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restored public access to the `PageLayout` and `ProcessBlock` components.
  * Improved availability of component prop types in published TypeScript declarations.
* **Bug Fixes**
  * Improved accessibility behavior and ARIA attribute handling across several components, including dialogs.
* **Release**
  * Updated the React package to version 0.1.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->