### PR TITLE
feat(ds): dogfood DS components on the ComponentUsage page

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-07-13T15:58:05.487Z",
+  "createdAt": "2026-07-13T16:17:03.021Z",
   "directory": "nextjs-app/shared",
   "findings": [
     {
@@ -6155,8 +6155,8 @@
     {
       "column": 25,
       "file": "nextjs-app/shared/stories/Docs/Documentation.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f490\u001f25\u001f-2px\u001fUnexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "line": 490,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f475\u001f25\u001f-2px\u001fUnexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 475,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -6165,8 +6165,8 @@
     {
       "column": 25,
       "file": "nextjs-app/shared/stories/Docs/Documentation.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f602\u001f25\u001f-2px\u001fUnexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "line": 602,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f587\u001f25\u001f-2px\u001fUnexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 587,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"-2px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -6245,8 +6245,8 @@
     {
       "column": 25,
       "file": "nextjs-app/shared/stories/Docs/Documentation.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f490\u001f25\u001f-2px\u001fUnexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 490,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f475\u001f25\u001f-2px\u001fUnexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 475,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -6255,8 +6255,8 @@
     {
       "column": 25,
       "file": "nextjs-app/shared/stories/Docs/Documentation.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f543\u001f25\u001f-50%\u001fUnexpected raw scale value \"-50%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 543,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f528\u001f25\u001f-50%\u001fUnexpected raw scale value \"-50%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 528,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"-50%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -6265,8 +6265,8 @@
     {
       "column": 25,
       "file": "nextjs-app/shared/stories/Docs/Documentation.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f602\u001f25\u001f-2px\u001fUnexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 602,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/stories/Docs/Documentation.module.css\u001f587\u001f25\u001f-2px\u001fUnexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 587,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"-2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",

--- a/nextjs-app/shared/stories/Docs/ComponentUsage.stories.tsx
+++ b/nextjs-app/shared/stories/Docs/ComponentUsage.stories.tsx
@@ -1,5 +1,11 @@
 import React, { useMemo, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import Card from "@dt/Card";
+import Select from "@dt/Select";
+import TextInput from "@dt/TextInput";
+import Title from "@dt/Title";
+import Text from "@dt/Text";
+import Badge from "@dt/Badge";
 import usageReport from "../../foundations/dist/component-usage.json";
 import styles from "./Documentation.module.css";
 
@@ -33,13 +39,24 @@ type SortKey =
   | "directImportCount"
   | "prodPageCount";
 
+type BadgeTone = "neutral" | "error" | "warning" | "success" | "info";
+
 const NUMERIC_SORT_KEYS: SortKey[] = [
   "exported",
   "directImportCount",
   "prodPageCount",
 ];
 
+const STATUS_TONE: Record<string, BadgeTone> = {
+  stable: "success",
+  beta: "info",
+  alpha: "warning",
+  deprecated: "error",
+};
+
 const statusLabel = (status: string | null) => status ?? "—";
+const statusTone = (status: string): BadgeTone =>
+  STATUS_TONE[status] ?? "neutral";
 
 const report = usageReport as {
   generatedAt: string;
@@ -72,6 +89,23 @@ const KIND_OPTIONS = Array.from(new Set(rows.map((row) => row.kind))).sort();
 const STATUS_OPTIONS = Array.from(
   new Set(rows.map((row) => statusLabel(row.status))),
 ).sort((a, b) => (a === "—" ? 1 : b === "—" ? -1 : a.localeCompare(b)));
+
+const StatCard = ({
+  figure,
+  children,
+}: {
+  figure: React.ReactNode;
+  children: React.ReactNode;
+}) => (
+  <Card variant="default" padding="md">
+    <Title size="xl" className={styles.statFigure}>
+      {figure}
+    </Title>
+    <Text size="s" className={styles.statLabel}>
+      {children}
+    </Text>
+  </Card>
+);
 
 const ComponentUsageContent = () => {
   const [query, setQuery] = useState("");
@@ -133,7 +167,15 @@ const ComponentUsageContent = () => {
   };
 
   const sortableHeader = (label: string, key: SortKey) => (
-    <th aria-sort={sortKey === key ? (sortDir === "asc" ? "ascending" : "descending") : "none"}>
+    <th
+      aria-sort={
+        sortKey === key
+          ? sortDir === "asc"
+            ? "ascending"
+            : "descending"
+          : "none"
+      }
+    >
       <button
         type="button"
         className={styles.sortHeader}
@@ -169,123 +211,93 @@ const ComponentUsageContent = () => {
 
       <section className={styles.section}>
         <div className={styles.principleGrid}>
-          <div className={styles.principle}>
-            <h3>{summary.governedCount}</h3>
-            <p>
-              Governed components{" "}
-              <span className={styles.subtle}>
-                (of {summary.catalogCount} catalog entries)
-              </span>
-            </p>
-          </div>
-          <div className={styles.principle}>
-            <h3>
-              {summary.transitiveConsumedCount}/{summary.governedCount}
-            </h3>
-            <p>
-              Shipped in <code>@digitaltableteur/react</code> and rendered in
-              production (transitive)
-            </p>
-          </div>
-          <div className={styles.principle}>
-            <h3>
-              {summary.strictConsumedCount}/{summary.governedCount}
-            </h3>
-            <p>
-              Directly imported from <code>@digitaltableteur/react</code> as a
-              runtime value (strict dogfooding)
-            </p>
-          </div>
-          <div className={styles.principle}>
-            <h3>{summary.exportedCount}</h3>
-            <p>Exported from the package barrel</p>
-          </div>
-          <div className={styles.principle}>
-            <h3>{new Date(generatedAt).toLocaleDateString("en-GB")}</h3>
-            <p>
-              Generated{" "}
-              {new Date(generatedAt).toLocaleTimeString("en-GB", {
-                hour: "2-digit",
-                minute: "2-digit",
-              })}
-            </p>
-          </div>
-          <div className={styles.principle}>
-            <h3>Regenerate</h3>
-            <p>
-              <code>npm run report:component-usage</code>
-            </p>
-          </div>
+          <StatCard figure={summary.governedCount}>
+            Governed components{" "}
+            <span className={styles.subtle}>
+              (of {summary.catalogCount} catalog entries)
+            </span>
+          </StatCard>
+          <StatCard
+            figure={`${summary.transitiveConsumedCount}/${summary.governedCount}`}
+          >
+            Shipped in <code>@digitaltableteur/react</code> and rendered in
+            production (transitive)
+          </StatCard>
+          <StatCard
+            figure={`${summary.strictConsumedCount}/${summary.governedCount}`}
+          >
+            Directly imported from <code>@digitaltableteur/react</code> as a
+            runtime value (strict dogfooding)
+          </StatCard>
+          <StatCard figure={summary.exportedCount}>
+            Exported from the package barrel
+          </StatCard>
+          <StatCard figure={new Date(generatedAt).toLocaleDateString("en-GB")}>
+            Generated{" "}
+            {new Date(generatedAt).toLocaleTimeString("en-GB", {
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
+          </StatCard>
+          <StatCard figure="Regenerate">
+            <code>npm run report:component-usage</code>
+          </StatCard>
         </div>
       </section>
 
       <section className={styles.section}>
         <div className={styles.usageControls}>
-          <div className={`${styles.usageControl} ${styles.usageControlGrow}`}>
-            <label className={styles.usageControlLabel} htmlFor="usage-search">
-              Search
-            </label>
-            <input
-              id="usage-search"
+          <div className={styles.usageControlGrow}>
+            <TextInput
+              label="Search"
               type="search"
-              className={styles.usageInput}
+              clearable
               placeholder="Component name or importer path…"
               value={query}
-              onChange={(event) => setQuery(event.target.value)}
+              onValueChange={(value) => setQuery(String(value))}
             />
           </div>
           <div className={styles.usageControl}>
-            <label className={styles.usageControlLabel} htmlFor="usage-kind">
-              Kind
-            </label>
-            <select
-              id="usage-kind"
-              className={styles.usageSelect}
+            <Select
+              label="Kind"
               value={kind}
-              onChange={(event) => setKind(event.target.value)}
-            >
-              <option value="all">All kinds</option>
-              {KIND_OPTIONS.map((option) => (
-                <option key={option} value={option}>
-                  {option}
-                </option>
-              ))}
-            </select>
+              onValueChange={setKind}
+              options={[
+                { value: "all", label: "All kinds" },
+                ...KIND_OPTIONS.map((option) => ({
+                  value: option,
+                  label: option,
+                })),
+              ]}
+            />
           </div>
           <div className={styles.usageControl}>
-            <label className={styles.usageControlLabel} htmlFor="usage-status">
-              Status
-            </label>
-            <select
-              id="usage-status"
-              className={styles.usageSelect}
+            <Select
+              label="Status"
               value={status}
-              onChange={(event) => setStatus(event.target.value)}
-            >
-              <option value="all">All statuses</option>
-              {STATUS_OPTIONS.map((option) => (
-                <option key={option} value={option}>
-                  {option}
-                </option>
-              ))}
-            </select>
+              onValueChange={setStatus}
+              options={[
+                { value: "all", label: "All statuses" },
+                ...STATUS_OPTIONS.map((option) => ({
+                  value: option,
+                  label: option,
+                })),
+              ]}
+            />
           </div>
           <div className={styles.usageControl}>
-            <label className={styles.usageControlLabel} htmlFor="usage-package">
-              In package
-            </label>
-            <select
-              id="usage-package"
-              className={styles.usageSelect}
+            <Select
+              label="In package"
               value={inPackage}
-              onChange={(event) =>
-                setInPackage(event.target.value as "all" | "in" | "out")
+              onValueChange={(value) =>
+                setInPackage(value as "all" | "in" | "out")
               }
-            >
-              <option value="all">Any</option>
-              <option value="in">Exported</option>
-              <option value="out">Not exported</option>
-            </select>
+              options={[
+                { value: "all", label: "Any" },
+                { value: "in", label: "Exported" },
+                { value: "out", label: "Not exported" },
+              ]}
+            />
           </div>
         </div>
         <p className={styles.resultCount}>
@@ -310,8 +322,24 @@ const ComponentUsageContent = () => {
                   <code>{row.name}</code>
                 </td>
                 <td>{row.kind}</td>
-                <td>{row.status ?? "—"}</td>
-                <td>{row.exported ? "✓" : "—"}</td>
+                <td>
+                  {row.status ? (
+                    <Badge variant="secondary" tone={statusTone(row.status)}>
+                      {row.status}
+                    </Badge>
+                  ) : (
+                    "—"
+                  )}
+                </td>
+                <td>
+                  {row.exported ? (
+                    <Badge variant="secondary" tone="success">
+                      In package
+                    </Badge>
+                  ) : (
+                    "—"
+                  )}
+                </td>
                 <td>{row.directImportCount}</td>
                 <td>{row.prodPageCount}</td>
                 <td>

--- a/nextjs-app/shared/stories/Docs/Documentation.module.css
+++ b/nextjs-app/shared/stories/Docs/Documentation.module.css
@@ -385,42 +385,27 @@
   margin-bottom: var(--space-layout-16, 1rem);
 }
 
+/* Each dropdown wrapper sizes the dogfooded Select; search grows to fill. */
+
 .usageControl {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-layout-4, 0.25rem);
+  min-width: 10rem;
+  flex: 0 1 12rem;
 }
 
 .usageControlGrow {
-  flex: 1 1 16rem;
+  flex: 1 1 18rem;
 }
 
-.usageControlLabel {
-  font-size: var(--font-size-text-xs, 0.75rem);
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+/* Stat tiles are dogfooded Card + Title + Text; these just tune the figure. */
+
+.statFigure {
+  margin: 0;
+  color: var(--color-primary);
+}
+
+.statLabel {
+  margin: var(--space-layout-8, 0.5rem) 0 0;
   color: var(--color-muted);
-}
-
-.usageInput,
-.usageSelect {
-  padding: var(--space-layout-8, 0.5rem) var(--space-layout-12, 0.75rem);
-  width: 100%;
-  border: 2px solid var(--color-border);
-  border-radius: var(--radius-m);
-  background: var(--main-body-background-color);
-  font-family: var(--font-text);
-  font-size: var(--font-size-text-s);
-  color: var(--color-text);
-  transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-}
-
-.usageInput:focus,
-.usageSelect:focus {
-  border-color: var(--color-primary);
-  outline: none;
-  box-shadow: 0 0 0 3px rgb(0 0 255 / 10%);
 }
 
 /* Sortable column header: full-width reset button inside the <th>. */

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -3783,36 +3783,36 @@
       "text": "Disallowed property \"padding-left\" (property-disallowed-list)"
     },
     {
-      "id": "nextjs-app/shared/stories/Docs/Documentation.module.css::634::3::property-disallowed-list::Disallowed property \"border-left\" (property-disallowed-list)",
+      "id": "nextjs-app/shared/stories/Docs/Documentation.module.css::619::3::property-disallowed-list::Disallowed property \"border-left\" (property-disallowed-list)",
       "file": "nextjs-app/shared/stories/Docs/Documentation.module.css",
-      "line": 634,
+      "line": 619,
       "column": 3,
       "rule": "property-disallowed-list",
       "severity": "warning",
       "text": "Disallowed property \"border-left\" (property-disallowed-list)"
     },
     {
-      "id": "nextjs-app/shared/stories/Docs/Documentation.module.css::642::33::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/stories/Docs/Documentation.module.css::627::33::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/stories/Docs/Documentation.module.css",
-      "line": 642,
+      "line": 627,
       "column": 33,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/stories/Docs/Documentation.module.css::643::32::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/stories/Docs/Documentation.module.css::628::32::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/stories/Docs/Documentation.module.css",
-      "line": 643,
+      "line": 628,
       "column": 32,
       "rule": "declaration-no-important",
       "severity": "warning",
       "text": "Disallowed !important (declaration-no-important)"
     },
     {
-      "id": "nextjs-app/shared/stories/Docs/Documentation.module.css::644::34::declaration-no-important::Disallowed !important (declaration-no-important)",
+      "id": "nextjs-app/shared/stories/Docs/Documentation.module.css::629::34::declaration-no-important::Disallowed !important (declaration-no-important)",
       "file": "nextjs-app/shared/stories/Docs/Documentation.module.css",
-      "line": 644,
+      "line": 629,
       "column": 34,
       "rule": "declaration-no-important",
       "severity": "warning",


### PR DESCRIPTION
## Why
The ComponentUsage page argues for consuming the design system while itself rendering hand-rolled `<div>` stat tiles, a raw `<input>`, and raw `<select>`s. That is the wrong look on the one page that should model dogfooding.

## What
Swapped the raw elements for our own components:
- **Stat tiles** → `Card` + `Title` + `Text`
- **Search** → `TextInput` (`type="search"`, `clearable`)
- **Kind / Status / In-package filters** → `Select`
- **Status / In-package table cells** → `Badge` (tone maps stable→success, beta→info, alpha→warning, deprecated→error)

The bespoke input/select/label CSS is deleted; the components bring their own field chrome, so the controls now match the rest of the DS in light and dark.

## Verified live in Storybook
Cards render as `Card-module__card`; Badges as `Badge-module__badge`; search is a real `TextInput`, filters are real `Select`s. Interactions still work: search "modal" → 5, Not exported → 134, patterns → 45, Prod-pages sort both directions. Screenshots captured.

## Local gate (CI dead; verified locally)
typecheck ✓ · lint ✓ (0 err) · test 2296/2296 ✓ · build ✓ · stylelint baseline ✓ · rhythmguard ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
