### PR TITLE
fix(consent): tear down loaded GA on revoke, not just future loads (C3)

### DIFF
--- a/app/components/DeferredAnalytics.test.tsx
+++ b/app/components/DeferredAnalytics.test.tsx
@@ -103,3 +103,55 @@ describe("DeferredAnalytics — C2: consent-gated loading", () => {
     );
   });
 });
+
+describe("DeferredAnalytics — C3: teardown when analytics is not consented", () => {
+  const disableKey = "ga-disable-G-TEST123";
+
+  beforeEach(() => {
+    delete (window as unknown as Record<string, unknown>)[disableKey];
+    for (const name of ["_ga", "_ga_ABC123", "_gid", "_gat_gtag"]) {
+      document.cookie = `${name}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+    }
+  });
+
+  it("sets the GA disable flag and clears _ga* cookies when analytics is rejected", async () => {
+    document.cookie = "_ga=GA1.1.987654; path=/";
+    document.cookie = "_ga_ABC123=GS1.1.session; path=/";
+    document.cookie = "_gid=GA1.2.123; path=/";
+
+    seedConsent({
+      essential: true,
+      analytics: false,
+      marketing: false,
+      functional: false,
+    });
+    renderAnalytics();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(
+      (window as unknown as Record<string, boolean>)[disableKey],
+    ).toBe(true);
+    expect(document.cookie).not.toMatch(/_ga=/);
+    expect(document.cookie).not.toMatch(/_ga_ABC123=/);
+    expect(document.cookie).not.toMatch(/_gid=/);
+  });
+
+  it("leaves the GA disable flag off when analytics is granted", async () => {
+    seedConsent({
+      essential: true,
+      analytics: true,
+      marketing: true,
+      functional: true,
+    });
+    renderAnalytics();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(
+      (window as unknown as Record<string, boolean>)[disableKey],
+    ).toBe(false);
+  });
+});

--- a/app/components/DeferredAnalytics.tsx
+++ b/app/components/DeferredAnalytics.tsx
@@ -17,6 +17,37 @@ const INTERACTION_EVENTS: (keyof WindowEventMap)[] = [
   "mousemove",
 ];
 
+/** GA/GTM identifiers that should be dropped when analytics consent is absent. */
+const ANALYTICS_COOKIE_PREFIXES = ["_ga", "_gid", "_gat", "_dc_gtm_"];
+
+/**
+ * Best-effort teardown of already-set analytics cookies on the client. GA sets
+ * `_ga*` on the registrable domain, so we expire each name across the plausible
+ * domain scopes (exact host, dotted host, registrable domain, and no domain).
+ */
+function clearAnalyticsCookies(): void {
+  if (typeof document === "undefined") return;
+
+  const names = document.cookie
+    .split(";")
+    .map((c) => c.split("=")[0].trim())
+    .filter(Boolean);
+
+  const host = window.location.hostname;
+  const registrable = host.split(".").slice(-2).join(".");
+  const domains = [undefined, host, `.${host}`, `.${registrable}`];
+
+  for (const name of names) {
+    if (!ANALYTICS_COOKIE_PREFIXES.some((prefix) => name.startsWith(prefix))) {
+      continue;
+    }
+    for (const domain of domains) {
+      const domainPart = domain ? `; domain=${domain}` : "";
+      document.cookie = `${name}=; path=/${domainPart}; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+    }
+  }
+}
+
 /**
  * Loads GTM + GA4 (and ahrefs in production) only after the first real user
  * interaction, with a long idle fallback.
@@ -34,11 +65,28 @@ const INTERACTION_EVENTS: (keyof WindowEventMap)[] = [
  * category. Before a choice is made (and after a "reject optional"/revoke)
  * `hasConsent("analytics")` is false, so GA/GTM/ahrefs never mount. This
  * component MUST be rendered inside <CookieConsentProvider>.
+ *
+ * Revocation also tears down already-initialized tracking: it sets GA's
+ * `ga-disable-<id>` flag (which halts any loaded gtag) and clears `_ga*`
+ * cookies, so withdrawing consent stops tracking that was live in the session.
  */
 export function DeferredAnalytics({ gaMeasurementId }: DeferredAnalyticsProps) {
   const { hasConsent } = useCookieConsent();
   const analyticsAllowed = hasConsent("analytics");
   const [shouldLoad, setShouldLoad] = useState(false);
+
+  // React to consent being absent/withdrawn: disable any loaded GA and drop its
+  // cookies. Re-enable when analytics is (re-)granted so a later load tracks.
+  useEffect(() => {
+    const disableFlag = `ga-disable-${gaMeasurementId}`;
+    const globals = window as unknown as Record<string, boolean>;
+    if (analyticsAllowed) {
+      globals[disableFlag] = false;
+      return;
+    }
+    globals[disableFlag] = true;
+    clearAnalyticsCookies();
+  }, [analyticsAllowed, gaMeasurementId]);
 
   useEffect(() => {
     if (!analyticsAllowed || shouldLoad) return;


### PR DESCRIPTION
Completes consent criterion **C3**.

Rejecting/revoking already stopped new analytics from loading (scripts unmount when consent is absent), but GA that had initialized earlier in the session kept its globals and `_ga*` cookies. Withdrawal must also stop tracking that is already live.

## Fix
`DeferredAnalytics` reacts to analytics consent being absent/withdrawn by setting GA's `ga-disable-<id>` flag (halts any loaded gtag) and expiring the `_ga`, `_gid`, `_gat`, `_dc_gtm_` cookies across plausible domain scopes. Re-granting flips the flag back off so a later load tracks normally.

## Verification (live app)
With analytics rejected: `ga-disable-G-09HMKEXGPX` is `true` and seeded `_ga*` cookies are cleared (`[]`).

Adds C3 teardown tests (reject -> flag set + cookies cleared; grant -> flag off). Local gate: typecheck, lint (0 errors), 2354 tests, build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)