### PR TITLE
fix(a11y): make the consent switch legible in high-contrast black

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-07-14T16:45:30.741Z",
+  "createdAt": "2026-07-14T17:19:51.620Z",
   "directory": "nextjs-app/shared",
   "findings": [
     {
@@ -1735,8 +1735,8 @@
     {
       "column": 23,
       "file": "nextjs-app/shared/components/CookieConsent/CookieConsent.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f133\u001f23\u001f3px\u001fUnexpected off-scale value \"3px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "line": 133,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f141\u001f23\u001f3px\u001fUnexpected off-scale value \"3px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 141,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"3px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -1745,8 +1745,8 @@
     {
       "column": 25,
       "file": "nextjs-app/shared/components/CookieConsent/CookieConsent.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f141\u001f25\u001f20px\u001fUnexpected off-scale value \"20px\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
-      "line": 141,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f155\u001f25\u001f20px\u001fUnexpected off-scale value \"20px\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
+      "line": 155,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"20px\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -1785,8 +1785,8 @@
     {
       "column": 23,
       "file": "nextjs-app/shared/components/CookieConsent/CookieConsent.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f133\u001f23\u001f3px\u001fUnexpected raw scale value \"3px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 133,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f141\u001f23\u001f3px\u001fUnexpected raw scale value \"3px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 141,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"3px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -1795,8 +1795,8 @@
     {
       "column": 25,
       "file": "nextjs-app/shared/components/CookieConsent/CookieConsent.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f141\u001f25\u001f20px\u001fUnexpected raw scale value \"20px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 141,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f155\u001f25\u001f20px\u001fUnexpected raw scale value \"20px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 155,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"20px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",

--- a/nextjs-app/shared/components/CookieConsent/CookieConsent.module.css
+++ b/nextjs-app/shared/components/CookieConsent/CookieConsent.module.css
@@ -108,6 +108,14 @@
   transition: background-color 0.2s ease;
 }
 
+/* High-contrast black: on a pure-black surface a flat grey track can't contrast
+   with BOTH the background and the white knob, so outline the track (pill reads
+   on black). Scoped to HCB; light/dark/HCW unchanged. */
+
+:global(.themeHCB) .slider {
+  border: 1px solid var(--color-title);
+}
+
 /* Off-state track background. Stated at the same specificity as the checked
    rule below (0,3,1) because the Modal content reset
    (`.content :is(p, span, div) { background: transparent }`, 0,2,1) otherwise
@@ -133,6 +141,12 @@
   inset-inline-start: 3px;
 }
 
+/* HCB: dark ring keeps the white knob distinct from the track. */
+
+:global(.themeHCB) .slider::before {
+  border: 1px solid var(--main-body-background-color);
+}
+
 .switch input:checked + .slider {
   background-color: var(--color-primary);
 }
@@ -144,6 +158,14 @@
 .switch input:disabled + .slider {
   cursor: not-allowed;
   opacity: 0.5;
+}
+
+/* HCB disabled: opacity dims track and knob to the same grey (the knob
+   vanishes), so use a distinct dark track at full opacity instead. */
+
+:global(.themeHCB) input:disabled + .slider {
+  background-color: var(--color-disabled-bg);
+  opacity: 1;
 }
 
 .switch input:focus-visible + .slider {


### PR DESCRIPTION
A regression from the switch-track token change: in HCB (pure-black surface) the OFF track was `#444` (too dark for a high-contrast theme) and the disabled **Essential** toggle used `opacity: 0.5`, which dimmed the white track and white knob to the same grey — the knob became invisible.

## Fix (scoped to `.themeHCB`; light/dark/HCW untouched, verified)
- Track gets a light outline so the pill reads on black.
- The knob gets a dark ring so it stays distinct from the track.
- Disabled drops the opacity-flatten and uses a distinct dark track (`--color-disabled-bg`) at full opacity, so the knob stays visible.

Overrides are interleaved after their base rules to keep specificity ascending (no stylelint no-descending / max-specificity debt).

## Verification (screenshots)
In HCB, all four toggles now show white-outlined pills with a visible white knob, including the previously-invisible disabled Essential. Dark theme re-checked: off-track still `#35393c`, no border — unchanged.

Local gate: typecheck, lint (0 errors), 2361 tests, build, check:contrast all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)