### PR TITLE
fix(ci): stop Snyk monitor and farm Verdaccio gap failing runs

### DIFF
--- a/.github/scripts/write-npm-read-config.sh
+++ b/.github/scripts/write-npm-read-config.sh
@@ -13,8 +13,16 @@ if [ -z "${RUNNER_TEMP:-}" ]; then
   exit 1
 fi
 
+# Pin the @digitaltableteur scope to public npm explicitly. The self-hosted farm
+# runner ships a machine-global npmrc that redirects this scope to a local Verdaccio
+# mirror (100.77.151.86:4873); that mirror lags newly published packages (e.g.
+# tokens-css@0.1.2 404s there) and diverges from the lockfile, which the
+# check:package-registry-resolution guard requires to resolve from registry.npmjs.org.
+# A userconfig scope entry overrides the global one, so npm ci fetches every
+# @digitaltableteur package from the same registry the lockfile integrity hashes cover.
 cat > "$RUNNER_TEMP/npm-read.npmrc" <<EOF
 registry=https://registry.npmjs.org/
+@digitaltableteur:registry=https://registry.npmjs.org/
 //registry.npmjs.org/:_authToken=${NPM_READ_TOKEN}
 EOF
 

--- a/.github/workflows/security-scanning.yml
+++ b/.github/workflows/security-scanning.yml
@@ -116,6 +116,11 @@ jobs:
 
       - name: Monitor with Snyk
         uses: snyk/actions/node@master
+        # Fire-and-forget telemetry push to the Snyk dashboard; monitoring must never
+        # gate the security workflow. The CLI can exit non-zero (SNYK-CLI-0000) even
+        # after all projects monitor successfully with --all-projects, which otherwise
+        # fails Security Scanning on every push to main.
+        continue-on-error: true
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## Problem

Two non-dependabot CI failures that were treated as permanently "quota-dead" but are actually systemic and fixable (PR Validation runs on the self-hosted farm, which isn't metered).

### 1. Security Scanning — fails on every push to `main`
The `Monitor with Snyk` step monitors all projects successfully but the Snyk CLI still exits non-zero (`SNYK-CLI-0000`) with `--all-projects`. It has no `continue-on-error`, unlike the two actual scan steps above it. `snyk monitor` is fire-and-forget telemetry to the Snyk dashboard and must never gate the workflow.

### 2. PR Validation — fails on every non-dependabot PR at `npm ci`
```
npm error 404 GET http://100.77.151.86:4873/@digitaltableteur/tokens-css/-/tokens-css-0.1.2.tgz - no such package available
```
The farm runner's machine-global npmrc redirects the `@digitaltableteur` scope to its Verdaccio mirror, which lags newly published packages. `tokens-css` is a recent dep that never landed there. The repo's own `check:package-registry-resolution` guard requires these packages to resolve from `registry.npmjs.org`, and `npm ci` enforces the lockfile's public-npm integrity hashes — so pinning the scope to public npm is safe (the mirror could only ever serve byte-identical copies).

## Changes
- `security-scanning.yml`: `continue-on-error: true` on `Monitor with Snyk`.
- `write-npm-read-config.sh`: pin `@digitaltableteur:registry=https://registry.npmjs.org/` in the read npmrc (userconfig scope overrides the runner's global redirect).

## Verification
- YAML validated (js-yaml), shell syntax + generated npmrc confirmed.
- Pre-commit hook: contrast / css / typecheck / lint all pass, baselines unchanged.
- Fix 2 can only be fully proven by a farm PR Validation run — that's what this PR triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package installation reliability by ensuring the designated npm scope uses the public npm registry.
  * Updated security monitoring so telemetry reporting issues do not block the overall security workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->