### PR TITLE
chore(deps): Vercel AI SDK v7 (coordinated ai + providers + react)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "2.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@ai-sdk/mcp": "^1.0.51",
-        "@ai-sdk/openai": "^3.0.71",
-        "@ai-sdk/react": "^3.0.207",
+        "@ai-sdk/mcp": "^2.0.10",
+        "@ai-sdk/openai": "^4.0.11",
+        "@ai-sdk/react": "^4.0.23",
         "@calcom/embed-react": "^1.5.3",
         "@digitaltableteur/react": "^0.1.12",
         "@digitaltableteur/tokens": "^0.1.1",
@@ -45,7 +45,7 @@
         "@swc/helpers": "^0.5.23",
         "@vercel/analytics": "^2.0.1",
         "@vitest/browser-playwright": "^4.1.10",
-        "ai": "^6.0.205",
+        "ai": "^7.0.22",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dompurify": "^3.4.11",
@@ -239,97 +239,100 @@
       "license": "MIT"
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.132",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.132.tgz",
-      "integrity": "sha512-sFZFGk6aVSNKmgDrb14efaAbvM71AB3UUvaTsU+bvhWP9jrkRrwix/jFX8IoOAJk0/X7Xf7p3m0J2O2G6ljZbA==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.16.tgz",
+      "integrity": "sha512-9iYxdOLquoOFk5e+02P9qfBIA+EJU0FNJvyjGxi4iXJabt2+GlbaCg7TX0sTtxOsBVkdabkatqWM6+kvp53tBg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.29",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.7",
         "@vercel/oidc": "3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/mcp": {
-      "version": "1.0.51",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-1.0.51.tgz",
-      "integrity": "sha512-03JEdJtB+K/I7a85GWJjrB+ypYY++ZFDTp2YJ5Wd0e0raZdFpBLvvX9LJIxPF1LRbs7PMtx6TIS1YMP0Dece+w==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.10.tgz",
+      "integrity": "sha512-LP47CEk3e6BwCqXamvv4nKbgOWQ5z5T/qS/J2fola5h98KTy7JT7I1yw5LKtB89MZBLviYmEh98Ep4ovHOz/vA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.29",
-        "pkce-challenge": "^5.0.0"
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.7",
+        "pkce-challenge": "^5.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "3.0.71",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.71.tgz",
-      "integrity": "sha512-j6eBAa5oHFZ4U5CxpIV3T4zXNM/BviodNCZCL1qHkA4aqkwK9iQ18TWYz2DZcXpw4BO5pikKzqpXORxb1EnZGA==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-4.0.11.tgz",
+      "integrity": "sha512-2PLnVPBsdJusgquPVYgPWd3ox4lbUFkp7DVUSmM0lQ4VISQoNxdgo6TvFAHgwQn9wJ/ckVYVRLU7+BvHc7T8ww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.29"
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.3.tgz",
+      "integrity": "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.29",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.29.tgz",
-      "integrity": "sha512-uhukHaCBvqkwBHkT8C2PrnqKTCoLn3pdHXqtcR9I8ErH+flbzgW4o7VHSNIup9LRu+WBvZIZDQLsx6rwl2tiOA==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.7.tgz",
+      "integrity": "sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider": "4.0.3",
         "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
         "eventsource-parser": "^3.0.8"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/react": {
-      "version": "3.0.208",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.208.tgz",
-      "integrity": "sha512-HEhPWLlg5wPqnadGqDRBek8V3GzmlLH3v4PCvDY/GCsDTNKk2nYpExvl8mXu20gVT4h+79OCAy9ozKrdTXi+4A==",
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-4.0.23.tgz",
+      "integrity": "sha512-nJ96yQE1013tafK9Pec3uSGTScXg8dc3t4xyydm+a0AfkaSewR58+Eg3l+xqmQAR8tzFAgo/38we5DeXrcgcqw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider-utils": "4.0.29",
-        "ai": "6.0.206",
-        "swr": "^2.2.5",
+        "@ai-sdk/mcp": "2.0.10",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.7",
+        "ai": "7.0.22",
+        "swr": "^2.4.1",
         "throttleit": "2.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
@@ -22385,6 +22388,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@xstate/react": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@xstate/react/-/react-6.1.0.tgz",
@@ -22581,18 +22590,17 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.206",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.206.tgz",
-      "integrity": "sha512-hVdB5PozMMxmkPBfbCxkFOn0eVeCMi/imkfPvk65cxL4O8oIrvjUxDUX8dGkdkWG1No+R7e7D9ti2DHO61Z4YQ==",
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.22.tgz",
+      "integrity": "sha512-iAXYwQtR18qN7GXwNmGVAQM4uSJOh2+nZ5RP9NtDXfH5d4tlYyYzAM133O3U+eVcyWrvNRzecN9yW58xpCdfMg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.132",
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.29",
-        "@opentelemetry/api": "^1.9.0"
+        "@ai-sdk/gateway": "4.0.16",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"

--- a/package.json
+++ b/package.json
@@ -187,9 +187,9 @@
     "check:figma-links": "node scripts/design-system/check-figma-links.mjs"
   },
   "dependencies": {
-    "@ai-sdk/mcp": "^1.0.51",
-    "@ai-sdk/openai": "^3.0.71",
-    "@ai-sdk/react": "^3.0.207",
+    "@ai-sdk/mcp": "^2.0.10",
+    "@ai-sdk/openai": "^4.0.11",
+    "@ai-sdk/react": "^4.0.23",
     "@calcom/embed-react": "^1.5.3",
     "@digitaltableteur/react": "^0.1.12",
     "@digitaltableteur/tokens": "^0.1.1",
@@ -223,7 +223,7 @@
     "@swc/helpers": "^0.5.23",
     "@vercel/analytics": "^2.0.1",
     "@vitest/browser-playwright": "^4.1.10",
-    "ai": "^6.0.205",
+    "ai": "^7.0.22",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dompurify": "^3.4.11",


### PR DESCRIPTION
Bumps the AI SDK as a **coordinated set** so the Donny chat server and client stay protocol-matched. Absorbs #1158, #1152, #1153 (auto-close on merge) and adds the client bump they omit.

- `ai` 6 → 7 (#1158)
- `@ai-sdk/openai` 3 → 4 (#1152)
- `@ai-sdk/mcp` 1 → 2 (#1153)
- **`@ai-sdk/react` 3 → 4 (added here)** — not in any Dependabot PR, but the client `useChat` hook must jump with the server or the streaming protocol skews. Merging the three server PRs alone would ship that skew, which is why I did this as one PR instead of auto-merging them.

**Verification — static + live runtime**
- typecheck ✅ lint ✅ vitest 2291 ✅ next build ✅
- Live chat smoke against a v7 production server (`next start`, real OpenAI/gateway keys):
  - **Text streaming** — full v7 data-stream protocol (start → text-start → text-delta ×N → finish); coherent model output
  - **Tool calling** — two-step run exercising the complete tool lifecycle (tool-input-start/delta/available → tool-output-available) then follow-up text, covering @ai-sdk/mcp v2 + the streamText tool loop

Held siblings (separate disposition): eslint 10 (plugin ecosystem), typescript 7 (baseUrl migration) — both `@dependabot ignore`d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)