### PR TITLE
test(consent): executable hardening suite for consent correctness criteria

### DIFF
--- a/app/components/DeferredAnalytics.test.tsx
+++ b/app/components/DeferredAnalytics.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Consent hardening — C2: no optional analytics loads before explicit consent.
+ *
+ * DeferredAnalytics must render zero GA/GTM/ahrefs script tags until the
+ * visitor has granted the `analytics` category, regardless of interaction or
+ * the idle fallback. next/script is stubbed to an identifiable marker so we can
+ * assert presence/absence without a real Next runtime.
+ */
+
+import React from "react";
+import { render, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("next/script", () => ({
+  default: (props: { id?: string; src?: string }) => (
+    <script data-testid="analytics-script" data-id={props.id} data-src={props.src} />
+  ),
+}));
+
+vi.mock("@/nextjs-app/shared/lib/translation", () => ({
+  useLocalization: () => ({
+    language: "en",
+    resolvedLanguage: "en",
+    translate: (key: string) => key,
+  }),
+  useTranslate: () => (key: string) => key,
+}));
+
+import { DeferredAnalytics } from "./DeferredAnalytics";
+import { CookieConsentProvider } from "@/nextjs-app/shared/lib/cookieConsent";
+
+const STORAGE_KEY = "dt-cookie-consent";
+
+function seedConsent(categories: Record<string, boolean>) {
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({
+      version: 1,
+      timestamp: new Date().toISOString(),
+      language: "en",
+      categories,
+    }),
+  );
+}
+
+function renderAnalytics() {
+  return render(
+    <CookieConsentProvider autoShow={false}>
+      <DeferredAnalytics gaMeasurementId="G-TEST123" />
+    </CookieConsentProvider>,
+  );
+}
+
+async function fireInteraction() {
+  await act(async () => {
+    window.dispatchEvent(new Event("pointerdown"));
+    window.dispatchEvent(new Event("scroll"));
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("DeferredAnalytics — C2: consent-gated loading", () => {
+  it("renders no analytics scripts with no stored consent, even after interaction", async () => {
+    const { queryAllByTestId } = renderAnalytics();
+    await fireInteraction();
+    expect(queryAllByTestId("analytics-script")).toHaveLength(0);
+  });
+
+  it("renders no analytics scripts when analytics is explicitly rejected", async () => {
+    seedConsent({
+      essential: true,
+      analytics: false,
+      marketing: false,
+      functional: false,
+    });
+    const { queryAllByTestId } = renderAnalytics();
+    await fireInteraction();
+    expect(queryAllByTestId("analytics-script")).toHaveLength(0);
+  });
+
+  it("loads analytics only after consent is granted and the user interacts", async () => {
+    seedConsent({
+      essential: true,
+      analytics: true,
+      marketing: true,
+      functional: true,
+    });
+    const { queryAllByTestId } = renderAnalytics();
+
+    // Consent is granted but nothing should load until an interaction fires.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(queryAllByTestId("analytics-script")).toHaveLength(0);
+
+    await fireInteraction();
+    await waitFor(() =>
+      expect(queryAllByTestId("analytics-script").length).toBeGreaterThan(0),
+    );
+  });
+});

--- a/nextjs-app/shared/lib/cookieConsent/consent-hardening.test.tsx
+++ b/nextjs-app/shared/lib/cookieConsent/consent-hardening.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * Consent hardening suite.
+ *
+ * Executable encoding of the consent correctness criteria (from the 2026-07-14
+ * review follow-up). Each test names the criterion it enforces (C1..C10). This
+ * file is the permanent regression gate for the two shipped consent fixes
+ * (#1197) plus the surrounding trust guarantees; the remaining gaps are marked
+ * `it.todo` and converted to real tests as they are implemented.
+ */
+
+import React from "react";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// The provider reads the active language via useLocalization; stub it so the
+// suite exercises consent logic in isolation.
+vi.mock("../translation", () => ({
+  useLocalization: () => ({
+    language: "en",
+    resolvedLanguage: "en",
+    translate: (key: string) => key,
+  }),
+  useTranslate: () => (key: string) => key,
+}));
+
+import {
+  CookieConsentProvider,
+  useCookieConsent,
+} from "./CookieConsentContext";
+import { loadConsentState, stateToConsents } from "./storage";
+import type { CookieCategory } from "./types";
+
+const STORAGE_KEY = "dt-cookie-consent";
+
+const validState = (categories: Record<CookieCategory, boolean>) =>
+  JSON.stringify({
+    version: 1,
+    timestamp: new Date().toISOString(),
+    language: "en",
+    categories,
+  });
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <CookieConsentProvider autoShow={false}>{children}</CookieConsentProvider>
+  );
+}
+
+async function mountConsent() {
+  const hook = renderHook(() => useCookieConsent(), { wrapper });
+  await waitFor(() => expect(hook.result.current.isReady).toBe(true));
+  return hook;
+}
+
+const consentedFor = (
+  consents: ReturnType<typeof stateToConsents>,
+  category: CookieCategory,
+) => consents.find((c) => c.category === category)?.consented;
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("consent hardening — C1: 'only essential' rejects every optional category", () => {
+  it("persists analytics/marketing/functional as false", async () => {
+    const { result } = await mountConsent();
+    act(() => result.current.acceptEssentialOnly());
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) as string);
+    expect(stored.categories).toMatchObject({
+      essential: true,
+      analytics: false,
+      marketing: false,
+      functional: false,
+    });
+  });
+});
+
+describe("consent hardening — C3: rejecting or revoking prevents tracking", () => {
+  it("rejecting optional leaves tracking categories unconsented", async () => {
+    const { result } = await mountConsent();
+    act(() => result.current.acceptEssentialOnly());
+
+    expect(result.current.hasConsent("analytics")).toBe(false);
+    expect(result.current.hasConsent("marketing")).toBe(false);
+    expect(result.current.hasConsent("functional")).toBe(false);
+    expect(result.current.hasConsent("essential")).toBe(true);
+  });
+
+  it("revoking clears storage and flips granted categories back to false", async () => {
+    const { result } = await mountConsent();
+    act(() => result.current.acceptAll());
+    expect(result.current.hasConsent("analytics")).toBe(true);
+
+    act(() => result.current.revokeAll());
+    expect(result.current.hasConsent("analytics")).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("consent hardening — C5: bad/missing/old storage fails closed", () => {
+  it("missing storage grants no optional category", () => {
+    expect(loadConsentState()).toBeNull();
+    const consents = stateToConsents(loadConsentState());
+    expect(consentedFor(consents, "analytics")).toBe(false);
+    expect(consentedFor(consents, "marketing")).toBe(false);
+    expect(consentedFor(consents, "functional")).toBe(false);
+    expect(consentedFor(consents, "essential")).toBe(true);
+  });
+
+  it("corrupt storage fails closed and is cleared", () => {
+    localStorage.setItem(STORAGE_KEY, "{ this is not valid json");
+    expect(loadConsentState()).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("an older schema version is discarded (treated as no consent)", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 0,
+        timestamp: new Date().toISOString(),
+        language: "en",
+        categories: {
+          essential: true,
+          analytics: true,
+          marketing: true,
+          functional: true,
+        },
+      }),
+    );
+    expect(loadConsentState()).toBeNull();
+    const consents = stateToConsents(loadConsentState());
+    expect(consentedFor(consents, "analytics")).toBe(false);
+  });
+
+  it("a structurally incomplete record is rejected", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ version: 1, categories: { essential: true } }),
+    );
+    expect(loadConsentState()).toBeNull();
+  });
+
+  // Gap: no expiry/TTL exists yet (only CURRENT_VERSION). Consent should lapse
+  // after a max age and re-prompt. Implemented in a follow-up PR.
+  it.todo(
+    "C5: consent older than the max age fails closed and re-prompts (needs storage TTL)",
+  );
+});
+
+describe("consent hardening — C8: consumers subscribe through the public API", () => {
+  it("useCookieConsent throws outside the provider (no silent storage reads)", () => {
+    // Analytics/consumers cannot bypass consent by reading storage directly;
+    // the only entry point is the provider hook, which fails loudly if misused.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => renderHook(() => useCookieConsent())).toThrow(
+      /CookieConsentProvider/,
+    );
+    spy.mockRestore();
+  });
+});
+
+describe("consent hardening — C10: valid stored consent is backward compatible", () => {
+  it("honors a valid v1 record on load", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      validState({
+        essential: true,
+        analytics: true,
+        marketing: false,
+        functional: true,
+      }),
+    );
+
+    const { result } = await mountConsent();
+    expect(result.current.hasConsent("analytics")).toBe(true);
+    expect(result.current.hasConsent("marketing")).toBe(false);
+    expect(result.current.hasConsent("functional")).toBe(true);
+  });
+});
+
+// Remaining criteria, tracked as gaps until implemented:
+// C4 — reopen preferences from the footer without clearing storage.
+// C6 — consent state must not flash/change during hydration.
+describe("consent hardening — open gaps", () => {
+  it.todo(
+    "C4: preferences reopen from the footer via openBanner without clearing storage",
+  );
+  it.todo("C6: consent state does not flash or change during hydration");
+  // C7 (keyboard/focus/axe/forced-colors/mobile for banner + settings modal) is
+  // covered by the Playwright a11y suite, not this unit gate.
+});


