### PR TITLE
refactor(design-system): rebuild ServicesGrid on the DS Grid atom

### DIFF
--- a/nextjs-app/shared/components/Grid/Grid.contract.json
+++ b/nextjs-app/shared/components/Grid/Grid.contract.json
@@ -60,6 +60,11 @@
     "consumers": [
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/layout.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
             "since": "2026-06-04"
         },

--- a/nextjs-app/shared/components/ServiceCard/ServiceCard.contract.json
+++ b/nextjs-app/shared/components/ServiceCard/ServiceCard.contract.json
@@ -115,7 +115,7 @@
     },
     "forbiddenUse": [
         "Use for a value or principle without a link/CTA — that is ValueCard.",
-        "Place outside a ServicesGrid; the tile is sized and gapped by that grid."
+        "Place outside the ServicesSection grid; the tile is sized and gapped by that section."
     ],
     "displayName": "ServiceCard",
     "keywords": [
@@ -126,6 +126,6 @@
     ],
     "dense": "Service tile: icon, title, description, optional link; services-grid unit",
     "usage": {
-        "description": "Tile for one service offering — icon, title, short description, optional link. Renders inside ServicesGrid."
+        "description": "Tile for one service offering — icon, title, short description, optional link. Renders inside the ServicesSection pattern's grid."
     }
 }

--- a/nextjs-app/shared/components/ServicesGrid/ServicesGrid.contract.json
+++ b/nextjs-app/shared/components/ServicesGrid/ServicesGrid.contract.json
@@ -28,7 +28,9 @@
     },
     "tokens": {
         "colors": [],
-        "spacing": []
+        "spacing": [
+            "--space-internal-16"
+        ]
     },
     "lightDarkVerified": true,
     "consumers": [],

--- a/nextjs-app/shared/components/ServicesGrid/ServicesGrid.module.css
+++ b/nextjs-app/shared/components/ServicesGrid/ServicesGrid.module.css
@@ -1,10 +1,10 @@
+/* Panel chrome only; the 2-column track and gap come from the DS Grid
+   component this class is applied to. */
+
 .root {
-  display: grid;
   padding: var(--space-internal-16);
   box-sizing: border-box;
   height: 100%;
-  grid-template-columns: repeat(2, 1fr);
-  gap: var(--space-internal-16);
   border-radius: var(--radius-medium);
   background: var(--color-surface);
 }

--- a/nextjs-app/shared/components/ServicesGrid/ServicesGrid.module.css
+++ b/nextjs-app/shared/components/ServicesGrid/ServicesGrid.module.css
@@ -5,7 +5,7 @@
   padding: var(--space-internal-16);
   box-sizing: border-box;
   height: 100%;
-  border-radius: var(--radius-medium);
+  border-radius: var(--radius-md);
   background: var(--color-surface);
 }
 
@@ -26,7 +26,7 @@
   justify-content: center;
   align-items: center;
   gap: 1rem; /* 1rem gap between icon and title */
-  border-radius: var(--radius-small);
+  border-radius: var(--radius-sm);
   background: var(--color-elevation-1);
   text-align: center;
 }
@@ -38,7 +38,7 @@
   flex-shrink: 0;
   justify-content: center;
   align-items: center;
-  border-radius: var(--radius-small);
+  border-radius: var(--radius-sm);
   background: transparent;
   font-size: clamp(1.75rem, 4vw, 2rem); /* 28px -> 1.75rem, 32px -> 2rem */
   color: var(--color-primary);

--- a/nextjs-app/shared/components/ServicesGrid/ServicesGrid.tsx
+++ b/nextjs-app/shared/components/ServicesGrid/ServicesGrid.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Grid } from "@digitaltableteur/react";
 import styles from "./ServicesGrid.module.css";
 import { useTranslate } from "../../lib/translation";
 import Icon from "@dt/Icon";
@@ -25,7 +26,14 @@ export const ServicesGrid: React.FC<ServicesGridProps> = ({ className }) => {
 
   return (
     <div className={[styles.fillVertical, className].filter(Boolean).join(" ")}>
-      <div className={styles.root} data-testid="services-grid">
+      {/* DS Grid owns the 2-column track and gap (component tribunal:
+          layout = Grid); the module class keeps the panel chrome only. */}
+      <Grid
+        className={styles.root}
+        columns={2}
+        gap="var(--space-internal-16)"
+        data-testid="services-grid"
+      >
         <span className={styles.gridLabel} aria-hidden="true">
           {ariaLabel}
         </span>
@@ -46,7 +54,7 @@ export const ServicesGrid: React.FC<ServicesGridProps> = ({ className }) => {
             <div className={styles.title}>{titles[idx]}</div>
           </div>
         ))}
