### PR TITLE
refactor(motion): drop KineticTitle's redundant matchMedia reduced-motion fallback

### DIFF
--- a/nextjs-app/shared/components/animations/KineticTitle/KineticTitle.tsx
+++ b/nextjs-app/shared/components/animations/KineticTitle/KineticTitle.tsx
@@ -113,12 +113,10 @@ export function KineticTitle({
 
       // For reduced motion, snap targets to their final visible state instead
       // of running any tween. Partial-opacity frames otherwise misreport as
-      // color-contrast failures in the matrix axe runs.
-      const prefersReduced =
-        motionPreference === "reduced" ||
-        (typeof window !== "undefined" &&
-          window.matchMedia?.("(prefers-reduced-motion: reduce)").matches);
-      if (prefersReduced) {
+      // color-contrast failures in the matrix axe runs. motionPreference is the
+      // single source of truth (AnimationProvider tracks the media query), so no
+      // redundant window.matchMedia fallback is needed.
+      if (motionPreference === "reduced") {
         gsap.set(targets, { opacity: 1, x: 0, y: 0, scale: 1, rotationX: 0 });
         gsap.set(ref.current, { opacity: 1 });
         return () => {


### PR DESCRIPTION
Follow-up from the #1194 motion-policy review. `motionPreference` (from AnimationProvider, which subscribes to the reduced-motion media query) is already the single source of truth, so KineticTitle's extra inline `window.matchMedia("(prefers-reduced-motion: reduce)")` read is redundant — the same anti-pattern #1194 removed from FadeIn/SlideIn. No behavior change; typecheck ✓.

Note: the broader audit found the primary flagged target (ClientLogoMarquee) is correct-by-design — a pure-CSS marquee with declarative `@media (prefers-reduced-motion)` handling; migrating it to the JS static-until-hydration policy would regress slow-hydration devices. The other GSAP candidates (ScrollIndicator, AnimatedFormField, ProjectHero) are behaviorally fine. So this cleanup is the only real improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)