### PR TITLE
Make dry runs prove npm publishing identity

### DIFF
--- a/.github/workflows/ds-publish.yml
+++ b/.github/workflows/ds-publish.yml
@@ -101,11 +101,11 @@ jobs:
         run: npm run check:react-public-surface -- --require-publishable
 
       - name: Verify @digitaltableteur/react OIDC publish auth
-        if: ${{ (inputs.package == 'react' || inputs.package == 'all') && inputs.dry_run == false }}
+        if: ${{ inputs.package == 'react' || inputs.package == 'all' }}
         run: NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/npm-publish.npmrc" node scripts/design-system/check-npm-oidc-publish-auth.mjs @digitaltableteur/react
 
       - name: Verify @digitaltableteur/web-components OIDC publish auth
-        if: ${{ (inputs.package == 'web-components' || inputs.package == 'all') && inputs.dry_run == false }}
+        if: ${{ inputs.package == 'web-components' || inputs.package == 'all' }}
         run: NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/npm-publish.npmrc" node scripts/design-system/check-npm-oidc-publish-auth.mjs @digitaltableteur/web-components
 
       - name: Publish @digitaltableteur/tokens


### PR DESCRIPTION
## Summary
- run React and Web Components OIDC auth probes during dry runs
- retain existing dry-run guards around every publish command
- provide a non-destructive Trusted Publisher verification path

## Verification
- workflow diff check
- pre-commit contrast/style/rhythm/typecheck/lint gates