### PR TITLE
feat(footer): add Home link, fix copyright alignment

### DIFF
--- a/nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx
+++ b/nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx
@@ -137,6 +137,9 @@ export function SiteFooter({ className }: SiteFooterProps) {
               {t("footerExploreTitle")}
             </p>
             <Stack gap="xs" align="start">
+              <DtLink underline="hover" href="/" size="sm">
+                {t("navHome")}
+              </DtLink>
               <DtLink underline="hover" href="/work" size="sm">
                 {t("navWork")}
               </DtLink>
@@ -205,9 +208,12 @@ export function SiteFooter({ className }: SiteFooterProps) {
             ))}
           </Stack>
 
-          <p className="font-body text-text-s text-muted-foreground">
+          {/* <span>, not <p>: a global `p { margin-block-end }` rule (unlayered,
+              so it beats Tailwind's m-0) added an asymmetric bottom margin that
+              pushed the copyright above the social icons' centre in this row. */}
+          <span className="font-body text-text-s text-muted-foreground">
             &copy; {currentYear} Digitaltableteur. {t("footerCopyright")}
-          </p>
+          </span>
         </div>
       </Container>
     </footer>

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--default.light.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--default.light.yaml
@@ -8,6 +8,8 @@
   - paragraph: Billing details
   - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
   - paragraph: Explore
+  - link "Home":
+    - /url: /
   - link "Work":
     - /url: /work
   - link "About":
@@ -29,6 +31,7 @@
     - /url: /accessibility
   - link "Sitemap":
     - /url: /sitemap
+  - button "Cookie preferences"
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
   - link "Facebook":
@@ -45,4 +48,4 @@
     - /url: https://substack.com/@petrilahdelma
   - link "Dribbble":
     - /url: https://dribbble.com/digitaltableteur
-  - paragraph: © 2026 Digitaltableteur. All rights reserved.
+  - text: © 2026 Digitaltableteur. All rights reserved.

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--default.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--default.yaml
@@ -8,6 +8,8 @@
   - paragraph: Billing details
   - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
   - paragraph: Explore
+  - link "Home":
+    - /url: /
   - link "Work":
     - /url: /work
   - link "About":
@@ -29,6 +31,7 @@
     - /url: /accessibility
   - link "Sitemap":
     - /url: /sitemap
+  - button "Cookie preferences"
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
   - link "Facebook":
@@ -45,4 +48,4 @@
     - /url: https://substack.com/@petrilahdelma
   - link "Dribbble":
     - /url: https://dribbble.com/digitaltableteur
-  - paragraph: © 2026 Digitaltableteur. All rights reserved.
+  - text: © 2026 Digitaltableteur. All rights reserved.

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--example.light.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--example.light.yaml
@@ -8,6 +8,8 @@
   - paragraph: Billing details
   - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
   - paragraph: Explore
+  - link "Home":
+    - /url: /
   - link "Work":
     - /url: /work
   - link "About":
@@ -29,6 +31,7 @@
     - /url: /accessibility
   - link "Sitemap":
     - /url: /sitemap
+  - button "Cookie preferences"
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
   - link "Facebook":
@@ -45,4 +48,4 @@
     - /url: https://substack.com/@petrilahdelma
   - link "Dribbble":
     - /url: https://dribbble.com/digitaltableteur
-  - paragraph: © 2026 Digitaltableteur. All rights reserved.
+  - text: © 2026 Digitaltableteur. All rights reserved.

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--example.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--example.yaml
@@ -8,6 +8,8 @@
   - paragraph: Billing details
   - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
   - paragraph: Explore
+  - link "Home":
+    - /url: /
   - link "Work":
     - /url: /work
   - link "About":
@@ -29,6 +31,7 @@
     - /url: /accessibility
   - link "Sitemap":
     - /url: /sitemap
+  - button "Cookie preferences"
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
   - link "Facebook":
@@ -45,4 +48,4 @@
     - /url: https://substack.com/@petrilahdelma
   - link "Dribbble":
     - /url: https://dribbble.com/digitaltableteur
