### PR TITLE
chore(deps): blog-dependencies group (#1146)

### DIFF
--- a/digitaltableteur-blog/package-lock.json
+++ b/digitaltableteur-blog/package-lock.json
@@ -9,18 +9,18 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@sanity/code-input": "^7.2.5",
-        "@sanity/vision": "^6.3.0",
+        "@sanity/code-input": "^7.2.6",
+        "@sanity/vision": "^6.4.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "sanity": "^6.3.0",
+        "sanity": "^6.4.0",
         "styled-components": "^6.4.3"
       },
       "devDependencies": {
         "@sanity/eslint-config-studio": "^6.0.0",
         "@types/react": "^19.2.17",
         "eslint": "^9.39",
-        "prettier": "^3.9.4",
+        "prettier": "^3.9.5",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -2951,9 +2951,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2963,7 +2963,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
@@ -2975,9 +2975,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4261,21 +4261,21 @@
       }
     },
     "node_modules/@portabletext/editor": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-7.9.0.tgz",
-      "integrity": "sha512-zF6a1SghGA0u7TN3rWaWYHEuQhZgY1YWgmcswbyLnrtNqvn59HvCMJlDUt+h4W+Z5cKsIVImfJhLyzG4YgOfZw==",
+      "version": "7.10.7",
+      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-7.10.7.tgz",
+      "integrity": "sha512-a45rs82qNVTxsbANxLXWTzzRSZQ0lGaYAbNRQMWXLhwl5khQqkXdb71b7pSnCqKNk+jMTm5taJImjmpfoEEMlg==",
       "license": "MIT",
       "dependencies": {
-        "@portabletext/html": "^1.1.0",
+        "@portabletext/html": "^1.1.1",
         "@portabletext/keyboard-shortcuts": "^2.1.3",
-        "@portabletext/markdown": "^1.4.2",
+        "@portabletext/markdown": "^1.4.4",
         "@portabletext/patches": "^2.0.5",
-        "@portabletext/schema": "^2.2.2",
+        "@portabletext/schema": "^2.2.3",
         "@portabletext/to-html": "^5.0.2",
         "@xstate/react": "^6.1.0",
         "debug": "^4.4.3",
         "scroll-into-view-if-needed": "^3.1.0",
-        "xstate": "^5.32.2"
+        "xstate": "^5.32.4"
       },
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
@@ -4285,12 +4285,12 @@
       }
     },
     "node_modules/@portabletext/html": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@portabletext/html/-/html-1.1.0.tgz",
-      "integrity": "sha512-5+gl7vuB0xHuKcEnT0aI4w8/Ob4xa1zNnxNgOJ3u5flV20wIzFbFYlWa1+LTA21jMQwoGExg7T+cnelnnDO9kQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@portabletext/html/-/html-1.1.1.tgz",
+      "integrity": "sha512-PoMAnbyT3Nz2v0pHF2IkhPKwOd8Rb/LxwwnfbK3SNBswdZmYODprrFgRe+wovUQxvTr6NQlPi1Zttydt5JKZ5A==",
       "license": "MIT",
       "dependencies": {
-        "@portabletext/schema": "^2.2.2",
+        "@portabletext/schema": "^2.2.3",
         "@vercel/stega": "^1.1.0"
       },
       "engines": {
@@ -4307,13 +4307,13 @@
       }
     },
     "node_modules/@portabletext/markdown": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@portabletext/markdown/-/markdown-1.4.2.tgz",
-      "integrity": "sha512-CEXSfH12Gs/F7fiqNq0fCAdY8NLxbpzYs+eTgDiXM/L51grbWlfdAaVnmXXwGbxa3z5cySIoZP+M7EzTKsBfKA==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@portabletext/markdown/-/markdown-1.4.4.tgz",
+      "integrity": "sha512-XNzCKBHaZ9e/4cB5qI+mpZBSFYvWNwSft7EYQ90kIT1e7nm++rwcOmF6BEjlpMnkny72NAhhgVH5stmqO2Eykg==",
       "license": "MIT",
       "dependencies": {
         "@mdit/plugin-alert": "^0.23.2",
-        "@portabletext/schema": "^2.2.2",
+        "@portabletext/schema": "^2.2.3",
         "@portabletext/toolkit": "^5.0.2",
         "markdown-it": "^14.2.0"
       },
