### PR TITLE
feat(design-system): Grid wide/ultra breakpoint rungs

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-07-13T08:01:50.491Z",
+  "createdAt": "2026-07-13T08:29:53.137Z",
   "directory": "nextjs-app/shared",
   "findings": [
     {
@@ -2695,8 +2695,8 @@
     {
       "column": 8,
       "file": "nextjs-app/shared/components/Grid/Grid.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Grid/Grid.module.css\u001f41\u001f8\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 41,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Grid/Grid.module.css\u001f74\u001f8\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 74,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -2705,8 +2705,8 @@
     {
       "column": 12,
       "file": "nextjs-app/shared/components/Grid/Grid.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Grid/Grid.module.css\u001f46\u001f12\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 46,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/Grid/Grid.module.css\u001f79\u001f12\u001f1rem\u001fUnexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 79,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"1rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",

--- a/nextjs-app/shared/components/Grid/Grid.contract.json
+++ b/nextjs-app/shared/components/Grid/Grid.contract.json
@@ -92,6 +92,14 @@
             "optional": true,
             "type": "number | string"
         },
+        "wideColumns": {
+            "optional": true,
+            "type": "number | string"
+        },
+        "ultraColumns": {
+            "optional": true,
+            "type": "number | string"
+        },
         "rows": {
             "optional": true,
             "type": "number | string"
@@ -105,6 +113,14 @@
             "type": "string"
         },
         "desktopGap": {
+            "optional": true,
+            "type": "string"
+        },
+        "wideGap": {
+            "optional": true,
+            "type": "string"
+        },
+        "ultraGap": {
             "optional": true,
             "type": "string"
         },

--- a/nextjs-app/shared/components/Grid/Grid.module.css
+++ b/nextjs-app/shared/components/Grid/Grid.module.css
@@ -4,12 +4,13 @@
   grid-auto-rows: minmax(6.25rem, auto); /* Converted 100px to rem */
 }
 
-/* Per-breakpoint column/gap resolution for tabletColumns/desktopColumns and
-   tabletGap/desktopGap. Values arrive as CSS custom properties set inline by
-   Grid.tsx; each breakpoint falls back through the previous one. Breakpoints
-   mirror --breakpoint-tablet (768px) and --breakpoint-desktop (1024px) from
-   variables.css — media queries cannot read custom properties, so the values
-   are repeated here. */
+/* Per-breakpoint column/gap resolution for the responsive props
+   (tablet/desktop/wide/ultra Columns and Gaps). Values arrive as CSS custom
+   properties set inline by Grid.tsx; each breakpoint falls back through the
+   previous one. Breakpoints mirror --breakpoint-tablet (768px),
+   --breakpoint-desktop (1024px), --breakpoint-wide (1440px) and
+   --breakpoint-ultra (1920px) from variables.css — media queries cannot read
+   custom properties, so the values are repeated here. */
 
 .responsive {
   grid-template-columns: var(--grid-cols);
@@ -30,6 +31,38 @@
       var(--grid-cols-tablet, var(--grid-cols))
     );
     gap: var(--grid-gap-desktop, var(--grid-gap-tablet, var(--grid-gap)));
+  }
+}
+
+@media (width >= 1440px) {
+  .responsive {
+    grid-template-columns: var(
+      --grid-cols-wide,
+      var(--grid-cols-desktop, var(--grid-cols-tablet, var(--grid-cols)))
+    );
+    gap: var(
+      --grid-gap-wide,
+      var(--grid-gap-desktop, var(--grid-gap-tablet, var(--grid-gap)))
+    );
+  }
+}
+
+@media (width >= 1920px) {
+  .responsive {
+    grid-template-columns: var(
+      --grid-cols-ultra,
+      var(
+        --grid-cols-wide,
+        var(--grid-cols-desktop, var(--grid-cols-tablet, var(--grid-cols)))
+      )
+    );
+    gap: var(
+      --grid-gap-ultra,
+      var(
+        --grid-gap-wide,
+        var(--grid-gap-desktop, var(--grid-gap-tablet, var(--grid-gap)))
+      )
+    );
   }
 }
 

--- a/nextjs-app/shared/components/Grid/Grid.stories.tsx
+++ b/nextjs-app/shared/components/Grid/Grid.stories.tsx
@@ -166,15 +166,25 @@ export const SpannedFeature: Story = {
   ),
 };
 
