### PR TITLE
chore(react): prepare 0.1.12 release

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.12 - 2026-07-13
+
+- `Grid` becomes the master responsive grid: additive per-breakpoint props `tabletColumns`/`desktopColumns`/`wideColumns`/`ultraColumns` and `tabletGap`/`desktopGap`/`wideGap`/`ultraGap` resolve at the token breakpoints (768/1024/1440/1920px) via CSS custom properties and module media queries, each falling back through the previous rung (#1141, #1143). Numeric responsive counts render as `repeat(n, minmax(0, 1fr))` so cells can shrink below content width. Without responsive props the legacy scalar path renders byte-identical to 0.1.11, so existing consumers are unaffected.
+- Adds the `GridItemProps` type export and registers `GridItem` as a contract subpart; contract and spec guidance rewritten around the responsive vs legacy-scalar contracts (#1160). Runtime public API unchanged (115 exports).
+- Executable PostCSS coverage locks all four responsive media-query rungs and the sparse column/gap fallback chains (#1160).
+- Verified by the full local gate (typecheck, lint, 2291 tests, build) plus check:react-package, check:react-public-api, and check:react-public-surface (0 alpha).
+
 ## 0.1.11 - 2026-07-13
 
 - Re-establishes the pattern rung: `PageLayout` and `ProcessBlock` are the first composite patterns exported from the package (runtime public API 113 → 115, both stable contracts, zero-alpha surface ceiling holds). ProcessBlock's own imports move off the published barrel onto package-internal source per the same-module-instance rule.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/react",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": false,
   "description": "React components and host adapters for the Digitaltableteur design system.",
   "type": "module",

--- a/scripts/design-system/check-site-package-dogfood.mjs
+++ b/scripts/design-system/check-site-package-dogfood.mjs
@@ -156,8 +156,21 @@ async function main() {
             (await page.getByRole("heading", { name: textPattern(homeSelectedWork) }).count()) > 0,
             `home selected-work heading is localized: ${homeSelectedWork}`,
           );
+          // Since NavLink 0.1.9 the active same-path item renders as a
+          // non-interactive <span aria-current="page">, so on "/" the Home
+          // label is a current-page marker, not a link.
+          const headerNav = page.getByRole("navigation", {
+            name: textPattern(tr(language, "navMenuAccessibleLabel")),
+          });
+          const homeAsLink = await headerNav
+            .getByRole("link", { name: textPattern(navHome) })
+            .count();
+          const homeAsCurrent = await headerNav
+            .locator('[aria-current="page"]')
+            .filter({ hasText: textPattern(navHome) })
+            .count();
           assert(
-            (await page.getByRole("link", { name: textPattern(navHome) }).count()) > 0,
+            homeAsLink + homeAsCurrent > 0,
             `site header home label is localized: ${navHome}`,
           );
           return { summary: await pageSummary(page) };
@@ -208,12 +221,14 @@ async function main() {
           });
           await nav.getByRole("link", { name: textPattern(navWork) }).click();
           await page.waitForURL("**/work", { timeout: 15_000 });
+          // Since NavLink 0.1.9 the now-active Work item re-renders as a
+          // non-interactive <span aria-current="page"> instead of a link.
           const activeWork = nav
-            .getByRole("link", { name: textPattern(navWork) })
-            .first();
+            .locator('[aria-current="page"]')
+            .filter({ hasText: textPattern(navWork) });
           assert(
-            (await activeWork.getAttribute("aria-current")) === "page",
-            "SiteHeader Work link routes through the injected link runtime and marks aria-current",
+            (await activeWork.count()) > 0,
+            "SiteHeader Work link routes through the injected link runtime and marks the current page",
           );
           return { summary: await pageSummary(page) };
         },


### PR DESCRIPTION
## @digitaltableteur/react 0.1.12 prep

Batch publish carrying everything since 0.1.11:
- Grid responsive breakpoint props (#1141 tablet/desktop, #1143 wide/ultra) — additive; the legacy scalar path is byte-identical, so existing registry consumers are unaffected
- Grid evolve batch (#1160): `GridItemProps` type export, GridItem contract subpart, PostCSS rung locks. Runtime public API unchanged (115 exports).

Also fixes the site-package-dogfood probes, which still asserted the pre-0.1.9 NavLink shape (active nav item as a link). Since 0.1.9 the active same-path item deliberately renders as `<span aria-current="page">`; the probes predate that (2026-07-08) and this preflight was the first to exercise them since. Routing re-verified live before changing the test: Work click routes to /work and the span carries aria-current in en/fi/sv.

**Preflight:** `check:react-publish-preflight -- --strict --require-clearance` 22/22 (includes site-package-dogfood 27/27).

After merge: `gh workflow run ds-publish.yml --ref main -f package=react -f dry_run=false`, then the consume PR (install 0.1.12, flip WorkIndexPage's `@dt/Grid` to the barrel, AT version-line recapture, registry checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released version 0.1.12.
  * Enhanced the Grid component with additive responsive properties for breakpoint-specific columns and gaps.
  * Added responsive token-based fallback behavior while preserving existing output when responsive properties are not used.
  * Added the exported `GridItemProps` type and documented Grid and GridItem contract behavior.
* **Documentation**
  * Updated release documentation with responsive Grid guidance and verification details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->