@@ -4334,121 +4334,120 @@
       }
     },
     "node_modules/@portabletext/plugin-character-pair-decorator": {
-      "version": "8.0.26",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-character-pair-decorator/-/plugin-character-pair-decorator-8.0.26.tgz",
-      "integrity": "sha512-UaFRqWIpc1qhlVWdUoXdg3Ec3mLuKr3xnHh4tLF/FCrc47g9uDgtHLXRssFaUwVPK1v55pzHlMuVq8ugA79F4A==",
+      "version": "8.0.35",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-character-pair-decorator/-/plugin-character-pair-decorator-8.0.35.tgz",
+      "integrity": "sha512-g/jjJ+spuRgKJIbxirzPMuQfnXLjnuydEtypUbCD5zeV+DkaHSFl4LstEnbudJ7g4UObsxc7ngx1vDMFNUOB9Q==",
       "license": "MIT",
       "dependencies": {
-        "@xstate/react": "^6.1.0",
-        "xstate": "^5.32.2"
+        "@portabletext/plugin-input-rule": "^6.0.4"
       },
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "@portabletext/editor": "^7.9.0",
+        "@portabletext/editor": "^7.10.7",
         "react": "^19.2"
       }
     },
     "node_modules/@portabletext/plugin-dnd": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-dnd/-/plugin-dnd-1.0.11.tgz",
-      "integrity": "sha512-Sg5vap7gJxD5uMyH77/K6LFj8s+ftxsqSN0+hSXR5FLYCgntduhsoT74cZGIVBGRNmJ9PX9d3Xuv7HNYL7KPXg==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-dnd/-/plugin-dnd-1.0.19.tgz",
+      "integrity": "sha512-4jENAcSckoEljCpHWgzXUvZND7u85QP0WbWh1WPTj5TN+jbxith2963eGXkOvXLH3in/0XNLl9B3uHQ4byog8A==",
       "license": "MIT",
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "@portabletext/editor": "^7.9.0",
+        "@portabletext/editor": "^7.10.7",
         "react": "^19.2"
       }
     },
     "node_modules/@portabletext/plugin-input-rule": {
-      "version": "5.0.26",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-input-rule/-/plugin-input-rule-5.0.26.tgz",
-      "integrity": "sha512-fnY0KkL6tTnTj9Ccsv4FJliFFlPrAyWUaSzuF5Gz6tNHDN8ixQbptfv3ZyNeu24OJEzbZwNW39fC9bz6sY4POw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-input-rule/-/plugin-input-rule-6.0.4.tgz",
+      "integrity": "sha512-hyi85dyN3Elr8lQLx43Q9w1dxrWtGujQSwuquoXjnsQk6o5plbwb1DTYEPE5zCSr2nMH+j5efM3xG0qBvr2VmA==",
       "license": "MIT",
       "dependencies": {
         "@xstate/react": "^6.1.0",
-        "xstate": "^5.32.2"
+        "xstate": "^5.32.4"
       },
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "@portabletext/editor": "^7.9.0",
+        "@portabletext/editor": "^7.10.7",
         "react": "^19.2"
       }
     },
     "node_modules/@portabletext/plugin-list-index": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-list-index/-/plugin-list-index-1.0.11.tgz",
