### PR TITLE
fix(a11y): trap focus inside the mobile drawer (#6)

### DIFF
--- a/nextjs-app/shared/patterns/SiteHeader/MobileDrawer.test.tsx
+++ b/nextjs-app/shared/patterns/SiteHeader/MobileDrawer.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * MobileDrawer focus trap (finding #6).
+ *
+ * Inerting #main-content did not contain Tab, so keyboard focus could walk out
+ * of the open drawer to the header/footer controls behind it. These tests lock
+ * in Tab/Shift+Tab containment and Escape-to-close.
+ */
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("gsap", () => ({
+  gsap: {
+    context: (fn?: () => void) => {
+      fn?.();
+      return { revert: () => {} };
+    },
+    fromTo: () => {},
+    set: () => {},
+  },
+}));
+
+vi.mock("../../lib/translation", () => ({
+  useTranslate: () => (key: string, fallback?: string) => fallback ?? key,
+}));
+
+vi.mock("../../lib/linkComponent", () => ({
+  Link: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("../../components/NavLink", () => ({
+  NavLink: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+import { MobileDrawer } from "./MobileDrawer";
+
+const navItems = [
+  { href: "/work", label: "navWork", exact: false },
+  { href: "/about", label: "navAbout", exact: false },
+];
+
+function renderDrawer(overrides: Record<string, unknown> = {}) {
+  return render(
+    <MobileDrawer
+      isOpen
+      onClose={vi.fn()}
+      navItems={navItems}
+      currentLang="en"
+      onLanguageChange={vi.fn()}
+      onThemeToggle={vi.fn()}
+      theme="light"
+      {...overrides}
+    />,
+  );
+}
+
+function panelFocusables() {
+  const panel = screen.getByRole("dialog");
+  return Array.from(
+    panel.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled])',
+    ),
+  );
+}
+
+beforeEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("MobileDrawer focus trap (#6)", () => {
+  it("has multiple focusable controls inside the panel", () => {
+    renderDrawer();
+    expect(panelFocusables().length).toBeGreaterThan(2);
+  });
+
+  it("wraps Tab from the last control back to the first", () => {
+    renderDrawer();
+    const focusable = panelFocusables();
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    last.focus();
+    expect(document.activeElement).toBe(last);
+
+    fireEvent.keyDown(window, { key: "Tab" });
+    expect(document.activeElement).toBe(first);
+  });
+
+  it("wraps Shift+Tab from the first control back to the last", () => {
+    renderDrawer();
+    const focusable = panelFocusables();
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    first.focus();
+    expect(document.activeElement).toBe(first);
+
+    fireEvent.keyDown(window, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(last);
+  });
+
+  it("pulls focus back into the panel if it lands outside", () => {
+    renderDrawer();
+    const outside = document.createElement("button");
+    outside.textContent = "outside";
+    document.body.appendChild(outside);
+    outside.focus();
+    expect(document.activeElement).toBe(outside);
+
+    fireEvent.keyDown(window, { key: "Tab" });
+    const panel = screen.getByRole("dialog");
+    expect(panel.contains(document.activeElement)).toBe(true);
+  });
+
+  it("closes on Escape", () => {
+    const onClose = vi.fn();
+    renderDrawer({ onClose });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx
+++ b/nextjs-app/shared/patterns/SiteHeader/MobileDrawer.tsx
@@ -122,16 +122,47 @@ export function MobileDrawer({
     return () => ctx.revert();
   }, [isOpen]);
 
-  // Escape key handler
+  // Keyboard handling: Escape closes; Tab is trapped inside the panel so focus
+  // can't walk out to the header/footer controls behind the drawer. Inerting
+  // #main-content alone did not contain Tab (finding #6).
   useEffect(() => {
     if (!isOpen) return;
 
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+    const FOCUSABLE =
+      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const panel = panelRef.current;
+      if (!panel) return;
+
+      const focusable = Array.from(
+        panel.querySelectorAll<HTMLElement>(FOCUSABLE),
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (e.shiftKey) {
+        if (active === first || !panel.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (active === last || !panel.contains(active)) {
+        e.preventDefault();
+        first.focus();
+      }
     };
 
-    window.addEventListener("keydown", handleEscape);
-    return () => window.removeEventListener("keydown", handleEscape);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, onClose]);
 
   if (!isOpen) return null;


### PR DESCRIPTION
First PR of the navigation-shell batch (findings #6/#7). Fixes finding **#6**.

## Problem
The mobile drawer inerted `#main-content` and handled Escape, but nothing contained **Tab** — keyboard focus walked out of the open drawer to the header/footer controls behind it (theme toggle, language switcher, logo). `aria-modal` alone does not enforce containment.

## Fix
Replace the Escape-only handler with a Tab-cycling focus trap scoped to the panel:
- Tab from the last control wraps to the first
- Shift+Tab from the first wraps to the last
- focus that lands outside the panel is pulled back in

Escape still closes; focus-on-open and restore-on-close are unchanged. No new dependency (no focus-lock library).

## Verification (live, 375px)
Tab wraps last→first, Shift+Tab wraps first→last, and focusing a header control then pressing Tab returns focus into the panel. Adds a focus-trap unit test (both wrap directions, outside-focus recovery, Escape-to-close).

Local gate: typecheck, lint (0 errors), 2361 tests, build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)