### PR TITLE
fix(seo): drop misleading trilingual hreflang from root metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -58,12 +58,12 @@ export const metadata: Metadata = {
     "product design",
   ],
   alternates: {
+    // No hreflang `languages` map: the site serves a single English URL tree
+    // (translation is client-side only, no locale-segmented routes). Advertising
+    // en/fi/sv alternates that all resolve to "/" is a misleading SEO signal, so
+    // we emit only the canonical. Add real hreflang here if/when locale routes
+    // (e.g. /fi, /sv) actually exist.
     canonical: "/",
-    languages: {
-      en: "/",
-      fi: "/",
-      sv: "/",
-    },
   },
   openGraph: {
     type: "website",


### PR DESCRIPTION
## What

Addresses the SEO half of findings #3/#4 from the Codex review, using the agreed **"honest signals now"** scope (no locale-routing refactor).

The root layout advertised `alternates.languages` mapping `en`/`fi`/`sv` all to the same `/` URL:

```ts
alternates: {
  canonical: "/",
  languages: { en: "/", fi: "/", sv: "/" },  // ← all point to the same URL
},
```

The site serves a **single English URL tree** (translation is client-side only via react-i18next; there are no `/fi` or `/sv` routes). Three hreflang entries resolving to one URL is a misleading signal — it tells crawlers there are distinct localized resources that don't exist.

## Fix

Remove the fake `languages` map; emit only the canonical. `<html lang="en">` stays (it matches the language actually served). A comment documents adding real hreflang if/when locale routes exist.

## Scope
- This was the **only** hreflang source. The shared metadata helper (`app/lib/metadata.ts`) and `sitemap.ts` emit canonical only. `agent.json`'s language list reflects the real UI language switcher, not URL alternates, so it's left alone.
- The homepage already overrode the layout with a canonical-only `alternates`, so the fake map only rendered on routes inheriting the layout.

## Not in scope (correctly represented now, not fixed)
Client-only localization (server emits `lang="en"`, fi/sv applied post-hydration) remains — but it's no longer *misrepresented* as a crawlable trilingual site. Full locale routing (`/fi`, `/sv` + server-rendered localized content) is a separate, larger project.

## Verification
Production build: **0 hreflang across all 147 prerendered pages**; per-route canonicals intact and correct (home→root, /about, /work, …). Local gate: `typecheck` ✓, `lint` ✓ (0 errors), `2334` tests ✓, `build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
