### PR TITLE
test(a11y): derive blog page registry from visible post metadata

### DIFF
--- a/tests/a11y/page-verification/blog-pages.spec.ts
+++ b/tests/a11y/page-verification/blog-pages.spec.ts
@@ -1,7 +1,9 @@
 /**
  * Blog Post Pages Accessibility Verification
  *
- * Tests all 12 blog post pages for WCAG 2.1 AA compliance.
+ * Tests every publicly visible blog post for WCAG 2.1 AA compliance.
+ * The post list is derived from generated metadata (see `blogPages` in
+ * page-registry), so coverage tracks published content automatically.
  * Blog posts are English-only MDX content with code blocks, images,
  * and potentially embedded content.
  *
@@ -9,10 +11,9 @@
  * Plan: 07-04 (Blog Pages)
  *
  * Test matrix:
- * - 12 blog posts
+ * - Every visible blog post (derived, not hardcoded)
  * - 4 themes (Light, Dark, HCB, HCW)
  * - English only (MDX content is English)
- * - 48 total combinations
  *
  * Run: npx playwright test tests/a11y/page-verification/blog-pages.spec.ts
  */

--- a/tests/a11y/page-verification/helpers/page-registry.ts
+++ b/tests/a11y/page-verification/helpers/page-registry.ts
@@ -8,6 +8,11 @@
  * Plan: 07-01 (Infrastructure Setup)
  */
 
+// Relative imports (not the "@/" alias): Playwright resolves this file with
+// esbuild, which does not honor tsconfig path aliases.
+import { allPosts } from "../../../../app/blog/postMetadata";
+import { isPostVisible } from "../../../../lib/blog/postVisibility";
+
 /**
  * Page information for accessibility verification.
  */
@@ -95,71 +100,21 @@ export const workPages: PageInfo[] = [
 ];
 
 /**
- * Blog post pages (12 pages)
- * From app/blog/postMetadata.ts
+ * Blog post pages — DERIVED from generated post metadata, never hand-listed.
+ *
+ * Every publicly visible post (not draft, `publishedAt` in the past) is audited.
+ * Deriving from the same source that drives routing/metadata means page-level
+ * a11y coverage can never silently drift behind published content: adding a post
+ * to `content/` regenerates `postMetadata` and this list picks it up on the next
+ * run. (Previously this was a hand-maintained array that fell 12 → 17 behind.)
  */
-export const blogPages: PageInfo[] = [
-  {
-    name: "From Tokens to Thinking Systems",
-    url: "/blog/from-tokens-to-thinking-systems-making-ai-native-design-systems-actually-work",
-    category: "blog",
-  },
-  {
-    name: "Constructive vs Constrictive Criticism",
-    url: "/blog/the-evolutionary-difference-between-constructive-and-constrictive-criticism",
-    category: "blog",
-  },
-  {
-    name: "Branding Design Systems",
-    url: "/blog/branding-design-systems-essay",
-    category: "blog",
-  },
-  {
-    name: "Design System Meets AI Pt 2",
-    url: "/blog/design-system-meets-ai-building-the-self-evolving-component-library-pt-2",
-    category: "blog",
-  },
-  {
-    name: "Design System Meets AI Pt 1",
-    url: "/blog/design-system-meets-ai-building-the-self-evolving-component-library-pt-1",
-    category: "blog",
-  },
-  {
-    name: "A Biography",
-    url: "/blog/petri-lahdelma-bio",
-    category: "blog",
-  },
-  {
-    name: "Digital Craftsmanship",
-    url: "/blog/digital-craftsmanship",
-    category: "blog",
-  },
-  {
-    name: "MCP, Design Systems, and Generative UI",
-    url: "/blog/figma-mcp-design-systems",
-    category: "blog",
-  },
-  {
-    name: "Workflow Tips",
-    url: "/blog/workflow-tips",
-    category: "blog",
-  },
-  {
-    name: "In Search of Impact",
-    url: "/blog/in-search-of-impact",
-    category: "blog",
-  },
-  {
-    name: "Designing in 2025",
-    url: "/blog/designing-in-2025",
-    category: "blog",
-  },
-  {
-    name: "Thoughts on Future Branding",
-    url: "/blog/thoughts-on-future-branding",
-    category: "blog",
-  },
-];
+export const blogPages: PageInfo[] = allPosts
+  .filter((post) => isPostVisible(post, false))
+  .map((post) => ({
+    name: post.title,
+    url: `/blog/${post.slug}`,
+    category: "blog" as const,
+  }));
 
 /**
  * Utility pages (2 pages)
@@ -213,8 +168,9 @@ export const legalPages: PageInfo[] = [
 ];
 
 /**
- * All public pages combined
- * 6 core + 11 work + 12 blog + 3 legal + 1 utility + 4 pseo = 37
+ * All public pages combined.
+ * Blog count is derived from visible post metadata, so the total is dynamic:
+ * 6 core + 11 work + (all visible blog) + 3 legal + 1 utility + 4 pseo.
  */
 export const allPages: PageInfo[] = [
   ...corePages,


### PR DESCRIPTION
## What

Fixes finding #12 from the Codex review: the page-level accessibility registry had silently drifted behind published content.

The a11y registry (`tests/a11y/page-verification/helpers/page-registry.ts`) **hand-listed 12 blog posts** while generated metadata (`app/blog/postMetadata.ts`) had grown to **17 visible posts**. The 5 uncovered posts are the "agentic design systems" series — `status: "scheduled"` with `publishedAt` now in the past, so they render publicly but had **zero page-level a11y coverage**. Nothing failed because the manual list and the generated source were never cross-checked.

## Fix

Derive `blogPages` from the same source that drives routing/metadata:

```ts
export const blogPages: PageInfo[] = allPosts
  .filter((post) => isPostVisible(post, false))
  .map((post) => ({ name: post.title, url: `/blog/${post.slug}`, category: "blog" as const }));
```

Coverage now tracks published content automatically — adding a post to `content/` regenerates `postMetadata` and the audit picks it up on the next run. This class of drift can't silently recur.

Relative imports (not the `@/` alias) are used because Playwright resolves specs with esbuild, which ignores tsconfig path aliases.

## Verification
- Derived list resolves to **17** well-formed blog entries (the 5 previously-missing posts now included); `allPages` total 37 → 42.
- Local gate: `typecheck` ✓, `lint` ✓ (0 errors), `2334` tests ✓, `build` ✓.

Note: the blog a11y axe runs are a Playwright suite (needs a running server + browsers, exercised on the farm), so `npm test`/`build` don't execute them — but they use the identical audit mechanism already proven for the other 12 posts; this change only expands the input list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Accessibility coverage now automatically includes all publicly visible blog posts based on generated post metadata.
  * Test documentation now clearly details coverage across visible blog posts, four themes, and English-only MDX content.
  * Reduced reliance on manually maintained page lists, helping keep accessibility verification aligned with published content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->