### PR TITLE
feat(consent): reopen cookie preferences from the footer (C4)

### DIFF
--- a/nextjs-app/shared/lib/cookieConsent/CookieConsentContext.tsx
+++ b/nextjs-app/shared/lib/cookieConsent/CookieConsentContext.tsx
@@ -49,6 +49,19 @@ export function useCookieConsent(): CookieConsentContextValue {
 }
 
 /**
+ * Non-throwing accessor for the cookie consent context.
+ *
+ * Returns `null` when rendered outside a `CookieConsentProvider` instead of
+ * throwing. Use this only for optional UI affordances (e.g. a footer
+ * "Cookie preferences" trigger) that should simply not render when consent
+ * isn't wired — never to read or bypass consent state. For consumers that
+ * require consent, use {@link useCookieConsent}.
+ */
+export function useCookieConsentOptional(): CookieConsentContextValue | null {
+  return useContext(CookieConsentContext);
+}
+
+/**
  * Provider component that manages consent state
  */
 export function CookieConsentProvider({

--- a/nextjs-app/shared/lib/cookieConsent/consent-hardening.test.tsx
+++ b/nextjs-app/shared/lib/cookieConsent/consent-hardening.test.tsx
@@ -180,13 +180,34 @@ describe("consent hardening — C10: valid stored consent is backward compatible
   });
 });
 
