### PR TITLE
fix(ds): correct discriminated-union prop extraction + add regression tests

### DIFF
--- a/nextjs-app/shared/components/Badge/Badge.test.tsx
+++ b/nextjs-app/shared/components/Badge/Badge.test.tsx
@@ -71,4 +71,20 @@ describe("Badge", () => {
     expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
     expect(container.querySelector('[class*="dot"]')).toBeNull();
   });
+
+  it("opts into polite live-region semantics with role status", () => {
+    render(<Badge role="status">3 updates</Badge>);
+    expect(screen.getByRole("status")).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("composes square corners with a non-default size", () => {
+    const { container } = render(
+      <Badge square size="lg">
+        Large square
+      </Badge>,
+    );
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.className).toContain("square");
+    expect(badge.className).toContain("lg");
+  });
 });

--- a/nextjs-app/shared/components/Button/Button.contract.json
+++ b/nextjs-app/shared/components/Button/Button.contract.json
@@ -251,19 +251,25 @@
     "props": {
         "submits": {
             "optional": true,
-            "type": "never"
+            "type": "boolean"
         },
         "clickAction": {
             "optional": true,
-            "type": "never"
+            "type": "(event: React.MouseEvent<HTMLButtonElement>) => void | Promise<void>"
         },
         "href": {
-            "optional": false,
+            "optional": true,
             "type": "string"
         },
         "target": {
             "optional": true,
-            "type": "HTMLAttributeAnchorTarget | undefined"
+            "type": "union",
+            "values": [
+                "_self",
+                "_blank",
+                "_parent",
+                "_top"
+            ]
         },
         "rel": {
             "optional": true,

--- a/nextjs-app/shared/components/Card/Card.test.tsx
+++ b/nextjs-app/shared/components/Card/Card.test.tsx
@@ -46,6 +46,18 @@ describe("Card", () => {
     expect(screen.getByText("Meta")).toBeInTheDocument();
   });
 
+  it("honors descriptionProps element and size", () => {
+    render(
+      <Card
+        description="Supporting line"
+        descriptionProps={{ as: "span", size: "xl" }}
+      />,
+    );
+    const description = screen.getByText("Supporting line");
+    expect(description.tagName).toBe("SPAN");
+    expect(description.className).toContain("textXL");
+  });
+
   it("renders the semantic element from as", () => {
     const { container } = render(<Card as="article">x</Card>);
     expect((container.firstChild as HTMLElement).tagName).toBe("ARTICLE");

--- a/nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.contract.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.contract.json
@@ -58,16 +58,18 @@
     "schemaVersion": 2,
     "props": {
         "type": {
-            "optional": false,
+            "optional": true,
             "type": "union",
             "values": [
                 "text",
                 "tel",
-                "email"
+                "email",
+                "textarea",
+                "select"
             ]
         },
         "children": {
-            "optional": false,
+            "optional": true,
             "type": "ReactNode"
         },
         "label": {

--- a/nextjs-app/shared/components/Modal/Modal.test.tsx
+++ b/nextjs-app/shared/components/Modal/Modal.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen, within } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import Modal from "@dt/Modal";
 
 describe("Modal", () => {
@@ -41,6 +41,52 @@ describe("Modal", () => {
     );
     expect(
       within(document.body).getByRole("button", { name: "Options" }),
+    ).toBeInTheDocument();
+  });
+
+  it("omits the default footer when showFooter is false", () => {
+    render(
+      <Modal isOpen title="Composed dialog" showFooter={false} onClose={() => {}}>
+        <div>Modal Content</div>
+      </Modal>,
+    );
+    expect(within(document.body).queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("wires object and callback panel refs to the dialog", () => {
+    const objectRef = React.createRef<HTMLDivElement>();
+    const callbackRef = vi.fn();
+    const { rerender } = render(
+      <Modal isOpen title="Object ref" panelRef={objectRef}>
+        content
+      </Modal>,
+    );
+    expect(objectRef.current).toBe(within(document.body).getByRole("dialog"));
+
+    rerender(
+      <Modal isOpen title="Callback ref" panelRef={callbackRef}>
+        content
+      </Modal>,
+    );
+    expect(callbackRef).toHaveBeenCalledWith(within(document.body).getByRole("dialog"));
+  });
+
+  it("renders the requested close icon", () => {
+    render(
+      <Modal
+        isOpen
+        title="Custom close icon"
+        showCloseIcon
+        closeIconName="check"
+        onClose={() => {}}
+      >
+        content
+      </Modal>,
+    );
+    expect(
+      within(document.body)
+        .getByRole("button", { name: "Close dialog" })
+        .querySelector('[data-icon-name="check"]'),
     ).toBeInTheDocument();
   });
 

--- a/nextjs-app/shared/components/Text/Text.contract.json
+++ b/nextjs-app/shared/components/Text/Text.contract.json
@@ -117,7 +117,7 @@
     "props": {
         "children": {
             "optional": true,
-            "type": "ReactI18NextChildren | Iterable<ReactI18NextChildren>"
+            "type": "React.ReactNode | ReactI18NextChildren | Iterable<ReactI18NextChildren>"
         },
         "as": {
             "optional": true,

--- a/nextjs-app/shared/components/Title/Title.contract.json
+++ b/nextjs-app/shared/components/Title/Title.contract.json
@@ -117,7 +117,7 @@
     "props": {
         "children": {
             "optional": true,
-            "type": "ReactI18NextChildren | Iterable<ReactI18NextChildren>"
+            "type": "React.ReactNode | ReactI18NextChildren | Iterable<ReactI18NextChildren>"
         },
         "as": {
             "optional": true,

--- a/nextjs-app/shared/components/Toast/Toast.test.tsx
+++ b/nextjs-app/shared/components/Toast/Toast.test.tsx
@@ -93,6 +93,22 @@ describe("Toast", () => {
     expect(container.querySelector("[aria-hidden='true']")).toBeInTheDocument();
   });
 
+  it("lets inline placement override a fixed position", () => {
+    render(
+      <Toast message="Stacked" open inline position="top-left" />,
+    );
+    const toast = screen.getByRole("status");
+    expect(toast.className).toContain("toast--inline");
+    expect(toast.className).not.toContain("toast--top-left");
+  });
+
+  it("applies non-default size and fixed position", () => {
+    render(<Toast message="Placed" open size="lg" position="top-right" />);
+    const toast = screen.getByRole("status");
+    expect(toast.className).toContain("toast--lg");
+    expect(toast.className).toContain("toast--top-right");
+  });
+
   it("clears timer when component unmounts", () => {
     const onClose = vi.fn();
     const { unmount } = render(

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-13T17:29:04.223Z",
+  "generatedAt": "2026-07-13T18:32:27.468Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -1234,19 +1234,25 @@
       "props": {
         "submits": {
           "optional": true,
-          "type": "never"
+          "type": "boolean"
         },
         "clickAction": {
           "optional": true,
-          "type": "never"
+          "type": "(event: React.MouseEvent<HTMLButtonElement>) => void | Promise<void>"
         },
         "href": {
-          "optional": false,
+          "optional": true,
           "type": "string"
         },
         "target": {
           "optional": true,
-          "type": "HTMLAttributeAnchorTarget | undefined"
+          "type": "union",
+          "values": [
+            "_self",
+            "_blank",
+            "_parent",
+            "_top"
+          ]
         },
         "rel": {
           "optional": true,
@@ -4018,16 +4024,18 @@
       "intent": "Documents how **FormFieldEditorial** is used in production layouts and Storybook examples.",
       "props": {
         "type": {
-          "optional": false,
+          "optional": true,
           "type": "union",
           "values": [
             "text",
             "tel",
-            "email"
+            "email",
+            "textarea",
+            "select"
           ]
         },
         "children": {
-          "optional": false,
+          "optional": true,
           "type": "ReactNode"
         },
         "label": {
@@ -4056,7 +4064,9 @@
           "values": [
             "text",
             "tel",
-            "email"
+            "email",
+            "textarea",
+            "select"
           ],
           "default": "text"
         }
@@ -9143,7 +9153,7 @@
       "props": {
         "children": {
           "optional": true,
-          "type": "ReactI18NextChildren | Iterable<ReactI18NextChildren>"
+          "type": "React.ReactNode | ReactI18NextChildren | Iterable<ReactI18NextChildren>"
         },
         "as": {
           "optional": true,
@@ -9649,7 +9659,7 @@
       "props": {
         "children": {
           "optional": true,
-          "type": "ReactI18NextChildren | Iterable<ReactI18NextChildren>"
+          "type": "React.ReactNode | ReactI18NextChildren | Iterable<ReactI18NextChildren>"
         },
         "as": {
           "optional": true,

--- a/nextjs-app/shared/patterns/WorkHero/WorkHero.contract.json
+++ b/nextjs-app/shared/patterns/WorkHero/WorkHero.contract.json
@@ -49,8 +49,5 @@
     "forbiddenUse": [
         "invent parallel primitives inside this folder",
         "promote to stable without production consumer evidence"
-    ],
-    "composesWith": [
-        "Grid"
     ]
 }

--- a/scripts/design-system/build-component-agent-blocks.ts
+++ b/scripts/design-system/build-component-agent-blocks.ts
@@ -143,8 +143,8 @@ function extractPropSchemasFromFile(
     const locallyDeclared = decls.some((d) => d.getSourceFile().getFilePath() === ownPath);
     if (!locallyDeclared) continue;
 
-    let optional = true;
-    let typeText = "unknown";
+    const optionalFlags: boolean[] = [];
+    const declaredTypeTexts: string[] = [];
     let deprecated = false;
 
     for (const d of decls) {
@@ -152,10 +152,12 @@ function extractPropSchemasFromFile(
         "hasQuestionToken" in d &&
         typeof (d as { hasQuestionToken: () => boolean }).hasQuestionToken === "function"
       ) {
-        optional = (d as { hasQuestionToken: () => boolean }).hasQuestionToken();
+        optionalFlags.push(
+          (d as { hasQuestionToken: () => boolean }).hasQuestionToken(),
+        );
       }
       const typeNodeInner = (d as { getTypeNode?: () => { getText: () => string } }).getTypeNode?.();
-      if (typeNodeInner) typeText = typeNodeInner.getText();
+      if (typeNodeInner) declaredTypeTexts.push(typeNodeInner.getText());
       const jsDocs =
         (d as { getJsDocs?: () => Array<{ getDescription: () => string }> }).getJsDocs?.() ?? [];
       if (jsDocs.some((doc) => doc.getDescription().includes("@deprecated"))) {
@@ -163,9 +165,36 @@ function extractPropSchemasFromFile(
       }
     }
 
-    const propType = (decls[0] as import("ts-morph").Node & { getType: () => import("ts-morph").Type }).getType?.() ??
-      sym.getDeclarations()[0]?.getType?.();
-    const literalValues = propType ? collectStringLiterals(propType) : [];
+    const optional = optionalFlags.length ? optionalFlags.some(Boolean) : true;
+    const uniqueTypeTexts = [...new Set(declaredTypeTexts)];
+    const nonNeverTypeTexts =
+      uniqueTypeTexts.length > 1
+        ? uniqueTypeTexts.filter((typeText) => typeText !== "never")
+        : uniqueTypeTexts;
+    const meaningfulTypeTexts = nonNeverTypeTexts.filter((candidate, index, all) => {
+      if (!/^[A-Za-z_$][\w.$]*$/.test(candidate)) return true;
+      return !all.some(
+        (other, otherIndex) =>
+          otherIndex !== index &&
+          other
+            .split("|")
+            .map((part) => part.trim())
+            .includes(candidate),
+      );
+    });
+    const typeText = meaningfulTypeTexts.join(" | ") || "unknown";
+    const literalValues = [
+      ...new Set(
+        decls.flatMap((decl) => {
+          const propType = (
+            decl as import("ts-morph").Node & {
+              getType?: () => import("ts-morph").Type;
+            }
+          ).getType?.();
+          return propType ? collectStringLiterals(propType) : [];
+        }),
+      ),
+    ];
     const values =
       literalValues.length >= 2
         ? literalValues


### PR DESCRIPTION
## Summary
The agent-block extractor took the *last* declaration per prop, so discriminated-union props (Button's `ButtonAsButton | ButtonAsLink`) mis-extracted as `submits: never`, `clickAction: never`, and a required `href`. This merges declarations across union branches: drops `never` when a real type exists, OR-folds the optional flag, and union-collects string literals.

## Changes
- **Extractor fix** (`build-component-agent-blocks.ts`) — the core union-merge logic.
- **Regenerated contracts** (reproducible; idempotent regen verified): Button, Text, Title, FormFieldEditorial + agent blocks.
- **Stale relationship dropped**: WorkHero `composesWith: [Grid]` (WorkHero.tsx has zero Grid references).
- **Regression tests** (purely additive, real props): Badge role/square/size, Card descriptionProps, Modal showFooter/panelRef/closeIconName, Toast inline/position/size.

No component runtime APIs changed.

## Verification (local, all green)
typecheck ✓ · lint ✓ (0 errors) · test ✓ 2304/2304 · build ✓ · check:contract-props ✓ · check:consumers ✓ · validate:components ✓

Originated from a Codex evolution campaign; independently reviewed and verified before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Expanded form fields to support text, telephone, email, textarea, and select inputs.
  - Improved Button behavior for submissions, click actions, links, and standard link targets.
  - Broadened supported content for Text and Title components.
  - Improved Badge accessibility and combined square/large styling.
  - Enhanced Modal options, including footer visibility, close icons, and dialog references.
  - Improved Toast placement and size styling.
  - Simplified WorkHero configuration.

- **Tests**
  - Added coverage for the updated Badge, Card, Modal, and Toast behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->