### PR TITLE
fix(a11y): make the skip link actually bypass the header (nav-shell)

### DIFF
--- a/nextjs-app/shared/components/NextLayout/NextLayout.tsx
+++ b/nextjs-app/shared/components/NextLayout/NextLayout.tsx
@@ -9,6 +9,7 @@ import React, {
 } from "react";
 
 import { SiteHeader, SiteFooter, SkipLink } from "../../patterns/navigation";
+import { useTranslate } from "../../lib/translation";
 import { PageTransition } from "../animations/PageTransition";
 import { DonnyActionProvider } from "../DonnyActionProvider";
 import styles from "./NextLayout.module.css";
@@ -40,6 +41,9 @@ export interface NextLayoutProps {
  * NextLayout component.
  */
 export function NextLayout({ children, className }: NextLayoutProps) {
+  // The skip link is the first focusable element on every page, so it must
+  // speak the visitor's language (EN/FI/SV) rather than the SkipLink default.
+  const t = useTranslate();
   return (
     <>
       <DonnyActionProvider>
@@ -48,9 +52,16 @@ export function NextLayout({ children, className }: NextLayoutProps) {
             className ? `${styles.layout} ${className}` : styles.layout
           }
         >
-          <SkipLink href="#main-content" />
+          <SkipLink href="#main-content">
+            {t("skipToMainContent", "Skip to main content")}
+          </SkipLink>
           <SiteHeader />
-          <main id="main-content" className={styles.main}>
+          {/* tabIndex=-1 makes the skip-link target programmatically
+              focusable, so activating the skip link moves focus INTO main
+              (not just scrolls). Without it the browser leaves focus on
+              <body> and the next Tab restarts from the header — defeating
+              the skip link (WCAG 2.4.1). */}
+          <main id="main-content" tabIndex={-1} className={styles.main}>
             <PageTransition>{children}</PageTransition>
           </main>
           <SiteFooter />

--- a/nextjs-app/shared/locales/en/translation.json
+++ b/nextjs-app/shared/locales/en/translation.json
@@ -11,6 +11,7 @@
   "navMenuClose": "Close navigation",
   "navMenuLinks": "Navigation links",
   "navMenuAccessibleLabel": "Main navigation",
+  "skipToMainContent": "Skip to main content",
   "navMenuCookiePolicy": "Privacy Policy",
   "navMenuAiUsage": "AI Usage",
   "navMenuAccessibility": "Accessibility Statement",

--- a/nextjs-app/shared/locales/fi/translation.json
+++ b/nextjs-app/shared/locales/fi/translation.json
@@ -11,6 +11,7 @@
   "navMenuClose": "Sulje navigointi",
   "navMenuLinks": "Navigointilinkit",
   "navMenuAccessibleLabel": "Päänavigaatio",
+  "skipToMainContent": "Siirry pääsisältöön",
   "navMenuCookiePolicy": "Tietosuojakäytäntö",
   "navMenuAiUsage": "Tekoälyn käyttö",
   "navMenuAccessibility": "Saavutettavuusseloste",

--- a/nextjs-app/shared/locales/sv/translation.json
+++ b/nextjs-app/shared/locales/sv/translation.json
@@ -11,6 +11,7 @@
   "navMenuClose": "Stäng navigering",
   "navMenuLinks": "Navigeringslänkar",
   "navMenuAccessibleLabel": "Huvudnavigering",
+  "skipToMainContent": "Hoppa till huvudinnehållet",
   "navMenuCookiePolicy": "Integritetspolicy",
   "navMenuAiUsage": "AI-användning",
   "navMenuAccessibility": "Tillgänglighetsutlåtande",

--- a/tests/a11y/operable/focus-trap.spec.ts
+++ b/tests/a11y/operable/focus-trap.spec.ts
@@ -703,6 +703,31 @@ test.describe("OPER-03: Skip Link Functionality", () => {
     ).toBe(true);
   });
 
+  test("Skip link moves focus INTO main content, not just scroll", async ({
+    page,
+  }) => {
+    // The whole point of a skip link is to relocate focus: without tabIndex=-1
+    // on <main> the browser leaves focus on <body> and the next Tab restarts
+    // from the header, so the bypass never happens (WCAG 2.4.1).
+    const skipLink = page.locator('a[href="#main-content"]');
+    await skipLink.focus();
+    await page.keyboard.press("Enter");
+
+    await expect
+      .poll(async () =>
+        page.evaluate(() => {
+          const main = document.getElementById("main-content");
+          const focused = document.activeElement;
+          return !!(
+            main &&
+            focused &&
+            (main === focused || main.contains(focused))
+          );
+        })
+      )
+      .toBe(true);
+  });
+
   test("Main content has correct ID for skip link target", async ({ page }) => {
     const mainContent = page.locator("#main-content");
     const exists = (await mainContent.count()) > 0;


### PR DESCRIPTION
## Summary
Nav-shell batch — targeted a11y fixes to the **global skip link** (the first focusable element on every page). Two genuine defects, both in `NextLayout`:

1. **i18n gap** — `NextLayout` rendered `<SkipLink href="#main-content" />` with no children, so FI/SV visitors got the English SkipLink default. Now passes the translated `skipToMainContent` (added to en/fi/sv). Browser-verified: switching to Finnish shows **"Siirry pääsisältöön"** with `html lang="fi"`.
2. **Focus never moved (WCAG 2.4.1)** — `<main id="main-content">` had no `tabIndex`, so activating the skip link only scrolled; `document.activeElement` stayed on `<body>` and the next Tab restarted from the header, so the bypass never happened. Added `tabIndex={-1}`. Browser-verified: `activeElement` is now `MAIN#main-content`, no stray outline (programmatic focus doesn't trigger `:focus-visible`).

The existing OPER-03 Playwright test passed on scroll alone — which is exactly how defect #2 slipped through. Added a strict regression test asserting focus moves **into** main.

## Review scope
Reviewed all five nav-shell components (SiteHeader, SiteFooter, NavLink, SkipLink, LanguageSwitcher). Only the skip link had real defects. Deliberately left alone:
- **LanguageSwitcher `aria-controls`** points at a status-text span rather than the tray — but that's an intentional, test-locked design (`LanguageSwitcher.test.tsx` asserts the target's text), not a bug.
- **NavLink** prefix active-match is latent (no colliding routes today).
- SiteHeader / SiteFooter had only optional enhancements (footer nav landmarks/lists), not defects — left per "targeted fixes, not evolve".

## Verification
- Browser (real Chromium): FI skip text + focus-into-main both confirmed
- `npx playwright test -g OPER-03` → 6/6 (incl. new focus assertion)
- `npm run typecheck` ✓, `npm run lint` ✓ (0 errors), `npm test` → **2,375 passed**, `npm run build` ✓
- Pre-push DS gates: contrast ✓, stylelint baseline ✓, rhythmguard 0 new drift ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved the “Skip to main content” link so keyboard users can move focus directly to the page’s main content.
  - Added clearer focus behavior for assistive technology and keyboard navigation.

- **Localization**
  - Added translated skip-link text in English, Finnish, and Swedish.

- **Tests**
  - Added automated coverage to verify that activating the skip link correctly moves keyboard focus to the main content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->