### PR TITLE
fix(ci): force @digitaltableteur scope to public npm on farm npm ci

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,7 +21,13 @@ jobs:
         env:
           NPM_READ_TOKEN: ${{ secrets.NPM_READ_TOKEN }}
         run: bash .github/scripts/write-npm-read-config.sh
-      - run: NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/npm-read.npmrc" npm ci
+      # Force the @digitaltableteur scope to public npm on the CLI (highest config
+      # precedence, beats the runner's machine-global Verdaccio redirect at
+      # 100.77.151.86:4873, which lags newly published packages e.g. tokens-css@0.1.2).
+      # npm rewrites the lockfile's registry.npmjs.org tarball host to the configured
+      # scoped registry, so this keeps it on public npm — matching the lockfile
+      # integrity hashes and the check:package-registry-resolution contract.
+      - run: NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/npm-read.npmrc" npm ci --@digitaltableteur:registry=https://registry.npmjs.org/
       - run: npm run build:tokens
       - run: npm run check:contract-drift -- --strict
       - run: npm run check:contract-props


### PR DESCRIPTION
Follow-up to #1171. The userconfig scope pin did not override the farm runner's machine-global Verdaccio redirect — npm still rewrote the lockfile's registry.npmjs.org tarball host to `100.77.151.86:4873` and 404'd on `@digitaltableteur/tokens-css@0.1.2`.

This passes the scoped registry as a **CLI flag** on the farm's `npm ci` step. CLI config is the highest precedence (beats env, project, user, global), so it wins regardless of where the farm injects its redirect. Only PR Validation runs on the farm; Security Scanning's `npm ci` is GitHub-hosted and already resolves from public npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)