### PR TITLE
feat(ds): dogfood Logo in SiteHeader and promote to stable

### DIFF
--- a/nextjs-app/shared/components/Logo/Logo.contract.json
+++ b/nextjs-app/shared/components/Logo/Logo.contract.json
@@ -3,12 +3,18 @@
     "name": "Logo",
     "tier": "atom",
     "group": "display",
-    "status": "beta",
-    "description": "Digitaltableteur brand mark — monochrome (currentColor), square footprint, optional hover pulse.",
+    "status": "stable",
+    "description": "Digitaltableteur brand mark — monochrome (currentColor), square footprint, optional controlled pulse.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=480-1588",
     "radixPrimitive": null,
     "element": "svg",
-    "variants": {},
+    "variants": {
+        "size": {
+            "propSourced": true,
+            "values": ["16", "24", "40", "64"],
+            "default": "24"
+        }
+    },
     "slots": [],
     "asChild": false,
     "subParts": [],
@@ -27,14 +33,52 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "Verified 2026-06-02: role=img/aria-label vs aria-hidden when decorative, focusable=false, non-interactive (no keyboard contract — wrap in link/button to activate). Every mark uses fill=currentColor → maps to system CanvasText in forced colors; the ForcedColors story passes axe. Hover pulse is disabled under prefers-reduced-motion. All Logo tests pass (7/7)."
+        "realBrowserForcedColorsVerified": true,
+        "accessibilityTreeVerified": true,
+        "reviewedNote": "Verified 2026-06-02: role=img/aria-label vs aria-hidden when decorative, focusable=false, non-interactive (no keyboard contract — wrap in link/button to activate). Every mark uses fill=currentColor → maps to system CanvasText in forced colors; the ForcedColors story passes axe. Pulse is disabled under prefers-reduced-motion. All Logo tests pass. Re-verified 2026-07-13 for stable promotion: AT snapshots committed for all required stories; `animated` is now a controlled signal (pulses while true) rather than self-hover, driven by SiteHeader's link-hover state. Swapped into SiteHeader (production consumer on every page) with byte-for-byte parity vs the prior inline mark — identical viewBox 0 0 395 323, geometry, dt-logo-pulse keyframes, badge scale, currentColor tokens; verified live in the running app (rest/hover/both themes)."
     },
     "tokens": {
         "colors": [],
         "spacing": []
     },
     "lightDarkVerified": true,
