### PR TITLE
fix(nav): stop NavLink activating sibling routes that share a prefix

### DIFF
--- a/nextjs-app/shared/components/NavLink/NavLink.test.tsx
+++ b/nextjs-app/shared/components/NavLink/NavLink.test.tsx
@@ -38,6 +38,15 @@ describe("NavLink", () => {
     );
   });
 
+  it("does not mark a sibling route that merely shares the prefix", () => {
+    // "/workshops" starts with "/work" but is a different route — a bare
+    // startsWith would wrongly light up the Work link here.
+    renderWithPathname("/workshops", <NavLink href="/work">Work</NavLink>);
+    expect(screen.getByRole("link", { name: "Work" })).not.toHaveAttribute(
+      "aria-current",
+    );
+  });
+
   it("exact requires the full pathname to match", () => {
     renderWithPathname(
       "/work/case-study",

--- a/nextjs-app/shared/components/NavLink/NavLink.tsx
+++ b/nextjs-app/shared/components/NavLink/NavLink.tsx
@@ -35,11 +35,15 @@ export function NavLink({
   // SSR fallback and outside the app router (e.g. Storybook). Treat null as
   // "no current pathname" → never active.
   const pathname = useNavigationPathname();
+  // Non-exact matches the route and its sub-routes, but a bare startsWith
+  // over-matches siblings that merely share a prefix (href "/work" would
+  // light up on "/workshops"). Require either an exact hit or a real path
+  // boundary ("/work/…").
   const isActive = pathname === null
     ? false
     : exact
       ? pathname === href
-      : pathname.startsWith(href);
+      : pathname === href || pathname.startsWith(`${href}/`);
   const isSamePath = pathname === href;
   const linkClassName = cn(
     // rounded-sm matches the LanguageSwitcher buttons so the global


### PR DESCRIPTION
## Summary
Nav-shell follow-up. Non-exact `NavLink` used `pathname.startsWith(href)`, which marks active any route that merely shares the prefix — `href="/work"` would show `aria-current="page"` on `/workshops`. Tightened to require an exact match or a real path boundary:

```ts
pathname === href || pathname.startsWith(`${href}/`)
```

Genuine sub-routes (`/work/case-study`) stay active; siblings (`/workshops`) don't. Latent today (no colliding nav routes) but a correctness trap the moment one is added.

## Verification
- Added a regression test for the sibling-prefix case; existing prefix/exact/root tests unchanged.
- `npm run typecheck` ✓, `npm run lint` ✓ (0 errors), `npm test` → **2,376 passed**, `npm run build` ✓
- Pre-push DS gates: contrast ✓, stylelint baseline ✓, rhythmguard 0 new drift ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation highlighting so links are not incorrectly marked active for similarly prefixed sibling paths.
  * Improved route matching to recognize only the exact path or valid nested paths.

* **Tests**
  * Added coverage for sibling-prefix navigation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->