### PR TITLE
fix(consent): honor cookie consent for analytics and reject-optional

### DIFF
--- a/app/components/DeferredAnalytics.tsx
+++ b/app/components/DeferredAnalytics.tsx
@@ -2,6 +2,7 @@
 
 import Script from "next/script";
 import { useEffect, useState } from "react";
+import { useCookieConsent } from "@/nextjs-app/shared/lib/cookieConsent";
 
 interface DeferredAnalyticsProps {
   /** GA4 measurement ID (e.g. G-XXXXXXXXXX). */
@@ -28,12 +29,19 @@ const INTERACTION_EVENTS: (keyof WindowEventMap)[] = [
  * while still tracking real visitors on their first scroll/pointer/key event.
  * The fallback fires well past any trace so engaged-but-idle visitors still
  * count without re-entering the perf window.
+ *
+ * Consent gate: nothing loads unless the visitor has granted the `analytics`
+ * category. Before a choice is made (and after a "reject optional"/revoke)
+ * `hasConsent("analytics")` is false, so GA/GTM/ahrefs never mount. This
+ * component MUST be rendered inside <CookieConsentProvider>.
  */
 export function DeferredAnalytics({ gaMeasurementId }: DeferredAnalyticsProps) {
+  const { hasConsent } = useCookieConsent();
+  const analyticsAllowed = hasConsent("analytics");
   const [shouldLoad, setShouldLoad] = useState(false);
 
   useEffect(() => {
-    if (shouldLoad) return;
+    if (!analyticsAllowed || shouldLoad) return;
 
     const load = () => setShouldLoad(true);
 
@@ -48,9 +56,9 @@ export function DeferredAnalytics({ gaMeasurementId }: DeferredAnalyticsProps) {
       }
       window.clearTimeout(fallback);
     };
-  }, [shouldLoad]);
+  }, [analyticsAllowed, shouldLoad]);
 
