### PR TITLE
feat(design-system): Grid evolve batch — GridItem surface, CSS rung locks, doc contracts

### DIFF
--- a/nextjs-app/shared/components/Grid/Grid.contract.json
+++ b/nextjs-app/shared/components/Grid/Grid.contract.json
@@ -4,7 +4,7 @@
     "tier": "atom",
     "group": "layout",
     "status": "stable",
-    "description": "CSS grid layout primitive with tokenized gaps.",
+    "description": "CSS grid layout primitive with scalar and token-breakpoint responsive columns and gaps.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1177-1654",
     "radixPrimitive": null,
     "element": "div",
@@ -35,7 +35,12 @@
     },
     "slots": [],
     "asChild": false,
-    "subParts": [],
+    "subParts": [
+        {
+            "name": "GridItem",
+            "element": "div"
+        }
+    ],
     "requiredStories": [
         "Default",
         "Playground",
@@ -238,9 +243,9 @@
         "grid item",
         "two dimensional"
     ],
-    "dense": "CSS-grid wrapper: numeric columns for equal tracks or template strings; gap/rowGap/colGap strings; Grid.Item adds span/rowSpan; extra grid CSS props pass through via style",
+    "dense": "CSS-grid wrapper with scalar or 768/1024/1440/1920 responsive columns and gaps; numeric responsive tracks use minmax(0, 1fr); Grid.Item adds spans",
     "usage": {
-        "description": "Grid is the two-dimensional layout primitive: pass `columns` as a number for equal tracks or a template string for custom ones, gaps as CSS strings (prefer space tokens), and wrap children needing to span in `Grid.Item` with `span`/`rowSpan`. Reach for it when both axes matter — card walls, media mosaics, dashboard modules; single-axis flows are Stack/FlexBox territory.",
+        "description": "Grid is the two-dimensional layout primitive: pass `columns` as a number for equal tracks or a template string for custom ones, then add `tabletColumns`/`desktopColumns`/`wideColumns`/`ultraColumns` and matching gap props when the layout changes at the 768/1024/1440/1920 token breakpoints. Sparse responsive values inherit through the previous rung, and numeric responsive tracks use `minmax(0, 1fr)`. Wrap children needing to span in `Grid.Item` with `span`/`rowSpan`; use Stack or FlexBox when only one axis matters.",
         "bestPractices": [
             {
                 "guidance": true,
@@ -253,6 +258,10 @@
             {
                 "guidance": true,
                 "description": "Set gaps with space tokens (\"var(--space-layout-24)\") so grid gutters follow the page rhythm."
+            },
+            {
+                "guidance": true,
+                "description": "Set only the responsive rungs that change; omitted tablet, desktop, wide, or ultra values inherit through the previous rung."
             },
             {
                 "guidance": true,

--- a/nextjs-app/shared/components/Grid/Grid.spec.md
+++ b/nextjs-app/shared/components/Grid/Grid.spec.md
@@ -1,17 +1,39 @@
 # Grid
 
 ## Intent
-Documents how **Grid** is used in production layouts and Storybook examples.
+
+Use **Grid** for two-dimensional layouts whose rows and columns both matter.
+Numeric columns create equal tracks; template strings describe asymmetric
+tracks. Use Stack or FlexBox for single-axis flow.
 
 ## Interaction contract
-- Keyboard: See **Playground** / **Example** stories and component tests.
-- Pointer: Standard click/tap on interactive affordances.
-- Screen readers: Verify labels, roles, and live regions in stories.
+
+- Grid adds no interaction or ARIA semantics of its own.
+- DOM order remains the keyboard and screen-reader order; do not use visual
+  placement to imply a different reading order.
+
+## Responsive contract
+
+- `columns` and `gap` are the base values. Add `tabletColumns`/`tabletGap`,
+  `desktopColumns`/`desktopGap`, `wideColumns`/`wideGap`, and
+  `ultraColumns`/`ultraGap` at 768/1024/1440/1920px.
+- Omitted values inherit through the previous rung, so set only the points
+  where the layout changes.
+- Numeric responsive columns render as `repeat(n, minmax(0, 1fr))`; template
+  strings pass through unchanged.
+- With no responsive props, Grid preserves the scalar inline API and numeric
+  `repeat(n, 1fr)` output used before the responsive props were added.
 
 ## Do / don't
-- Do: Match the **Example** story composition on Grid pages.
-- Don't: Bypass design tokens or skip forced-colors verification at beta.
+
+- Do: Use responsive props on Grid instead of creating page-specific grid wrappers or duplicating token breakpoints in consumer stylesheets.
+- Do: Wrap only spanning children in `Grid.Item` with `span` or `rowSpan`.
+- Don't: Replace the flat responsive props with object syntax; the flat API is the published compatibility boundary.
+- Don't: Size grid cells with child widths or use Grid for a one-dimensional sequence.
 
 ## Design notes
-- Tokens: Uses semantic colors/spacing from `variables.css`.
+
+- Breakpoints mirror the layout tokens in `variables.css`; media queries repeat
+  their fixed values because CSS custom properties cannot be used in queries.
+- Prefer spacing tokens in gap strings.
 - Figma: Linked from the component contract `figma` URL.

--- a/nextjs-app/shared/components/Grid/Grid.stories.tsx
+++ b/nextjs-app/shared/components/Grid/Grid.stories.tsx
@@ -184,6 +184,7 @@ export const ResponsiveColumns: Story = {
       tabletGap="2rem"
       desktopGap="2.5rem"
       wideGap="3rem"
+      ultraGap="4rem"
     >
       {Array.from({ length: 6 }, (_, i) => (
         <div key={i} style={{ border: "1px dashed var(--color-border, #999)", padding: "1rem", textAlign: "center" }}>

--- a/nextjs-app/shared/components/Grid/Grid.test.tsx
+++ b/nextjs-app/shared/components/Grid/Grid.test.tsx
@@ -1,7 +1,20 @@
 import React from "react";
 import { render } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import postcss from "postcss";
 import Grid from "@dt/Grid";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const normalizeCssValue = (value: string | undefined) =>
+  value
+    ?.replace(/\s+/g, " ")
+    .replace(/\(\s+/g, "(")
+    .replace(/\s+\)/g, ")")
+    .trim();
 
 describe("Grid", () => {
   it("renders children", () => {
@@ -120,5 +133,67 @@ describe("Grid", () => {
       "200px 1fr",
     );
     expect(grid.style.getPropertyValue("--grid-cols-tablet")).toBe("");
+  });
+
+  it("locks responsive breakpoints and sparse-rung CSS fallbacks", () => {
+    const css = postcss.parse(
+      readFileSync(join(here, "Grid.module.css"), "utf8"),
+    );
+    const expected = [
+      {
+        query: "(width >= 768px)",
+        columns: "var(--grid-cols-tablet, var(--grid-cols))",
+        gap: "var(--grid-gap-tablet, var(--grid-gap))",
+      },
+      {
+        query: "(width >= 1024px)",
+        columns:
+          "var(--grid-cols-desktop, var(--grid-cols-tablet, var(--grid-cols)))",
+        gap: "var(--grid-gap-desktop, var(--grid-gap-tablet, var(--grid-gap)))",
+      },
+      {
+        query: "(width >= 1440px)",
+        columns:
+          "var(--grid-cols-wide, var(--grid-cols-desktop, var(--grid-cols-tablet, var(--grid-cols))))",
+        gap: "var(--grid-gap-wide, var(--grid-gap-desktop, var(--grid-gap-tablet, var(--grid-gap))))",
+      },
+      {
+        query: "(width >= 1920px)",
+        columns:
+          "var(--grid-cols-ultra, var(--grid-cols-wide, var(--grid-cols-desktop, var(--grid-cols-tablet, var(--grid-cols)))))",
+        gap: "var(--grid-gap-ultra, var(--grid-gap-wide, var(--grid-gap-desktop, var(--grid-gap-tablet, var(--grid-gap)))))",
+      },
+    ];
+
+    const mediaQueries = css.nodes.filter(
+      (node) =>
+        node.type === "atrule" &&
+        node.name === "media" &&
+        node.nodes?.some(
+          (child) => child.type === "rule" && child.selector === ".responsive",
+        ),
+    );
+    expect(mediaQueries.map((query) => query.params)).toEqual(
+      expected.map(({ query }) => query),
+    );
+
+    for (const expectedRung of expected) {
+      const media = mediaQueries.find(
+        (query) => query.params === expectedRung.query,
+      );
+      const responsiveRule = media?.nodes?.find(
+        (node) => node.type === "rule" && node.selector === ".responsive",
+      );
+      const declarations = Object.fromEntries(
+        (responsiveRule?.nodes ?? [])
+          .filter((node) => node.type === "decl")
+          .map((declaration) => [declaration.prop, declaration.value]),
+      );
+
+      expect(normalizeCssValue(declarations["grid-template-columns"])).toBe(
+        expectedRung.columns,
+      );
+      expect(normalizeCssValue(declarations.gap)).toBe(expectedRung.gap);
+    }
   });
 });

--- a/nextjs-app/shared/components/Grid/Grid.tsx
+++ b/nextjs-app/shared/components/Grid/Grid.tsx
@@ -56,7 +56,7 @@ export interface GridProps {
 /**
  * GridItemProps: span for columns, rowSpan for rows, and style/className
  */
-interface GridItemProps {
+export interface GridItemProps {
   children?: ReactNode;
   span?: number;
   rowSpan?: number;

--- a/nextjs-app/shared/components/Grid/index.ts
+++ b/nextjs-app/shared/components/Grid/index.ts
@@ -1,2 +1,2 @@
 export { default } from "./Grid";
-export type { GridProps } from "./Grid";
+export type { GridItemProps, GridProps } from "./Grid";

--- a/nextjs-app/shared/components/index.ts
+++ b/nextjs-app/shared/components/index.ts
@@ -87,7 +87,7 @@ export type { FileUploadProps } from "./FileUpload/FileUpload";
 export { default as Gallery } from "./Gallery/Gallery";
 export type { GalleryProps } from "./Gallery";
 export { default as Grid } from "./Grid/Grid";
-export type { GridProps } from "./Grid/Grid";
+export type { GridItemProps, GridProps } from "./Grid/Grid";
 export { default as GroupLabel } from "./GroupLabel/GroupLabel";
 export type { GroupLabelProps } from "./GroupLabel/GroupLabel";
 export { default as Icon } from "./Icon/Icon";

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-13T09:27:24.070Z",
+  "generatedAt": "2026-07-13T09:58:18.163Z",
   "summary": {
     "componentCount": 162,
     "statusCounts": {
@@ -13385,7 +13385,7 @@
         "tier": "atom",
         "group": "layout",
         "status": "stable",
-        "description": "CSS grid layout primitive with tokenized gaps.",
+        "description": "CSS grid layout primitive with scalar and token-breakpoint responsive columns and gaps.",
         "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1177-1654",
         "radixPrimitive": null,
         "element": "div",
@@ -13416,7 +13416,12 @@
         },
         "slots": [],
         "asChild": false,
-        "subParts": [],
+        "subParts": [
+          {
+            "name": "GridItem",
+            "element": "div"
+          }
+        ],
         "requiredStories": [
           "Default",
           "Playground",
@@ -13619,9 +13624,9 @@
           "grid item",
           "two dimensional"
         ],
-        "dense": "CSS-grid wrapper: numeric columns for equal tracks or template strings; gap/rowGap/colGap strings; Grid.Item adds span/rowSpan; extra grid CSS props pass through via style",
+        "dense": "CSS-grid wrapper with scalar or 768/1024/1440/1920 responsive columns and gaps; numeric responsive tracks use minmax(0, 1fr); Grid.Item adds spans",
         "usage": {
-          "description": "Grid is the two-dimensional layout primitive: pass `columns` as a number for equal tracks or a template string for custom ones, gaps as CSS strings (prefer space tokens), and wrap children needing to span in `Grid.Item` with `span`/`rowSpan`. Reach for it when both axes matter — card walls, media mosaics, dashboard modules; single-axis flows are Stack/FlexBox territory.",
+          "description": "Grid is the two-dimensional layout primitive: pass `columns` as a number for equal tracks or a template string for custom ones, then add `tabletColumns`/`desktopColumns`/`wideColumns`/`ultraColumns` and matching gap props when the layout changes at the 768/1024/1440/1920 token breakpoints. Sparse responsive values inherit through the previous rung, and numeric responsive tracks use `minmax(0, 1fr)`. Wrap children needing to span in `Grid.Item` with `span`/`rowSpan`; use Stack or FlexBox when only one axis matters.",
           "bestPractices": [
             {
               "guidance": true,
@@ -13634,6 +13639,10 @@
             {
               "guidance": true,
               "description": "Set gaps with space tokens (\"var(--space-layout-24)\") so grid gutters follow the page rhythm."
+            },
+            {
+              "guidance": true,
+              "description": "Set only the responsive rungs that change; omitted tablet, desktop, wide, or ultra values inherit through the previous rung."
             },
             {
               "guidance": true,
@@ -13669,7 +13678,7 @@
           }
         }
       },
-      "spec": "# Grid\n\n## Intent\nDocuments how **Grid** is used in production layouts and Storybook examples.\n\n## Interaction contract\n- Keyboard: See **Playground** / **Example** stories and component tests.\n- Pointer: Standard click/tap on interactive affordances.\n- Screen readers: Verify labels, roles, and live regions in stories.\n\n## Do / don't\n- Do: Match the **Example** story composition on Grid pages.\n- Don't: Bypass design tokens or skip forced-colors verification at beta.\n\n## Design notes\n- Tokens: Uses semantic colors/spacing from `variables.css`.\n- Figma: Linked from the component contract `figma` URL.\n",
+      "spec": "# Grid\n\n## Intent\n\nUse **Grid** for two-dimensional layouts whose rows and columns both matter.\nNumeric columns create equal tracks; template strings describe asymmetric\ntracks. Use Stack or FlexBox for single-axis flow.\n\n## Interaction contract\n\n- Grid adds no interaction or ARIA semantics of its own.\n- DOM order remains the keyboard and screen-reader order; do not use visual\n  placement to imply a different reading order.\n\n## Responsive contract\n\n- `columns` and `gap` are the base values. Add `tabletColumns`/`tabletGap`,\n  `desktopColumns`/`desktopGap`, `wideColumns`/`wideGap`, and\n  `ultraColumns`/`ultraGap` at 768/1024/1440/1920px.\n- Omitted values inherit through the previous rung, so set only the points\n  where the layout changes.\n- Numeric responsive columns render as `repeat(n, minmax(0, 1fr))`; template\n  strings pass through unchanged.\n- With no responsive props, Grid preserves the scalar inline API and numeric\n  `repeat(n, 1fr)` output used before the responsive props were added.\n\n## Do / don't\n\n- Do: Use responsive props on Grid instead of creating page-specific grid wrappers or duplicating token breakpoints in consumer stylesheets.\n- Do: Wrap only spanning children in `Grid.Item` with `span` or `rowSpan`.\n- Don't: Replace the flat responsive props with object syntax; the flat API is the published compatibility boundary.\n- Don't: Size grid cells with child widths or use Grid for a one-dimensional sequence.\n\n## Design notes\n\n- Breakpoints mirror the layout tokens in `variables.css`; media queries repeat\n  their fixed values because CSS custom properties cannot be used in queries.\n- Prefer spacing tokens in gap strings.\n- Figma: Linked from the component contract `figma` URL.\n",
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Grid",
@@ -13706,7 +13715,7 @@
       },
       "agent": {
         "preferredImport": "@dt/Grid",
-        "intent": "Documents how **Grid** is used in production layouts and Storybook examples.",
+        "intent": "Use **Grid** for two-dimensional layouts whose rows and columns both matter. Numeric columns create equal tracks; template strings describe asymmetric tracks. Use Stack or FlexBox for single-axis flow.",
         "props": {
           "children": {
             "optional": false,
@@ -13849,10 +13858,12 @@
         "cvaVariants": {},
         "variantsFnName": null,
         "useWhen": [
-          "Match the **Example** story composition on Grid pages."
+          "Use responsive props on Grid instead of creating page-specific grid wrappers or duplicating token breakpoints in consumer stylesheets.",
+          "Wrap only spanning children in `Grid.Item` with `span` or `rowSpan`."
         ],
         "avoidWhen": [
-          "Bypass design tokens or skip forced-colors verification at beta."
+          "Replace the flat responsive props with object syntax; the flat API is the published compatibility boundary.",
+          "Size grid cells with child widths or use Grid for a one-dimensional sequence."
         ],
         "requiredA11y": [],
         "keyboard": [],
@@ -13867,7 +13878,8 @@
           "manual CSS grid with arbitrary gap literals"
         ],
         "forbiddenUse": [
-          "Bypass design tokens or skip forced-colors verification at beta."
+          "Replace the flat responsive props with object syntax; the flat API is the published compatibility boundary.",
+          "Size grid cells with child widths or use Grid for a one-dimensional sequence."
         ],
         "composesWith": [
           "FlexBox",

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-13T09:00:54.945Z",
+  "generatedAt": "2026-07-13T09:52:29.167Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -4142,7 +4142,7 @@
     },
     "Grid": {
       "preferredImport": "@dt/Grid",
-      "intent": "Documents how **Grid** is used in production layouts and Storybook examples.",
+      "intent": "Use **Grid** for two-dimensional layouts whose rows and columns both matter. Numeric columns create equal tracks; template strings describe asymmetric tracks. Use Stack or FlexBox for single-axis flow.",
       "props": {
         "children": {
           "optional": false,
@@ -4285,10 +4285,12 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "Match the **Example** story composition on Grid pages."
+        "Use responsive props on Grid instead of creating page-specific grid wrappers or duplicating token breakpoints in consumer stylesheets.",
+        "Wrap only spanning children in `Grid.Item` with `span` or `rowSpan`."
       ],
       "avoidWhen": [
-        "Bypass design tokens or skip forced-colors verification at beta."
+        "Replace the flat responsive props with object syntax; the flat API is the published compatibility boundary.",
+        "Size grid cells with child widths or use Grid for a one-dimensional sequence."
       ],
       "requiredA11y": [],
       "keyboard": [],
@@ -4303,7 +4305,8 @@
         "manual CSS grid with arbitrary gap literals"
       ],
       "forbiddenUse": [
-        "Bypass design tokens or skip forced-colors verification at beta."
+        "Replace the flat responsive props with object syntax; the flat API is the published compatibility boundary.",
+        "Size grid cells with child widths or use Grid for a one-dimensional sequence."
       ],
       "composesWith": [
         "FlexBox",

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -6535,8 +6535,8 @@
       "group": "layout",
       "tier": 1,
       "status": "stable",
-      "description": "CSS grid layout primitive with tokenized gaps.",
-      "dense": "CSS-grid wrapper: numeric columns for equal tracks or template strings; gap/rowGap/colGap strings; Grid.Item adds span/rowSpan; extra grid CSS props pass through via style",
+      "description": "CSS grid layout primitive with scalar and token-breakpoint responsive columns and gaps.",
+      "dense": "CSS-grid wrapper with scalar or 768/1024/1440/1920 responsive columns and gaps; numeric responsive tracks use minmax(0, 1fr); Grid.Item adds spans",
       "keywords": [
         "grid",
         "columns",
@@ -6704,7 +6704,7 @@
         "Size cells by styling children with widths; spans and templates belong on the grid, not in the card."
       ],
       "usage": {
-        "description": "Grid is the two-dimensional layout primitive: pass `columns` as a number for equal tracks or a template string for custom ones, gaps as CSS strings (prefer space tokens), and wrap children needing to span in `Grid.Item` with `span`/`rowSpan`. Reach for it when both axes matter — card walls, media mosaics, dashboard modules; single-axis flows are Stack/FlexBox territory.",
+        "description": "Grid is the two-dimensional layout primitive: pass `columns` as a number for equal tracks or a template string for custom ones, then add `tabletColumns`/`desktopColumns`/`wideColumns`/`ultraColumns` and matching gap props when the layout changes at the 768/1024/1440/1920 token breakpoints. Sparse responsive values inherit through the previous rung, and numeric responsive tracks use `minmax(0, 1fr)`. Wrap children needing to span in `Grid.Item` with `span`/`rowSpan`; use Stack or FlexBox when only one axis matters.",
         "bestPractices": [
           {
             "guidance": true,
@@ -6717,6 +6717,10 @@
           {
             "guidance": true,
             "description": "Set gaps with space tokens (\"var(--space-layout-24)\") so grid gutters follow the page rhythm."
+          },
+          {
+            "guidance": true,
+            "description": "Set only the responsive rungs that change; omitted tablet, desktop, wide, or ultra values inherit through the previous rung."
           },
           {
             "guidance": true,
@@ -6762,7 +6766,7 @@
         {
           "story": "ResponsiveColumns",
           "description": "Per-breakpoint columns and gaps: tabletColumns/desktopColumns/wideColumns/ultraColumns and the matching Gap props resolve at the design-token breakpoints (768 / 1024 / 1440 / 1920px), each falling back through the previous rung. Resize the viewport to see the tracks change. Numeric responsive counts render as minmax(0, 1fr) tracks so cells can shrink below content width.",
-          "source": "export const ResponsiveColumns: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: { description: { story: \"Per-breakpoint columns and gaps: tabletColumns/desktopColumns/wideColumns/ultraColumns and the matching Gap props resolve at the design-token breakpoints (768 / 1024 / 1440 / 1920px), each falling back through the previous rung. Resize the viewport to see the tracks change. Numeric responsive counts render as minmax(0, 1fr) tracks so cells can shrink below content width.\" } },\n  },\n  render: () => (\n    <Grid\n      columns={1}\n      tabletColumns={2}\n      desktopColumns={3}\n      wideColumns={4}\n      ultraColumns={6}\n      gap=\"1.25rem\"\n      tabletGap=\"2rem\"\n      desktopGap=\"2.5rem\"\n      wideGap=\"3rem\"\n    >\n      {Array.from({ length: 6 }, (_, i) => (\n        <div key={i} style={{ border: \"1px dashed var(--color-border, #999)\", padding: \"1rem\", textAlign: \"center\" }}>\n          Cell {i + 1}\n        </div>\n      ))}\n    </Grid>\n  ),\n};\n\n/** A template string when tracks genuinely differ — sidebar plus content here. */"
+          "source": "export const ResponsiveColumns: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: { description: { story: \"Per-breakpoint columns and gaps: tabletColumns/desktopColumns/wideColumns/ultraColumns and the matching Gap props resolve at the design-token breakpoints (768 / 1024 / 1440 / 1920px), each falling back through the previous rung. Resize the viewport to see the tracks change. Numeric responsive counts render as minmax(0, 1fr) tracks so cells can shrink below content width.\" } },\n  },\n  render: () => (\n    <Grid\n      columns={1}\n      tabletColumns={2}\n      desktopColumns={3}\n      wideColumns={4}\n      ultraColumns={6}\n      gap=\"1.25rem\"\n      tabletGap=\"2rem\"\n      desktopGap=\"2.5rem\"\n      wideGap=\"3rem\"\n      ultraGap=\"4rem\"\n    >\n      {Array.from({ length: 6 }, (_, i) => (\n        <div key={i} style={{ border: \"1px dashed var(--color-border, #999)\", padding: \"1rem\", textAlign: \"center\" }}>\n          Cell {i + 1}\n        </div>\n      ))}\n    </Grid>\n  ),\n};\n\n/** A template string when tracks genuinely differ — sidebar plus content here. */"
         },
         {
           "story": "CustomTemplate",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -115,7 +115,10 @@ export {
 export { default as Gallery } from "../../../nextjs-app/shared/components/Gallery/Gallery";
 export type { GalleryProps } from "../../../nextjs-app/shared/components/Gallery";
 export { default as Grid } from "../../../nextjs-app/shared/components/Grid/Grid";
-export type { GridProps } from "../../../nextjs-app/shared/components/Grid/Grid";
+export type {
+  GridItemProps,
+  GridProps,
+} from "../../../nextjs-app/shared/components/Grid/Grid";
 export { default as GroupLabel } from "../../../nextjs-app/shared/components/GroupLabel/GroupLabel";
 export type { GroupLabelProps } from "../../../nextjs-app/shared/components/GroupLabel/GroupLabel";
 export { default as HelperText } from "../../../nextjs-app/shared/components/HelperText/HelperText";


### PR DESCRIPTION
## Grid AlphaEvolve batch (reviewed + independently verified)

Codex ran 40 Vertex Gemini evolutions over Grid; this is the surviving batch after review. **Runtime behavior and existing props are unchanged** (frozen public API stays at 115 runtime exports; `GridItemProps` is type-only).

**Changes**
- `GridItemProps` exported through source, folder, shared, and package entrypoints
- `GridItem` registered as a contract subpart
- New executable PostCSS test locks the four responsive media-query rungs (768/1024/1440/1920) and the sparse column/gap `var()` fallback chains — jsdom can't compute module media queries (the known Vitest CSS-module gap), so the test asserts the authored CSS structure directly
- Contract `dense`/`usage` rewritten around the responsive vs legacy-scalar contracts; spec now documents the responsive contract and encodes the flat-props owner ruling as a Don't
- `ResponsiveColumns` story exercises `ultraGap` (prop-only edit; AT snapshots unaffected)

**Review notes:** settings.json, hooks, and .git/info/exclude audited — clean. Diff is additive; no object-syntax drift; media queries stay on the token scale.

**Local gate (re-run by reviewer, not just Codex):** typecheck ✅ lint ✅ vitest 2291 ✅ build ✅ build:tokens + check:contract-props + check:consumers + validate:components ✅ check:react-public-surface (70 contract exports, alpha ceiling 0) ✅ check:react-public-api (115 runtime, frozen) ✅ docs-registry snapshot ✅

Next: 0.1.12 release prep (this batch + the #1141/#1143 responsive props that are still main-only), then the WorkIndexPage barrel flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)