### PR DESCRIPTION
## What

Delivers the consent-review criteria as a permanent, executable regression gate rather than running them as a one-off evolution loop (see the discussion on why the evolution engine is the wrong tool for trust/legal-critical code).

Two new test files encode the criteria, each test named for the criterion it enforces:

**`consent-hardening.test.tsx`** (lib level)
- **C1** "only essential" persists every optional category as `false`
- **C3** rejecting/revoking leaves tracking categories unconsented; revoke clears storage
- **C5** missing / corrupt / older-version / structurally-incomplete storage all fail closed; corrupt entries are cleared
- **C8** `useCookieConsent` throws outside the provider — consumers can't bypass consent by reading storage directly
- **C10** a valid v1 record is honored on load (backward compatible)

**`DeferredAnalytics.test.tsx`** (the C2 headline)
- **C2** zero GA/GTM/ahrefs scripts with no consent, zero when analytics is explicitly rejected, and (positive path) scripts load only after consent **and** interaction. `next/script` is stubbed to a marker.

## Gaps, tracked as `it.todo` (converted to real tests as they land)
- **C4** reopen preferences from the footer via `openBanner` without clearing storage
- **C5** consent expiry/TTL fail-closed (no expiry concept exists yet)
- **C6** consent state does not flash during hydration
- **C7** keyboard/focus/axe/forced-colors/mobile stays in the Playwright a11y suite

## Why this shape
Locks in the #1197 consent fixes permanently and grounds the remaining work: the suite is green today because C1/C2/C3/C5(most)/C8/C10 already hold, so there is no 40-run sweep to do, just the four narrow gaps above, each its own follow-up PR.

## Verification
`typecheck` ✓, `lint` ✓ (0 errors), `2346` tests (+12) ✓, `build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for consent-gated analytics loading, ensuring scripts load only after explicit analytics consent and user interaction.
  * Added regression tests for essential-only consent, optional consent revocation, invalid or outdated consent data, and provider usage safeguards.
  * Added compatibility checks for valid legacy consent records and documented remaining consent scenarios for future coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->