-  if (!shouldLoad) return null;
+  if (!analyticsAllowed || !shouldLoad) return null;
 
   return (
     <>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -123,9 +123,10 @@ export default function RootLayout({
             strategy="beforeInteractive"
           />
         ) : null}
-        {/* GTM + GA4 (+ ahrefs) are interaction-gated in <DeferredAnalytics>
-            (rendered in the body) so ~280 KiB of third-party JS stays off the
-            critical path and out of the Lighthouse/PSI trace entirely. */}
+        {/* GTM + GA4 (+ ahrefs) are consent- AND interaction-gated in
+            <DeferredAnalytics> (rendered inside CookieConsentProvider) so they
+            only load after the visitor grants the analytics category, and even
+            then stay off the critical path / out of the Lighthouse/PSI trace. */}
       </head>
       <body suppressHydrationWarning>
         <noscript>
@@ -153,7 +154,6 @@ export default function RootLayout({
           }}
         />
         <Analytics />
-        <DeferredAnalytics gaMeasurementId={gaMeasurementId} />
         <WebMcpProvider>
           <NextThemeProvider>
             <NextLinkProvider>
@@ -165,6 +165,9 @@ export default function RootLayout({
                       <SmoothScrollProvider>
                         <ToastProvider>
                           <CookieConsentProvider autoShow={true}>
+                            <DeferredAnalytics
+                              gaMeasurementId={gaMeasurementId}
+                            />
                             <NextLayout>{children}</NextLayout>
                           </CookieConsentProvider>
                         </ToastProvider>

--- a/nextjs-app/shared/components/CookieConsent/CookieConsent.test.tsx
+++ b/nextjs-app/shared/components/CookieConsent/CookieConsent.test.tsx
@@ -150,6 +150,29 @@ describe("CookieConsent", () => {
     );
   });
 
+  it("rejects all optional categories on essential only", () => {
+    render(
+      <CookieConsentProvider autoShow>
+        <CookieConsent />
+      </CookieConsentProvider>,
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /only essential/i,
+      }),
+    );
+    const stored = localStorageMock.setItem.mock.calls.at(-1)?.[1] as string;
+    const { categories } = JSON.parse(stored) as {
+      categories: Record<string, boolean>;
+    };
+    expect(categories).toMatchObject({
+      essential: true,
+      analytics: false,
+      marketing: false,
+      functional: false,
+    });
+  });
+
   it("renders cookie policy link on the banner", () => {
     render(
       <CookieConsentProvider autoShow>

--- a/nextjs-app/shared/lib/cookieConsent/CookieConsentContext.tsx
+++ b/nextjs-app/shared/lib/cookieConsent/CookieConsentContext.tsx
@@ -123,7 +123,13 @@ export function CookieConsentProvider({
    * Accept only essential (reject all optional)
    */
   const acceptEssentialOnly = useCallback(() => {
-    updateConsents(DEFAULT_CONSENTS, "accept-required");
+    const essentialOnly: Record<CookieCategory, boolean> = {
+      essential: true,
+      analytics: false,
+      marketing: false,
+      functional: false,
+    };
+    updateConsents(essentialOnly, "accept-required");
   }, [updateConsents]);
 
   /**

--- a/nextjs-app/shared/lib/cookieConsent/storage.ts
+++ b/nextjs-app/shared/lib/cookieConsent/storage.ts
@@ -10,13 +10,17 @@ const MINIMIZED_KEY = "dt-cookie-consent-minimized";
 const CURRENT_VERSION = 1;
 
 /**
- * Default consent state structure
+ * Default consent state structure.
+ *
+ * Optional categories default to `false`: under an opt-in consent model the
+ * baseline before any explicit choice (and the "reject all optional" outcome)
+ * must NOT grant analytics/marketing/functional. Only `essential` is on.
  */
 export const DEFAULT_CONSENTS: Record<CookieCategory, boolean> = {
   essential: true, // Always true, can't be disabled
-  analytics: true,
-  marketing: true,
-  functional: true,
+  analytics: false,
+  marketing: false,
+  functional: false,
 };
 
 /**


### PR DESCRIPTION
## What

Fixes two confirmed cookie-consent defects where shipped behavior contradicted the consent UI and privacy policy. Both were surfaced by a Codex review and verified against the code before fixing.

### 1. "Only essential" persisted every optional cookie as granted
`acceptEssentialOnly()` stored `DEFAULT_CONSENTS`, which set `analytics`/`marketing`/`functional` to `true`. Clicking "reject optional / essential only" actually opted the visitor **into** all optional categories.

- `DEFAULT_CONSENTS` optional categories flipped to `false` so the pre-choice baseline and the reject path are opt-in correct.
- `acceptEssentialOnly` now builds an explicit essential-only object, decoupling its correctness from the constant.

### 2. Analytics loaded regardless of consent
`DeferredAnalytics` (GTM / GA4 / ahrefs) was mounted **outside** `CookieConsentProvider` and never checked consent — it loaded on first interaction or a 20s fallback even after rejection.

- Loading is now gated on `hasConsent("analytics")`.
- `<DeferredAnalytics>` moved **inside** `CookieConsentProvider` so it can read consent.

Consent- and interaction-gating compose, so the PSI / critical-path benefit is preserved (a headless run neither consents nor interacts, so analytics stays out of the trace).

## Verification
Verified in the running app (localhost:3001):
- No consent + repeated interaction → **no** GTM/GA scripts inject (`gtmBase:false, hasGtmSrc:false`).
- Analytics granted + interaction → scripts inject, `dataLayer` present.
- "Essential only" → optional categories persist as `false` (new unit test asserts this).

Local gate: `typecheck` ✓, `lint` ✓ (0 errors), `2334` tests ✓, `build` ✓.

## Not in scope (flagged for follow-up)
- The GTM `<noscript>` iframe in `app/layout.tsx` still loads unconditionally for no-JS visitors; consent is JS-based so this can't read consent. Left as-is, worth a separate decision.
- Revoking after granting stops future loads and unmounts the script tags, but does not tear down GA globals / clear `_ga` cookies mid-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analytics now loads only after analytics consent is granted and the user interacts with the site or the fallback delay completes.
  * Optional cookie categories now require explicit opt-in consent by default.

* **Bug Fixes**
  * Choosing “Only essential” now correctly disables analytics, marketing, and functional cookies while retaining essential cookies.

* **Tests**
  * Added coverage verifying essential-only consent is saved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->