### PR TITLE
fix(consent): make switch off-track visible + on-tone in dark mode

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-07-13T16:35:58.810Z",
+  "createdAt": "2026-07-14T16:45:30.741Z",
   "directory": "nextjs-app/shared",
   "findings": [
     {
@@ -1735,8 +1735,8 @@
     {
       "column": 23,
       "file": "nextjs-app/shared/components/CookieConsent/CookieConsent.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f123\u001f23\u001f3px\u001fUnexpected off-scale value \"3px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "line": 123,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f133\u001f23\u001f3px\u001fUnexpected off-scale value \"3px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 133,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"3px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -1745,8 +1745,8 @@
     {
       "column": 25,
       "file": "nextjs-app/shared/components/CookieConsent/CookieConsent.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f131\u001f25\u001f20px\u001fUnexpected off-scale value \"20px\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
-      "line": 131,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f141\u001f25\u001f20px\u001fUnexpected off-scale value \"20px\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
+      "line": 141,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"20px\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -1785,8 +1785,8 @@
     {
       "column": 23,
       "file": "nextjs-app/shared/components/CookieConsent/CookieConsent.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f123\u001f23\u001f3px\u001fUnexpected raw scale value \"3px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 123,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f133\u001f23\u001f3px\u001fUnexpected raw scale value \"3px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 133,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"3px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -1795,8 +1795,8 @@
     {
       "column": 25,
       "file": "nextjs-app/shared/components/CookieConsent/CookieConsent.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f131\u001f25\u001f20px\u001fUnexpected raw scale value \"20px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 131,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f141\u001f25\u001f20px\u001fUnexpected raw scale value \"20px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 141,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"20px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -7345,8 +7345,8 @@
     {
       "column": 19,
       "file": "nextjs-app/shared/styles/variables.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/styles/variables.css\u001f708\u001f19\u001f6px\u001fUnexpected off-scale value \"6px\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
-      "line": 708,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/styles/variables.css\u001f716\u001f19\u001f6px\u001fUnexpected off-scale value \"6px\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
+      "line": 716,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"6px\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -7355,8 +7355,8 @@
     {
       "column": 19,
       "file": "nextjs-app/shared/styles/variables.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/styles/variables.css\u001f708\u001f19\u001f6px\u001fUnexpected raw scale value \"6px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 708,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/styles/variables.css\u001f716\u001f19\u001f6px\u001fUnexpected raw scale value \"6px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 716,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"6px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -144,6 +144,7 @@
   --color-dt-react: var(--color-react);
   --color-dt-success: var(--color-success);
   --color-dt-surface: var(--color-surface);
+  --color-dt-switch-track-off: var(--color-switch-track-off);
   --color-dt-text: var(--color-text);
   --color-dt-title: var(--color-title);
   --color-dt-warning: var(--color-warning);

--- a/nextjs-app/shared/components/CookieConsent/CookieConsent.module.css
+++ b/nextjs-app/shared/components/CookieConsent/CookieConsent.module.css
@@ -104,8 +104,18 @@
   position: absolute;
   inset: 0;
   border-radius: 24px;
-  background-color: var(--color-gray);
+  background-color: var(--color-switch-track-off);
   transition: background-color 0.2s ease;
+}
+
+/* Off-state track background. Stated at the same specificity as the checked
+   rule below (0,3,1) because the Modal content reset
+   (`.content :is(p, span, div) { background: transparent }`, 0,2,1) otherwise
+   outspecifies a bare `.slider` and makes the off track invisible on the dark
+   modal surface. */
+
+.switch input:not(:checked) + .slider {
+  background-color: var(--color-switch-track-off);
 }
 
 .slider::before {

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-13T22:51:02.818Z",
+  "generatedAt": "2026-07-14T16:39:59.880Z",
   "summary": {
     "componentCount": 162,
     "statusCounts": {
@@ -25,8 +25,8 @@
   },
   "tokens": {
     "source": "nextjs-app/shared/styles/variables.css",
-    "tokenCount": 184,
-    "usageCoverage": 150,
+    "tokenCount": 185,
+    "usageCoverage": 151,
     "catalogPath": "nextjs-app/shared/foundations/token-catalog.json",
     "dtcgExport": "nextjs-app/shared/foundations/tokens/production/",
     "tailwindBridge": "app/tailwind.css (DT-THEME block)",
@@ -63,7 +63,7 @@
     "catalogCompletenessPercent": 88,
     "artifactCoverage": {
       "stories": 146,
-      "tests": 147,
+      "tests": 148,
       "mdx": 6,
       "spec": 162
     },

--- a/nextjs-app/shared/foundations/dist/tokens-manifest.json
+++ b/nextjs-app/shared/foundations/dist/tokens-manifest.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": "1.0",
   "source": "nextjs-app/shared/styles/variables.css",
-  "tokenCount": 184,
-  "usageCoverage": 150,
+  "tokenCount": 185,
+  "usageCoverage": 151,
   "dtcgFiles": [
     "tokens/production/color.json",
     "tokens/production/elevation.json",
@@ -52,6 +52,7 @@
     "--color-dark",
     "--color-border",
     "--color-border-light",
+    "--color-switch-track-off",
     "--color-light-bg",
     "--color-react",
     "--color-header-bg",
@@ -213,5 +214,5 @@
     "--line-height-relaxed",
     "--line-height-loose"
   ],
-  "generatedAt": "2026-07-08T23:25:38.640Z"
+  "generatedAt": "2026-07-14T16:39:51.727Z"
 }

--- a/nextjs-app/shared/foundations/token-catalog.json
+++ b/nextjs-app/shared/foundations/token-catalog.json
@@ -1,8 +1,8 @@
 {
   "source": "nextjs-app/shared/styles/variables.css",
-  "generatedAt": "2026-07-11T16:39:46.044Z",
-  "tokenCount": 184,
-  "usageCoverage": 150,
+  "generatedAt": "2026-07-14T16:39:51.626Z",
+  "tokenCount": 185,
+  "usageCoverage": 151,
   "themes": [
     {
       "id": "light",
@@ -942,6 +942,13 @@
           "name": "--color-border-light",
           "value": "#ccc",
           "usage": "Color token (border-light).",
+          "category": "color",
+          "subgroup": "Semantic"
+        },
+        {
+          "name": "--color-switch-track-off",
+          "value": "#ccc",
+          "usage": "Color token (switch-track-off).",
           "category": "color",
           "subgroup": "Semantic"
         },

--- a/nextjs-app/shared/foundations/tokens/production/color.json
+++ b/nextjs-app/shared/foundations/tokens/production/color.json
@@ -305,6 +305,22 @@
         }
       }
     },
+    "switch": {
+      "track": {
+        "off": {
+          "$value": "#ccc",
+          "$description": "Color token (switch-track-off).",
+          "$type": "color",
+          "$extensions": {
+            "digitaltableteur": {
+              "cssVar": "--color-switch-track-off",
+              "category": "color",
+              "subgroup": "Semantic"
+            }
+          }
+        }
+      }
+    },
     "light": {
       "bg": {
         "$value": "#f9f9f9",

--- a/nextjs-app/shared/styles/variables.css
+++ b/nextjs-app/shared/styles/variables.css
@@ -130,6 +130,11 @@
   --color-muted-light: #909090;
   --color-border: #c0c0c0;
   --color-border-light: #ccc;
+
+  /* Off-state track for switch/toggle controls. Theme-aware: a light gray on
+     light surfaces, a subtle slate on dark, so the track reads clearly as OFF
+     (not half-on) while the white knob carries the state. */
+  --color-switch-track-off: #ccc;
   --color-disabled-bg: #e8e8e8; /* 3.01:1 with --color-disabled-placeholder */
   --color-disabled-bg-light: #efefef; /* 3.21:1 with --color-disabled-placeholder */
   --color-disabled-placeholder: #858585;
@@ -385,6 +390,7 @@
   --color-muted-light: #555;
   --color-border: #333;
   --color-border-light: #444;
+  --color-switch-track-off: #35393c;
   --color-disabled-bg: #23272a;
   --color-disabled-bg-light: #23272a;
   --color-disabled-placeholder: #767676; /* 3.31:1 on #23272a; #555 was 2.02:1 */
@@ -453,6 +459,7 @@
   --color-muted-light: #555;
   --color-border: #333;
   --color-border-light: #444;
+  --color-switch-track-off: #444;
   --color-disabled-bg: #313131;
   --color-disabled-bg-light: #313131; /* #7b7b7b midtone was 1.76:1 with any gray text */
   --color-disabled-placeholder: #9e9e9e; /* 4.86:1 on #313131; #555 was 1.74:1 */
@@ -565,6 +572,7 @@
   --color-muted-light: #555;
   --color-border: #333;
   --color-border-light: #444;
+  --color-switch-track-off: #ccc;
   --color-disabled-bg: #e8e8e8; /* dark-on-light HC theme: near-black fields were illegible */
   --color-disabled-bg-light: #efefef;
   --color-disabled-placeholder: #6b6b6b; /* 4.63:1 on #efefef, 4.35:1 on #e8e8e8 */

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -3963,27 +3963,27 @@
       "text": "Expected variable, function or keyword for \"none\" of \"forced-color-adjust\" (scale-unlimited/declaration-strict-value)"
     },
     {
-      "id": "nextjs-app/shared/styles/variables.css::346::3::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"dark\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)",
+      "id": "nextjs-app/shared/styles/variables.css::351::3::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"dark\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)",
       "file": "nextjs-app/shared/styles/variables.css",
-      "line": 346,
+      "line": 351,
       "column": 3,
       "rule": "scale-unlimited/declaration-strict-value",
       "severity": "warning",
       "text": "Expected variable, function or keyword for \"dark\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)"
     },
     {
-      "id": "nextjs-app/shared/styles/variables.css::421::3::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"dark\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)",
+      "id": "nextjs-app/shared/styles/variables.css::427::3::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"dark\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)",
       "file": "nextjs-app/shared/styles/variables.css",
-      "line": 421,
+      "line": 427,
       "column": 3,
       "rule": "scale-unlimited/declaration-strict-value",
       "severity": "warning",
       "text": "Expected variable, function or keyword for \"dark\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)"
     },
     {
-      "id": "nextjs-app/shared/styles/variables.css::615::5::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"light\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)",
+      "id": "nextjs-app/shared/styles/variables.css::623::5::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"light\" of \"color-scheme\" (scale-unlimited/declaration-strict-value)",
       "file": "nextjs-app/shared/styles/variables.css",
-      "line": 615,
+      "line": 623,
       "column": 5,
       "rule": "scale-unlimited/declaration-strict-value",
       "severity": "warning",


### PR DESCRIPTION
The cookie-settings toggles were invisible when OFF on the dark modal surface; restoring the track then read too light. Two root causes + a new theme-aware token.

## Root causes
1. **Visibility**: the Modal content reset `.content :is(p, span, div) { background: transparent }` (specificity 0,2,1) outspecified the bare `.slider` (0,1,0) and forced the off-track transparent inside the modal. Only the checked “Essential” toggle survived, because its `input:checked + .slider` rule (0,3,1) outranks the reset — which is exactly why only the OFF toggles vanished. Fixed by stating the off-track background at the same 0,3,1 specificity.
2. **Tone**: `--color-gray` is `#aaa` in dark, which reads as half-on.

## New token
`--color-switch-track-off` — theme-aware: light `#ccc`, dark `#35393c` (your target), HCB `#444`, HCW `#ccc`. Off track is a subtle slate on dark / light gray on light; the white knob carries the state. The slider consumes it. Regenerated token artifacts (build:tokens + build:zod-catalog).

## Verified live (dark theme)
Off-track = `rgb(53,57,60)` = `#35393c`; all four toggles visible. Gate: typecheck, lint (0 errors), 2356 tests, build, check:contrast, token-packages, check:generated all pass. Line-keyed stylelint/rhythm baselines re-keyed (pure line shifts; 443 warnings held, 0 new drift).

## Heads-up
HCW (high-contrast white) uses `#ccc` per the approved values, but on that white surface a `#ccc` track with the white knob is low-contrast. Happy to bump HCW to `#444` (matching its `--color-border-light`) if you want stronger HC contrast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated color token for switch and toggle controls when turned off.
  * Added theme-specific off-state colors for default, dark, and high-contrast themes.

* **Bug Fixes**
  * Improved cookie consent toggle styling so the off-state track remains visible and uses the correct theme color.

* **Chores**
  * Updated design-system metadata and baseline references to reflect current source locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->