-  - paragraph: © 2026 Digitaltableteur. All rights reserved.
+  - text: © 2026 Digitaltableteur. All rights reserved.

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--forced-colors.light.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--forced-colors.light.yaml
@@ -8,6 +8,8 @@
   - paragraph: Billing details
   - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
   - paragraph: Explore
+  - link "Home":
+    - /url: /
   - link "Work":
     - /url: /work
   - link "About":
@@ -29,6 +31,7 @@
     - /url: /accessibility
   - link "Sitemap":
     - /url: /sitemap
+  - button "Cookie preferences"
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
   - link "Facebook":
@@ -45,4 +48,4 @@
     - /url: https://substack.com/@petrilahdelma
   - link "Dribbble":
     - /url: https://dribbble.com/digitaltableteur
-  - paragraph: © 2026 Digitaltableteur. All rights reserved.
+  - text: © 2026 Digitaltableteur. All rights reserved.

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--forced-colors.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--forced-colors.yaml
@@ -8,6 +8,8 @@
   - paragraph: Billing details
   - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
   - paragraph: Explore
+  - link "Home":
+    - /url: /
   - link "Work":
     - /url: /work
   - link "About":
@@ -29,6 +31,7 @@
     - /url: /accessibility
   - link "Sitemap":
     - /url: /sitemap
+  - button "Cookie preferences"
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
   - link "Facebook":
@@ -45,4 +48,4 @@
     - /url: https://substack.com/@petrilahdelma
   - link "Dribbble":
     - /url: https://dribbble.com/digitaltableteur
-  - paragraph: © 2026 Digitaltableteur. All rights reserved.
+  - text: © 2026 Digitaltableteur. All rights reserved.

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--playground.light.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--playground.light.yaml
@@ -8,6 +8,8 @@
   - paragraph: Billing details
   - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
   - paragraph: Explore
+  - link "Home":
+    - /url: /
   - link "Work":
     - /url: /work
   - link "About":
@@ -29,6 +31,7 @@
     - /url: /accessibility
   - link "Sitemap":
     - /url: /sitemap
+  - button "Cookie preferences"
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
   - link "Facebook":
@@ -45,4 +48,4 @@
     - /url: https://substack.com/@petrilahdelma
   - link "Dribbble":
     - /url: https://dribbble.com/digitaltableteur
-  - paragraph: © 2026 Digitaltableteur. All rights reserved.
+  - text: © 2026 Digitaltableteur. All rights reserved.

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--playground.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--playground.yaml
@@ -8,6 +8,8 @@
   - paragraph: Billing details
   - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
   - paragraph: Explore
+  - link "Home":
+    - /url: /
   - link "Work":
     - /url: /work
   - link "About":
@@ -29,6 +31,7 @@
     - /url: /accessibility
   - link "Sitemap":
     - /url: /sitemap
+  - button "Cookie preferences"
   - link "Instagram":
     - /url: https://www.instagram.com/digitaltableteur/
   - link "Facebook":
@@ -45,4 +48,4 @@
     - /url: https://substack.com/@petrilahdelma
   - link "Dribbble":
     - /url: https://dribbble.com/digitaltableteur
-  - paragraph: © 2026 Digitaltableteur. All rights reserved.
+  - text: © 2026 Digitaltableteur. All rights reserved.


### PR DESCRIPTION
Three footer fixes.

## Changes
- **Home link**: added `navHome` (href `/`) as the first link in the Explore column, ahead of Work.
- **Copyright alignment**: the copyright sat higher than the social icons because a global, unlayered `p { margin-block-end: var(--space-layout-16) }` rule (which beats Tailwind `m-0`, since unlayered wins over `@layer utilities`) gave the `<p>` an asymmetric 18px bottom margin in the `items-center` row. Rendering it as a `<span>` (does not match the global `p` rule) makes it centre cleanly with the icons. Verified: `margin-bottom` now `0px`.
- **a11y snapshots**: recaptured all 8 SiteFooter snapshots (both themes). They gain the Home link and the copyright becomes `text` (span) not `paragraph`; this also folds in the `Cookie preferences` button that the earlier footer PRs had left **stale** in these snapshots.

Verified via computed styles (the footer sits ~9000px down and Lenis blocks a clean scroll-to capture). Local gate: typecheck, lint (0 errors), 2361 tests, build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)