-      </div>
+      </Grid>
     </div>
   );
 };

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-13T09:00:57.891Z",
+  "generatedAt": "2026-07-13T09:13:35.743Z",
   "summary": {
     "componentCount": 162,
     "statusCounts": {
@@ -25199,7 +25199,7 @@
         },
         "forbiddenUse": [
           "Use for a value or principle without a link/CTA — that is ValueCard.",
-          "Place outside a ServicesGrid; the tile is sized and gapped by that grid."
+          "Place outside the ServicesSection grid; the tile is sized and gapped by that section."
         ],
         "displayName": "ServiceCard",
         "keywords": [
@@ -25210,7 +25210,7 @@
         ],
         "dense": "Service tile: icon, title, description, optional link; services-grid unit",
         "usage": {
-          "description": "Tile for one service offering — icon, title, short description, optional link. Renders inside ServicesGrid."
+          "description": "Tile for one service offering — icon, title, short description, optional link. Renders inside the ServicesSection pattern's grid."
         }
       },
       "spec": "# ServiceCard\n\n## Intent\nDocuments how **ServiceCard** is used in production layouts and Storybook examples.\n\n## Interaction contract\n- Keyboard: See **Playground** / **Example** stories and component tests.\n- Pointer: Standard click/tap on interactive affordances.\n- Screen readers: Verify labels, roles, and live regions in stories.\n\n## Do / don't\n- Do: Match the **Example** story composition on ServiceCard pages.\n- Don't: Bypass design tokens or skip forced-colors verification at beta.\n\n## Design notes\n- Tokens: Uses semantic colors/spacing from `variables.css`.\n- Figma: Linked from the component contract `figma` URL.\n",

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -12174,10 +12174,10 @@
       "prefersOver": [],
       "forbiddenUse": [
         "Use for a value or principle without a link/CTA — that is ValueCard.",
-        "Place outside a ServicesGrid; the tile is sized and gapped by that grid."
+        "Place outside the ServicesSection grid; the tile is sized and gapped by that section."
       ],
       "usage": {
-        "description": "Tile for one service offering — icon, title, short description, optional link. Renders inside ServicesGrid."
+        "description": "Tile for one service offering — icon, title, short description, optional link. Renders inside the ServicesSection pattern's grid."
       },
       "tokens": {
         "colors": [],


### PR DESCRIPTION
## Component tribunal — case 4: ServicesGrid → REBUILT ON ATOMS

Per the grid-family docket: unlike WorkGrid/BlogGrid this one keeps its component identity (real consumer, bespoke tile visuals = Donny chat furniture), but stops re-rolling the Grid atom's job.

**Evidence:** beta organism whose only render site is Donny's chat (`ChatMessageBubble` interleaves it on the `[[servicesGrid]]` token or a services heuristic). Its module CSS hand-rolled `display: grid; grid-template-columns: repeat(2, 1fr); gap: var(--space-internal-16)`.

**Changes**
1. **Grid rebuild:** the DS `Grid` (registry import from `@digitaltableteur/react` — ServicesGrid is forbidden-listed/app-side, not compiled into the package) now owns the 2-column track and gap; `.root` keeps panel chrome only (padding, radius, surface). Byte-parity verified live in chat: 2 equal tracks, 16px gap, 4 tiles, 110px tile min-height.
2. **Phantom-token fix (found during verification):** `--radius-medium`/`--radius-small` don't exist in `variables.css` (scale is `--radius-sm/md/lg`), so the authored rounding always computed 0px in chat. Mapped to real tokens; chat now renders panel 4px / tiles 2px, browser-verified. Separate commit, revertable independently.
3. ServiceCard contract prose drift corrected (claimed it renders inside ServicesGrid; it renders in the ServicesSection pattern).
4. `--space-internal-16` declared in the contract (token moved from CSS into the Grid gap prop); Grid contract consumer list + foundation dist regenerated.

**Verification:** live in the Donny chat widget (services question → grid part): tracks `199px 199px`, gap 16px, radii 4px/2px, all four tiles (Design / Development / Strategy / AI Innovation).

**Local gate:** typecheck ✅ lint ✅ vitest 2290 ✅ build ✅ check:contract-props ✅ check:consumers ✅ validate:components ✅ dogfood-ratchet holds ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)