### PR TITLE
fix(consent): expire stored consent after 12 months and re-prompt (C5)

### DIFF
--- a/nextjs-app/shared/lib/cookieConsent/consent-hardening.test.tsx
+++ b/nextjs-app/shared/lib/cookieConsent/consent-hardening.test.tsx
@@ -27,7 +27,12 @@ import {
   CookieConsentProvider,
   useCookieConsent,
 } from "./CookieConsentContext";
-import { loadConsentState, stateToConsents } from "./storage";
+import {
+  loadConsentState,
+  stateToConsents,
+  hasGivenConsent,
+  CONSENT_MAX_AGE_MS,
+} from "./storage";
 import type { CookieCategory } from "./types";
 
 const STORAGE_KEY = "dt-cookie-consent";
@@ -142,11 +147,54 @@ describe("consent hardening — C5: bad/missing/old storage fails closed", () =>
     expect(loadConsentState()).toBeNull();
   });
 
-  // Gap: no expiry/TTL exists yet (only CURRENT_VERSION). Consent should lapse
-  // after a max age and re-prompt. Implemented in a follow-up PR.
-  it.todo(
-    "C5: consent older than the max age fails closed and re-prompts (needs storage TTL)",
-  );
+  it("consent older than the max age fails closed and re-prompts", () => {
+    const expired = new Date(
+      Date.now() - (CONSENT_MAX_AGE_MS + 60_000),
+    ).toISOString();
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        timestamp: expired,
+        language: "en",
+        categories: {
+          essential: true,
+          analytics: true,
+          marketing: true,
+          functional: true,
+        },
+      }),
+    );
+
+    expect(loadConsentState()).toBeNull();
+    // Re-prompt: with no valid consent, hasGivenConsent is false so the banner
+    // auto-shows again.
+    expect(hasGivenConsent()).toBe(false);
+    const consents = stateToConsents(loadConsentState());
+    expect(consentedFor(consents, "analytics")).toBe(false);
+  });
+
+  it("consent within the max age is retained", () => {
+    const recent = new Date(Date.now() - 60_000).toISOString();
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        timestamp: recent,
+        language: "en",
+        categories: {
+          essential: true,
+          analytics: true,
+          marketing: false,
+          functional: true,
+        },
+      }),
+    );
+
+    const state = loadConsentState();
+    expect(state).not.toBeNull();
+    expect(state?.categories.analytics).toBe(true);
+  });
 });
 
 describe("consent hardening — C8: consumers subscribe through the public API", () => {

--- a/nextjs-app/shared/lib/cookieConsent/storage.ts
+++ b/nextjs-app/shared/lib/cookieConsent/storage.ts
@@ -10,6 +10,13 @@ const MINIMIZED_KEY = "dt-cookie-consent-minimized";
 const CURRENT_VERSION = 1;
 
 /**
+ * Consent lapses after this age and the visitor is re-prompted. 12 months sits
+ * under the EU (CNIL) 13-month ceiling for consent validity. Exported so tests
+ * and callers can reason about the window.
+ */
+export const CONSENT_MAX_AGE_MS = 365 * 24 * 60 * 60 * 1000;
+
+/**
  * Default consent state structure.
  *
  * Optional categories default to `false`: under an opt-in consent model the
@@ -53,6 +60,19 @@ export function loadConsentState(): ConsentState | null {
     // Handle version migration if needed
     if (parsed.version < CURRENT_VERSION) {
       // Future: migration logic
+      return null;
+    }
+
+    // Expiry: consent older than the max age (or with an unparseable
+    // timestamp) fails closed so the visitor is re-prompted rather than tracked
+    // on a stale choice.
+    const savedAt = Date.parse(parsed.timestamp);
+    if (!Number.isFinite(savedAt) || Date.now() - savedAt > CONSENT_MAX_AGE_MS) {
+      try {
+        localStorage.removeItem(STORAGE_KEY);
+      } catch {
+        // ignore storage cleanup errors
+      }
       return null;
     }
 


### PR DESCRIPTION
Closes consent criterion **C5** (expiry).

Storage had a version field but no expiry, so a consent choice was honored forever. Consent should lapse and be re-collected periodically (EU/CNIL caps consent validity at 13 months).

## Fix
`loadConsentState` now fails closed when the stored timestamp is older than `CONSENT_MAX_AGE_MS` (12 months, under the 13-month ceiling) or is unparseable: the record is cleared and `null` returned, so `hasGivenConsent()` is false and the banner auto-shows for a fresh choice. Records within the window are unchanged (backward compatible).

## Verification
Converts the C5 expiry `it.todo` into real tests: expired -> fails closed + re-prompts + optional categories read false; recent -> retained. The one existing consent fixture (2026-01-01) is within the window, so nothing else changes.

Local gate: typecheck, lint (0 errors), 2352 tests, build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)