### PR TITLE
fix(ds): right-size ComponentUsage stat figure (Title xl to m)

### DIFF
--- a/nextjs-app/shared/stories/Docs/ComponentUsage.stories.tsx
+++ b/nextjs-app/shared/stories/Docs/ComponentUsage.stories.tsx
@@ -98,7 +98,7 @@ const StatCard = ({
   children: React.ReactNode;
 }) => (
   <Card variant="default" padding="md">
-    <Title size="xl" className={styles.statFigure}>
+    <Title size="m" className={styles.statFigure}>
       {figure}
     </Title>
     <Text size="s" className={styles.statLabel}>


### PR DESCRIPTION
The xl display size made the stat number fill the entire card. Drop to `m` so the figure stays prominent but proportionate to its label and card.

One-line story change. Verified live: figure now renders at 36px (was ~60px+). Gate green: typecheck, lint, 2296 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)