-      "integrity": "sha512-m2snUoINZxyvXiPawLwu+KzAvFqTPrjF2vKeKc0ciuBxS/hI+D8mQyMOQjBhuXgab+efQVzVGu6R6SwEgECatw==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-list-index/-/plugin-list-index-1.0.19.tgz",
+      "integrity": "sha512-NCZClukyi04YW2s8WsDkR2HJS7LpmmJKbmVtfq8IWHtB6Lfvi0Ul7826FGYtFYqvbWvJPn4ulFuE/cCTYf1dKA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "@portabletext/editor": "^7.9.0",
+        "@portabletext/editor": "^7.10.7",
         "react": "^19.2"
       }
     },
     "node_modules/@portabletext/plugin-markdown-shortcuts": {
-      "version": "8.0.26",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-markdown-shortcuts/-/plugin-markdown-shortcuts-8.0.26.tgz",
-      "integrity": "sha512-se+Xk5HZpupVWY938/ebGmcl5S2bd65w76EshGGrm2KH52snLggAiuSJEx0a1wGJdHEuRdOB8Uu7chADkfYK/A==",
+      "version": "8.0.35",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-markdown-shortcuts/-/plugin-markdown-shortcuts-8.0.35.tgz",
+      "integrity": "sha512-jVchMcwIdctJwaU6X5qZ4YiIIPSajoYrlgKQtro3Hb8qgowAoNZnasXGUM62Fx105Opy3ZifoIeuha/D+CYIvw==",
       "license": "MIT",
       "dependencies": {
-        "@portabletext/plugin-character-pair-decorator": "^8.0.26",
-        "@portabletext/plugin-input-rule": "^5.0.26"
+        "@portabletext/plugin-character-pair-decorator": "^8.0.35",
+        "@portabletext/plugin-input-rule": "^6.0.4"
       },
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "@portabletext/editor": "^7.9.0",
+        "@portabletext/editor": "^7.10.7",
         "react": "^19.2"
       }
     },
     "node_modules/@portabletext/plugin-one-line": {
-      "version": "7.0.26",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-one-line/-/plugin-one-line-7.0.26.tgz",
-      "integrity": "sha512-C1KEeDjq0JIGD1sUxbZjjgOm1zhX+cm4i8pwlZ34uF4LTGxOdw6xVWChUXAxb8p1i2iHBeIepTP2ldfMxkR9Qw==",
+      "version": "7.0.34",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-one-line/-/plugin-one-line-7.0.34.tgz",
+      "integrity": "sha512-ypnNid40lqyaFoJZ/LKCJQnFLwXkw9tgdOZhDrDHclZwgIDRYSBTC+BIg8cClQtVdqxHrcmD4rDVtmL5qwuvYw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "@portabletext/editor": "^7.9.0",
+        "@portabletext/editor": "^7.10.7",
         "react": "^19.2"
       }
     },
     "node_modules/@portabletext/plugin-paste-link": {
-      "version": "4.0.26",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-paste-link/-/plugin-paste-link-4.0.26.tgz",
-      "integrity": "sha512-9Qgq9MUrmjkufk9smlXFGvRIS3bP9jkpEA/oZOZCuJYY6yVnBDxkPnRtuwcTd/B1u9FNHANDjlEdmLoKFzb5lA==",
+      "version": "4.0.34",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-paste-link/-/plugin-paste-link-4.0.34.tgz",
+      "integrity": "sha512-WUSdsvQY+NfvSzQNDNCGmy2F2Ie+OztDX6eyXAb2xSpaNXhu0IOSXnH2qGYqlq4uAOTdeOfzE0W7ArMeAvu19A==",
       "license": "MIT",
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "@portabletext/editor": "^7.9.0",
+        "@portabletext/editor": "^7.10.7",
         "react": "^19.2"
       }
     },
     "node_modules/@portabletext/plugin-typography": {
-      "version": "8.0.26",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-typography/-/plugin-typography-8.0.26.tgz",
-      "integrity": "sha512-DqrI59PRBCNioIVUuxaoJkZUCPwkMfnmIWslx5U9ab3LwaTBH1KkWTT1mdKnmXnTTP6SMaa4OG55T/cTqGxxag==",
+      "version": "8.0.35",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-typography/-/plugin-typography-8.0.35.tgz",
+      "integrity": "sha512-LxdI82vxPZRjdHzIsT3uyvSidYWgeftodISNi87a3OHSkghVTJcPcCtvtuTwt2zVyWZnmmW1Skif1aysGOeKEQ==",
       "license": "MIT",
       "dependencies": {
-        "@portabletext/plugin-input-rule": "^5.0.26"
+        "@portabletext/plugin-input-rule": "^6.0.4"
       },
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "@portabletext/editor": "^7.9.0",
+        "@portabletext/editor": "^7.10.7",
         "react": "^19.2"
       }
     },
@@ -4483,9 +4482,9 @@
       }
     },
     "node_modules/@portabletext/schema": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@portabletext/schema/-/schema-2.2.2.tgz",