-    "consumers": [],
+    "consumers": [
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/dev/tailwind-test/page.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/layout.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/navigation/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/SiteHeader/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx",
+            "since": "2026-06-04"
+        }
+    ],
     "schemaVersion": 2,
     "props": {
         "size": {

--- a/nextjs-app/shared/components/Logo/Logo.module.css
+++ b/nextjs-app/shared/components/Logo/Logo.module.css
@@ -29,17 +29,19 @@
     transition: opacity 0.3s ease;
   }
 
-  /* Opt-in: pulse the three leading bars on hover. */
+  /* Controlled: pulse the three leading bars whenever `animated` is set. The
+     consumer drives it from hover/focus state (e.g. the SiteHeader link), so
+     the pulse fires for the whole logo affordance, not just the mark itself. */
 
-  .animated:hover .bar1 {
+  .animated .bar1 {
     animation: dt-logo-pulse-1 0.9s ease-in-out infinite;
   }
 
-  .animated:hover .bar2 {
+  .animated .bar2 {
     animation: dt-logo-pulse-2 0.9s ease-in-out infinite;
   }
 
-  .animated:hover .bar3 {
+  .animated .bar3 {
     animation: dt-logo-pulse-3 0.9s ease-in-out infinite;
   }
 
@@ -84,9 +86,9 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .animated:hover .bar1,
-    .animated:hover .bar2,
-    .animated:hover .bar3 {
+    .animated .bar1,
+    .animated .bar2,
+    .animated .bar3 {
       animation: none;
     }
   }

--- a/nextjs-app/shared/components/Logo/Logo.stories.tsx
+++ b/nextjs-app/shared/components/Logo/Logo.stories.tsx
@@ -5,7 +5,7 @@ import contract from "./Logo.contract.json";
 const meta = {
   title: "Site/Logo",
   component: Logo,
-  tags: ["beta", "!autodocs"],
+  tags: ["stable", "autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/Logo/Logo.tsx
+++ b/nextjs-app/shared/components/Logo/Logo.tsx
@@ -4,7 +4,8 @@ import styles from "./Logo.module.css";
 export interface LogoProps {
   /** Square render box in pixels. Default 24. */
   size?: number;
-  /** Enable the three-bar pulse on hover (respects prefers-reduced-motion). Default false. */
+  /** Pulse the three leading bars while true; a controlled signal driven from the
+   * consumer's hover/focus state (respects prefers-reduced-motion). Default false. */
   animated?: boolean;
   /** Wrap the mark in the brand lime circle (`--logo-background` / `--logo-color`). Default false. */
   badge?: boolean;
@@ -18,8 +19,9 @@ export interface LogoProps {
 
 /**
  * Digitaltableteur brand mark. Monochrome (inherits `currentColor`) and renders
- * inside a square `size`×`size` box. Opt into the hover pulse with `animated`,
- * or the lime brand badge with `badge` (a filled circle behind a contrast mark).
+ * inside a square `size`×`size` box. Drive the three-bar pulse with `animated`
+ * (controlled from the consumer's hover/focus state), or the lime brand badge
+ * with `badge` (a filled circle behind a contrast mark).
  */
 export const Logo = React.forwardRef<SVGSVGElement, LogoProps>(function Logo(
   {

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--default.dark.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--default.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - img "Digitaltableteur"

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--default.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - img "Digitaltableteur"

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--default.light.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--default.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - img "Digitaltableteur"

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--default.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--default.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - img "Digitaltableteur"

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--example.dark.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--example.dark.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - img "Digitaltableteur"
 - text: Digitaltableteur

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--example.forced-colors.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - img "Digitaltableteur"
 - text: Digitaltableteur

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--example.light.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--example.light.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - img "Digitaltableteur"
 - text: Digitaltableteur

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--example.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--example.yaml
@@ -1,3 +1,2 @@
-- status: Work in progress (beta)
 - img "Digitaltableteur"
 - text: Digitaltableteur

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--forced-colors.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - img "Digitaltableteur"

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--forced-colors.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - img "Digitaltableteur"

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--forced-colors.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - img "Digitaltableteur"

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--forced-colors.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - img "Digitaltableteur"

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--playground.dark.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--playground.dark.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - img "Digitaltableteur"

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--playground.forced-colors.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - img "Digitaltableteur"

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--playground.light.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--playground.light.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - img "Digitaltableteur"

--- a/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--playground.yaml
+++ b/nextjs-app/shared/components/Logo/__a11y-snapshots__/site-logo--playground.yaml
@@ -1,2 +1,1 @@
-- status: Work in progress (beta)
 - img "Digitaltableteur"

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,11 +1,11 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-13T16:35:13.376Z",
+  "generatedAt": "2026-07-13T17:29:04.432Z",
   "summary": {
     "componentCount": 162,
     "statusCounts": {
-      "beta": 48,
-      "stable": 92,
+      "beta": 47,
+      "stable": 93,
       "alpha": 21,
       "deprecated": 1
     },
@@ -20,7 +20,7 @@
     "importSurface": "@dt/<ComponentName>",
     "npmPackage": null,
     "semverDoc": "docs/PUBLIC_API.md",
-    "stableCount": 92,
+    "stableCount": 93,
     "releaseGate": "npm run release:gate"
   },
   "tokens": {
@@ -81,17 +81,17 @@
     "withAnyUsage": 151,
     "withProductionUsage": 33,
     "uniqueImportedComponents": 151,
-    "totalEvidenceRows": 749,
+    "totalEvidenceRows": 750,
     "aliasImportFiles": 386,
-    "relativeImportFiles": 392,
+    "relativeImportFiles": 393,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
   },
   "relationshipGraph": {
     "description": "Merged static composesWith policy + co-import evidence (see generate-relationship-graph.mjs).",
-    "generatedAt": "2026-07-13T10:30:06.202Z",
+    "generatedAt": "2026-07-13T17:29:02.407Z",
     "coImportMinFiles": 3,
-    "nodesWithComposesWith": 79,
+    "nodesWithComposesWith": 80,
     "regenerate": "npm run build:relationship-graph or npm run build:tokens",
     "path": "nextjs-app/shared/foundations/dist/relationship-graph.json"
   },
@@ -107,8 +107,8 @@
     },
     "statusMix": {
       "digitaltableteur": {
-        "beta": 48,
-        "stable": 92,
+        "beta": 47,
+        "stable": 93,
         "alpha": 21,
         "deprecated": 1
       },
@@ -16376,6 +16376,7 @@
         "composesWith": [
           "NavLink",
           "Container",
+          "Logo",
           "IconButton",
           "ThemeProvider"
         ],
@@ -17585,12 +17586,23 @@
         "name": "Logo",
         "tier": "atom",
         "group": "display",
-        "status": "beta",
-        "description": "Digitaltableteur brand mark — monochrome (currentColor), square footprint, optional hover pulse.",
+        "status": "stable",
+        "description": "Digitaltableteur brand mark — monochrome (currentColor), square footprint, optional controlled pulse.",
         "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=480-1588",
         "radixPrimitive": null,
         "element": "svg",
-        "variants": {},
+        "variants": {
+          "size": {
+            "propSourced": true,
+            "values": [
+              "16",
+              "24",
+              "40",
+              "64"
+            ],
+            "default": "24"
+          }
+        },
         "slots": [],
         "asChild": false,
         "subParts": [],
@@ -17609,14 +17621,52 @@
           "reducedMotion": true,
           "reviewed": true,
           "forcedColorsVerified": true,
-          "reviewedNote": "Verified 2026-06-02: role=img/aria-label vs aria-hidden when decorative, focusable=false, non-interactive (no keyboard contract — wrap in link/button to activate). Every mark uses fill=currentColor → maps to system CanvasText in forced colors; the ForcedColors story passes axe. Hover pulse is disabled under prefers-reduced-motion. All Logo tests pass (7/7)."
+          "realBrowserForcedColorsVerified": true,
+          "accessibilityTreeVerified": true,
+          "reviewedNote": "Verified 2026-06-02: role=img/aria-label vs aria-hidden when decorative, focusable=false, non-interactive (no keyboard contract — wrap in link/button to activate). Every mark uses fill=currentColor → maps to system CanvasText in forced colors; the ForcedColors story passes axe. Pulse is disabled under prefers-reduced-motion. All Logo tests pass. Re-verified 2026-07-13 for stable promotion: AT snapshots committed for all required stories; `animated` is now a controlled signal (pulses while true) rather than self-hover, driven by SiteHeader's link-hover state. Swapped into SiteHeader (production consumer on every page) with byte-for-byte parity vs the prior inline mark — identical viewBox 0 0 395 323, geometry, dt-logo-pulse keyframes, badge scale, currentColor tokens; verified live in the running app (rest/hover/both themes)."
         },
         "tokens": {
           "colors": [],
           "spacing": []
         },
         "lightDarkVerified": true,
-        "consumers": [],
+        "consumers": [
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/dev/tailwind-test/page.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/layout.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/index.ts",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/navigation/index.ts",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/SiteHeader/index.ts",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx",
+            "since": "2026-06-04"
+          }
+        ],
         "schemaVersion": 2,
         "props": {
           "size": {
@@ -17660,11 +17710,17 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Logo",
-        "importCount": 1,
+        "importCount": 2,
         "productionImportCount": 0,
-        "patternImportCount": 0,
+        "patternImportCount": 1,
         "componentImportCount": 0,
         "evidence": [
+          {
+            "path": "nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx",
+            "importKind": "relative",
+            "importPath": "../../components/Logo",
+            "context": "pattern"
+          },
           {
             "path": "nextjs-app/shared/components/icons/Logo.test.tsx",
             "importKind": "relative",
@@ -17721,7 +17777,13 @@
         ],
         "replacementFor": [],
         "forbiddenUse": [],
-        "composesWith": [],
+        "composesWith": [
+          "NavLink",
+          "Container",
+          "IconButton",
+          "LanguageSwitcher",
+          "ThemeProvider"
+        ],
         "prefersOver": [],
         "declaredPropCount": 6
       }
@@ -19871,6 +19933,7 @@
           "IconButton",
           "ThemeProvider",
           "Container",
+          "Logo",
           "LanguageSwitcher",
           "SkipLink"
         ],
@@ -30933,9 +30996,9 @@
           "NavLink",
           "IconButton",
           "Container",
+          "Logo",
           "LanguageSwitcher",
-          "Badge",
-          "SentrySummaryCard"
+          "Badge"
         ],
         "prefersOver": [],
         "declaredPropCount": 2

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-13T16:35:13.111Z",
+  "generatedAt": "2026-07-13T17:29:04.223Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -4956,6 +4956,7 @@
       "composesWith": [
         "NavLink",
         "Container",
+        "Logo",
         "IconButton",
         "ThemeProvider"
       ],
@@ -5370,7 +5371,13 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [],
-      "composesWith": [],
+      "composesWith": [
+        "NavLink",
+        "Container",
+        "IconButton",
+        "LanguageSwitcher",
+        "ThemeProvider"
+      ],
       "prefersOver": [],
       "declaredPropCount": 6
     },
@@ -5996,6 +6003,7 @@
         "IconButton",
         "ThemeProvider",
         "Container",
+        "Logo",
         "LanguageSwitcher",
         "SkipLink"
       ],
@@ -9509,9 +9517,9 @@
         "NavLink",
         "IconButton",
         "Container",
+        "Logo",
         "LanguageSwitcher",
-        "Badge",
-        "SentrySummaryCard"
+        "Badge"
       ],
       "prefersOver": [],
       "declaredPropCount": 2

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -8458,8 +8458,8 @@
       "name": "Logo",
       "group": "display",
       "tier": 2,
-      "status": "beta",
-      "description": "Digitaltableteur brand mark — monochrome (currentColor), square footprint, optional hover pulse.",
+      "status": "stable",
+      "description": "Digitaltableteur brand mark — monochrome (currentColor), square footprint, optional controlled pulse.",
       "dense": "Digitaltableteur brand mark: monochrome currentColor, square footprint, optional link wrapper",
       "keywords": [
         "logo",

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -1134,6 +1134,27 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "structure",
     "import": "import List from "@dt/List";",
   },
+  "Logo": {
+    "exampleStories": [],
+    "fields": [
+      "composesWith",
+      "dense",
+      "description",
+      "examples",
+      "forbiddenUse",
+      "group",
+      "import",
+      "keywords",
+      "name",
+      "prefersOver",
+      "props",
+      "status",
+      "tokens",
+      "usage",
+    ],
+    "group": "display",
+    "import": "import { Logo } from "@dt/Logo";",
+  },
   "Menu": {
     "exampleStories": [
       "WithIcons",

--- a/nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx
+++ b/nextjs-app/shared/patterns/SiteHeader/SiteHeader.tsx
@@ -6,6 +6,7 @@ import { Link as RouterLink } from "../../lib/linkComponent";
 import { useLocalization } from "../../lib/translation";
 import { NavLink } from "../../components/NavLink";
 import { Container } from "../../components/Container";
+import Logo from "../../components/Logo";
 import { useNavigation } from "../../hooks/useNavigation";
 import { usePersistentTheme } from "../../hooks/usePersistentTheme";
 import { useToast } from "../../lib/toast";
@@ -183,94 +184,12 @@ export function SiteHeader({
               "bg-[var(--logo-background)] text-[var(--logo-color)]",
             )}
           >
-            <svg
-              width="24"
-              height="24"
-              viewBox="0 0 395 323"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
+            <Logo
+              size={24}
+              animated={isLogoHovered}
+              decorative
               className="h-6 w-6"
-              aria-hidden="true"
-              focusable="false"
-            >
-            <style>{`
-              @keyframes pulse-1 {
-                0%, 33%, 100% { opacity: 1; }
-                5%, 28% { opacity: 0.5; }
-              }
-              @keyframes pulse-2 {
-                0%, 5%, 66%, 100% { opacity: 1; }
-                33%, 61% { opacity: 0.5; }
-              }
-              @keyframes pulse-3 {
-                0%, 61%, 100% { opacity: 1; }
-                66%, 95% { opacity: 0.5; }
-              }
-              .logo-bar {
-                transition: opacity 0.3s ease;
-              }
-              .logo-bar.pulse-1 {
-                animation: pulse-1 0.9s ease-in-out infinite;
-              }
-              .logo-bar.pulse-2 {
-                animation: pulse-2 0.9s ease-in-out infinite;
-              }
-              .logo-bar.pulse-3 {
-                animation: pulse-3 0.9s ease-in-out infinite;
-              }
-              @media (prefers-reduced-motion: reduce) {
-                .logo-bar.pulse-1,
-                .logo-bar.pulse-2,
-                .logo-bar.pulse-3 {
-                  animation: none;
-                }
-              }
-            `}</style>
-            <g clipPath="url(#clip0_header)">
-              <rect
-                x="190.742"
-                width="39.0494"
-                height="142.681"
-                fill="currentColor"
-                className={cn(
-                  "logo-bar",
-                  isLogoHovered && "pulse-1",
-                )}
-              />
-              <rect
-                x="190.742"
-                y="180.228"
-                width="39.0494"
-                height="142.681"
-                fill="currentColor"
-                className={cn(
-                  "logo-bar",
-                  isLogoHovered && "pulse-2",
-                )}
-              />
-              <rect
-                x="267.338"
-                y="181.73"
-                width="39.0494"
-                height="127.662"
-                transform="rotate(-90 267.338 181.73)"
-                fill="currentColor"
-                className={cn(
-                  "logo-bar",
-                  isLogoHovered && "pulse-3",
-                )}
-              />
-              <rect y="37.5475" width="39.0494" height="246.312" fill="currentColor"/>
-              <rect x="115.646" y="76.597" width="39.0494" height="168.213" fill="currentColor"/>
-              <path d="M39.0493 76.597L39.0493 37.5475L118.65 37.5475L154.696 76.5969L39.0493 76.597Z" fill="currentColor"/>
-              <path d="M39.0493 244.81L39.0493 283.859L118.65 283.859L154.696 244.81L39.0493 244.81Z" fill="currentColor"/>
-            </g>
-            <defs>
-              <clipPath id="clip0_header">
-                <rect width="395" height="322.909" fill="white"/>
-              </clipPath>
-            </defs>
-          </svg>
+            />
           </div>
           <span className="font-heading text-lg lg:text-xl font-bold tracking-tight transition-colors text-[var(--logo-text-color)] group-hover:text-primary">
             Digitaltableteur


### PR DESCRIPTION
## Why
The header rendered a **bespoke inline copy** of the brand mark (hand-coded `.logo-bar` rects + a local `<style>` pulse block) while the `Logo` DS component sat unused at **beta with zero consumers**. This dogfoods `Logo` into the header and promotes it to stable on the back of that real, every-page consumer.

## The swap — exact parity (no visual regressions)
Replaced the header's inline `<svg>` with `<Logo animated={isLogoHovered} decorative className="h-6 w-6" />`. The circular badge div (background + `scale-110` on hover) and the "Digitaltableteur" wordmark are untouched.

Verified **live in the running app** (not just Storybook):
- Identical `viewBox 0 0 395 323`, geometry (5 rects + 2 paths), decorative `aria-hidden`.
- Same tokens: `--logo-background` badge, `--logo-color` (white) mark via `currentColor`.
- `dt-logo-pulse-1/2/3` keyframes are **identical** to the old `pulse-1/2/3`.
- On real hover: badge `scale: 1.1` **and** bars pulse (`dt-logo-pulse-1`), fired by the link hover — mark **or** wordmark, matching the old behavior exactly.

## Controlled pulse
Changed `.animated:hover .barN` → `.animated .barN` so `animated` is a controlled signal the consumer drives from hover/focus. This is what lets the whole logo link (not just the mark) trigger the pulse. Zero prior consumers, so nothing depended on the old self-hover semantics.

## Promotion to stable
- `status` beta → stable; added `a11y.accessibilityTreeVerified` + `realBrowserForcedColorsVerified` (the forced-colors story test passes for Logo); declared the `propSourced` `size` axis; `consumers[]` synced (SiteHeader).
- Story meta tags `beta`/`!autodocs` → `stable`/`autodocs`.
- Re-captured 16 AT snapshots — **the only diff is removal of the beta "Work in progress" badge line**; the Logo mark tree is byte-identical in every mode. Updated the stable-components docs-registry test snapshot; regenerated agent-manifest / agent-blocks / docs-registry.

## Local gate (CI dead; verified locally)
typecheck ✓ · lint ✓ (0 err) · test 2296/2296 ✓ · build ✓ · validate:components ✓ · check:generated ✓ · check:consumers ✓ · check:contract-props ✓ · stylelint ✓ · rhythmguard ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
