### PR TITLE
fix(wc): story trigger quality + faithful React menu/empty-state replicas

### DIFF
--- a/nextjs-app/shared/stories/WebComponents/CommandPalette/CommandPalette.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/CommandPalette/CommandPalette.stories.tsx
@@ -10,6 +10,7 @@ import {
   forcedColorsStory,
   NativeElement,
   nativeStoryParameters,
+  TriggerButton,
 } from "../NativeStory";
 
 if (!globalThis.customElements?.get("dt-command-palette")) {
@@ -86,9 +87,9 @@ function CommandPaletteHarness(args: Args) {
 
   return (
     <div ref={rootRef} style={{ minHeight: "60vh", padding: "1rem" }}>
-      <button type="button" onClick={() => setOpen(true)}>
+      <TriggerButton onClick={() => setOpen(true)}>
         Open command palette
-      </button>
+      </TriggerButton>
       <NativeElement
         tagName="dt-command-palette"
         attributes={{

--- a/nextjs-app/shared/stories/WebComponents/MacWindowFrame/MacWindowFrame.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/MacWindowFrame/MacWindowFrame.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from "storybook/test";
 import {
   NativeElement,
   Stage,
+  TriggerButton,
   assertNative,
   exampleStory,
   forcedColorsStory,
@@ -129,9 +130,7 @@ export const Example: Story = {
     <Stage width="min(44rem, 90vw)">
       <NativeElement tagName="dt-mac-window-frame" attributes={{ density: "comfortable" }}>
         <span slot="title">Showcase transcript</span>
-        <button slot="toolbar" type="button">
-          Download
-        </button>
+        <TriggerButton slot="toolbar">Download</TriggerButton>
         <pre
           slot="content"
           style={{

--- a/nextjs-app/shared/stories/WebComponents/Menu/Menu.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/Menu/Menu.stories.tsx
@@ -4,7 +4,6 @@ import {
   Row,
   Stage,
   Stack,
-  TriggerButton,
   assertNative,
   exampleStory,
   forcedColorsStory,
@@ -81,7 +80,11 @@ function NativeMenu(args: MenuArgs) {
           items: args.items,
         }}
       >
-        <TriggerButton slot="trigger">Actions</TriggerButton>
+        <NativeElement
+          tagName="dt-button"
+          slot="trigger"
+          attributes={{ label: "Actions" }}
+        />
       </NativeElement>
     </Stage>
   );
@@ -157,7 +160,11 @@ export const WithSubmenu: Story = {
           items: withSubmenu,
         }}
       >
-        <TriggerButton slot="trigger">Share</TriggerButton>
+        <NativeElement
+          tagName="dt-button"
+          slot="trigger"
+          attributes={{ label: "Share" }}
+        />
       </NativeElement>
     </Stage>
   ),
@@ -182,7 +189,11 @@ export const AsLinks: Story = {
           items: asLinks,
         }}
       >
-        <TriggerButton slot="trigger">Account</TriggerButton>
+        <NativeElement
+          tagName="dt-button"
+          slot="trigger"
+          attributes={{ label: "Account" }}
+        />
       </NativeElement>
     </Stage>
   ),
@@ -193,7 +204,11 @@ export const DeclarativeItems: Story = {
   render: () => (
     <Stage height="14rem">
       <NativeElement tagName="dt-menu">
-        <TriggerButton slot="trigger">Account</TriggerButton>
+        <NativeElement
+          tagName="dt-button"
+          slot="trigger"
+          attributes={{ label: "Account" }}
+        />
         <button data-id="profile" type="button">
           Profile
         </button>
@@ -216,19 +231,31 @@ export const Alignments: Story = {
             tagName="dt-menu"
             attributes={{ align: "start", items: actions }}
           >
-            <TriggerButton slot="trigger">Start</TriggerButton>
+            <NativeElement
+          tagName="dt-button"
+          slot="trigger"
+          attributes={{ label: "Start" }}
+        />
           </NativeElement>
           <NativeElement
             tagName="dt-menu"
             attributes={{ align: "center", items: actions }}
           >
-            <TriggerButton slot="trigger">Center</TriggerButton>
+            <NativeElement
+          tagName="dt-button"
+          slot="trigger"
+          attributes={{ label: "Center" }}
+        />
           </NativeElement>
           <NativeElement
             tagName="dt-menu"
             attributes={{ align: "end", items: actions }}
           >
-            <TriggerButton slot="trigger">End</TriggerButton>
+            <NativeElement
+          tagName="dt-button"
+          slot="trigger"
+          attributes={{ label: "End" }}
+        />
           </NativeElement>
         </Row>
       </Stack>
@@ -241,7 +268,11 @@ export const Example: Story = {
   render: () => (
     <Stage height="17rem">
       <NativeElement tagName="dt-menu" attributes={{ items: withIcons }}>
-        <TriggerButton slot="trigger">File</TriggerButton>
+        <NativeElement
+          tagName="dt-button"
+          slot="trigger"
+          attributes={{ label: "File" }}
+        />
       </NativeElement>
     </Stage>
   ),

--- a/nextjs-app/shared/stories/WebComponents/Stack/Stack.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/Stack/Stack.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import {
   NativeElement,
+  TriggerButton,
   assertNative,
   exampleStory,
   forcedColorsStory,
@@ -108,8 +109,8 @@ export const HorizontalCluster: Story = {
       tagName="dt-stack"
       attributes={{ direction: "horizontal", gap: "sm", align: "center" }}
     >
-      <button type="button">Save</button>
-      <button type="button">Cancel</button>
+      <TriggerButton>Save</TriggerButton>
+      <TriggerButton>Cancel</TriggerButton>
       <span>Last saved 2 min ago</span>
     </NativeElement>
   ),

--- a/nextjs-app/shared/stories/WebComponents/Toast/Toast.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/Toast/Toast.stories.tsx
@@ -7,7 +7,12 @@ import {
   type DtToastTone,
 } from "../../../../../packages/web-components/src/native/toast";
 import { DtToastStackElement } from "../../../../../packages/web-components/src/native/toast-stack";
-import { Row, TriggerButton, assertNative, nativeStoryParameters } from "../NativeStory";
+import {
+  NativeElement,
+  Row,
+  assertNative,
+  nativeStoryParameters,
+} from "../NativeStory";
 
 if (!customElements.get("dt-toast")) {
   customElements.define("dt-toast", DtToastElement);
@@ -74,7 +79,11 @@ function DefaultDemo() {
   const [open, setOpen] = useState(false);
   return (
     <>
-      <TriggerButton onClick={() => setOpen(true)}>Show Toast</TriggerButton>
+      <NativeElement
+        tagName="dt-button"
+        attributes={{ label: "Show Toast" }}
+        onClick={() => setOpen(true)}
+      />
       <NativeToast
         {...baseArgs}
         message="Toast notification!"
@@ -128,7 +137,7 @@ export const Default: Story = {
   render: () => <DefaultDemo />,
   play: async ({ canvasElement }) => {
     await assertNative("dt-toast")({ canvasElement });
-    const button = canvasElement.querySelector<HTMLButtonElement>("button");
+    const button = canvasElement.querySelector<HTMLElement>("dt-button");
     await userEvent.click(button!);
     await waitFor(() => {
       const toast = canvasElement.querySelector<DtToastElement>("dt-toast");
@@ -154,9 +163,12 @@ export const Tones: Story = {
       <>
         <Row>
           {(Object.keys(messages) as DtToastTone[]).map((value) => (
-            <TriggerButton key={value} onClick={() => setTone(value)}>
-              {value}
-            </TriggerButton>
+            <NativeElement
+              key={value}
+              tagName="dt-button"
+              attributes={{ label: value, variant: "secondary", size: "sm" }}
+              onClick={() => setTone(value)}
+            />
           ))}
         </Row>
         <NativeToast
@@ -191,9 +203,12 @@ export const Placement: Story = {
       <>
         <Row>
           {positions.map((value) => (
-            <TriggerButton key={value} onClick={() => setPosition(value)}>
-              {value}
-            </TriggerButton>
+            <NativeElement
+              key={value}
+              tagName="dt-button"
+              attributes={{ label: value, variant: "secondary", size: "sm" }}
+              onClick={() => setPosition(value)}
+            />
           ))}
         </Row>
         <NativeToast
@@ -216,9 +231,11 @@ export const ProviderDriven: Story = {
     const [open, setOpen] = useState(false);
     return (
       <>
-        <TriggerButton onClick={() => setOpen(true)}>
-          Save settings
-        </TriggerButton>
+        <NativeElement
+          tagName="dt-button"
+          attributes={{ label: "Save settings" }}
+          onClick={() => setOpen(true)}
+        />
         <NativeToast
           {...baseArgs}
           duration={4000}

--- a/nextjs-app/shared/stories/WebComponents/Toast/Toast.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/Toast/Toast.stories.tsx
@@ -7,7 +7,7 @@ import {
   type DtToastTone,
 } from "../../../../../packages/web-components/src/native/toast";
 import { DtToastStackElement } from "../../../../../packages/web-components/src/native/toast-stack";
-import { assertNative, nativeStoryParameters } from "../NativeStory";
+import { Row, TriggerButton, assertNative, nativeStoryParameters } from "../NativeStory";
 
 if (!customElements.get("dt-toast")) {
   customElements.define("dt-toast", DtToastElement);
@@ -74,9 +74,7 @@ function DefaultDemo() {
   const [open, setOpen] = useState(false);
   return (
     <>
-      <button type="button" onClick={() => setOpen(true)}>
-        Show Toast
-      </button>
+      <TriggerButton onClick={() => setOpen(true)}>Show Toast</TriggerButton>
       <NativeToast
         {...baseArgs}
         message="Toast notification!"
@@ -154,11 +152,13 @@ export const Tones: Story = {
     };
     return (
       <>
-        {(Object.keys(messages) as DtToastTone[]).map((value) => (
-          <button key={value} type="button" onClick={() => setTone(value)}>
-            {value}
-          </button>
-        ))}
+        <Row>
+          {(Object.keys(messages) as DtToastTone[]).map((value) => (
+            <TriggerButton key={value} onClick={() => setTone(value)}>
+              {value}
+            </TriggerButton>
+          ))}
+        </Row>
         <NativeToast
           {...baseArgs}
           duration={60_000}
@@ -189,11 +189,13 @@ export const Placement: Story = {
     const [position, setPosition] = useState<DtToastPosition | null>(null);
     return (
       <>
-        {positions.map((value) => (
-          <button key={value} type="button" onClick={() => setPosition(value)}>
-            {value}
-          </button>
-        ))}
+        <Row>
+          {positions.map((value) => (
+            <TriggerButton key={value} onClick={() => setPosition(value)}>
+              {value}
+            </TriggerButton>
+          ))}
+        </Row>
         <NativeToast
           {...baseArgs}
           duration={60_000}
@@ -214,9 +216,9 @@ export const ProviderDriven: Story = {
     const [open, setOpen] = useState(false);
     return (
       <>
-        <button type="button" onClick={() => setOpen(true)}>
+        <TriggerButton onClick={() => setOpen(true)}>
           Save settings
-        </button>
+        </TriggerButton>
         <NativeToast
           {...baseArgs}
           duration={4000}

--- a/nextjs-app/shared/stories/WebComponents/ToastStack/ToastStack.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/ToastStack/ToastStack.stories.tsx
@@ -6,7 +6,7 @@ import {
   type DtToastStackItem,
   type DtToastStackPosition,
 } from "../../../../../packages/web-components/src/native/toast-stack";
-import { assertNative, nativeStoryParameters } from "../NativeStory";
+import { TriggerButton, assertNative, nativeStoryParameters } from "../NativeStory";
 
 if (!customElements.get("dt-toast")) {
   customElements.define("dt-toast", DtToastElement);
@@ -91,9 +91,7 @@ function PlaygroundHarness({ position, max }: Pick<Args, "position" | "max">) {
 
   return (
     <div style={{ minHeight: "60vh", padding: "1rem" }}>
-      <button type="button" onClick={push}>
-        Push toast
-      </button>
+      <TriggerButton onClick={push}>Push toast</TriggerButton>
       <NativeToastStack
         max={max}
         onDismiss={dismiss}

--- a/nextjs-app/shared/stories/WebComponents/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import {
   NativeElement,
+  TriggerButton,
   assertNative,
   exampleStory,
   forcedColorsStory,
@@ -30,12 +31,12 @@ export const Default: Story = { play: assertNative("dt-visually-hidden") };
 export const Example: Story = {
   ...exampleStory,
   render: () => (
-    <button type="button">
+    <TriggerButton>
       Save
       <NativeElement tagName="dt-visually-hidden">
         Saves your profile changes
       </NativeElement>
-    </button>
+    </TriggerButton>
   ),
 };
 export const ForcedColors: Story = { ...forcedColorsStory };

--- a/packages/web-components/src/native/button.ts
+++ b/packages/web-components/src/native/button.ts
@@ -106,6 +106,9 @@ export class DtButtonElement extends DigitaltableteurElement {
     "accessible-name",
     "accessible-name-ref",
     "accessible-description",
+    "aria-haspopup",
+    "aria-expanded",
+    "aria-controls",
     "tooltip",
     "href",
     "target",
@@ -332,6 +335,17 @@ export class DtButtonElement extends DigitaltableteurElement {
       this.getAttribute("aria-label") ||
       "";
     if (ariaLabel) control.setAttribute("aria-label", ariaLabel);
+    // Menu-style composers (dt-menu, Radix asChild) write popup state onto
+    // the slotted trigger element; mirror it onto the real control so AT
+    // hears it where focus actually lands.
+    for (const stateAttribute of [
+      "aria-haspopup",
+      "aria-expanded",
+      "aria-controls",
+    ] as const) {
+      const value = this.getAttribute(stateAttribute);
+      if (value !== null) control.setAttribute(stateAttribute, value);
+    }
     const referencedName = this.referencedText(this.accessibleNameRef);
     if (referencedName) {
       control.setAttribute("aria-labelledby", "accessible-name-ref");

--- a/packages/web-components/src/native/empty-state.ts
+++ b/packages/web-components/src/native/empty-state.ts
@@ -15,11 +15,10 @@ const styles = `
   :host { display: block; inline-size: 100%; }
   :host([hidden]) { display: none; }
   .root { display: flex; inline-size: 100%; box-sizing: border-box; flex-direction: column; justify-content: center; align-items: center; text-align: center; }
-  .sm { padding-block: var(--space-internal-16); padding-inline: var(--space-internal-16); gap: var(--space-internal-4); --dt-empty-icon-size: 2rem; --dt-empty-title-size: var(--font-size-title-xxs, 1.25rem); --dt-empty-text-size: var(--font-size-text-xs, 0.75rem); }
-  .md { padding-block: var(--space-internal-32); padding-inline: var(--space-internal-16); gap: var(--space-internal-8); --dt-empty-icon-size: 3rem; --dt-empty-title-size: var(--font-size-title-xs, 1.5rem); --dt-empty-text-size: var(--font-size-text-s, 0.875rem); }
-  .lg { padding-block: var(--space-layout-48); padding-inline: var(--space-internal-16); gap: var(--space-internal-12); --dt-empty-icon-size: 4rem; --dt-empty-title-size: var(--font-size-title-s, 2rem); --dt-empty-text-size: var(--font-size-text-m, 1rem); }
+  .sm { padding-block: var(--space-internal-16); padding-inline: var(--space-internal-16); gap: var(--space-internal-4); --dt-empty-title-size: var(--font-size-title-xxs, 1.25rem); --dt-empty-text-size: var(--font-size-text-xs, 0.75rem); }
+  .md { padding-block: var(--space-internal-32); padding-inline: var(--space-internal-16); gap: var(--space-internal-8); --dt-empty-title-size: var(--font-size-title-xs, 1.5rem); --dt-empty-text-size: var(--font-size-text-s, 0.875rem); }
+  .lg { padding-block: var(--space-layout-48); padding-inline: var(--space-internal-16); gap: var(--space-internal-12); --dt-empty-title-size: var(--font-size-title-s, 2rem); --dt-empty-text-size: var(--font-size-text-m, 1rem); }
   .icon { display: inline-flex; color: var(--color-muted); }
-  .icon dt-icon { inline-size: var(--dt-empty-icon-size); block-size: var(--dt-empty-icon-size); }
   .title { margin: 0; font-family: var(--font-heading, var(--font-body)); font-size: var(--dt-empty-title-size); line-height: var(--line-height-tight, 1.2); color: var(--color-text); }
   .description { margin: 0; max-inline-size: 40ch; font-family: var(--font-text); font-size: var(--dt-empty-text-size); line-height: var(--line-height-normal, 1.5); color: var(--color-muted); }
   .actions { display: flex; margin-block-start: var(--space-internal-8); flex-wrap: wrap; justify-content: center; align-items: center; gap: var(--space-internal-8); }
@@ -97,6 +96,12 @@ export class DtEmptyStateElement extends DigitaltableteurElement {
       if (this.icon) {
         const icon = this.ownerDocument.createElement("dt-icon");
         icon.setAttribute("name", this.icon);
+        // Mirrors the React iconSizeMap; sizing the dt-icon host from outside
+        // cannot reach the preset-sized box inside its shadow root.
+        icon.setAttribute(
+          "size",
+          { sm: "lg", md: "xl", lg: "2xl" }[this.size],
+        );
         icon.setAttribute("decorative", "");
         iconSlot.append(icon);
       }

--- a/packages/web-components/src/native/menu.ts
+++ b/packages/web-components/src/native/menu.ts
@@ -73,9 +73,12 @@ const styles = `
   .item,
   .slotHost::slotted([data-dt-menu-item]) {
     display: flex;
+    box-sizing: border-box;
     min-block-size: 2.5rem;
     padding-block: var(--space-internal-8);
     padding-inline: var(--space-internal-12);
+    flex: 1 1 auto;
+    inline-size: 100%;
     align-items: center;
     gap: var(--space-internal-8);
     border: none;
@@ -102,10 +105,11 @@ const styles = `
     color: var(--color-muted);
     cursor: not-allowed;
   }
+  /* Focus is signalled by the data-highlighted row background (kept in sync
+     by highlightControl), matching the React/Radix menu; no extra ring. */
   .item:focus-visible,
   .slotHost::slotted([data-dt-menu-item]:focus-visible) {
-    outline: var(--focus-ring-width, 2px) solid var(--focus-ring-color, var(--color-primary));
-    outline-offset: -1px;
+    outline: none;
   }
   .itemIcon,
   .itemTrailing {

--- a/packages/web-components/src/native/split-button.ts
+++ b/packages/web-components/src/native/split-button.ts
@@ -74,8 +74,7 @@ const styles = `
       transform var(--duration-instant) var(--ease-out-cubic);
   }
   .primary:focus-visible,
-  .toggle:focus-visible,
-  .menuItem:focus-visible {
+  .toggle:focus-visible {
     outline: var(--focus-ring-width, 2px) solid var(--focus-ring-color, var(--color-primary));
     outline-offset: 2px;
   }
@@ -207,13 +206,19 @@ const styles = `
   .menuWrap { position: relative; display: flex; }
   .menuItem {
     display: flex;
+    box-sizing: border-box;
     min-block-size: 2.5rem;
     padding-block: var(--space-internal-8);
     padding-inline: var(--space-internal-12);
+    flex: 1 1 auto;
+    inline-size: 100%;
     align-items: center;
     gap: var(--space-internal-8);
     border: none;
     border-radius: var(--radius-md);
+    /* Focus is signalled by the data-highlighted row background, matching
+       the React/Radix menu; forced-colors keeps its explicit ring. */
+    outline: none;
     background: none;
     color: var(--color-dark);
     font: inherit;

--- a/tests/web-components/web-components.test.ts
+++ b/tests/web-components/web-components.test.ts
@@ -1003,3 +1003,47 @@ describe("existing native feedback elements", () => {
     );
   });
 });
+
+describe("trigger and sizing review regressions (#1228 follow-up)", () => {
+  it("mirrors menu popup state from the dt-button host onto its inner control", () => {
+    const button = document.createElement("dt-button") as DtButtonElement;
+    button.label = "Actions";
+    document.body.append(button);
+
+    // dt-menu writes these onto the slotted trigger element (the host).
+    button.setAttribute("aria-haspopup", "menu");
+    button.setAttribute("aria-expanded", "true");
+    button.setAttribute("aria-controls", "menu-panel");
+
+    const control = button.shadowRoot?.querySelector('[part="control"]');
+    expect(control).toHaveAttribute("aria-haspopup", "menu");
+    expect(control).toHaveAttribute("aria-expanded", "true");
+    expect(control).toHaveAttribute("aria-controls", "menu-panel");
+
+    button.setAttribute("aria-expanded", "false");
+    expect(
+      button.shadowRoot?.querySelector('[part="control"]'),
+    ).toHaveAttribute("aria-expanded", "false");
+    button.remove();
+  });
+
+  it("scales the empty-state icon with size like the React iconSizeMap", () => {
+    for (const [size, iconSize] of [
+      ["sm", "lg"],
+      ["md", "xl"],
+      ["lg", "2xl"],
+    ] as const) {
+      const element = document.createElement(
+        "dt-empty-state",
+      ) as DtEmptyStateElement;
+      element.setAttribute("title-text", "No results");
+      element.setAttribute("icon", "magnifying-glass");
+      element.setAttribute("size", size);
+      document.body.append(element);
+      expect(
+        element.shadowRoot?.querySelector("dt-icon"),
+      ).toHaveAttribute("size", iconSize);
+      element.remove();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **dt-button as menu trigger, properly**: dt-button now mirrors aria-haspopup/aria-expanded/aria-controls from its host onto the inner control, so composed menus announce popup state where focus lands. Menu + Toast stories consume dt-button as triggers, matching canonical React usage; the styled TriggerButton story helper remains only where React stories themselves use plain buttons (CommandPalette, Stack, VisuallyHidden, MacWindowFrame, Toast switchers were converted to dt-button too where React uses Button).
- **Menu/SplitButton row parity**: items fill the panel row and focus is signalled by the data-highlighted background alone, exactly like the React/Radix menu (the redundant focus ring is gone; forced-colors keeps its ring).
- **EmptyState icon scaling**: native icons now follow the React iconSizeMap (sm→lg, md→xl, lg→2xl) — they previously stayed 1.5rem at every size because host-level CSS cannot reach the preset box inside dt-icon's shadow root.
- Text-only story triggers (Toast, ToastStack, CommandPalette, Stack, VisuallyHidden, MacWindowFrame) no longer render as bare text.

## Verification

- Browser-verified: dt-button trigger announces expanded state on its inner control; menu rows highlight full-width with no ring; empty-state icons render 36/54/72px across sizes; all triggers render as buttons and fire.
- 266/266 wc tests (2 new regressions), typecheck, lint 0 errors, check:web-components 84 tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for menu-trigger buttons by ensuring popup state attributes are exposed on the focused control.
  * Corrected empty-state icon sizing across size variants.
  * Improved menu and split-button layout and focus behavior.

* **Tests**
  * Added regression coverage for accessible menu states and empty-state icon sizing.

* **Style**
  * Updated Storybook examples to use consistent web-component button controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->