### PR TITLE
fix(security): namespace-import js-yaml for v5 (default export removed)

### DIFF
--- a/tests/security/run-security-tests.mjs
+++ b/tests/security/run-security-tests.mjs
@@ -13,7 +13,7 @@
 
 import fs from "fs";
 import path from "path";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
**Regression fix for #1166.** js-yaml 5 ships ESM named exports only (no default), so `import yaml from 'js-yaml'` in the security runner threw `SyntaxError: does not provide an export named 'default'` at module load — crashing `npm run test:security` before any test ran.

Switched to a namespace import (`import * as yaml`); the sole call site (`yaml.load` of the YAML test-suite config) is unchanged.

**Why it slipped through #1166:** `test:security` targets `http://localhost:3000/api/chat` and is a manual/staging tool — it's not in the pre-push hook or CI, and the standard gate (typecheck/lint/vitest/build) doesn't import js-yaml. My earlier js-yaml grep scoped scripts/app/nextjs-app and missed `tests/`.

**Verified:** the runner now loads and parses its YAML suite (52 tests enumerated instead of an import crash). Remaining failures are the expected 'no dev server on :3000' network state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)