-      "integrity": "sha512-nQ9g0c1RJZyObLsuNWecIgYl69Irimpf+m9g+u26mhtUFxS4kc6fjqZWtiJUowC5nUGIkjg+Pnr36WGxCE/65g==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@portabletext/schema/-/schema-2.2.3.tgz",
+      "integrity": "sha512-C3+BvyDmUk3ZMgdTXowVdzqxHHPotgy2tFsiuuaxhOsXCeb1+iYUnxoDQKV+7HO9CYwA3H6I85/t+1b5VJWPEA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
@@ -5461,9 +5460,9 @@
       }
     },
     "node_modules/@sanity/code-input": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/@sanity/code-input/-/code-input-7.2.5.tgz",
-      "integrity": "sha512-OCa+1BDsTeKjDmmh7zWWjEJeZ3DjoxhxUoCwBBN3org2b27C7iwWp6JkX36EEq+VlUFdDfc/XxPJKZwP3GpL+A==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/@sanity/code-input/-/code-input-7.2.6.tgz",
+      "integrity": "sha512-ItnqinzE50AW9JZoNE4p70KWJCzFnoQ+qqfBUcKAj57tiWZxKjPVv2CHerIIpiIeYax2bQZY8cnYPjGKepHOxg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-html": "^6.4.11",
@@ -5475,12 +5474,12 @@
         "@codemirror/lang-sql": "^6.10.0",
         "@codemirror/language": "^6.12.4",
         "@codemirror/legacy-modes": "^6.5.3",
-        "@codemirror/state": "^6.7.0",
-        "@codemirror/view": "^6.43.3",
+        "@codemirror/state": "^6.7.1",
+        "@codemirror/view": "^6.43.6",
         "@lezer/highlight": "^1.2.3",
         "@sanity/icons": "^5.0.0",
         "@sanity/lezer-groq": "^1.0.4",
-        "@sanity/ui": "^3.3.0",
+        "@sanity/ui": "^3.3.1",
         "@uiw/codemirror-themes": "^4.25.10",
         "@uiw/react-codemirror": "^4.25.10"
       },
@@ -5656,9 +5655,9 @@
       }
     },
     "node_modules/@sanity/diff": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-6.3.0.tgz",
-      "integrity": "sha512-PJ3MYRY0bOtyZGA2otlvdqFWIYKQF+jJ6EYgFAmxRhTyIMN4wnL7w7wbZsQVmqdKsbks8ZcaU/CJfBH9LQpjDA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-6.4.0.tgz",
+      "integrity": "sha512-Gq6FyqipfJCc+Ju9te4X7ZFUsclKMLNrXTi6nA+p1zysEgIu3xBZhXZRnYOnC8BZslqqQXlMjHOWpb4S9qCy0g==",
       "license": "MIT",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.2.0"
@@ -5948,13 +5947,13 @@
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-6.3.0.tgz",
-      "integrity": "sha512-Rfwx+U1lxzjSecZ9k41rjCa8KTwv9H9PMLhxw/sojAG+kbEfo0TwFjM9BqxVq2Cu9+U02DoE4c4tv6zXqQMqIQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-6.4.0.tgz",
+      "integrity": "sha512-WlXp1U7U406bDDocsd3Kt9y6PQyIod/cEDwWtsI9YT+i+oITylowEQmBZ4s8VX0jJjFYi200DaemupbJKj4oDw==",
       "license": "MIT",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.2.0",
-        "@sanity/types": "6.3.0",
+        "@sanity/types": "6.4.0",
         "@sanity/uuid": "^3.0.3",
         "debug": "^4.4.3",
         "lodash-es": "^4.18.1"
@@ -6396,14 +6395,14 @@
       }
     },
     "node_modules/@sanity/schema": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-6.3.0.tgz",
-      "integrity": "sha512-2Bud3VCBSiS0B4KwHlCx4jYUAWX3OWVByq+JwnfCKrDWGFgxRohrmS0Lx8G9fjbUJ4fUX868HFEdyTt1METW7w==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-6.4.0.tgz",
+      "integrity": "sha512-qtEqKuEEyMaFE+5a7WE3zhK+WgnN9tI+Sb1grBwq1Jc8tY97NzASxD+o6MxQagjsqQ9L7PO4ser2UeqPBH8Jdg==",
       "license": "MIT",
       "dependencies": {
         "@sanity/descriptors": "^1.3.0",
         "@sanity/generate-help-url": "^4.0.0",
-        "@sanity/types": "6.3.0",
+        "@sanity/types": "6.4.0",
         "arrify": "^3.0.0",
         "groq-js": "^1.30.3",
         "humanize-list": "^1.0.1",
@@ -6529,13 +6528,13 @@
       }
     },
     "node_modules/@sanity/types": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-6.3.0.tgz",
