### PR TITLE
feat(ds): ComponentUsage table search, filters, and sortable columns

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-07-13T08:29:53.137Z",
+  "createdAt": "2026-07-13T15:58:05.487Z",
   "directory": "nextjs-app/shared",
   "findings": [
     {
@@ -6155,8 +6155,8 @@
     {
       "column": 25,
       "file": "nextjs-app/shared/stories/Docs/Documentation.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f403\u001f25\u001f-2px\u001fUnexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "line": 403,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f490\u001f25\u001f-2px\u001fUnexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 490,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -6165,8 +6165,8 @@
     {
       "column": 25,
       "file": "nextjs-app/shared/stories/Docs/Documentation.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f515\u001f25\u001f-2px\u001fUnexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "line": 515,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f602\u001f25\u001f-2px\u001fUnexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 602,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -6245,8 +6245,8 @@
     {
       "column": 25,
       "file": "nextjs-app/shared/stories/Docs/Documentation.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f403\u001f25\u001f-2px\u001fUnexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 403,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f490\u001f25\u001f-2px\u001fUnexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 490,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -6255,8 +6255,8 @@
     {
       "column": 25,
       "file": "nextjs-app/shared/stories/Docs/Documentation.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f456\u001f25\u001f-50%\u001fUnexpected raw scale value \"-50%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 456,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f543\u001f25\u001f-50%\u001fUnexpected raw scale value \"-50%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 543,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"-50%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -6265,8 +6265,8 @@
     {
       "column": 25,
       "file": "nextjs-app/shared/stories/Docs/Documentation.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f515\u001f25\u001f-2px\u001fUnexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 515,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f602\u001f25\u001f-2px\u001fUnexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 602,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",

--- a/nextjs-app/shared/stories/Docs/ComponentUsage.stories.tsx
+++ b/nextjs-app/shared/stories/Docs/ComponentUsage.stories.tsx
@@ -25,7 +25,21 @@ type UsageSummary = {
   transitiveConsumedCount: number;
 };
 
-type SortKey = "name" | "directImportCount" | "prodPageCount";
+type SortKey =
+  | "name"
+  | "kind"
+  | "status"
+  | "exported"
+  | "directImportCount"
+  | "prodPageCount";
+
+const NUMERIC_SORT_KEYS: SortKey[] = [
+  "exported",
+  "directImportCount",
+  "prodPageCount",
+];
+
+const statusLabel = (status: string | null) => status ?? "—";
 
 const report = usageReport as {
   generatedAt: string;
@@ -54,20 +68,89 @@ const computeSummary = (): UsageSummary => {
 };
 const summary = report.summary ?? computeSummary();
 
+const KIND_OPTIONS = Array.from(new Set(rows.map((row) => row.kind))).sort();
+const STATUS_OPTIONS = Array.from(
+  new Set(rows.map((row) => statusLabel(row.status))),
+).sort((a, b) => (a === "—" ? 1 : b === "—" ? -1 : a.localeCompare(b)));
+
 const ComponentUsageContent = () => {
+  const [query, setQuery] = useState("");
+  const [kind, setKind] = useState("all");
+  const [status, setStatus] = useState("all");
+  const [inPackage, setInPackage] = useState<"all" | "in" | "out">("all");
   const [sortKey, setSortKey] = useState<SortKey>("directImportCount");
-  const [onlyUnused, setOnlyUnused] = useState(false);
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
 
   const sorted = useMemo(() => {
-    const filtered = onlyUnused
-      ? rows.filter((row) => row.directImportCount === 0)
-      : rows;
-    return [...filtered].sort((a, b) =>
-      sortKey === "name"
-        ? a.name.localeCompare(b.name)
-        : b[sortKey] - a[sortKey] || a.name.localeCompare(b.name),
-    );
-  }, [sortKey, onlyUnused]);
+    const sortValue = (row: UsageRow): string | number => {
+      switch (sortKey) {
+        case "name":
+          return row.name.toLowerCase();
+        case "kind":
+          return row.kind;
+        case "status":
+          return statusLabel(row.status);
+        case "exported":
+          return row.exported ? 1 : 0;
+        default:
+          return row[sortKey];
+      }
+    };
+    const q = query.trim().toLowerCase();
+    const filtered = rows.filter((row) => {
+      if (kind !== "all" && row.kind !== kind) return false;
+      if (status !== "all" && statusLabel(row.status) !== status) return false;
+      if (inPackage === "in" && !row.exported) return false;
+      if (inPackage === "out" && row.exported) return false;
+      if (q) {
+        const haystack = [row.name, ...row.directImporters]
+          .join(" ")
+          .toLowerCase();
+        if (!haystack.includes(q)) return false;
+      }
+      return true;
+    });
+    const dir = sortDir === "asc" ? 1 : -1;
+    return filtered.sort((a, b) => {
+      const av = sortValue(a);
+      const bv = sortValue(b);
+      let cmp =
+        typeof av === "number" && typeof bv === "number"
+          ? av - bv
+          : String(av).localeCompare(String(bv));
+      if (cmp === 0) cmp = a.name.localeCompare(b.name);
+      return cmp * dir;
+    });
+  }, [query, kind, status, inPackage, sortKey, sortDir]);
+
+  const toggleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir((dir) => (dir === "asc" ? "desc" : "asc"));
+      return;
+    }
+    setSortKey(key);
+    setSortDir(NUMERIC_SORT_KEYS.includes(key) ? "desc" : "asc");
+  };
+
+  const sortableHeader = (label: string, key: SortKey) => (
+    <th aria-sort={sortKey === key ? (sortDir === "asc" ? "ascending" : "descending") : "none"}>
+      <button
+        type="button"
+        className={styles.sortHeader}
+        onClick={() => toggleSort(key)}
+      >
+        {label}
+        <span
+          className={
+            sortKey === key ? styles.sortIndicator : styles.sortIndicatorIdle
+          }
+          aria-hidden="true"
+        >
+          {sortKey === key ? (sortDir === "asc" ? "▲" : "▼") : "↕"}
+        </span>
+      </button>
+    </th>
+  );
 
   return (
     <article className={styles.wrapper}>
@@ -90,7 +173,7 @@ const ComponentUsageContent = () => {
             <h3>{summary.governedCount}</h3>
             <p>
               Governed components{" "}
-              <span style={{ opacity: 0.6 }}>
+              <span className={styles.subtle}>
                 (of {summary.catalogCount} catalog entries)
               </span>
             </p>
@@ -137,36 +220,86 @@ const ComponentUsageContent = () => {
       </section>
 
       <section className={styles.section}>
-        <div style={{ display: "flex", gap: "1rem", alignItems: "center" }}>
-          <label>
-            Sort by{" "}
-            <select
-              value={sortKey}
-              onChange={(event) => setSortKey(event.target.value as SortKey)}
-            >
-              <option value="directImportCount">direct imports</option>
-              <option value="prodPageCount">prod pages</option>
-              <option value="name">name</option>
-            </select>
-          </label>
-          <label>
+        <div className={styles.usageControls}>
+          <div className={`${styles.usageControl} ${styles.usageControlGrow}`}>
+            <label className={styles.usageControlLabel} htmlFor="usage-search">
+              Search
+            </label>
             <input
-              type="checkbox"
-              checked={onlyUnused}
-              onChange={(event) => setOnlyUnused(event.target.checked)}
-            />{" "}
-            only zero-import components
-          </label>
+              id="usage-search"
+              type="search"
+              className={styles.usageInput}
+              placeholder="Component name or importer path…"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+          </div>
+          <div className={styles.usageControl}>
+            <label className={styles.usageControlLabel} htmlFor="usage-kind">
+              Kind
+            </label>
+            <select
+              id="usage-kind"
+              className={styles.usageSelect}
+              value={kind}
+              onChange={(event) => setKind(event.target.value)}
+            >
+              <option value="all">All kinds</option>
+              {KIND_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className={styles.usageControl}>
+            <label className={styles.usageControlLabel} htmlFor="usage-status">
+              Status
+            </label>
+            <select
+              id="usage-status"
+              className={styles.usageSelect}
+              value={status}
+              onChange={(event) => setStatus(event.target.value)}
+            >
+              <option value="all">All statuses</option>
+              {STATUS_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className={styles.usageControl}>
+            <label className={styles.usageControlLabel} htmlFor="usage-package">
+              In package
+            </label>
+            <select
+              id="usage-package"
+              className={styles.usageSelect}
+              value={inPackage}
+              onChange={(event) =>
+                setInPackage(event.target.value as "all" | "in" | "out")
+              }
+            >
+              <option value="all">Any</option>
+              <option value="in">Exported</option>
+              <option value="out">Not exported</option>
+            </select>
+          </div>
         </div>
+        <p className={styles.resultCount}>
+          {sorted.length} of {rows.length} components
+        </p>
         <table className={styles.table}>
           <thead>
             <tr>
-              <th>Component</th>
-              <th>Kind</th>
-              <th>Status</th>
-              <th>In package</th>
-              <th>Direct imports</th>
-              <th>Prod pages</th>
+              {sortableHeader("Component", "name")}
+              {sortableHeader("Kind", "kind")}
+              {sortableHeader("Status", "status")}
+              {sortableHeader("In package", "exported")}
+              {sortableHeader("Direct imports", "directImportCount")}
+              {sortableHeader("Prod pages", "prodPageCount")}
               <th>Importers</th>
             </tr>
           </thead>

--- a/nextjs-app/shared/stories/Docs/Documentation.module.css
+++ b/nextjs-app/shared/stories/Docs/Documentation.module.css
@@ -375,6 +375,93 @@
   margin-top: var(--space-layout-12, 0.75rem);
 }
 
+/* Usage-table controls: search + per-field filters. */
+
+.usageControls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--space-layout-16, 1rem);
+  margin-bottom: var(--space-layout-16, 1rem);
+}
+
+.usageControl {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-layout-4, 0.25rem);
+}
+
+.usageControlGrow {
+  flex: 1 1 16rem;
+}
+
+.usageControlLabel {
+  font-size: var(--font-size-text-xs, 0.75rem);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.usageInput,
+.usageSelect {
+  padding: var(--space-layout-8, 0.5rem) var(--space-layout-12, 0.75rem);
+  width: 100%;
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-m);
+  background: var(--main-body-background-color);
+  font-family: var(--font-text);
+  font-size: var(--font-size-text-s);
+  color: var(--color-text);
+  transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+.usageInput:focus,
+.usageSelect:focus {
+  border-color: var(--color-primary);
+  outline: none;
+  box-shadow: 0 0 0 3px rgb(0 0 255 / 10%);
+}
+
+/* Sortable column header: full-width reset button inside the <th>. */
+
+.sortHeader {
+  display: inline-flex;
+  padding: 0;
+  align-items: center;
+  gap: var(--space-layout-4, 0.25rem);
+  border: none;
+  background: none;
+  font: inherit;
+  font-weight: 600;
+  color: inherit;
+  cursor: pointer;
+}
+
+.sortHeader:hover {
+  color: var(--color-primary);
+}
+
+.sortHeader:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.sortIndicator {
+  font-size: 0.75em;
+  color: var(--color-primary);
+}
+
+.sortIndicatorIdle {
+  font-size: 0.75em;
+  color: var(--color-muted);
+  opacity: 0.5;
+}
+
+.subtle {
+  opacity: 0.6;
+}
+
 .iconGrid {
   display: grid;
   margin: var(--space-layout-24, 1.5rem) 0;

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -3783,36 +3783,36 @@
       "text": "Disallowed property \"padding-left\" (property-disallowed-list)"
     },
     {
-      "id": "nextjs-app/shared/stories/Docs/Documentation.module.css::547::3::property-disallowed-list::Disallowed property \"border-left\" (property-disallowed-list)",
+      "id": "nextjs-app/shared/stories/Docs/Documentation.module.css::634::3::property-disallowed-list::Disallowed property \"border-left\" (property-disallowed-list)",
       "file": "nextjs-app/shared/stories/Docs/Documentation.module.css",
-      "line": 547,
+      "line": 634,
       "column": 3,
       "rule": "property-disallowed-list",
       "severity": "warning",
       "text": "Disallowed property \"border-left\" (property-disallowed-list)"
     },
     {
-      "id": "nextjs-app/shared/stories/Docs/Documentation.module.css::555::33::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/stories/Docs/Documentation.module.css::642::33::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/stories/Docs/Documentation.module.css",
-      "line": 555,
+      "line": 642,
       "column": 33,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/stories/Docs/Documentation.module.css::556::32::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/stories/Docs/Documentation.module.css::643::32::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/stories/Docs/Documentation.module.css",
-      "line": 556,
+      "line": 643,
       "column": 32,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/stories/Docs/Documentation.module.css::557::34::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/stories/Docs/Documentation.module.css::644::34::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/stories/Docs/Documentation.module.css",
-      "line": 557,
+      "line": 644,
       "column": 34,
       "rule": "declaration-no-important",
       "severity": "warning",


### PR DESCRIPTION
## What
Replaces the single "Sort by" select and the "only zero-import components" checkbox on the ComponentUsage docs page with proper table controls:

- **Search** matching component name **or** any importer path.
- **Kind / Status / In-package** dropdown filters (options derived from the data).
- Live **"N of M components"** result count.
- Every data column (Component, Kind, Status, In package, Direct imports, Prod pages) is a clickable **sort header** with asc/desc toggle, `aria-sort`, and a ▲/▼/↕ indicator.

Control and sort-header styles added to `Documentation.module.css` using design tokens; leftover inline styles on the story moved into the module.

## Verified live in Storybook
Drove the real React inputs: search "modal" → 5; Not exported → 134 (204−70); patterns → 45; Prod-pages and In-package headers sort both directions with correct indicators.

Baselines re-keyed for the line shift from added CSS (stylelint + rhythmguard); no new real warnings.

## Local gate (CI dead; verified locally)
typecheck ✓ · lint ✓ (0 err) · test 2296/2296 ✓ · build ✓ · stylelint baseline ✓ · rhythmguard ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)