### PR TITLE
fix(newsbulletin): make the npm badge theme-aware

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-07-14T17:19:51.620Z",
+  "createdAt": "2026-07-14T17:44:46.357Z",
   "directory": "nextjs-app/shared",
   "findings": [
     {
@@ -5885,8 +5885,8 @@
     {
       "column": 19,
       "file": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css\u001f228\u001f19\u001f0.45rem\u001fUnexpected off-scale value \"0.45rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
-      "line": 228,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css\u001f256\u001f19\u001f0.45rem\u001fUnexpected off-scale value \"0.45rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
+      "line": 256,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"0.45rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -5895,8 +5895,8 @@
     {
       "column": 19,
       "file": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css\u001f238\u001f19\u001f0.45rem\u001fUnexpected off-scale value \"0.45rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
-      "line": 238,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css\u001f266\u001f19\u001f0.45rem\u001fUnexpected off-scale value \"0.45rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
+      "line": 266,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"0.45rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -5925,8 +5925,8 @@
     {
       "column": 19,
       "file": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css\u001f228\u001f19\u001f0.45rem\u001fUnexpected raw scale value \"0.45rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 228,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css\u001f256\u001f19\u001f0.45rem\u001fUnexpected raw scale value \"0.45rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 256,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.45rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -5935,8 +5935,8 @@
     {
       "column": 19,
       "file": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css\u001f238\u001f19\u001f0.45rem\u001fUnexpected raw scale value \"0.45rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 238,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css\u001f266\u001f19\u001f0.45rem\u001fUnexpected raw scale value \"0.45rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 266,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"0.45rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",

--- a/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css
+++ b/nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css
@@ -212,6 +212,13 @@
 }
 
 .npmBadge {
+  /* npm badge palette — theme-aware so the brand chip stays legible on every
+     surface. White text throughout (keeps the shared shadow valid), so the
+     backgrounds stay dark enough for WCAG AA; theme overrides live below. */
+  --npm-badge-label-bg: #5c5c5c;
+  --npm-badge-version-bg: #006da3; /* npm blue #0085ca darkened for AA on white text */
+  --npm-badge-fg: #fff;
+
   display: inline-flex;
   flex-shrink: 0;
   border-radius: 0.2rem;
@@ -223,14 +230,35 @@
   text-shadow: 0 0.05rem 0 rgb(0 0 0 / 55%);
 }
 
+/* Dark: lighten the grey label so the chip lifts off the dark bulletin
+   surface (blue stays AA-safe as-is). */
+
+:global(.themeDark) .npmBadge {
+  --npm-badge-label-bg: #6e6e6e;
+}
+
+/* HCB: colours can't contrast with both a pure-black surface and white text at
+   once, so outline the whole chip. */
+
+:global(.themeHCB) .npmBadge {
+  border: 1px solid var(--color-title);
+}
+
+/* HCW: deepen both chips for stronger contrast on the white surface. */
+
+:global(.themeHCW) .npmBadge {
+  --npm-badge-label-bg: #454545;
+  --npm-badge-version-bg: #005e8a;
+}
+
 .npmBadgeLabel {
   display: inline-flex;
   padding-inline: 0.45rem;
   min-block-size: 1.506rem;
   justify-content: center;
   align-items: center;
-  background-color: #5c5c5c;
-  color: #fff;
+  background-color: var(--npm-badge-label-bg);
+  color: var(--npm-badge-fg);
 }
 
 .npmBadgeVersion {
@@ -239,11 +267,9 @@
   min-block-size: 1.506rem;
   justify-content: center;
   align-items: center;
-
-  /* npm brand blue #0085ca is 4.03:1 on white @ ~13px — darken for WCAG AA */
-  background-color: #006da3;
+  background-color: var(--npm-badge-version-bg);
   letter-spacing: -0.06em;
-  color: #fff;
+  color: var(--npm-badge-fg);
 }
 
 .placeholderBadge {

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -1,6 +1,6 @@
 {
   "generatedBy": "npm run lint:css:update",
-  "warningCount": 443,
+  "warningCount": 439,
   "warnings": [
     {
       "id": "app/blog/NextBlogNav.module.css::7::3::order/properties-order::Expected \"margin-inline\" to come before \"max-width\" (order/properties-order)",
@@ -3207,90 +3207,54 @@
       "text": "Expected selector \":global(.themeHCB) .backgroundBase\" to come before selector \":global(.themeDark) .gradient .backgroundBase\", at line 249 (no-descending-specificity)"
     },
     {
-      "id": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css::232::3::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"#5c5c5c\" of \"background-color\" (scale-unlimited/declaration-strict-value)",
+      "id": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css::280::3::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"#d9d9d9\" of \"background-color\" (scale-unlimited/declaration-strict-value)",
       "file": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css",
-      "line": 232,
-      "column": 3,
-      "rule": "scale-unlimited/declaration-strict-value",
-      "severity": "warning",
-      "text": "Expected variable, function or keyword for \"#5c5c5c\" of \"background-color\" (scale-unlimited/declaration-strict-value)"
-    },
-    {
-      "id": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css::233::3::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"#fff\" of \"color\" (scale-unlimited/declaration-strict-value)",
-      "file": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css",
-      "line": 233,
-      "column": 3,
-      "rule": "scale-unlimited/declaration-strict-value",
-      "severity": "warning",
-      "text": "Expected variable, function or keyword for \"#fff\" of \"color\" (scale-unlimited/declaration-strict-value)"
-    },
-    {
-      "id": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css::244::3::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"#006da3\" of \"background-color\" (scale-unlimited/declaration-strict-value)",
-      "file": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css",
-      "line": 244,
-      "column": 3,
-      "rule": "scale-unlimited/declaration-strict-value",
-      "severity": "warning",
-      "text": "Expected variable, function or keyword for \"#006da3\" of \"background-color\" (scale-unlimited/declaration-strict-value)"
-    },
-    {
-      "id": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css::246::3::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"#fff\" of \"color\" (scale-unlimited/declaration-strict-value)",
-      "file": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css",
-      "line": 246,
-      "column": 3,
-      "rule": "scale-unlimited/declaration-strict-value",
-      "severity": "warning",
-      "text": "Expected variable, function or keyword for \"#fff\" of \"color\" (scale-unlimited/declaration-strict-value)"
-    },
-    {
-      "id": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css::254::3::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"#d9d9d9\" of \"background-color\" (scale-unlimited/declaration-strict-value)",
-      "file": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css",
-      "line": 254,
+      "line": 280,
       "column": 3,
       "rule": "scale-unlimited/declaration-strict-value",
       "severity": "warning",
       "text": "Expected variable, function or keyword for \"#d9d9d9\" of \"background-color\" (scale-unlimited/declaration-strict-value)"
     },
     {
-      "id": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css::274::5::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"Canvas\" of \"background-color\" (scale-unlimited/declaration-strict-value)",
+      "id": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css::300::5::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"Canvas\" of \"background-color\" (scale-unlimited/declaration-strict-value)",
       "file": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css",
-      "line": 274,
+      "line": 300,
       "column": 5,
       "rule": "scale-unlimited/declaration-strict-value",
       "severity": "warning",
       "text": "Expected variable, function or keyword for \"Canvas\" of \"background-color\" (scale-unlimited/declaration-strict-value)"
     },
     {
-      "id": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css::275::5::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"CanvasText\" of \"color\" (scale-unlimited/declaration-strict-value)",
+      "id": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css::301::5::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"CanvasText\" of \"color\" (scale-unlimited/declaration-strict-value)",
       "file": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css",
-      "line": 275,
+      "line": 301,
       "column": 5,
       "rule": "scale-unlimited/declaration-strict-value",
       "severity": "warning",
       "text": "Expected variable, function or keyword for \"CanvasText\" of \"color\" (scale-unlimited/declaration-strict-value)"
     },
     {
-      "id": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css::286::5::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"CanvasText\" of \"background-color\" (scale-unlimited/declaration-strict-value)",
+      "id": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css::312::5::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"CanvasText\" of \"background-color\" (scale-unlimited/declaration-strict-value)",
       "file": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css",
-      "line": 286,
+      "line": 312,
       "column": 5,
       "rule": "scale-unlimited/declaration-strict-value",
       "severity": "warning",
       "text": "Expected variable, function or keyword for \"CanvasText\" of \"background-color\" (scale-unlimited/declaration-strict-value)"
     },
     {
-      "id": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css::291::5::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"Canvas\" of \"background-color\" (scale-unlimited/declaration-strict-value)",
+      "id": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css::317::5::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"Canvas\" of \"background-color\" (scale-unlimited/declaration-strict-value)",
       "file": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css",
-      "line": 291,
+      "line": 317,
       "column": 5,
       "rule": "scale-unlimited/declaration-strict-value",
       "severity": "warning",
       "text": "Expected variable, function or keyword for \"Canvas\" of \"background-color\" (scale-unlimited/declaration-strict-value)"
     },
     {
-      "id": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css::292::5::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"CanvasText\" of \"color\" (scale-unlimited/declaration-strict-value)",
+      "id": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css::318::5::scale-unlimited/declaration-strict-value::Expected variable, function or keyword for \"CanvasText\" of \"color\" (scale-unlimited/declaration-strict-value)",
       "file": "nextjs-app/shared/patterns/NewsBulletin/NewsBulletin.module.css",
-      "line": 292,
+      "line": 318,
       "column": 5,
       "rule": "scale-unlimited/declaration-strict-value",
       "severity": "warning",


### PR DESCRIPTION
The npm version chip used hardcoded colours (`#5c5c5c` label, `#006da3` version, white text) that stayed identical in every theme, so it did not adapt like the rest of the bulletin.

## Fix
Extracted the palette to local CSS vars and added per-theme overrides (white text throughout keeps the shared text-shadow valid and the backgrounds WCAG AA):
- **light**: `#5c5c5c` / `#006da3` (unchanged)
- **dark**: label lightened to `#6e6e6e` so the chip lifts off the dark band
- **HCB**: outline the chip (a filled colour can not contrast with both pure black and the white text at once)
- **HCW**: deepen both chips (`#454545` / `#005e8a`) for stronger contrast on white

## Verification (computed colours per theme)
light `92,92,92` / `0,109,163`; dark label `110,110,110`; HCB `1px solid white` outline; HCW `69,69,69` / `0,94,138`. (Verified via computed styles — the bulletin sits above the footer ~8000px down and Lenis blocks scroll-to.)

Re-keyed the line-keyed stylelint + rhythm baselines (pure shift; no new warnings — custom-property values are exempt from declaration-strict-value and consumers use `var()`). typecheck, lint (0 errors), 2361 tests, build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)