### PR TITLE
chore(react): prepare 0.1.15 release — family subpaths + resolveMotionPlan

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.15 - 2026-07-14
+
+- Adds 12 tree-shakeable family subpath entrypoints alongside the root barrel: `@digitaltableteur/react/{actions,consent,content,feedback,forms,hooks,identity,layout,navigation,patterns,runtime,typography}`, each with isolated JS, `.d.ts`, and `./style.css`. Consumers can import a single family to pull a smaller graph (median family JS is 34.8% of the root bundle, largest 46.9%). The root entrypoint is unchanged and fully back-compatible; the 12 families form an exact partition of it (117 runtime exports, 0 duplicated/orphaned ownership), frozen in the public API manifest and enforced by `check:react-package-topology`.
+- Adds the exported `resolveMotionPlan` runtime API (with `MotionKind` / `MotionPlan` / `MotionRequest` types) — the shared reduced-motion / hydration policy behind the site's GSAP animations. Motion stays static until hydration readiness and reverts active work on a live full→reduced preference flip.
+- No component prop contracts changed; runtime public API 116 → 117 (additive). Verified by the full local gate (typecheck, lint, 2333 tests, build) plus check:react-package, check:react-public-api (117 exports, 26 entrypoints), check:react-public-surface (0 alpha), check:react-package-topology, check:package-tarballs, and check:npm-consumer-install.
+
 ## 0.1.14 - 2026-07-14
 
 - Adds the `useStreamingText(targetText, isStreaming, options)` hook (runtime public API 115 → 116): smooths bursty accumulated stream text into an adaptive, grapheme-safe reveal. `natural`/`fast`/`instant` speeds, reduced-motion bypass, completion snap when streaming ends, and clean reset when the accumulated target is replaced. RAF loop polls a ref for the latest target so new chunks are absorbed without re-subscribing. Exports `StreamingTextSpeed` and `UseStreamingTextOptions` types (#1191).

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/react",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": false,
   "description": "React components and host adapters for the Digitaltableteur design system.",
   "type": "module",

--- a/packages/react/public-api.manifest.json
+++ b/packages/react/public-api.manifest.json
@@ -1,6 +1,6 @@
 {
   "packageName": "@digitaltableteur/react",
-  "packageVersion": "0.1.14",
+  "packageVersion": "0.1.15",
   "packageExports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
Version bump + CHANGELOG for @digitaltableteur/react 0.1.15, shipping [#1194](https://github.com/PetriLahdelma/digitaltableteur/pull/1194): 12 tree-shakeable family subpath entrypoints (117 runtime exports, 26 package entrypoints) and the exported `resolveMotionPlan` API.

Publish-readiness green: check:react-public-api (117), check:react-public-surface (0 alpha), check:react-package-topology (12 families), check:package-tarballs, check:npm-consumer-install, check:package-release-notes, clearance, registry-resolution. Publish via ds-publish OIDC workflow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)