-// Remaining criteria, tracked as gaps until implemented:
-// C4 — reopen preferences from the footer without clearing storage.
+describe("consent hardening — C4: preferences reopen without clearing storage", () => {
+  it("openBanner re-opens the banner and leaves stored consent intact", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      validState({
+        essential: true,
+        analytics: true,
+        marketing: false,
+        functional: true,
+      }),
+    );
+
+    const { result } = await mountConsent();
+    expect(result.current.isBannerOpen).toBe(false);
+
+    act(() => result.current.openBanner());
+
+    expect(result.current.isBannerOpen).toBe(true);
+    // Reopening preferences must not wipe the existing choice.
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+    expect(result.current.hasConsent("analytics")).toBe(true);
+    expect(result.current.hasConsent("marketing")).toBe(false);
+  });
+});
+
+// Remaining gap, tracked until implemented:
 // C6 — consent state must not flash/change during hydration.
 describe("consent hardening — open gaps", () => {
-  it.todo(
-    "C4: preferences reopen from the footer via openBanner without clearing storage",
-  );
   it.todo("C6: consent state does not flash or change during hydration");
   // C7 (keyboard/focus/axe/forced-colors/mobile for banner + settings modal) is
   // covered by the Playwright a11y suite, not this unit gate.

--- a/nextjs-app/shared/lib/cookieConsent/index.ts
+++ b/nextjs-app/shared/lib/cookieConsent/index.ts
@@ -7,4 +7,5 @@ export * from "./storage";
 export {
   CookieConsentProvider,
   useCookieConsent,
+  useCookieConsentOptional,
 } from "./CookieConsentContext";

--- a/nextjs-app/shared/locales/en/translation.json
+++ b/nextjs-app/shared/locales/en/translation.json
@@ -379,6 +379,7 @@
   "footerAiUse": "AI Usage",
   "footerAccessibility": "Accessibility Statement",
   "footerSiteMap": "Sitemap",
+  "footerCookiePreferences": "Cookie preferences",
   "sitemapPageTitle": "Sitemap",
   "sitemapPageIntro": "Every public page on this site, grouped by section. Expand a folder to browse case studies, articles, guides, and more.",
   "sitemapTreeLabel": "Sitemap",

--- a/nextjs-app/shared/locales/fi/translation.json
+++ b/nextjs-app/shared/locales/fi/translation.json
@@ -379,6 +379,7 @@
   "footerAiUse": "Tekoälyn käyttö",
   "footerAccessibility": "Saavutettavuusseloste",
   "footerSiteMap": "Sivukartta",
+  "footerCookiePreferences": "Evästeasetukset",
   "sitemapPageTitle": "Sivukartta",
   "sitemapPageIntro": "Kaikki julkiset sivut ryhmiteltynä. Laajenna kansio nähdäksesi case-tutkimukset, artikkelit, oppaat ja muut sivut.",
   "sitemapTreeLabel": "Sivukartta",

--- a/nextjs-app/shared/locales/sv/translation.json
+++ b/nextjs-app/shared/locales/sv/translation.json
@@ -379,6 +379,7 @@
   "footerAiUse": "AI-användning",
   "footerAccessibility": "Tillgänglighetsutlåtande",
   "footerSiteMap": "Webbplatskarta",
+  "footerCookiePreferences": "Cookie-inställningar",
   "sitemapPageTitle": "Webbplatskarta",
   "sitemapPageIntro": "Alla offentliga sidor grupperade efter avsnitt. Expandera en mapp för att bläddra bland case, artiklar, guider med mera.",
   "sitemapTreeLabel": "Webbplatskarta",

--- a/nextjs-app/shared/patterns/SiteFooter/SiteFooter.test.tsx
+++ b/nextjs-app/shared/patterns/SiteFooter/SiteFooter.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * SiteFooter — C4: cookie preferences can be reopened from the footer.
+ *
+ * The footer exposes a "Cookie preferences" trigger that reopens the consent
+ * banner via the provider's public API (openBanner), and only appears when a
+ * CookieConsentProvider is present. It must never touch stored consent.
+ */
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const openBanner = vi.fn();
+let consentValue: { openBanner: () => void } | null = { openBanner };
+
+vi.mock("../../lib/translation", () => ({
+  useTranslate: () => (key: string) =>
+    key === "footerCookiePreferences" ? "Cookie preferences" : key,
+  useLocalization: () => ({
+    language: "en",
+    resolvedLanguage: "en",
+    translate: (key: string) => key,
+  }),
+}));
+
+vi.mock("../../lib/cookieConsent", () => ({
+  useCookieConsentOptional: () => consentValue,
+}));
+
+import { SiteFooter } from "./SiteFooter";
+
+beforeEach(() => {
+  openBanner.mockClear();
+  consentValue = { openBanner };
+});
+
+describe("SiteFooter — C4 cookie preferences reopen", () => {
+  it("renders a Cookie preferences trigger when a consent provider is present", () => {
+    render(<SiteFooter />);
+    expect(
+      screen.getByRole("button", { name: /cookie preferences/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("reopens the consent banner on click without clearing stored consent", () => {
+    const removeItem = vi.spyOn(Storage.prototype, "removeItem");
+    const clear = vi.spyOn(Storage.prototype, "clear");
+
+    render(<SiteFooter />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /cookie preferences/i }),
+    );
+
+    expect(openBanner).toHaveBeenCalledTimes(1);
+    expect(removeItem).not.toHaveBeenCalled();
+    expect(clear).not.toHaveBeenCalled();
+
+    removeItem.mockRestore();
+    clear.mockRestore();
+  });
+
+  it("omits the trigger when no consent provider is present", () => {
+    consentValue = null;
+    render(<SiteFooter />);
+    expect(
+      screen.queryByRole("button", { name: /cookie preferences/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx
+++ b/nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslate } from "../../lib/translation";
+import { useCookieConsentOptional } from "../../lib/cookieConsent";
 import { cn } from "../../lib/cn";
 import { Link as RouterLink } from "../../lib/linkComponent";
 import { Container } from "../../components/Container";
@@ -73,6 +74,10 @@ export interface SiteFooterProps {
 export function SiteFooter({ className }: SiteFooterProps) {
   const t = useTranslate();
   const currentYear = new Date().getFullYear();
+  // Null-safe: renders the "Cookie preferences" trigger only where a
+  // CookieConsentProvider is present (the live site). Stories/tests that render
+  // the footer bare simply omit it, so the footer stays provider-agnostic.
+  const consent = useCookieConsentOptional();
 
   return (
     <footer
@@ -187,9 +192,24 @@ export function SiteFooter({ className }: SiteFooterProps) {
             ))}
           </Stack>
 
-          <p className="font-body text-text-s text-muted-foreground">
-            &copy; {currentYear} Digitaltableteur. {t("footerCopyright")}
-          </p>
+          <div className="flex flex-col sm:flex-row items-center gap-4">
+            {consent ? (
+              // Consent withdrawal must be as easy as granting it (GDPR). A real
+              // <button> (Link is anchor-only) styled to match the subtle
+              // copyright/legal tone of the bottom bar rather than the primary
+              // nav links. Only rendered where a CookieConsentProvider exists.
+              <button
+                type="button"
+                onClick={consent.openBanner}
+                className="font-body text-text-s text-muted-foreground hover:text-foreground hover:underline bg-transparent border-0 p-0 cursor-pointer rounded-sm"
+              >
+                {t("footerCookiePreferences")}
+              </button>
+            ) : null}
+            <p className="font-body text-text-s text-muted-foreground">
+              &copy; {currentYear} Digitaltableteur. {t("footerCopyright")}
+            </p>
+          </div>
         </div>
       </Container>
     </footer>


### PR DESCRIPTION
## What

Closes consent criterion **C4** and a real GDPR-withdrawal gap: once a visitor chose consent, there was **no way to reopen preferences** (`openBanner` was wired to nothing), so withdrawing consent was impossible without manually clearing browser storage.

## Changes
- **`useCookieConsentOptional()`** — a non-throwing accessor so the footer trigger renders only where a `CookieConsentProvider` exists. This keeps `SiteFooter` provider-agnostic: stories and the `NextLayout` unit tests (which render the footer bare) are untouched, no provider coupling.
- **SiteFooter** renders a "Cookie preferences" action in the bottom bar next to the copyright, calling `openBanner`.
- **EN/FI/SV** copy: `footerCookiePreferences`.

## Design notes
- It's a real `<button>` (the DS `Link` is anchor-only and can't drive an `onClick`), so it stays keyboard- and screen-reader-correct.
- Placed **next to the copyright** rather than among the legal `DtLink`s. Those DtLinks render in the themed link color (blue in dark mode); a raw button can't match that cleanly, and reaching into Link's CSS module from a pattern is fragile. Beside the copyright it matches a stable, subtle tone. Verified in-browser: identical to the copyright text (16px, muted-foreground, theme-responsive).

## Verification (live app)
- Footer shows "Cookie preferences"; clicking it reopens the consent banner (all cues present).
- Stored consent is **unchanged** on reopen (before === after).

Converts the `C4` `it.todo` into real tests:
- consent-hardening: `openBanner` reopens without clearing storage or changing the saved choice.
- SiteFooter: trigger present with a provider + calls `openBanner` without touching storage; absent without a provider.

Local gate: `typecheck` ✓, `lint` ✓ (0 errors), `2350` tests (+4) ✓, `build` ✓, translations validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
