### PR TITLE
refactor(footer): move cookie preferences into the legal links column

### DIFF
--- a/nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx
+++ b/nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx
@@ -176,6 +176,19 @@ export function SiteFooter({ className }: SiteFooterProps) {
               <DtLink underline="hover" href="/sitemap" size="sm">
                 {t("footerSiteMap")}
               </DtLink>
+              {consent ? (
+                // "Cookie preferences" belongs with the legal links. Link is
+                // anchor-only, so this is a real <button> matched to the sibling
+                // DtLinks (themed --link-color, 1rem, hover underline). Only
+                // rendered where a CookieConsentProvider exists.
+                <button
+                  type="button"
+                  onClick={consent.openBanner}
+                  className="font-body text-base text-[color:var(--link-color)] bg-transparent border-0 p-0 cursor-pointer text-left hover:underline rounded-sm"
+                >
+                  {t("footerCookiePreferences")}
+                </button>
+              ) : null}
             </Stack>
           </div>
         </div>
@@ -192,24 +205,9 @@ export function SiteFooter({ className }: SiteFooterProps) {
             ))}
           </Stack>
 
-          <div className="flex flex-col sm:flex-row items-center gap-4">
-            {consent ? (
-              // Consent withdrawal must be as easy as granting it (GDPR). A real
-              // <button> (Link is anchor-only) styled to match the subtle
-              // copyright/legal tone of the bottom bar rather than the primary
-              // nav links. Only rendered where a CookieConsentProvider exists.
-              <button
-                type="button"
-                onClick={consent.openBanner}
-                className="font-body text-text-s text-muted-foreground hover:text-foreground hover:underline bg-transparent border-0 p-0 cursor-pointer rounded-sm"
-              >
-                {t("footerCookiePreferences")}
-              </button>
-            ) : null}
-            <p className="font-body text-text-s text-muted-foreground">
-              &copy; {currentYear} Digitaltableteur. {t("footerCopyright")}
-            </p>
-          </div>
+          <p className="font-body text-text-s text-muted-foreground">
+            &copy; {currentYear} Digitaltableteur. {t("footerCopyright")}
+          </p>
         </div>
       </Container>
     </footer>


### PR DESCRIPTION
Placing "Cookie preferences" next to the copyright crowded the bottom bar (social icons / preferences / copyright poorly aligned) and was not where users look for it.

## Changes
- Moved the trigger into the **Legal column** (Privacy Policy / Imprint / AI Usage / Accessibility / Sitemap) — the conventional location.
- Matched it to its DtLink siblings: a real `<button>` (Link is anchor-only) styled with the same themed `--link-color`, 1rem size, left align, hover underline. Verified in light theme it computes **identically** to the sitemap DtLink (18px, `rgb(4,27,35)`, Satoshi, 0 padding); both resolve `--link-color`, so they track across themes.
- Bottom bar is now just social icons + copyright, cleanly `space-between`.

Still a real `<button>` for GDPR withdrawal, still null without a provider, still reopens the banner without clearing storage (SiteFooter tests unchanged, pass).

Local gate: typecheck, lint (0 errors), 2361 tests, build all pass. Footer sits ~9000px down and Lenis blocks scroll-to, so verified via computed-style parity rather than a capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)