-/** Per-breakpoint columns and gaps — one column on mobile, two from tablet, three from desktop. */
+/** Per-breakpoint columns and gaps — one column on mobile, two from tablet, three from desktop, four from wide, six from ultra. */
 export const ResponsiveColumns: Story = {
   tags: ["example"],
   parameters: {
     controls: { disable: true },
-    docs: { description: { story: "Per-breakpoint columns and gaps: tabletColumns/desktopColumns and tabletGap/desktopGap resolve at the design-token breakpoints (768px / 1024px), falling back through the previous breakpoint. Resize the viewport to see the tracks change. Numeric responsive counts render as minmax(0, 1fr) tracks so cells can shrink below content width." } },
+    docs: { description: { story: "Per-breakpoint columns and gaps: tabletColumns/desktopColumns/wideColumns/ultraColumns and the matching Gap props resolve at the design-token breakpoints (768 / 1024 / 1440 / 1920px), each falling back through the previous rung. Resize the viewport to see the tracks change. Numeric responsive counts render as minmax(0, 1fr) tracks so cells can shrink below content width." } },
   },
   render: () => (
-    <Grid columns={1} tabletColumns={2} desktopColumns={3} gap="1.25rem" tabletGap="2rem" desktopGap="2.5rem">
+    <Grid
+      columns={1}
+      tabletColumns={2}
+      desktopColumns={3}
+      wideColumns={4}
+      ultraColumns={6}
+      gap="1.25rem"
+      tabletGap="2rem"
+      desktopGap="2.5rem"
+      wideGap="3rem"
+    >
       {Array.from({ length: 6 }, (_, i) => (
         <div key={i} style={{ border: "1px dashed var(--color-border, #999)", padding: "1rem", textAlign: "center" }}>
           Cell {i + 1}

--- a/nextjs-app/shared/components/Grid/Grid.test.tsx
+++ b/nextjs-app/shared/components/Grid/Grid.test.tsx
@@ -67,6 +67,47 @@ describe("Grid", () => {
     expect(grid.style.gap).toBe("");
   });
 
+  it("resolves the wide and ultra breakpoint rungs", () => {
+    const { container } = render(
+      <Grid
+        columns={1}
+        tabletColumns={2}
+        desktopColumns={3}
+        wideColumns={4}
+        ultraColumns={6}
+        wideGap="3rem"
+        ultraGap="4rem"
+      >
+        <div>Item</div>
+      </Grid>,
+    );
+    const grid = container.firstChild as HTMLElement;
+    expect(grid.style.getPropertyValue("--grid-cols-wide")).toBe(
+      "repeat(4, minmax(0, 1fr))",
+    );
+    expect(grid.style.getPropertyValue("--grid-cols-ultra")).toBe(
+      "repeat(6, minmax(0, 1fr))",
+    );
+    expect(grid.style.getPropertyValue("--grid-gap-wide")).toBe("3rem");
+    expect(grid.style.getPropertyValue("--grid-gap-ultra")).toBe("4rem");
+  });
+
+  it("enters the responsive path when only a wide/ultra prop is set", () => {
+    const { container } = render(
+      <Grid columns={2} wideColumns={4}>
+        <div>Item</div>
+      </Grid>,
+    );
+    const grid = container.firstChild as HTMLElement;
+    expect(grid.style.getPropertyValue("--grid-cols")).toBe(
+      "repeat(2, minmax(0, 1fr))",
+    );
+    expect(grid.style.getPropertyValue("--grid-cols-wide")).toBe(
+      "repeat(4, minmax(0, 1fr))",
+    );
+    expect(grid.style.gridTemplateColumns).toBe("");
+  });
+
   it("accepts template strings for responsive columns", () => {
     const { container } = render(
       <Grid columns="1fr" desktopColumns="200px 1fr">

--- a/nextjs-app/shared/components/Grid/Grid.tsx
+++ b/nextjs-app/shared/components/Grid/Grid.tsx
@@ -18,6 +18,12 @@ export interface GridProps {
   /** Columns from the desktop breakpoint (1024px) up. Falls back to
    * tabletColumns, then columns. */
   desktopColumns?: number | string;
+  /** Columns from the wide breakpoint (1440px) up. Falls back through
+   * desktopColumns, tabletColumns, columns. */
+  wideColumns?: number | string;
+  /** Columns from the ultra breakpoint (1920px) up. Falls back through
+   * wideColumns, desktopColumns, tabletColumns, columns. */
+  ultraColumns?: number | string;
   /** Row count or grid-template-rows string. */
   rows?: number | string;
   /** Grid gap. @default "1rem" */
@@ -27,6 +33,12 @@ export interface GridProps {
   /** Gap from the desktop breakpoint (1024px) up. Falls back to tabletGap,
    * then gap. */
   desktopGap?: string;
+  /** Gap from the wide breakpoint (1440px) up. Falls back through desktopGap,
+   * tabletGap, gap. */
+  wideGap?: string;
+  /** Gap from the ultra breakpoint (1920px) up. Falls back through wideGap,
+   * desktopGap, tabletGap, gap. */
+  ultraGap?: string;
   /** Row gap override. */
   rowGap?: string;
   /** Column gap override. */
@@ -61,10 +73,14 @@ function Grid({
   columns = 1,
   tabletColumns,
   desktopColumns,
+  wideColumns,
+  ultraColumns,
   rows,
   gap = "1rem",
   tabletGap,
   desktopGap,
+  wideGap,
+  ultraGap,
   rowGap,
   colGap,
   align,
@@ -104,8 +120,12 @@ function Grid({
   const isResponsive =
     tabletColumns != null ||
     desktopColumns != null ||
+    wideColumns != null ||
+    ultraColumns != null ||
     tabletGap != null ||
-    desktopGap != null;
+    desktopGap != null ||
+    wideGap != null ||
+    ultraGap != null;
 
   // Responsive tracks use minmax(0, 1fr) so cells can shrink below their
   // content's intrinsic width (matches utility-grid column behavior).
@@ -123,9 +143,17 @@ function Grid({
           ...(desktopColumns != null && {
             "--grid-cols-desktop": toTemplate(desktopColumns),
           }),
+          ...(wideColumns != null && {
+            "--grid-cols-wide": toTemplate(wideColumns),
+          }),
+          ...(ultraColumns != null && {
+            "--grid-cols-ultra": toTemplate(ultraColumns),
+          }),
           "--grid-gap": gap,
           ...(tabletGap != null && { "--grid-gap-tablet": tabletGap }),
           ...(desktopGap != null && { "--grid-gap-desktop": desktopGap }),
+          ...(wideGap != null && { "--grid-gap-wide": wideGap }),
+          ...(ultraGap != null && { "--grid-gap-ultra": ultraGap }),
         } as CSSProperties)
       : {
           gridTemplateColumns:

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-13T08:13:34.046Z",
+  "generatedAt": "2026-07-13T08:26:10.489Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -4242,6 +4242,14 @@
           "optional": true,
           "type": "number | string"
         },
+        "wideColumns": {
+          "optional": true,
+          "type": "number | string"
+        },
+        "ultraColumns": {
+          "optional": true,
+          "type": "number | string"
+        },
         "rows": {
           "optional": true,
           "type": "number | string"
@@ -4255,6 +4263,14 @@
           "type": "string"
         },
         "desktopGap": {
+          "optional": true,
+          "type": "string"
+        },
+        "wideGap": {
+          "optional": true,
+          "type": "string"
+        },
+        "ultraGap": {
           "optional": true,
           "type": "string"
         },
@@ -4380,7 +4396,7 @@
         "Avatar"
       ],
       "prefersOver": [],
-      "declaredPropCount": 14
+      "declaredPropCount": 18
     },
     "GroupLabel": {
       "preferredImport": "@dt/GroupLabel",

--- a/scripts/design-system/dogfood-ratchet.baseline.json
+++ b/scripts/design-system/dogfood-ratchet.baseline.json
@@ -397,10 +397,6 @@
       "rawElements": 1,
       "utilityLines": 14
     },
-    "nextjs-app/shared/components/WorkGrid/WorkGrid.tsx": {
-      "rawElements": 0,
-      "utilityLines": 1
-    },
     "nextjs-app/shared/components/animations/KineticTitle/KineticTitle.tsx": {
       "rawElements": 0,
       "utilityLines": 2


### PR DESCRIPTION
Owner-directed completion of the responsive scale: `wideColumns`/`ultraColumns` + `wideGap`/`ultraGap` at the 1440/1920 token breakpoints, full fallback chain (ultra→wide→desktop→tablet→base). Live-verified at 1500px (4 cols) and 1950px (6 cols, ultraGap falls back to wideGap). 2295 tests green; AT snapshots unchanged; dogfood-ratchet DECREASE from the WorkGrid dissolution locked in (154 files / 698 utility lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)