### PR TITLE
feat(ds): honest npm-consumption metric (governed denominator + transitive credit)

### DIFF
--- a/nextjs-app/shared/foundations/dist/component-usage.json
+++ b/nextjs-app/shared/foundations/dist/component-usage.json
@@ -1,10 +1,19 @@
 {
-  "generatedAt": "2026-07-13T08:13:47.685Z",
+  "generatedAt": "2026-07-13T15:32:23.548Z",
+  "summary": {
+    "catalogCount": 204,
+    "governedCount": 162,
+    "exportedCount": 70,
+    "strictConsumedCount": 22,
+    "transitiveConsumedCount": 59
+  },
   "components": [
     {
       "name": "__templates__",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 0,
       "directImporters": [],
       "packageImportCount": 0,
@@ -16,6 +25,8 @@
       "name": "AboutHero",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx",
@@ -37,6 +48,8 @@
       "name": "AboutPageContent",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
@@ -56,6 +69,8 @@
       "name": "Accordion",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 0,
       "directImporters": [],
       "packageImportCount": 0,
@@ -67,6 +82,8 @@
       "name": "AlertBanner",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/Mermaid/Mermaid.tsx",
@@ -86,18 +103,19 @@
       "name": "animations",
       "kind": "component",
       "status": null,
-      "directImportCount": 26,
+      "governed": false,
+      "exported": false,
+      "directImportCount": 25,
       "directImporters": [
-        "nextjs-app/shared/components/BlogGrid/BlogGrid.tsx",
         "nextjs-app/shared/components/ContactFormSuccess/ContactFormSuccess.tsx",
         "nextjs-app/shared/components/LocationCard/LocationCard.tsx",
         "nextjs-app/shared/components/NextLayout/NextLayout.tsx",
-        "nextjs-app/shared/components/SkillsGrid/SkillsGrid.tsx",
         "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx",
         "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
         "nextjs-app/shared/patterns/AboutHero/AboutHero.tsx",
         "nextjs-app/shared/patterns/ArticleHero/ArticleHero.tsx",
         "nextjs-app/shared/patterns/BlogHero/BlogHero.tsx",
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx",
         "nextjs-app/shared/patterns/CTASection/CTASection.tsx",
         "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx",
         "nextjs-app/shared/patterns/ContactHero/ContactHero.tsx",
@@ -124,6 +142,8 @@
       "name": "AppLoading",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -137,6 +157,8 @@
       "name": "ArticleCard",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -150,6 +172,8 @@
       "name": "ArticleContent",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 4,
       "directImporters": [
         "app/blog/[slug]/BlogArticleMdxBody.tsx",
@@ -177,6 +201,8 @@
       "name": "ArticleHero",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx",
@@ -202,6 +228,8 @@
       "name": "ArticleLayout",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 3,
       "directImporters": [
         "app/blog/[slug]/ClientArticleShell.tsx",
@@ -229,6 +257,8 @@
       "name": "ArticlePageTemplate",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 3,
       "directImporters": [
         "app/blog/[slug]/BlogArticleMdxBody.tsx",
@@ -253,6 +283,8 @@
       "name": "ArticleShareSection",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/index.ts",
@@ -277,6 +309,8 @@
       "name": "AskAI",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/components/pages/AboutPage/AboutPage.tsx",
@@ -292,6 +326,8 @@
       "name": "AspectRatio",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx"
@@ -307,6 +343,8 @@
       "name": "Author",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -320,6 +358,8 @@
       "name": "AuthorBio",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/components/index.ts",
@@ -346,6 +386,8 @@
       "name": "Avatar",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/components/Author/Author.tsx",
@@ -372,6 +414,8 @@
       "name": "AvatarGroup",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": true,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -385,6 +429,8 @@
       "name": "Badge",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 8,
       "directImporters": [
         "nextjs-app/shared/components/CookieConsent/CookieConsent.tsx",
@@ -422,26 +468,8 @@
       "name": "BlogCategoryFilter",
       "kind": "component",
       "status": "stable",
-      "directImportCount": 2,
-      "directImporters": [
-        "nextjs-app/shared/components/index.ts",
-        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx"
-      ],
-      "packageImportCount": 0,
-      "packageImporters": [],
-      "prodPageCount": 5,
-      "prodPages": [
-        "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
-        "nextjs-app/shared/components/pages/Blog/index.ts",
-        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx",
-        "nextjs-app/shared/patterns/BlogIndexContent/index.ts",
-        "nextjs-app/shared/patterns/index.ts"
-      ]
-    },
-    {
-      "name": "BlogGrid",
-      "kind": "component",
-      "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/index.ts",
@@ -462,6 +490,8 @@
       "name": "BlogHero",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx",
@@ -483,6 +513,8 @@
       "name": "BlogIndexContent",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
@@ -502,6 +534,8 @@
       "name": "BlogMediaImage",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/components/EnhancedArticleCard/EnhancedArticleCard.tsx",
@@ -530,6 +564,8 @@
       "name": "BlogNav",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 0,
       "directImporters": [],
       "packageImportCount": 0,
@@ -541,6 +577,8 @@
       "name": "Breadcrumb",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/index.ts",
@@ -559,6 +597,8 @@
       "name": "Button",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 47,
       "directImporters": [
         "app/blog/NextBlogNav.tsx",
@@ -646,6 +686,8 @@
       "name": "ButtonGroup",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": true,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -659,6 +701,8 @@
       "name": "Card",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 7,
       "directImporters": [
         "nextjs-app/shared/components/ComplianceCard/ComplianceCard.tsx",
@@ -686,6 +730,8 @@
       "name": "CategoryFilter",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
@@ -706,6 +752,8 @@
       "name": "Center",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx"
@@ -721,6 +769,8 @@
       "name": "ChatWidget",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/NextLayout/NextLayout.tsx",
@@ -737,6 +787,8 @@
       "name": "Checkbox",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 4,
       "directImporters": [
         "nextjs-app/shared/components/AskAI/AskAI.tsx",
@@ -762,6 +814,8 @@
       "name": "CheckboxGroup",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 4,
       "directImporters": [
         "nextjs-app/shared/components/ChatWidget/emailWorkflow/FieldPrompt.tsx",
@@ -784,6 +838,8 @@
       "name": "ChunkErrorBoundary",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -797,6 +853,8 @@
       "name": "ClientLogoMarquee",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/pages/Home/HomePage.tsx"
@@ -812,6 +870,8 @@
       "name": "CodeBlockWindow",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 3,
       "directImporters": [
         "app/dev/code-window/page.tsx",
@@ -841,6 +901,8 @@
       "name": "CodeSnippet",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx"
@@ -859,6 +921,8 @@
       "name": "Combobox",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/components/FileUpload/FileUpload.tsx",
@@ -879,6 +943,8 @@
       "name": "CommandPalette",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": true,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -892,6 +958,8 @@
       "name": "ComplianceCard",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -905,6 +973,8 @@
       "name": "ContactForm",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/ChatWidget/emailWorkflow/FieldPrompt.tsx",
@@ -921,6 +991,8 @@
       "name": "ContactFormEditorial",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx"
@@ -939,6 +1011,8 @@
       "name": "ContactFormSuccess",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/ui/index.ts"
@@ -952,6 +1026,8 @@
       "name": "ContactFormSuccessEditorial",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx"
@@ -965,6 +1041,8 @@
       "name": "ContactHero",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/patterns/index.ts"
@@ -981,6 +1059,8 @@
       "name": "ContactInquiryPanel",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
@@ -1001,6 +1081,8 @@
       "name": "ContactPage",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "app/contact/ContactContent.tsx"
@@ -1014,6 +1096,8 @@
       "name": "ContactPageContentEditorial",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx"
@@ -1031,6 +1115,8 @@
       "name": "Container",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 34,
       "directImporters": [
         "app/blog/[slug]/ServerArticleHero.tsx",
@@ -1096,6 +1182,8 @@
       "name": "ContentSection",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/patterns/ProjectDetailTemplate/ProjectDetailTemplate.tsx",
@@ -1115,6 +1203,8 @@
       "name": "CookieConsent",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": true,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/NextLayout/NextLayout.tsx",
@@ -1131,6 +1221,8 @@
       "name": "CTASection",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 4,
       "directImporters": [
         "nextjs-app/shared/components/pages/Home/HomePage.tsx",
@@ -1160,6 +1252,8 @@
       "name": "CVDownloadSection",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/patterns/index.ts"
@@ -1176,6 +1270,8 @@
       "name": "DashLeadList",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx"
@@ -1199,6 +1295,8 @@
       "name": "Designerman",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 0,
       "directImporters": [],
       "packageImportCount": 0,
@@ -1210,6 +1308,8 @@
       "name": "DesignSprintsSection",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/pages/Home/HomePage.tsx",
@@ -1228,6 +1328,8 @@
       "name": "Display",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 0,
       "directImporters": [],
       "packageImportCount": 0,
@@ -1239,6 +1341,8 @@
       "name": "Divider",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/components/index.ts",
@@ -1261,6 +1365,8 @@
       "name": "DonnyActionProvider",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 6,
       "directImporters": [
         "nextjs-app/shared/components/ChatWidget/chatToolLead.ts",
@@ -1279,6 +1385,8 @@
       "name": "DonnyAvatar",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 7,
       "directImporters": [
         "nextjs-app/shared/components/ChatWidget/ChatHeader.tsx",
@@ -1300,6 +1408,8 @@
       "name": "DonnyBookingEmbed",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/ChatWidget/ChatMessageBubble.tsx",
@@ -1322,6 +1432,8 @@
       "name": "EmailSignatureGenerator",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "app/tools/email-signature/EmailSignatureContent.tsx",
@@ -1339,28 +1451,38 @@
       "name": "EmptyState",
       "kind": "component",
       "status": "stable",
-      "directImportCount": 2,
+      "governed": true,
+      "exported": true,
+      "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/components/index.ts",
-        "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx"
+        "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx"
       ],
-      "packageImportCount": 1,
+      "packageImportCount": 2,
       "packageImporters": [
-        "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx"
+        "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx"
       ],
-      "prodPageCount": 2,
+      "prodPageCount": 7,
       "prodPages": [
+        "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
         "nextjs-app/shared/components/pages/Work/WorkIndex/index.ts",
-        "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx"
+        "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx",
+        "nextjs-app/shared/patterns/BlogIndexContent/index.ts",
+        "nextjs-app/shared/patterns/index.ts"
       ]
     },
     {
       "name": "EnhancedArticleCard",
       "kind": "component",
       "status": null,
-      "directImportCount": 4,
+      "governed": false,
+      "exported": false,
+      "directImportCount": 3,
       "directImporters": [
-        "nextjs-app/shared/components/BlogGrid/BlogGrid.tsx",
         "nextjs-app/shared/components/index.ts",
         "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx",
         "nextjs-app/shared/patterns/RelatedPosts/RelatedPosts.tsx"
@@ -1374,6 +1496,8 @@
       "name": "EnhancedAuthorCard",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/index.ts",
@@ -1388,6 +1512,8 @@
       "name": "EnhancedProjectCard",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 5,
       "directImporters": [
         "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
@@ -1418,6 +1544,8 @@
       "name": "ExpandableSection",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx"
@@ -1436,6 +1564,8 @@
       "name": "FileUpload",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/components/ContactForm/ContactForm.tsx",
@@ -1457,6 +1587,8 @@
       "name": "FilterChip",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/BlogCategoryFilter/BlogCategoryFilter.tsx",
@@ -1480,6 +1612,8 @@
       "name": "FinnishTransportAgency",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "app/work/finnish-transport-agency/page.tsx"
@@ -1493,6 +1627,8 @@
       "name": "FlexBox",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/index.ts",
@@ -1512,6 +1648,8 @@
       "name": "Footer",
       "kind": "pattern",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 0,
       "directImporters": [],
       "packageImportCount": 0,
@@ -1523,6 +1661,8 @@
       "name": "FormField",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/ui/index.ts"
@@ -1538,6 +1678,8 @@
       "name": "FormFieldEditorial",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx"
@@ -1556,6 +1698,8 @@
       "name": "Gallery",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": true,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/index.ts",
@@ -1575,6 +1719,8 @@
       "name": "GarageJunction",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "app/work/garage-junction/page.tsx"
@@ -1588,6 +1734,8 @@
       "name": "GradientDots",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 0,
       "directImporters": [],
       "packageImportCount": 0,
@@ -1599,27 +1747,42 @@
       "name": "Grid",
       "kind": "component",
       "status": "stable",
-      "directImportCount": 3,
+      "governed": true,
+      "exported": true,
+      "directImportCount": 5,
       "directImporters": [
+        "nextjs-app/shared/components/ServicesGrid/ServicesGrid.tsx",
         "nextjs-app/shared/components/index.ts",
         "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx",
         "nextjs-app/shared/patterns/Footer/Footer.tsx"
       ],
-      "packageImportCount": 1,
+      "packageImportCount": 4,
       "packageImporters": [
+        "nextjs-app/shared/components/ServicesGrid/ServicesGrid.tsx",
+        "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx",
         "nextjs-app/shared/patterns/Footer/Footer.tsx"
       ],
-      "prodPageCount": 3,
+      "prodPageCount": 9,
       "prodPages": [
+        "app/layout.tsx",
+        "nextjs-app/shared/components/pages/Blog/BlogPage.tsx",
+        "nextjs-app/shared/components/pages/Blog/index.ts",
         "nextjs-app/shared/components/pages/Work/WorkIndex/index.ts",
         "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
-        "nextjs-app/shared/patterns/Footer/Footer.tsx"
+        "nextjs-app/shared/patterns/BlogIndexContent/BlogIndexContent.tsx",
+        "nextjs-app/shared/patterns/BlogIndexContent/index.ts",
+        "nextjs-app/shared/patterns/Footer/Footer.tsx",
+        "nextjs-app/shared/patterns/index.ts"
       ]
     },
     {
       "name": "GridBlock",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 12,
       "directImporters": [
         "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
@@ -1657,6 +1820,8 @@
       "name": "GroupLabel",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/CheckboxGroup/CheckboxGroup.tsx",
@@ -1677,6 +1842,8 @@
       "name": "HelperText",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 12,
       "directImporters": [
         "nextjs-app/shared/components/ChatWidget/ChatComposer.tsx",
@@ -1714,6 +1881,8 @@
       "name": "HelsinkiClock",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -1727,6 +1896,8 @@
       "name": "Hero",
       "kind": "pattern",
       "status": "deprecated",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/patterns/index.ts"
@@ -1743,6 +1914,8 @@
       "name": "HeroBackground",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx"
@@ -1756,6 +1929,8 @@
       "name": "HeroSection",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
@@ -1776,6 +1951,8 @@
       "name": "HighlightSection",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/pages/Home/HomePage.tsx",
@@ -1794,6 +1971,8 @@
       "name": "HomeHero",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/pages/Home/HomePage.tsx",
@@ -1812,6 +1991,8 @@
       "name": "Icon",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 46,
       "directImporters": [
         "app/blog/NextBlogNav.tsx",
@@ -1894,6 +2075,8 @@
       "name": "IconButton",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/components/ui/index.ts",
@@ -1917,6 +2100,8 @@
       "name": "icons",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/pages/Home/HomePage.tsx"
@@ -1930,6 +2115,8 @@
       "name": "Illustrations",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "app/work/illustrations/page.tsx"
@@ -1943,6 +2130,8 @@
       "name": "ImagePlaceholder",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 0,
       "directImporters": [],
       "packageImportCount": 0,
@@ -1954,6 +2143,8 @@
       "name": "interactive",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 0,
       "directImporters": [],
       "packageImportCount": 0,
@@ -1965,6 +2156,8 @@
       "name": "Intrum",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "app/work/intrum/page.tsx"
@@ -1978,6 +2171,8 @@
       "name": "Kbd",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": true,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -1991,6 +2186,8 @@
       "name": "KnobSmithAudio",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "app/work/knobsmith-audio/page.tsx"
@@ -2004,6 +2201,8 @@
       "name": "Label",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 10,
       "directImporters": [
         "nextjs-app/shared/components/ChatWidget/ChatComposer.tsx",
@@ -2039,6 +2238,8 @@
       "name": "LanguageSwitcher",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx"
@@ -2060,6 +2261,8 @@
       "name": "Lightbox",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/components/ProjectGallery/ProjectGallery.tsx",
@@ -2075,6 +2278,8 @@
       "name": "Link",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 16,
       "directImporters": [
         "nextjs-app/shared/components/AuthorBio/AuthorBio.tsx",
@@ -2121,6 +2326,8 @@
       "name": "LinkedInQuoteCard",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 0,
       "directImporters": [],
       "packageImportCount": 0,
@@ -2132,6 +2339,8 @@
       "name": "List",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 6,
       "directImporters": [
         "nextjs-app/shared/components/index.ts",
@@ -2168,6 +2377,8 @@
       "name": "LocationCard",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/ui/index.ts"
@@ -2183,6 +2394,8 @@
       "name": "Logo",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 0,
       "directImporters": [],
       "packageImportCount": 0,
@@ -2194,6 +2407,8 @@
       "name": "LogoConstruction",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx"
@@ -2207,6 +2422,8 @@
       "name": "LogoReveal",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx"
@@ -2220,6 +2437,8 @@
       "name": "MacWindowFrame",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": true,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -2233,6 +2452,8 @@
       "name": "ManifestoSection",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx",
@@ -2254,6 +2475,8 @@
       "name": "MarkdownMessage",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/components/ChatWidget/ChatMessageBubble.tsx",
@@ -2272,6 +2495,8 @@
       "name": "MCPActionButton",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -2285,6 +2510,8 @@
       "name": "MdxImage",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/patterns/ArticlePageTemplate/ArticlePageTemplate.tsx"
@@ -2298,6 +2525,8 @@
       "name": "Menu",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 4,
       "directImporters": [
         "nextjs-app/shared/components/Avatar/Avatar.tsx",
@@ -2327,6 +2556,8 @@
       "name": "Mermaid",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/pages/Work/KnobSmithAudio/KnobSmithAudioPage.tsx",
@@ -2341,6 +2572,8 @@
       "name": "Modal",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 6,
       "directImporters": [
         "nextjs-app/shared/components/ContactForm/ContactForm.tsx",
@@ -2366,6 +2599,8 @@
       "name": "MultiCombobox",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx"
@@ -2384,6 +2619,8 @@
       "name": "navigation",
       "kind": "pattern",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 25,
       "directImporters": [
         "app/blog/NextBlogNav.tsx",
@@ -2421,6 +2658,8 @@
       "name": "NavLink",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx",
@@ -2444,6 +2683,8 @@
       "name": "NavMenuList",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": true,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -2457,6 +2698,8 @@
       "name": "NewsBulletin",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/pages/Home/HomePage.tsx"
@@ -2474,6 +2717,8 @@
       "name": "NewsletterWaitlist",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 0,
       "directImporters": [],
       "packageImportCount": 0,
@@ -2485,6 +2730,8 @@
       "name": "NewThingsCo",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "app/work/new-things-co/page.tsx"
@@ -2498,6 +2745,8 @@
       "name": "NextLayout",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "app/layout.tsx",
@@ -2514,6 +2763,8 @@
       "name": "OpenHours",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/ChatWidget/ChatMessageBubble.tsx",
@@ -2530,6 +2781,8 @@
       "name": "PageLayout",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 13,
       "directImporters": [
         "nextjs-app/shared/components/pages/Blog/AuthorPage.tsx",
@@ -2573,6 +2826,8 @@
       "name": "pages",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 20,
       "directImporters": [
         "nextjs-app/shared/components/ContactPage/index.ts",
@@ -2605,6 +2860,8 @@
       "name": "Pagination",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/index.ts",
@@ -2625,6 +2882,8 @@
       "name": "PersonCard",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -2638,6 +2897,8 @@
       "name": "PhoneInput",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/components/ContactForm/ContactForm.tsx",
@@ -2659,6 +2920,8 @@
       "name": "PricingPageContent",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/pages/PricingPage/PricingPage.tsx"
@@ -2676,6 +2939,8 @@
       "name": "ProcessBlock",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 12,
       "directImporters": [
         "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
@@ -2725,6 +2990,8 @@
       "name": "Progress",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/components/DonnyBookingEmbed/DonnyBookingEmbed.tsx",
@@ -2749,6 +3016,8 @@
       "name": "ProjectCard",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.tsx"
@@ -2769,6 +3038,8 @@
       "name": "ProjectDetailLayout",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 17,
       "directImporters": [
         "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
@@ -2811,6 +3082,8 @@
       "name": "ProjectDetailTemplate",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/patterns/index.ts"
@@ -2827,6 +3100,8 @@
       "name": "ProjectGallery",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/ui/index.ts",
@@ -2846,6 +3121,8 @@
       "name": "ProjectHero",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 16,
       "directImporters": [
         "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
@@ -2887,6 +3164,8 @@
       "name": "ProjectMetaSection",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 7,
       "directImporters": [
         "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
@@ -2919,6 +3198,8 @@
       "name": "ProjectNav",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 16,
       "directImporters": [
         "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
@@ -2960,6 +3241,8 @@
       "name": "ProofBlock",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/patterns/index.ts"
@@ -2976,6 +3259,8 @@
       "name": "Prose",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/ui/index.ts"
@@ -2989,6 +3274,8 @@
       "name": "Radio",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": true,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/RadioGroup/RadioGroup.tsx",
@@ -3003,6 +3290,8 @@
       "name": "RadioGroup",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": true,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -3016,6 +3305,8 @@
       "name": "RawView",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "app/work/raw-view/page.tsx"
@@ -3029,6 +3320,8 @@
       "name": "ReadingProgress",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/index.ts",
@@ -3056,6 +3349,8 @@
       "name": "RelatedPosts",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 3,
       "directImporters": [
         "app/blog/[slug]/page.tsx",
@@ -3082,6 +3377,8 @@
       "name": "RelatedProjects",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 16,
       "directImporters": [
         "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
@@ -3123,6 +3420,8 @@
       "name": "ScrollIndicator",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 4,
       "directImporters": [
         "nextjs-app/shared/patterns/AboutHero/AboutHero.tsx",
@@ -3139,6 +3438,8 @@
       "name": "Section",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 24,
       "directImporters": [
         "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
@@ -3193,6 +3494,8 @@
       "name": "SecureCVDownload",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/index.ts",
@@ -3211,6 +3514,8 @@
       "name": "SegmentedControl",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": true,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -3224,6 +3529,8 @@
       "name": "Select",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/components/ContactForm/ContactForm.tsx",
@@ -3245,6 +3552,8 @@
       "name": "SelectableCard",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": true,
       "directImportCount": 0,
       "directImporters": [],
       "packageImportCount": 0,
@@ -3256,6 +3565,8 @@
       "name": "SentrySummaryCard",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 0,
       "directImporters": [],
       "packageImportCount": 0,
@@ -3267,6 +3578,8 @@
       "name": "ServiceCard",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/patterns/ServicesSection/ServicesSection.tsx"
@@ -3285,6 +3598,8 @@
       "name": "ServicesBlock",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/patterns/index.ts"
@@ -3301,6 +3616,8 @@
       "name": "ServicesGrid",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/ChatWidget/ChatMessageBubble.tsx",
@@ -3317,6 +3634,8 @@
       "name": "ServicesSection",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/pages/Home/HomePage.tsx",
@@ -3335,6 +3654,8 @@
       "name": "Sitefooter",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 0,
       "directImporters": [],
       "packageImportCount": 0,
@@ -3346,6 +3667,8 @@
       "name": "SiteFooter",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/patterns/index.ts",
@@ -3366,6 +3689,8 @@
       "name": "Siteheader",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 0,
       "directImporters": [],
       "packageImportCount": 0,
@@ -3377,6 +3702,8 @@
       "name": "SiteHeader",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/patterns/index.ts",
@@ -3399,6 +3726,8 @@
       "name": "SiteTree",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 3,
       "directImporters": [
         "app/lib/siteStructure.ts",
@@ -3418,6 +3747,8 @@
       "name": "Skeleton",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 4,
       "directImporters": [
         "nextjs-app/shared/components/ArticleCard/ArticleCard.tsx",
@@ -3435,22 +3766,11 @@
       ]
     },
     {
-      "name": "SkillsGrid",
-      "kind": "component",
-      "status": "beta",
-      "directImportCount": 1,
-      "directImporters": [
-        "nextjs-app/shared/components/index.ts"
-      ],
-      "packageImportCount": 0,
-      "packageImporters": [],
-      "prodPageCount": 0,
-      "prodPages": []
-    },
-    {
       "name": "SkipLink",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/patterns/navigation/index.ts"
@@ -3469,6 +3789,8 @@
       "name": "SocialIconLink",
       "kind": "component",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/ArticleShareSection/ArticleShareSection.tsx",
@@ -3496,6 +3818,8 @@
       "name": "SocialShare",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "app/blog/[slug]/BlogArticleShare.tsx",
@@ -3515,6 +3839,8 @@
       "name": "Spacer",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 0,
       "directImporters": [],
       "packageImportCount": 0,
@@ -3526,6 +3852,8 @@
       "name": "Spinner",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 4,
       "directImporters": [
         "nextjs-app/shared/components/AppLoading/AppLoading.tsx",
@@ -3549,6 +3877,8 @@
       "name": "SplitButton",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/CodeSnippet/CodeSnippet.tsx"
@@ -3565,6 +3895,8 @@
       "name": "Stack",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx",
@@ -3590,6 +3922,8 @@
       "name": "StatsSection",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx"
@@ -3609,6 +3943,8 @@
       "name": "StatusDot",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/Badge/Badge.tsx",
@@ -3636,6 +3972,8 @@
       "name": "StoryBlock",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 15,
       "directImporters": [
         "nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx",
@@ -3676,6 +4014,8 @@
       "name": "StudioMap",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/ChatWidget/ChatMessageBubble.tsx",
@@ -3692,6 +4032,8 @@
       "name": "Switch",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": true,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -3705,6 +4047,8 @@
       "name": "TableOfContents",
       "kind": "component",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/components/index.ts",
@@ -3730,6 +4074,8 @@
       "name": "Tabs",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/index.ts",
@@ -3751,6 +4097,8 @@
       "name": "TailwindTest",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "app/dev/tailwind-test/page.tsx"
@@ -3764,6 +4112,8 @@
       "name": "TeamBlock",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/pages/Work/HelsinkiDesignSystem/HelsinkiDesignSystemPage.tsx",
@@ -3783,6 +4133,8 @@
       "name": "Testimonial",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -3796,6 +4148,8 @@
       "name": "Text",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 60,
       "directImporters": [
         "app/dev/code-window/page.tsx",
@@ -3914,6 +4268,8 @@
       "name": "TextArea",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/components/ChatWidget/emailWorkflow/FieldPrompt.tsx",
@@ -3932,6 +4288,8 @@
       "name": "TextInput",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 7,
       "directImporters": [
         "nextjs-app/shared/components/ChatWidget/emailWorkflow/FieldPrompt.tsx",
@@ -3963,6 +4321,8 @@
       "name": "ThemeProvider",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": true,
       "directImportCount": 7,
       "directImporters": [
         "app/layout.tsx",
@@ -3991,6 +4351,8 @@
       "name": "Timestamp",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/pages/AccessibilityPage/AccessibilityPage.tsx",
@@ -4010,6 +4372,8 @@
       "name": "Title",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 52,
       "directImporters": [
         "app/dev/code-window/page.tsx",
@@ -4121,6 +4485,8 @@
       "name": "Toast",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 7,
       "directImporters": [
         "nextjs-app/shared/components/CodeSnippet/CodeSnippet.tsx",
@@ -4151,6 +4517,8 @@
       "name": "ToastStack",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 1,
       "directImporters": [
         "providers/ToastProvider.tsx"
@@ -4169,9 +4537,10 @@
       "name": "Tooltip",
       "kind": "component",
       "status": "beta",
-      "directImportCount": 2,
+      "governed": true,
+      "exported": false,
+      "directImportCount": 1,
       "directImporters": [
-        "nextjs-app/shared/components/SkillsGrid/SkillsGrid.tsx",
         "nextjs-app/shared/components/interactive/index.ts"
       ],
       "packageImportCount": 0,
@@ -4183,6 +4552,8 @@
       "name": "TransformingActionInput",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/index.ts"
@@ -4196,6 +4567,8 @@
       "name": "Tulli",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "app/work/tulli/page.tsx"
@@ -4209,6 +4582,8 @@
       "name": "ui",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/TailwindTest/TailwindTest.tsx",
@@ -4223,6 +4598,8 @@
       "name": "ValueCard",
       "kind": "component",
       "status": "stable",
+      "governed": true,
+      "exported": true,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/index.ts",
@@ -4245,6 +4622,8 @@
       "name": "ValuesSection",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx",
@@ -4266,6 +4645,8 @@
       "name": "VertaaUX",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "app/work/vertaaux/page.tsx"
@@ -4279,6 +4660,8 @@
       "name": "VisuallyHidden",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": true,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/index.ts",
@@ -4295,6 +4678,8 @@
       "name": "WipBadge",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 0,
       "directImporters": [],
       "packageImportCount": 0,
@@ -4306,6 +4691,8 @@
       "name": "WorkCTA",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/patterns/ProjectDetailLayout/ProjectDetailLayout.tsx"
@@ -4332,6 +4719,8 @@
       "name": "WorkHero",
       "kind": "pattern",
       "status": "alpha",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/pages/Work/WorkIndex/WorkIndexPage.tsx",
@@ -4351,6 +4740,8 @@
       "name": "WorkIndex",
       "kind": "component",
       "status": null,
+      "governed": false,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "app/work/page.tsx"
@@ -4364,6 +4755,8 @@
       "name": "WorkMagneticField",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 1,
       "directImporters": [
         "nextjs-app/shared/components/pages/Home/HomePage.tsx"
@@ -4380,6 +4773,8 @@
       "name": "WorkNav",
       "kind": "component",
       "status": "beta",
+      "governed": true,
+      "exported": false,
       "directImportCount": 2,
       "directImporters": [
         "nextjs-app/shared/components/index.ts",
@@ -4397,6 +4792,8 @@
       "name": "WorkPreviewSection",
       "kind": "pattern",
       "status": "stable",
+      "governed": true,
+      "exported": false,
       "directImportCount": 3,
       "directImporters": [
         "nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.tsx",

--- a/nextjs-app/shared/stories/Docs/ComponentUsage.stories.tsx
+++ b/nextjs-app/shared/stories/Docs/ComponentUsage.stories.tsx
@@ -7,6 +7,8 @@ type UsageRow = {
   name: string;
   kind: string;
   status: string | null;
+  governed?: boolean;
+  exported?: boolean;
   directImportCount: number;
   directImporters: string[];
   packageImportCount?: number;
@@ -15,11 +17,42 @@ type UsageRow = {
   prodPages: string[];
 };
 
+type UsageSummary = {
+  catalogCount: number;
+  governedCount: number;
+  exportedCount: number;
+  strictConsumedCount: number;
+  transitiveConsumedCount: number;
+};
+
 type SortKey = "name" | "directImportCount" | "prodPageCount";
 
-const rows = (usageReport as { generatedAt: string; components: UsageRow[] })
-  .components;
-const generatedAt = (usageReport as { generatedAt: string }).generatedAt;
+const report = usageReport as {
+  generatedAt: string;
+  summary?: UsageSummary;
+  components: UsageRow[];
+};
+const rows = report.components;
+const generatedAt = report.generatedAt;
+
+// Prefer the report's own summary; fall back to computing it from the rows so
+// the page still renders against a report generated before the summary block
+// (and before the governed/exported per-row fields) existed.
+const computeSummary = (): UsageSummary => {
+  const governed = rows.filter((row) => row.governed ?? row.status !== null);
+  return {
+    catalogCount: rows.length,
+    governedCount: governed.length,
+    exportedCount: rows.filter((row) => row.exported).length,
+    strictConsumedCount: governed.filter(
+      (row) => (row.packageImportCount ?? 0) > 0,
+    ).length,
+    transitiveConsumedCount: governed.filter(
+      (row) => row.exported && row.prodPageCount > 0,
+    ).length,
+  };
+};
+const summary = report.summary ?? computeSummary();
 
 const ComponentUsageContent = () => {
   const [sortKey, setSortKey] = useState<SortKey>("directImportCount");
@@ -36,40 +69,53 @@ const ComponentUsageContent = () => {
     );
   }, [sortKey, onlyUnused]);
 
-  const unusedCount = rows.filter((row) => row.directImportCount === 0).length;
-  const viaPackageCount = rows.filter(
-    (row) => (row.packageImportCount ?? 0) > 0,
-  ).length;
-
   return (
     <article className={styles.wrapper}>
       <header className={styles.header}>
         <h1>Component Usage</h1>
         <p className={styles.lead}>
-          Real adoption data from the production codebase: how many source
-          files import each component (statically or via dynamic import), and
-          how many production pages transitively render it.
+          Real adoption data from the production codebase, measured over the{" "}
+          <strong>{summary.governedCount} governed</strong> (contract-bearing)
+          components rather than the raw catalog, which also lists non-component
+          dirs and bespoke one-off page components. Two honest consumption
+          signals: components this repo imports directly from the npm barrel
+          (strict dogfooding), and components that ship in the package and reach
+          a production page (transitive).
         </p>
       </header>
 
       <section className={styles.section}>
         <div className={styles.principleGrid}>
           <div className={styles.principle}>
-            <h3>{rows.length}</h3>
-            <p>Components in the catalog</p>
-          </div>
-          <div className={styles.principle}>
-            <h3>{unusedCount}</h3>
-            <p>Without any importer</p>
+            <h3>{summary.governedCount}</h3>
+            <p>
+              Governed components{" "}
+              <span style={{ opacity: 0.6 }}>
+                (of {summary.catalogCount} catalog entries)
+              </span>
+            </p>
           </div>
           <div className={styles.principle}>
             <h3>
-              {viaPackageCount}/{rows.length}
+              {summary.transitiveConsumedCount}/{summary.governedCount}
             </h3>
             <p>
-              Consumed via <code>@digitaltableteur/react</code> (runtime
-              imports from the npm package)
+              Shipped in <code>@digitaltableteur/react</code> and rendered in
+              production (transitive)
             </p>
+          </div>
+          <div className={styles.principle}>
+            <h3>
+              {summary.strictConsumedCount}/{summary.governedCount}
+            </h3>
+            <p>
+              Directly imported from <code>@digitaltableteur/react</code> as a
+              runtime value (strict dogfooding)
+            </p>
+          </div>
+          <div className={styles.principle}>
+            <h3>{summary.exportedCount}</h3>
+            <p>Exported from the package barrel</p>
           </div>
           <div className={styles.principle}>
             <h3>{new Date(generatedAt).toLocaleDateString("en-GB")}</h3>
@@ -118,6 +164,7 @@ const ComponentUsageContent = () => {
               <th>Component</th>
               <th>Kind</th>
               <th>Status</th>
+              <th>In package</th>
               <th>Direct imports</th>
               <th>Prod pages</th>
               <th>Importers</th>
@@ -131,6 +178,7 @@ const ComponentUsageContent = () => {
                 </td>
                 <td>{row.kind}</td>
                 <td>{row.status ?? "—"}</td>
+                <td>{row.exported ? "✓" : "—"}</td>
                 <td>{row.directImportCount}</td>
                 <td>{row.prodPageCount}</td>
                 <td>

--- a/scripts/design-system/report-component-usage.mjs
+++ b/scripts/design-system/report-component-usage.mjs
@@ -102,7 +102,30 @@ function barrelImportedNames(source) {
   return { value, typeOnly };
 }
 
+// Runtime-value exports of the @digitaltableteur/react barrel: the names an
+// external consumer can import as running code. Powers the "shipped in the
+// package" signal — `export type {}` blocks and inline `type` specifiers are
+// skipped because they carry no runtime surface.
+function packageExportedValueNames() {
+  const barrelPath = join(ROOT, "packages/react/src/index.ts");
+  if (!existsSync(barrelPath)) return new Set();
+  const src = readFileSync(barrelPath, "utf8");
+  const names = new Set();
+  for (const match of src.matchAll(/export\s+(type\s+)?\{([^}]+)\}/g)) {
+    if (match[1]) continue; // `export type { … }` block — no runtime surface
+    for (const raw of match[2].split(",")) {
+      const spec = raw.trim();
+      if (!spec || /^type\s/.test(spec)) continue; // inline `type X` specifier
+      const parts = spec.split(/\s+as\s+/);
+      const exportedName = (parts.length > 1 ? parts[1] : parts[0]).trim();
+      if (/^[A-Z][A-Za-z0-9]*$/.test(exportedName)) names.add(exportedName);
+    }
+  }
+  return names;
+}
+
 const components = listComponents();
+const exportedValueNames = packageExportedValueNames();
 const files = collectSourceFiles();
 const fileEntries = files.map((path) => {
   const source = readFileSync(path, "utf8");
@@ -130,10 +153,17 @@ const rows = components.map(({ name, kind, status }) => {
     if (viaBarrelValue) packageImporters.push(entry.path);
   }
   const consumers = computeConsumersForComponent(name);
+  // governed = a contract-bearing DS component (the honest denominator); the
+  // catalog also lists non-component dirs (animations, icons, navigation…) and
+  // bespoke one-off page components (Tulli, VertaaUX…) that carry no contract.
+  const governed = status !== null;
+  const exported = exportedValueNames.has(name);
   return {
     name,
     kind,
     status,
+    governed,
+    exported,
     directImportCount: importers.length,
     directImporters: importers.sort(),
     packageImportCount: packageImporters.length,
@@ -143,10 +173,29 @@ const rows = components.map(({ name, kind, status }) => {
   };
 });
 
+// Two honest consumption signals over the governed denominator:
+//  - strict: this repo imports the component as a runtime value from the barrel
+//    (pure dogfooding; capped low because the app renders the DS through page
+//    shells that live inside the package boundary and cannot self-import it).
+//  - transitive: the component ships in the package AND is rendered by at least
+//    one production page, i.e. it reaches production as a package-shipped unit.
+const governedRows = rows.filter((row) => row.governed);
+const strictConsumed = governedRows.filter((row) => row.packageImportCount > 0);
+const transitiveConsumed = governedRows.filter(
+  (row) => row.exported && row.prodPageCount > 0,
+);
+const summary = {
+  catalogCount: rows.length,
+  governedCount: governedRows.length,
+  exportedCount: rows.filter((row) => row.exported).length,
+  strictConsumedCount: strictConsumed.length,
+  transitiveConsumedCount: transitiveConsumed.length,
+};
+
 mkdirSync(dirname(OUT_PATH), { recursive: true });
 writeFileSync(
   OUT_PATH,
-  `${JSON.stringify({ generatedAt: new Date().toISOString(), components: rows }, null, 2)}\n`,
+  `${JSON.stringify({ generatedAt: new Date().toISOString(), summary, components: rows }, null, 2)}\n`,
 );
 
 const sorted = [...rows].sort(
@@ -164,9 +213,13 @@ for (const row of sorted) {
   );
 }
 const unused = sorted.filter((row) => row.directImportCount === 0);
-const viaPackage = rows.filter((row) => row.packageImportCount > 0);
-console.log(`\n${rows.length} components; ${unused.length} with zero direct imports.`);
 console.log(
-  `${viaPackage.length} of ${rows.length} consumed via @digitaltableteur/react (runtime imports).`,
+  `\n${summary.catalogCount} catalog entries; ${summary.governedCount} governed (contract-bearing) components; ${unused.length} with zero direct imports.`,
+);
+console.log(
+  `${summary.strictConsumedCount}/${summary.governedCount} directly imported from @digitaltableteur/react (strict runtime dogfooding).`,
+);
+console.log(
+  `${summary.transitiveConsumedCount}/${summary.governedCount} shipped in the package and rendered in production (transitive).`,
 );
 console.log(`Report: ${relative(ROOT, OUT_PATH)}`);


### PR DESCRIPTION
## Why
The ComponentUsage page headlined **22/206 consumed via @digitaltableteur/react**, which badly undercounts real adoption and hid *why* the number is low. Two flaws:
- **Denominator**: 206 is the raw catalog, including non-component dirs (`animations`, `icons`, `navigation`...) and bespoke one-off page components (`Tulli`, `VertaaUX`, `Intrum`...) that will never be shared library units.
- **Numerator**: only direct runtime barrel imports *in this repo* counted. But the app renders the DS through page shells that live inside the package boundary and cannot self-import the barrel, so strict dogfooding is structurally capped near this level.

## What
The report now emits a `summary` block with two honest signals over a **governed** (contract-bearing) denominator:

| Signal | Value | Meaning |
|---|---|---|
| Governed components | **162** | contract-bearing DS components (was 206 catalog) |
| Transitive | **59/162** | shipped in the package **and** rendered on ≥1 production page |
| Strict dogfooding | **22/162** | direct runtime barrel import in this repo |
| Exported | **70** | runtime-value exports of the barrel |

Each row gains `governed`/`exported` flags. The story shows the three headline cards, an **In package** ✓ column, and a computed-summary fallback so it renders against reports generated before the summary block existed.

No runtime app behavior changed; measurement only.

## Local gate (CI dead; verified locally)
- typecheck ✓ · lint ✓ (0 errors) · test 2296/2296 ✓ · build ✓
- Rendered in a fresh Storybook (screenshot verified): 162 / 59 / 22 / 70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Component usage reports now include governed and exported component metrics.
  * Added strict and transitive adoption summaries for clearer consumption insights.
  * Component usage tables now show whether each component is included in the package.

* **Documentation**
  * Updated component usage guidance and metric descriptions to reflect governed, exported, strict, and transitive adoption data.
  * Reports remain compatible with older generated data when summary information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->