### PR TITLE
fix(a11y): make LanguageSwitcher options reachable by forward Tab

### DIFF
--- a/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.tsx
@@ -116,6 +116,32 @@ export function LanguageSwitcher({
       role="group"
       aria-label={t("navMenuLanguages", "Language")}
     >
+      {/* Trigger first in DOM so that opening the tray and pressing Tab walks
+          FORWARD into the revealed options. The tray is position:absolute, so
+          its DOM order is decoupled from the visual left-fan — keeping it
+          after the trigger fixes the focus order without moving the fan. */}
+      <button
+        type="button"
+        className={cn(
+          styles.trigger,
+          styles.option,
+          buttonClassName,
+          activeButtonClassName,
+          isOpen && openTriggerClassName,
+        )}
+        aria-expanded={isOpen}
+        aria-controls={optionsId}
+        aria-label={
+          isOpen
+            ? t("languageSwitcherCollapse", "Hide language options")
+            : `${current.ariaLabel}. ${t("languageSwitcherExpand", "Show language options")}`
+        }
+        aria-current="true"
+        onClick={() => setIsOpen((open) => !open)}
+      >
+        {current.label}
+      </button>
+
       <div
         className={styles.optionsTrayAnchor}
         data-open={isOpen ? "true" : "false"}
@@ -161,28 +187,6 @@ export function LanguageSwitcher({
           )}
         </AnimatePresence>
       </div>
-
-      <button
-        type="button"
-        className={cn(
-          styles.trigger,
-          styles.option,
-          buttonClassName,
-          activeButtonClassName,
-          isOpen && openTriggerClassName,
-        )}
-        aria-expanded={isOpen}
-        aria-controls={optionsId}
-        aria-label={
-          isOpen
-            ? t("languageSwitcherCollapse", "Hide language options")
-            : `${current.ariaLabel}. ${t("languageSwitcherExpand", "Show language options")}`
-        }
-        aria-current="true"
-        onClick={() => setIsOpen((open) => !open)}
-      >
-        {current.label}
-      </button>
       <span id={optionsId} className={styles.srOnly}>
         {isOpen
           ? t("languageSwitcherCollapse", "Hide language options")

--- a/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--fan-open.yaml
+++ b/nextjs-app/shared/components/LanguageSwitcher/__a11y-snapshots__/navigation-languageswitcher--fan-open.yaml
@@ -1,5 +1,5 @@
 - group "Language":
+  - button "Hide language options" [expanded]: EN
   - button "Swedish": SV
   - button "Finnish": FI
-  - button "Hide language options" [expanded]: EN
   - text: Hide language options

--- a/tests/a11y/operable/language-switcher.spec.ts
+++ b/tests/a11y/operable/language-switcher.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * LanguageSwitcher focus order (WCAG 2.4.3 Focus Order).
+ *
+ * The tray of language options is position:absolute and fans out to the LEFT
+ * of the trigger. It must still sit AFTER the trigger in the DOM so that
+ * opening the tray and pressing Tab walks FORWARD into the revealed options —
+ * otherwise the options are only reachable with Shift+Tab, which no one
+ * expects right after activating a disclosure.
+ */
+test.describe("OPER-04: LanguageSwitcher focus order", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    // The desktop switcher only renders at >=lg; the default Desktop Chrome
+    // viewport clears that. Wait for the closed trigger to render.
+    await page
+      .getByRole("button", { name: /show language options/i })
+      .waitFor();
+  });
+
+  // Opens the tray from the trigger and returns the (now "Hide…") trigger,
+  // retrying to absorb the client-header hydration gap: a click that lands
+  // before hydration focuses the button but doesn't toggle it.
+  async function openTray(page: Page) {
+    const closed = page.getByRole("button", {
+      name: /show language options/i,
+    });
+    const open = page.getByRole("button", { name: /hide language options/i });
+    await expect(async () => {
+      await closed.click();
+      await expect(open).toBeVisible({ timeout: 1500 });
+    }).toPass({ timeout: 15000 });
+    // Playwright's click focuses the trigger; confirm before we tab off it.
+    await expect(open).toBeFocused();
+    return open;
+  }
+
+  test("Tab from the open trigger moves focus into the revealed options", async ({
+    page,
+  }) => {
+    await openTray(page);
+
+    await page.keyboard.press("Tab");
+
+    const landing = await page.evaluate(() => {
+      const active = document.activeElement as HTMLElement | null;
+      const trig = document.querySelector("button[aria-controls]");
+      const root = trig?.closest('[role="group"]');
+      const tray = root?.querySelector("[data-open]");
+      return {
+        isButton: active?.tagName === "BUTTON",
+        isTrigger: active === trig,
+        inTray: !!(tray && active && tray.contains(active)),
+      };
+    });
+
+    expect(landing.inTray, "Tab should move focus into the options tray").toBe(
+      true
+    );
+    expect(landing.isButton).toBe(true);
+    expect(landing.isTrigger).toBe(false);
+  });
+
+  test("Shift+Tab from the first option returns focus to the trigger", async ({
+    page,
+  }) => {
+    const openTrigger = await openTray(page);
+
+    await page.keyboard.press("Tab"); // into the first option
+    await page.keyboard.press("Shift+Tab"); // back toward the trigger
+
+    await expect(openTrigger).toBeFocused();
+  });
+});


### PR DESCRIPTION
## Summary
Nav-shell follow-up. The `LanguageSwitcher` options tray rendered **before** the trigger in the DOM, so opening the tray and pressing Tab walked forward *out* of the group — the revealed options were only reachable with **Shift+Tab**, which no one expects right after activating a disclosure (WCAG 2.4.3; the ARIA APG disclosure pattern wants the disclosed content to follow its trigger).

The tray is `position: absolute`, so moving it **after** the trigger in the DOM fixes the focus order without moving the visual left-fan at all. Forward Tab now lands on the first option; Shift+Tab returns to the trigger.

## Browser-verified
- Fan visual unchanged: opening still renders `SV EN [FI]` fanned to the left of the boxed current-language trigger (screenshot confirmed).
- Playwright (real Chromium): Tab from the open trigger lands inside the options tray; Shift+Tab returns to the trigger. Both directions pass.

## Notes
- Updated the single open-state a11y snapshot (`fan-open`) to the new trigger-then-options tree order. Closed-state snapshots are unaffected — the tray is `inert` + `aria-hidden` when closed, so it's excluded from the accessibility tree regardless of DOM position.
- No CSS changed; `otherLanguages`/`reverse()` untouched, so the intra-option order still matches the visual left-to-right fan.

## Verification
- `npx playwright test tests/a11y/operable/language-switcher.spec.ts` → 2/2
- `npm run typecheck` ✓, `npm run lint` ✓ (0 errors), `npm test` → **2,376 passed**, `npm run build` ✓
- Pre-push DS gates: contrast ✓, stylelint baseline ✓, rhythmguard 0 new drift ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
