### PR TITLE
chore(deps): consume @digitaltableteur/react 0.1.16 from registry

### DIFF
--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.12
+  - definition: 0.1.16
   - term: tokens
-  - definition: 0.1.1
-  - term: tokens-css
   - definition: 0.1.2
+  - term: tokens-css
+  - definition: 0.1.3
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.12
+  - definition: 0.1.16
   - term: tokens
-  - definition: 0.1.1
-  - term: tokens-css
   - definition: 0.1.2
+  - term: tokens-css
+  - definition: 0.1.3
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.12
+  - definition: 0.1.16
   - term: tokens
-  - definition: 0.1.1
-  - term: tokens-css
   - definition: 0.1.2
+  - term: tokens-css
+  - definition: 0.1.3
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.12
+  - definition: 0.1.16
   - term: tokens
-  - definition: 0.1.1
-  - term: tokens-css
   - definition: 0.1.2
+  - term: tokens-css
+  - definition: 0.1.3
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.12
+  - definition: 0.1.16
   - term: tokens
-  - definition: 0.1.1
-  - term: tokens-css
   - definition: 0.1.2
+  - term: tokens-css
+  - definition: 0.1.3
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.12
+  - definition: 0.1.16
   - term: tokens
-  - definition: 0.1.1
-  - term: tokens-css
   - definition: 0.1.2
+  - term: tokens-css
+  - definition: 0.1.3
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.12
+  - definition: 0.1.16
   - term: tokens
-  - definition: 0.1.1
-  - term: tokens-css
   - definition: 0.1.2
+  - term: tokens-css
+  - definition: 0.1.3
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.12
+  - definition: 0.1.16
   - term: tokens
-  - definition: 0.1.1
-  - term: tokens-css
   - definition: 0.1.2
+  - term: tokens-css
+  - definition: 0.1.3
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.12
+  - definition: 0.1.16
   - term: tokens
-  - definition: 0.1.1
-  - term: tokens-css
   - definition: 0.1.2
+  - term: tokens-css
+  - definition: 0.1.3
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.12
+  - definition: 0.1.16
   - term: tokens
-  - definition: 0.1.1
-  - term: tokens-css
   - definition: 0.1.2
+  - term: tokens-css
+  - definition: 0.1.3
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.12
+  - definition: 0.1.16
   - term: tokens
-  - definition: 0.1.1
-  - term: tokens-css
   - definition: 0.1.2
+  - term: tokens-css
+  - definition: 0.1.3
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
@@ -69,11 +69,11 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.12
+  - definition: 0.1.16
   - term: tokens
-  - definition: 0.1.1
-  - term: tokens-css
   - definition: 0.1.2
+  - term: tokens-css
+  - definition: 0.1.3
 - region "Ready to build something great?":
   - heading "Ready to build something great?" [level=2]
   - paragraph: Let's discuss your next project and explore how we can help bring your vision to life.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ai-sdk/openai": "^4.0.11",
         "@ai-sdk/react": "^4.0.23",
         "@calcom/embed-react": "^1.5.3",
-        "@digitaltableteur/react": "^0.1.12",
+        "@digitaltableteur/react": "^0.1.16",
         "@digitaltableteur/tokens": "^0.1.2",
         "@digitaltableteur/tokens-css": "^0.1.3",
         "@emailjs/browser": "^4.4.1",
@@ -3402,9 +3402,9 @@
       "license": "MIT"
     },
     "node_modules/@digitaltableteur/react": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.12.tgz",
-      "integrity": "sha512-uzNuAc0WxTP13FBH0LTOVpA3dGR+dTapSvJmFzApP7tGKJ9sdOdMsZBS5dJ/j9f7z94PE+FTfd1JCROOnnv1ag==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.16.tgz",
+      "integrity": "sha512-g240qbVfi7XVY3sSpEKZA+sHjStSvlDPjTwiK/XcIit/yWVO9pPCRS+J7BViFzc4C0FbIKa9nZoXGMujzhENFg==",
       "license": "UNLICENSED",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "@ai-sdk/openai": "^4.0.11",
     "@ai-sdk/react": "^4.0.23",
     "@calcom/embed-react": "^1.5.3",
-    "@digitaltableteur/react": "^0.1.12",
+    "@digitaltableteur/react": "^0.1.16",
     "@digitaltableteur/tokens": "^0.1.2",
     "@digitaltableteur/tokens-css": "^0.1.3",
     "@emailjs/browser": "^4.4.1",

--- a/providers/SmoothScrollProvider.tsx
+++ b/providers/SmoothScrollProvider.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import type { ReactNode } from "react";
-import { resolveMotionPlan } from "@/nextjs-app/shared/lib/motionPolicy";
+import { resolveMotionPlan } from "@digitaltableteur/react";
 import { useAnimationContext } from "@/providers/AnimationProvider";
 
 interface SmoothScrollProviderProps {


### PR DESCRIPTION
## Summary

- Bump the app's registry dependency from `@digitaltableteur/react@0.1.12` to `0.1.16` (the version published today carrying the Accordion/Tooltip exports that back the native web-components batch; absorbs the never-consumed additive 0.1.13-0.1.15 deltas).
- Flip `SmoothScrollProvider` to import `resolveMotionPlan` from the registry package — it became a published export in 0.1.15, and `check:package-registry-resolution` correctly rejects app-local imports of published symbols.
- True up the 12 AboutPageContent a11y snapshots' package-version definition lines, including the previously-drifted token lines (tokens 0.1.1→0.1.2, tokens-css 0.1.2→0.1.3) that the earlier token consume skipped.

## Verification

- Registry checks: `check:package-registry-resolution` ✓ (react 0.1.16 / tokens 0.1.2 / tokens-css 0.1.3), `check:storybook-registry-package` ✓, `check:react-registry-install` ✓ (0.1.16, 126 exports, runtime + types)
- Full local gate: typecheck ✓, lint 0 errors ✓, 2566/2566 tests ✓, build ✓
- Browser-verified: live `/about` page renders **react 0.1.16 · tokens 0.1.2 · tokens-css 0.1.3** from the installed registry packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the smooth-scrolling experience to use the latest motion behavior, improving consistency across supported interactions.

* **Documentation**
  * Updated the About page’s technology stack information to reflect the latest package versions across light, dark, and forced-color themes.

* **Tests**
  * Refreshed accessibility snapshots to match the updated technology stack metadata and motion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->