### PR TITLE
chore(storybook): move Button surface stories into the Button folder

### DIFF
--- a/docs/SHADCN_TO_DT_MIGRATION.md
+++ b/docs/SHADCN_TO_DT_MIGRATION.md
@@ -16,7 +16,7 @@ Shared UI lives in `nextjs-app/shared/stories/MigrationDecisionBoard/` (`Migrati
 
 | Board | Storybook path | Production touchpoints | Status |
 |-------|----------------|------------------------|--------|
-| Button surfaces | `Atoms/Button/Surface comparison` (Cta Bands + Home Hero Band) | `CTASection`, `HomeHero` | Approved |
+| Button surfaces | `Actions/Button` (Cta Bands + Home Hero Band) | `CTASection`, `HomeHero` | Approved |
 | Button contexts | `Migration boards/Button contexts` | `StudioMap`, `IconButton`, `ContactFormSuccess` | Migrated |
 | Contact flow | `Migration boards/Contact flow` | `ContactFormEditorial`, `ContactFormSuccessEditorial` | Migrated (success state + work-samples checkbox) |
 | Form primitives | `Migration boards/Form primitives` | `FormField`, `CheckboxField` | Migrated |

--- a/nextjs-app/shared/components/Button/ButtonSurfaceComparison.stories.tsx
+++ b/nextjs-app/shared/components/Button/ButtonSurfaceComparison.stories.tsx
@@ -12,7 +12,7 @@ import {
 import board from "../../stories/MigrationDecisionBoard/MigrationDecisionBoard.module.css";
 
 const meta = {
-  title: "Actions/Button/Surface comparison",
+  title: "Actions/Button",
   parameters: {
     layout: "fullscreen",
     docs: { disable: true },

--- a/nextjs-app/shared/stories/MigrationDecisionBoard/MigrationBoardsHub.stories.tsx
+++ b/nextjs-app/shared/stories/MigrationDecisionBoard/MigrationBoardsHub.stories.tsx
@@ -12,13 +12,13 @@ type Story = StoryObj<typeof meta>;
 const BOARDS = [
   {
     title: "Button surfaces — CTA bands",
-    storyId: "actions-button-surface-comparison--cta-bands",
+    storyId: "actions-button--cta-bands",
     note: "Approved — surface onDark / onBrand / default on tinted bands.",
     status: "approved" as const,
   },
   {
     title: "Button surfaces — Home hero (light)",
-    storyId: "actions-button-surface-comparison--home-hero-band",
+    storyId: "actions-button--home-hero-band",
     note: "Approved — surface=default only; not onDark.",
     status: "approved" as const,
   },

--- a/scripts/migration-visual-matrix.mjs
+++ b/scripts/migration-visual-matrix.mjs
@@ -39,8 +39,8 @@ const STORIES = [
   { id: "actions-iconbutton--example", label: "IconButton" },
   { id: "forms-formfield--example", label: "FormField" },
   { id: "site-contactformeditorial--example", label: "ContactFormEditorial" },
-  { id: "actions-button-surface-comparison--cta-bands", label: "ButtonSurfaceCtaBands" },
-  { id: "actions-button-surface-comparison--home-hero-band", label: "ButtonSurfaceHomeHero" },
+  { id: "actions-button--cta-bands", label: "ButtonSurfaceCtaBands" },
+  { id: "actions-button--home-hero-band", label: "ButtonSurfaceHomeHero" },
 ];
 
 const PAGES = [


### PR DESCRIPTION
Retitles `Actions/Button/Surface comparison` → `Actions/Button` so the **Cta Bands** and **Home Hero Band** stories sit directly under the Button folder instead of a nested "Surface comparison" subfolder.

Both stories are kept. Story IDs change (`actions-button-surface-comparison--*` → `actions-button--*`), so the deep-links in the Migration boards hub and the visual-matrix script are updated to match, plus the migration doc path. No component or runtime change.

Verified: typecheck ✓, lint ✓ (0 errors), validate:components ✓, audit:snapshot-debt ✓ (0 stable missing — retitle does not pull these into a11y capture), check:astryx-roadmap ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration guidance to reference the consolidated Button Storybook location.

* **Refactor**
  * Consolidated Button surface stories under the `Actions/Button` Storybook path.
  * Updated review boards and visual comparison checks to use the new story references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->