### PR TITLE
chore(app): consume @digitaltableteur/react@0.1.12 — Grid responsive flip

### DIFF
--- a/nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx
@@ -6,11 +6,9 @@ import {
   CategoryFilter,
   Container,
   EmptyState,
+  Grid,
   Section,
 } from "@digitaltableteur/react";
-// Grid stays a local import until its responsive props ship in the next
-// package release; flip to the barrel with that consume.
-import Grid from "@dt/Grid";
 import { WorkHero } from "../../../../patterns/WorkHero";
 import { EnhancedProjectCard } from "../../../EnhancedProjectCard";
 import { FadeIn } from "../../../../components/animations/FadeIn";

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-13T09:58:18.163Z",
+  "generatedAt": "2026-07-13T10:30:10.418Z",
   "summary": {
     "componentCount": 162,
     "statusCounts": {
@@ -13,7 +13,7 @@
     "catalogCompletenessPercent": 88,
     "codebaseComponentCount": 184,
     "usageCoveragePercent": 93.2,
-    "componentsWithProductionUsage": 34,
+    "componentsWithProductionUsage": 33,
     "notReadyForStablePromotion": false
   },
   "exportPolicy": {
@@ -79,19 +79,19 @@
     "description": "Auto-detected import evidence from app/** and nextjs-app/**. Separate from contract.consumers[], which remains the stable-promotion gate for shipping-product proof.",
     "catalogedComponents": 162,
     "withAnyUsage": 151,
-    "withProductionUsage": 34,
+    "withProductionUsage": 33,
     "uniqueImportedComponents": 151,
-    "totalEvidenceRows": 742,
-    "aliasImportFiles": 379,
+    "totalEvidenceRows": 741,
+    "aliasImportFiles": 378,
     "relativeImportFiles": 392,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
   },
   "relationshipGraph": {
     "description": "Merged static composesWith policy + co-import evidence (see generate-relationship-graph.mjs).",
-    "generatedAt": "2026-07-13T08:53:55.054Z",
+    "generatedAt": "2026-07-13T10:30:06.202Z",
     "coImportMinFiles": 3,
-    "nodesWithComposesWith": 80,
+    "nodesWithComposesWith": 79,
     "regenerate": "npm run build:relationship-graph or npm run build:tokens",
     "path": "nextjs-app/shared/foundations/dist/relationship-graph.json"
   },
@@ -13682,17 +13682,11 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Grid",
-        "importCount": 4,
-        "productionImportCount": 1,
+        "importCount": 3,
+        "productionImportCount": 0,
         "patternImportCount": 0,
         "componentImportCount": 1,
         "evidence": [
-          {
-            "path": "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/Grid",
-            "context": "production"
-          },
           {
             "path": "nextjs-app/shared/components/index.ts",
             "importKind": "relative",
@@ -42513,10 +42507,7 @@
           "invent parallel primitives inside this folder",
           "promote to stable without production consumer evidence"
         ],
-        "composesWith": [
-          "Grid",
-          "animations"
-        ],
+        "composesWith": [],
         "prefersOver": [],
         "declaredPropCount": 4
       }

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-13T09:52:29.167Z",
+  "generatedAt": "2026-07-13T10:30:10.002Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -13478,10 +13478,7 @@
         "invent parallel primitives inside this folder",
         "promote to stable without production consumer evidence"
       ],
-      "composesWith": [
-        "Grid",
-        "animations"
-      ],
+      "composesWith": [],
       "prefersOver": [],
       "declaredPropCount": 4
     },

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.11
+  - definition: 0.1.12
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.11
+  - definition: 0.1.12
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.11
+  - definition: 0.1.12
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.11
+  - definition: 0.1.12
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.11
+  - definition: 0.1.12
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.11
+  - definition: 0.1.12
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.11
+  - definition: 0.1.12
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.11
+  - definition: 0.1.12
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.11
+  - definition: 0.1.12
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.11
+  - definition: 0.1.12
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.11
+  - definition: 0.1.12
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.11
+  - definition: 0.1.12
   - term: tokens
   - definition: 0.1.1
   - term: tokens-css

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ai-sdk/openai": "^3.0.71",
         "@ai-sdk/react": "^3.0.207",
         "@calcom/embed-react": "^1.5.3",
-        "@digitaltableteur/react": "^0.1.11",
+        "@digitaltableteur/react": "^0.1.12",
         "@digitaltableteur/tokens": "^0.1.1",
         "@digitaltableteur/tokens-css": "^0.1.2",
         "@emailjs/browser": "^4.4.1",
@@ -3429,9 +3429,9 @@
       "license": "MIT"
     },
     "node_modules/@digitaltableteur/react": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.11.tgz",
-      "integrity": "sha512-hFut95gBUBdUeeSaPco4TRHOMtTvdJRwV9pOPe3c7OIOFmhycqi7iH8n7b4Qd9wkgsiSH1EBY4g2nOApXZYCuQ==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.12.tgz",
+      "integrity": "sha512-uzNuAc0WxTP13FBH0LTOVpA3dGR+dTapSvJmFzApP7tGKJ9sdOdMsZBS5dJ/j9f7z94PE+FTfd1JCROOnnv1ag==",
       "license": "UNLICENSED",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "@ai-sdk/openai": "^3.0.71",
     "@ai-sdk/react": "^3.0.207",
     "@calcom/embed-react": "^1.5.3",
-    "@digitaltableteur/react": "^0.1.11",
+    "@digitaltableteur/react": "^0.1.12",
     "@digitaltableteur/tokens": "^0.1.1",
     "@digitaltableteur/tokens-css": "^0.1.2",
     "@emailjs/browser": "^4.4.1",


### PR DESCRIPTION
## Consume react 0.1.12 (publish run 29242524156)

- Dependency `^0.1.11` → `^0.1.12`; registry now ships the Grid responsive breakpoint props (#1141/#1143) and the `GridItemProps` type export (#1160)
- **WorkIndexPage flips Grid to the package barrel**, retiring the flip-comment left by the WorkGrid dissolution (#1142). Browser-verified /work rendering from the installed package: 700px = 1 col / 1.25rem, 900px = 2 col / 2rem, 1280px = 4 col / 2.5rem (module class hash confirms package CSS, not local source)
- AboutPageContent AT yamls: embedded react `definition` line trued 0.1.11 → 0.1.12 (12 files, one line each, zero strays — the documented version-only recapture shape)
- Registry checks: react-registry-install (@0.1.12, 115 exports, runtime + types) ✅ package-registry-resolution ✅ storybook-registry-package ✅ published-tokens-freshness --strict ✅

**Local gate:** typecheck ✅ lint ✅ vitest 2291 ✅ build ✅ build:tokens + check:contract-props + check:consumers ✅

Grid's registry consumption is now complete across the tribunal fleet: WorkIndexPage (responsive), BlogIndexContent and ServicesGrid (scalar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)