### PR TITLE
chore(deps): postcss 8.5.19 (dev group re-scan)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,7 @@
         "pixelmatch": "^7.2.0",
         "playwright": "^1.61.0",
         "pngjs": "^7.0.0",
-        "postcss": "^8.5.18",
+        "postcss": "^8.5.19",
         "react-chartjs-2": "^5.3.1",
         "storybook": "^10.5.0",
         "style-dictionary": "^5.4.4",
@@ -38746,9 +38746,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -349,7 +349,7 @@
     "pixelmatch": "^7.2.0",
     "playwright": "^1.61.0",
     "pngjs": "^7.0.0",
-    "postcss": "^8.5.18",
+    "postcss": "^8.5.19",
     "react-chartjs-2": "^5.3.1",
     "storybook": "^10.5.0",
     "style-dictionary": "^5.4.4",


### PR DESCRIPTION
Patch bump dependabot re-cut after #1163 landed postcss 8.5.18. Verified: next build + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)