### PR TITLE
fix(a11y): keep the HCB switch knob centered

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-07-14T17:44:46.357Z",
+  "createdAt": "2026-07-14T18:00:15.021Z",
   "directory": "nextjs-app/shared",
   "findings": [
     {
@@ -1735,8 +1735,8 @@
     {
       "column": 23,
       "file": "nextjs-app/shared/components/CookieConsent/CookieConsent.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f141\u001f23\u001f3px\u001fUnexpected off-scale value \"3px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
-      "line": 141,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f142\u001f23\u001f3px\u001fUnexpected off-scale value \"3px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
+      "line": 142,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"3px\". Use scale values (nearest: 0px or 4px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -1745,8 +1745,8 @@
     {
       "column": 25,
       "file": "nextjs-app/shared/components/CookieConsent/CookieConsent.module.css",
-      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f155\u001f25\u001f20px\u001fUnexpected off-scale value \"20px\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
-      "line": 155,
+      "key": "rhythmguard/use-scale\u001foff-scale\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f157\u001f25\u001f20px\u001fUnexpected off-scale value \"20px\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
+      "line": 157,
       "rule": "rhythmguard/use-scale",
       "text": "Unexpected off-scale value \"20px\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
       "type": "off-scale",
@@ -1785,8 +1785,8 @@
     {
       "column": 23,
       "file": "nextjs-app/shared/components/CookieConsent/CookieConsent.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f141\u001f23\u001f3px\u001fUnexpected raw scale value \"3px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 141,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f142\u001f23\u001f3px\u001fUnexpected raw scale value \"3px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 142,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"3px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",
@@ -1795,8 +1795,8 @@
     {
       "column": 25,
       "file": "nextjs-app/shared/components/CookieConsent/CookieConsent.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f155\u001f25\u001f20px\u001fUnexpected raw scale value \"20px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 155,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/components/CookieConsent/CookieConsent.module.css\u001f157\u001f25\u001f20px\u001fUnexpected raw scale value \"20px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 157,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"20px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",

--- a/nextjs-app/shared/components/CookieConsent/CookieConsent.module.css
+++ b/nextjs-app/shared/components/CookieConsent/CookieConsent.module.css
@@ -110,10 +110,11 @@
 
 /* High-contrast black: on a pure-black surface a flat grey track can't contrast
    with BOTH the background and the white knob, so outline the track (pill reads
-   on black). Scoped to HCB; light/dark/HCW unchanged. */
+   on black). box-shadow (not border) keeps the knob's box geometry intact so it
+   stays centered. Scoped to HCB; light/dark/HCW unchanged. */
 
 :global(.themeHCB) .slider {
-  border: 1px solid var(--color-title);
+  box-shadow: 0 0 0 1px var(--color-title);
 }
 
 /* Off-state track background. Stated at the same specificity as the checked
@@ -141,10 +142,11 @@
   inset-inline-start: 3px;
 }
 
-/* HCB: dark ring keeps the white knob distinct from the track. */
+/* HCB: dark ring keeps the white knob distinct from the track (box-shadow, not
+   border, so the knob keeps its 18px box and stays centered). */
 
 :global(.themeHCB) .slider::before {
-  border: 1px solid var(--main-body-background-color);
+  box-shadow: 0 0 0 1px var(--main-body-background-color);
 }
 
 .switch input:checked + .slider {


### PR DESCRIPTION
Follow-up to the HCB switch fix: the outlines used `border`, which (with border-box) shrinks the track and knob boxes and threw the knob off-center — it sat high.

Switched both rings to `box-shadow: 0 0 0 1px` — identical visual outline, but zero layout impact, so the 18px knob keeps `bottom: 3px` symmetric in the 24px track (3px top / 3px bottom) and stays centered.

Screenshot-verified in HCB: knob centered, track + knob rings intact. typecheck, lint (0 errors), 2361 tests, build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved high-contrast styling for the cookie consent toggle.
  * Enhanced visibility of the toggle track and knob rings in high-contrast mode.
* **Chores**
  * Updated accessibility baseline metadata to reflect current source locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->