-      "integrity": "sha512-IMll1cRPr8DGHEwiOoYiGIvRCA4i0ug25V5tzrCBeWhvJPX9vr4vA7jTHf6dEzvSZW9q6Fo/0X/9aBS42IOrxQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-6.4.0.tgz",
+      "integrity": "sha512-WaUiVKVjnf/qoQ1nbSxz5ayJoycos3ljh4dcg3d17gjCn/Qaqo67yUjYnM3z4qNtZT2vPwHedTSQpsqwsa/1qA==",
       "license": "MIT",
       "dependencies": {
         "@sanity/client": "^7.23.0",
-        "@sanity/media-library-types": "^1.4.0"
+        "@sanity/media-library-types": "^1.5.0"
       },
       "peerDependencies": {
         "@types/react": "*"
@@ -6568,15 +6567,15 @@
       }
     },
     "node_modules/@sanity/util": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-6.3.0.tgz",
-      "integrity": "sha512-VUA3Mzf3xiO4Zyhe2bXbYQYbK2SLdayn5ubQyu1a+DMbABe9eAWA1/CpapFYEgoJR3I2YED8owoQJid2yx70vg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-6.4.0.tgz",
+      "integrity": "sha512-1gnj//YClpPshx6ogaWZ5+cHdlI+Wp0+XbLAhQu+g22YtPrMVYAxFoPpZnmKAMEORjvQZuDaX226PU8R23HVzw==",
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "^1.5.0",
         "@date-fns/utc": "^2.1.1",
         "@sanity/client": "^7.23.0",
-        "@sanity/types": "6.3.0",
+        "@sanity/types": "6.4.0",
         "date-fns": "^4.4.0",
         "rxjs": "^7.8.2"
       },
@@ -6594,9 +6593,9 @@
       }
     },
     "node_modules/@sanity/vision": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-6.3.0.tgz",
-      "integrity": "sha512-MVeFvY2O5nSMO7xaL60JJS4rdXY7t41j0EKsFKKKlvceJCRfpp1st9gU7s9cX8yjVfP4Gd67JtqgMplWsbmqog==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-6.4.0.tgz",
+      "integrity": "sha512-JPzSQCgsIZ1IfwnonPBP8HL+IAPl09IOAexzZTPIF57H26HBp45NPllZtpapLb6nSaHvwZkNG0r67HhDrsSr2w==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",
@@ -6610,9 +6609,9 @@
         "@rexxars/react-json-inspector": "^9.0.1",
         "@rexxars/react-split-pane": "^1.0.0",
         "@sanity/color": "^3.0.6",
-        "@sanity/icons": "^3.7.4",
+        "@sanity/icons": "^5.0.0",
         "@sanity/lezer-groq": "^1.0.4",
-        "@sanity/ui": "^3.2.0",
+        "@sanity/ui": "^3.3.0",
         "@sanity/uuid": "^3.0.3",
         "@uiw/react-codemirror": "^4.25.10",
         "@vanilla-extract/dynamic": "^2.1.5",
@@ -6621,12 +6620,24 @@
         "json5": "^2.2.3",
         "lodash-es": "^4.18.1",
         "quick-lru": "^7.3.0",
-        "react-rx": "^4.2.2",
+        "react-rx": "^4.2.3",
         "rxjs": "^7.8.2"
       },
       "peerDependencies": {
         "react": "^19.2.2",
         "sanity": "^6.0.0-0"
+      }
+    },
+    "node_modules/@sanity/vision/node_modules/@sanity/icons": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-5.0.0.tgz",
+      "integrity": "sha512-fINQLovVnCANwQbQ63iO2mUVh2ZX3T4h3hiSEaIStvladI5tmrGAuT+XbUuk3jTmBwOHDGD0EL9lpsghGAS+Sg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12"
+      },
+      "peerDependencies": {
+        "react": "^19"
       }
     },
     "node_modules/@sanity/visual-editing-types": {
@@ -6924,6 +6935,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -8489,12 +8501,6 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "license": "MIT"
     },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "license": "MIT"
