### PR TITLE
chore(design-system): drop dead WorkGrid references (case 1 tail)

### DIFF
--- a/nextjs-app/shared/components/CategoryFilter/CategoryFilter.contract.json
+++ b/nextjs-app/shared/components/CategoryFilter/CategoryFilter.contract.json
@@ -130,8 +130,7 @@
     "composesWith": [
         "Container",
         "Section",
-        "WorkHero",
-        "WorkGrid"
+        "WorkHero"
     ],
     "displayName": "CategoryFilter",
     "keywords": [

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-13T09:13:35.743Z",
+  "generatedAt": "2026-07-13T09:27:24.070Z",
   "summary": {
     "componentCount": 162,
     "statusCounts": {
@@ -5591,8 +5591,7 @@
         "composesWith": [
           "Container",
           "Section",
-          "WorkHero",
-          "WorkGrid"
+          "WorkHero"
         ],
         "displayName": "CategoryFilter",
         "keywords": [
@@ -13440,6 +13439,11 @@
         },
         "lightDarkVerified": true,
         "consumers": [
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/layout.tsx",
+            "since": "2026-06-04"
+          },
           {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
@@ -25346,7 +25350,9 @@
         },
         "tokens": {
           "colors": [],
-          "spacing": []
+          "spacing": [
+            "--space-internal-16"
+          ]
         },
         "lightDarkVerified": true,
         "consumers": [],

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -2723,8 +2723,7 @@
       "composesWith": [
         "Container",
         "Section",
-        "WorkHero",
-        "WorkGrid"
+        "WorkHero"
       ],
       "prefersOver": [],
       "forbiddenUse": [
@@ -12227,7 +12226,9 @@
       },
       "tokens": {
         "colors": [],
-        "spacing": []
+        "spacing": [
+          "--space-internal-16"
+        ]
       },
       "examples": []
     },

--- a/scripts/design-system/audit-controls.mjs
+++ b/scripts/design-system/audit-controls.mjs
@@ -36,9 +36,6 @@ const EFFECT_EXEMPT = {
     FormFieldEditorial: {
         children: 'the <option> list feeds the select-mode Combobox popover, which is closed in the static canvas — swapping the preset changes options that only render once the popover opens; verified by the select-variant unit test (open popover → pick option → onChange payload) and the Playground mapping presets',
     },
-    WorkGrid: {
-        animateItems: 'scroll-triggered GSAP entrance stagger — only fires on scroll into view, so it has no stable DOM signature in the static effect probe (and is gated by the AnimationProvider motion preference); stories seed it off for a settled, deterministic grid, verified by the reduced-motion guard in the component',
-    },
     BlogMediaImage: {
         fit: 'object-fit class only applies in fill mode; the Playground renders inline (fill=false) so it is inert there; verified by the FillContain story and the fill-mode cover/contain unit tests',
     },

--- a/scripts/design-system/catalog-backfill.mjs
+++ b/scripts/design-system/catalog-backfill.mjs
@@ -237,13 +237,6 @@ const BACKFILL = [
     description: "Prev/next navigation for case studies.",
   },
   {
-    name: "WorkGrid",
-    root: "components",
-    tier: "organism",
-    group: "content",
-    description: "Portfolio work index grid.",
-  },
-  {
     name: "WorkNav",
     root: "components",
     tier: "molecule",


### PR DESCRIPTION
Tail cleanup from component tribunal case 1 (WorkGrid dissolved in #1142). Three inert references to the deleted component removed:

- `CategoryFilter.contract.json`: `WorkGrid` dropped from `composesWith` (dead name in an authored contract)
- `scripts/design-system/audit-controls.mjs`: WorkGrid controls-audit exemption entry removed
- `scripts/design-system/catalog-backfill.mjs`: WorkGrid catalog entry removed

`figma-component-index.json` intentionally keeps its WorkGrid entry: it is generated from the Figma file by `audit-figma-components.mjs`, and the WorkGrid node still exists in Figma.

Agent blocks and foundation dist regenerated; docs-registry snapshot re-checked post-build:tokens (unchanged).

**Local gate:** typecheck ✅ lint ✅ vitest 2290 ✅ build ✅ check:contract-props ✅ check:consumers ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)