### PR TITLE
fix(ds): refine ComponentUsage table badges (sm, primary, icon-only in-package)

### DIFF
--- a/nextjs-app/shared/stories/Docs/ComponentUsage.stories.tsx
+++ b/nextjs-app/shared/stories/Docs/ComponentUsage.stories.tsx
@@ -330,7 +330,11 @@ const ComponentUsageContent = () => {
                 <td>{row.kind}</td>
                 <td>
                   {row.status ? (
-                    <Badge variant="secondary" tone={statusTone(row.status)}>
+                    <Badge
+                      variant="primary"
+                      size="sm"
+                      tone={statusTone(row.status)}
+                    >
                       {row.status}
                     </Badge>
                   ) : (
@@ -339,11 +343,17 @@ const ComponentUsageContent = () => {
                 </td>
                 <td>
                   {row.exported ? (
-                    <Badge variant="secondary" tone="success">
-                      In package
-                    </Badge>
+                    <Icon
+                      name="check-circle"
+                      color="var(--color-success)"
+                      ariaLabel="In package"
+                    />
                   ) : (
-                    "—"
+                    <Icon
+                      name="x-circle"
+                      color="var(--color-error)"
+                      ariaLabel="Not in package"
+                    />
                   )}
                 </td>
                 <td>{row.directImportCount}</td>


### PR DESCRIPTION
Per review feedback on the table badges:

- **Smallest badge**: status badges now use `size="sm"`.
- **Primary, not secondary**: status badges are `variant="primary"` (filled).
- **In-package is icon-only**: green `check-circle` for exported rows, red `x-circle` for missing ones (replacing the text badge and the em-dash), each with an `ariaLabel`. Colored via `--color-success` / `--color-error`.

Verified live in Storybook: check fill `#4fd18b` (success), x fill `#ff6b6b` (error), badges render `sm`+`primary`; screenshot confirms green checks / red x's and filled green/amber status pills. No new icons (check-circle/x-circle already registered), so no registry or CSS churn.

Local gate: typecheck ✓ · lint ✓ (0 err) · test 2296/2296 ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)