-    },
     "node_modules/clean-stack": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
@@ -8568,6 +8574,15 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -9551,9 +9566,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9562,8 +9577,8 @@
         "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -11470,6 +11485,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-network-error": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -11905,9 +11932,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -13847,9 +13874,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
-      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -14129,9 +14156,9 @@
       }
     },
     "node_modules/react-rx": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/react-rx/-/react-rx-4.2.2.tgz",
-      "integrity": "sha512-L0M51QxRnb5RndopV3lGPtG+O2rGVZl6aIzH1Fyx5ieOog/E947Xu00JERxksPJ9Lxn7kdME2wFtsWpiKTgI+A==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/react-rx/-/react-rx-4.2.3.tgz",
+      "integrity": "sha512-AzuecrOdmoIgVA/wYCCFUnWc1nFtu+6sd++uH03gYAHte/ujYApHPOPEgSlWbKDhMjiXrcYtzv9IJrxwtmurIw==",
       "license": "MIT",
       "dependencies": {
         "observable-callback": "^1.0.3",
@@ -14677,9 +14704,9 @@
       "license": "MIT"
     },
     "node_modules/sanity": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-6.3.0.tgz",
-      "integrity": "sha512-7ZTmLeofwpiwqOiXhqJIDUGFQYMAaH2BLFezQjKT0A0VlPQXEm/rlKLjJXoA+HvKYSRZ0wn3n1GvBItBojeikQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-6.4.0.tgz",
+      "integrity": "sha512-GLLFtHWhLWBW+mgu2XlCs7YQSQWCY6cAFhLZIyDO81p89CgFlTXjGpQGc+2QGUPq5jG4eWG1C+U1p+2GcTaaKA==",
       "license": "MIT",
       "dependencies": {
         "@algorithm.ts/lcs": "^4.0.6",
@@ -14690,15 +14717,15 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@isaacs/ttlcache": "^1.4.1",
         "@mux/mux-player-react": "^3.13.0",
-        "@portabletext/editor": "^7.9.0",
+        "@portabletext/editor": "^7.10.1",
         "@portabletext/html": "^1.1.0",
         "@portabletext/patches": "^2.0.5",
-        "@portabletext/plugin-dnd": "^1.0.11",
-        "@portabletext/plugin-list-index": "^1.0.11",
-        "@portabletext/plugin-markdown-shortcuts": "^8.0.26",
-        "@portabletext/plugin-one-line": "^7.0.26",
-        "@portabletext/plugin-paste-link": "^4.0.26",
-        "@portabletext/plugin-typography": "^8.0.26",
+        "@portabletext/plugin-dnd": "^1.0.13",
+        "@portabletext/plugin-list-index": "^1.0.13",
+        "@portabletext/plugin-markdown-shortcuts": "^8.0.28",
+        "@portabletext/plugin-one-line": "^7.0.28",
+        "@portabletext/plugin-paste-link": "^4.0.28",
+        "@portabletext/plugin-typography": "^8.0.28",
         "@portabletext/react": "^6.2.0",
         "@portabletext/sanity-bridge": "^3.2.0",
         "@portabletext/to-html": "^5.0.2",
@@ -14706,39 +14733,39 @@
         "@rexxars/react-json-inspector": "^9.0.1",
         "@sanity/asset-utils": "^2.3.0",
         "@sanity/bifur-client": "^1.0.0",
-        "@sanity/cli": "^7.4.2",
+        "@sanity/cli": "^7.5.0",
         "@sanity/client": "^7.23.0",
         "@sanity/color": "^3.0.6",
         "@sanity/comlink": "^4.0.1",
-        "@sanity/diff": "6.3.0",
+        "@sanity/diff": "6.4.0",
         "@sanity/diff-match-patch": "^3.2.0",
         "@sanity/diff-patch": "^5.0.0",
         "@sanity/eventsource": "^5.0.2",
-        "@sanity/icons": "^3.7.4",
+        "@sanity/icons": "^5.0.0",
         "@sanity/id-utils": "^1.0.0",
         "@sanity/image-url": "^2.1.1",
         "@sanity/insert-menu": "^3.0.8",
         "@sanity/logos": "^2.2.2",
-        "@sanity/media-library-types": "^1.4.0",
+        "@sanity/media-library-types": "^1.5.0",
         "@sanity/message-protocol": "^0.23.0",
         "@sanity/migrate": "^7.0.3",
         "@sanity/mutate": "^0.18.1",
-        "@sanity/mutator": "6.3.0",
+        "@sanity/mutator": "6.4.0",
         "@sanity/presentation-comlink": "^2.1.0",
         "@sanity/preview-url-secret": "^4.0.7",
         "@sanity/prism-groq": "^1.1.2",
-        "@sanity/schema": "6.3.0",
+        "@sanity/schema": "6.4.0",
         "@sanity/sdk": "^2.15.0",
         "@sanity/telemetry": "^1.1.0",
-        "@sanity/types": "6.3.0",
-        "@sanity/ui": "^3.2.0",
-        "@sanity/util": "6.3.0",
+        "@sanity/types": "6.4.0",
+        "@sanity/ui": "^3.3.0",
+        "@sanity/util": "6.4.0",
         "@sanity/uuid": "^3.0.3",
         "@sentry/react": "^10.62.0",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.14.4",
         "@xstate/react": "^6.1.0",
-        "classnames": "^2.5.1",
+        "clsx": "^2.1.1",
         "color2k": "^2.0.3",
         "dataloader": "^2.2.3",
         "date-fns": "^4.4.0",
@@ -14749,6 +14776,7 @@
         "history": "^5.3.0",
         "i18next": "^26.3.3",
         "is-hotkey-esm": "^1.0.0",
+        "is-network-error": "^1.3.1",
         "isomorphic-dompurify": "2.36.0",
         "json-reduce": "^3.0.0",
         "json-stable-stringify": "^1.3.0",
@@ -14768,7 +14796,7 @@
         "react-i18next": "^17.0.8",
         "react-is": "^19.2.7",
         "react-refractor": "^4.0.0",
-        "react-rx": "^4.2.2",
+        "react-rx": "^4.2.3",
         "refractor": "^5.0.0",
         "rxjs": "^7.8.2",
         "rxjs-exhaustmap-with-trailing": "^2.1.1",
@@ -14797,6 +14825,18 @@
         "react": "^19.2.2",
         "react-dom": "^19.2.2",
         "styled-components": "^6.1.15"
+      }
+    },
+    "node_modules/sanity/node_modules/@sanity/icons": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-5.0.0.tgz",
+      "integrity": "sha512-fINQLovVnCANwQbQ63iO2mUVh2ZX3T4h3hiSEaIStvladI5tmrGAuT+XbUuk3jTmBwOHDGD0EL9lpsghGAS+Sg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12"
+      },
+      "peerDependencies": {
+        "react": "^19"
       }
     },
     "node_modules/sanity/node_modules/semver": {
@@ -15897,6 +15937,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/digitaltableteur-blog/package-lock.json
+++ b/digitaltableteur-blog/package-lock.json
@@ -6935,7 +6935,6 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -15937,7 +15936,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/digitaltableteur-blog/package.json
+++ b/digitaltableteur-blog/package.json
@@ -18,18 +18,18 @@
     "sanity"
   ],
   "dependencies": {
-    "@sanity/code-input": "^7.2.5",
-    "@sanity/vision": "^6.3.0",
+    "@sanity/code-input": "^7.2.6",
+    "@sanity/vision": "^6.4.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "sanity": "^6.3.0",
+    "sanity": "^6.4.0",
     "styled-components": "^6.4.3"
   },
   "devDependencies": {
     "@sanity/eslint-config-studio": "^6.0.0",
     "@types/react": "^19.2.17",
     "eslint": "^9.39",
-    "prettier": "^3.9.4",
+    "prettier": "^3.9.5",
     "typescript": "^6.0.3"
   },
   "prettier": {


### PR DESCRIPTION
Sanity studio minor/patch bumps: `sanity` + `@sanity/vision` 6.4.0, `@sanity/code-input` 7.2.6, `prettier` 3.9.5 (plus grouped transitive @portabletext/* and xstate patches).

**Gate:** `npm install` + `sanity build` clean in digitaltableteur-blog/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)