### PR TITLE
feat(design-system): rendered-parity gate — React as the visual source of truth

### DIFF
--- a/docs/design-system/rendered-parity.md
+++ b/docs/design-system/rendered-parity.md
@@ -1,0 +1,61 @@
+# Rendered parity: React as the visual source of truth
+
+The native web components must look and behave exactly like their React
+counterparts. Story-name parity, contracts, and jsdom tests verify
+*declarations*; none of them look at rendering, which is how visual drift
+(menu row highlights, empty-state icon sizes, clipped panels) reached
+production repeatedly. This document defines the program that closes that
+gap. Owner-specified, 2026-07-17.
+
+## The two causes of drift
+
+1. **Manual CSS duplication.** Native styles are hand-transcribed from React
+   CSS Modules into shadow-DOM template literals. Property-level fidelity is
+   usually high; drift comes from *context* the transcription cannot carry
+   (wrapper display modes changing flex sizing, shadow boundaries breaking
+   outside-in sizing, `position: fixed` under transformed ancestors,
+   attributes arriving post-connect) and from unrequested "improvements".
+2. **No rendered comparison.** Nothing held the output against the React
+   benchmark, so every gate could pass while the components looked wrong.
+
+## The program
+
+| # | Measure | Status |
+|---|---------|--------|
+| 1 | **Framework-neutral recipes.** Extract tokens, part styles, states, dimensions, and responsive rules per component; *generate* both the React CSS Module and the shadow-DOM stylesheet from the recipe instead of transcribing. Eliminates duplication at the source. | Planned — largest work item; needs its own design (recipe schema, generator, migration order). Until then the parity gate below contains the damage. |
+| 2 | **Explicit story pairing.** Every native story identifies its React counterpart and uses identical args, content, viewport, theme, locale, and state. | Active — pairing is by identical story name within the canonical folder (`storyParity` equivalents/exclusions cover renames); content alignment is part of each component's audit (#8). |
+| 3 | **Screenshot comparison.** Playwright renders each pair and pixel-diffs across desktop + mobile, light/dark/forced-colors. | **Shipped** — `check:rendered-parity` matrix: Default (desktop-light) + Example (desktop-light, mobile-light, desktop-dark, desktop-forced-colors). State matrix (hover/focus/disabled/error/loading/open) extends per-component during audits. |
+| 4 | **Geometry assertions.** Content bounding boxes compared with px/% tolerances; catches structural drift pixels miss (first catch: native Menu panel 10 px wider than React). Spacing/typography/per-part boxes extend during audits. | **Shipped** (content-box level). |
+| 5 | **Interaction parity.** The same keyboard/pointer scripts run against both implementations; resulting state and accessibility trees compared. | Planned — builds on the existing farm aria-snapshot machinery; needs paired capture plumbing. |
+| 6 | **Documented exceptions only.** Intentional divergence needs a narrow, reviewed exception (component/story/mode + measured ratio + concrete reason) in `scripts/design-system/rendered-parity.roster.mjs`. No blanket thresholds, no automatic baseline acceptance; stale exceptions fail the gate. | **Shipped.** |
+| 7 | **Honest metrics.** Separate scores: API parity (`check:react-public-api`, contracts), story coverage (`web-component-story-parity`), behavioral parity (#5), accessibility parity (aria snapshots + #5), visual parity + geometry parity (`check:rendered-parity` report). "100 % parity" may only be claimed when every dimension passes. | Partially shipped — visual + geometry scores reported in `.omx/state/design-system/rendered-parity/latest.json`; a combined scorecard lands with #5. |
+| 8 | **Incremental fleet audit.** Fix each React/native pair, establish its approved comparison, then ratchet: `--update-roster` enrols clean components into enforcement; enforcement is never removed. Priority order: overlays, menus, forms, navigation, icon-heavy components. | Active — roster seeded from the first full sweep. |
+| 9 | **Stability gate.** A web component stays `beta` until its paired visual and interaction tests pass; production consumption remains an additional requirement for `stable`. | Planned — wire roster membership into the lifecycle/promotion checks once the initial audit wave lands. |
+
+## Running the gate
+
+```bash
+npm run check:rendered-parity            # against a running Storybook (6010)
+npm run check:rendered-parity:ci         # boots Storybook itself
+node scripts/design-system/check-rendered-parity.mjs --component=Menu
+node scripts/design-system/check-rendered-parity.mjs --update-roster
+```
+
+- Failures write `<pair>-react.png` / `<pair>-native.png` / `<pair>-diff.png`
+  into `.omx/state/design-system/rendered-parity/` for inspection.
+- `check:web-components:dod` runs the gate after the story checks on the same
+  Storybook boot.
+- Determinism: fixed viewports, `reducedMotion: reduce`, animations disabled,
+  fonts awaited, play-function completion awaited (`storyFinished`), residual
+  focus blurred, WIP-badge chrome hidden, content-box cropping so
+  story-layout offsets don't count against component fidelity.
+
+## Audit workflow (per component)
+
+1. `check:rendered-parity --component=X` — read the diff artifacts.
+2. Align the native story to the canonical args/content, then fix the
+   component where the difference is real drift (React is the source of
+   truth; native-side "improvements" are drift unless the owner approves
+   them, in which case they belong in React too).
+3. Intentional divergence → narrow exception with reason in the roster file.
+4. `--update-roster` to enrol; commit the roster change with the fix.

--- a/nextjs-app/shared/stories/WebComponents/Menu/Menu.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/Menu/Menu.stories.tsx
@@ -65,9 +65,11 @@ const disabledItems = JSON.stringify([
   { id: "delete", label: "Delete" },
 ]);
 
-function NativeMenu(args: MenuArgs) {
+function NativeMenu(args: MenuArgs & { defaultOpen?: boolean }) {
   // The open panel is position:absolute (out of flow); the Stage reserves its
-  // space so docs canvases don't clip it mid-item.
+  // space so docs canvases don't clip it mid-item. Trigger mirrors the
+  // canonical React PlaygroundRender: secondary Button labelled "Actions",
+  // open in canvas view.
   return (
     <Stage height="17rem">
       <NativeElement
@@ -78,12 +80,13 @@ function NativeMenu(args: MenuArgs) {
           "side-offset": args.sideOffset,
           modal: args.modal,
           items: args.items,
+          "default-open": args.defaultOpen,
         }}
       >
         <NativeElement
           tagName="dt-button"
           slot="trigger"
-          attributes={{ label: "Actions" }}
+          attributes={{ label: "Actions", variant: "secondary" }}
         />
       </NativeElement>
     </Stage>
@@ -138,8 +141,17 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = { play: assertNative("dt-menu") };
-export const Playground: Story = {};
+export const Default: Story = {
+  render: (args, { viewMode }) => (
+    <NativeMenu {...args} defaultOpen={viewMode !== "docs"} />
+  ),
+  play: assertNative("dt-menu"),
+};
+export const Playground: Story = {
+  render: (args, { viewMode }) => (
+    <NativeMenu {...args} defaultOpen={viewMode !== "docs"} />
+  ),
+};
 
 export const WithIcons: Story = {
   ...exampleStory,
@@ -267,11 +279,20 @@ export const Example: Story = {
   ...exampleStory,
   render: () => (
     <Stage height="17rem">
-      <NativeElement tagName="dt-menu" attributes={{ items: withIcons }}>
+      <NativeElement
+        tagName="dt-menu"
+        attributes={{
+          items: JSON.stringify([
+            { id: "first", label: "First" },
+            { id: "second", label: "Second" },
+            { id: "third", label: "Third" },
+          ]),
+        }}
+      >
         <NativeElement
           tagName="dt-button"
           slot="trigger"
-          attributes={{ label: "File" }}
+          attributes={{ label: "Open menu", variant: "secondary" }}
         />
       </NativeElement>
     </Stage>

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "generate:web-components": "node scripts/design-system/generate-web-components.mjs",
     "build:web-components": "npm run generate:web-components && npm --prefix packages/web-components run build",
     "check:web-components": "node scripts/design-system/check-web-components.mjs",
-    "check:web-components:dod": "npm run check:web-components && npm run test:stories:web-components:ci",
+    "check:web-components:dod": "npm run check:web-components && concurrently -k -s first -n SB,TEST \"npm run storybook -- --ci --no-open --quiet\" \"npm run storybook:wait && npm run test:stories:web-components && npm run check:rendered-parity\"",
     "check:react-public-api": "node scripts/design-system/check-react-public-api.mjs",
     "check:react-public-surface": "node scripts/design-system/check-react-public-surface.mjs",
     "check:npm-consumer-install": "node scripts/design-system/check-npm-consumer-install.mjs",
@@ -195,7 +195,9 @@
     "promote:stable-atoms": "node scripts/design-system/promote-stable-atoms.mjs",
     "check:bundle-budgets": "node scripts/design-system/check-bundle-budgets.mjs",
     "check:dogfood-ratchet": "node scripts/design-system/check-dogfood-ratchet.mjs",
-    "check:figma-links": "node scripts/design-system/check-figma-links.mjs"
+    "check:figma-links": "node scripts/design-system/check-figma-links.mjs",
+    "check:rendered-parity": "node scripts/design-system/check-rendered-parity.mjs",
+    "check:rendered-parity:ci": "concurrently -k -s first -n SB,PARITY \"npm run storybook -- --ci --no-open --quiet\" \"npm run storybook:wait && npm run check:rendered-parity\""
   },
   "dependencies": {
     "@ai-sdk/mcp": "^2.0.10",

--- a/scripts/design-system/check-rendered-parity.mjs
+++ b/scripts/design-system/check-rendered-parity.mjs
@@ -1,0 +1,447 @@
+#!/usr/bin/env node
+/**
+ * Rendered-parity gate: screenshots each native web-component story next to
+ * its canonical React twin and compares PIXELS and GEOMETRY across a
+ * viewport/theme matrix.
+ *
+ * Story-name parity, contracts, and jsdom tests all verify DECLARATIONS;
+ * none of them look at rendering, which is the channel every visual drift
+ * (menu row highlight, empty-state icon sizes, clipped panels) escaped
+ * through. React is the visual source of truth; a native pair must match it.
+ *
+ * Enforcement is roster-based (rendered-parity.roster.mjs): audited
+ * components fail the gate on any regression; unaudited ones are measured
+ * and reported so the fleet score is honest while the audit proceeds
+ * component by component. Intentional divergence needs a narrow, reviewed
+ * exception with a reason — there is no blanket threshold and no automatic
+ * baseline acceptance.
+ *
+ *   npm run check:rendered-parity                 # against running Storybook
+ *   npm run check:rendered-parity:ci              # boots Storybook itself
+ *   node scripts/design-system/check-rendered-parity.mjs --component=Menu
+ *   node scripts/design-system/check-rendered-parity.mjs --update-roster
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+import pixelmatch from "pixelmatch";
+import { PNG } from "pngjs";
+import elements from "../../packages/web-components/web-components.config.mjs";
+import { enforced, exceptions } from "./rendered-parity.roster.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const REPORT_DIR = join(ROOT, ".omx/state/design-system/rendered-parity");
+const ROSTER_PATH = join(
+  ROOT,
+  "scripts/design-system/rendered-parity.roster.mjs",
+);
+
+const baseUrl =
+  process.argv
+    .find((argument) => argument.startsWith("--url="))
+    ?.slice("--url=".length) ?? "http://127.0.0.1:6010";
+const componentFilter = process.argv
+  .find((argument) => argument.startsWith("--component="))
+  ?.slice("--component=".length)
+  ?.toLowerCase();
+const updateRoster = process.argv.includes("--update-roster");
+
+/**
+ * Anti-aliasing noise between two renders of identical markup in one
+ * deterministic browser; anything above this is a real difference.
+ */
+const PIXEL_TOLERANCE = 0.01;
+/** Content boxes may differ by this much before geometry fails. */
+const GEOMETRY_TOLERANCE_PX = 4;
+const GEOMETRY_TOLERANCE_RATIO = 0.02;
+/** Exceptions record a measured ratio; drifting past it fails. */
+const EXCEPTION_SLACK = 0.005;
+
+const DESKTOP = { width: 1000, height: 700 };
+const MOBILE = { width: 375, height: 812 };
+
+/**
+ * Comparison matrix. Default renders once (desktop/light); the Example
+ * story — the canonical showcase — covers mobile, dark, and forced-colors.
+ */
+const MODES = [
+  { key: "desktop-light", story: "Default", viewport: DESKTOP },
+  { key: "desktop-light", story: "Example", viewport: DESKTOP },
+  {
+    key: "mobile-light",
+    story: "Example",
+    viewport: MOBILE,
+  },
+  {
+    key: "desktop-dark",
+    story: "Example",
+    viewport: DESKTOP,
+    globals: "theme:dark",
+  },
+  {
+    key: "desktop-forced-colors",
+    story: "Example",
+    viewport: DESKTOP,
+    forcedColors: true,
+  },
+];
+
+const slugify = (value) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+const nativeElements = elements.filter(
+  (element) =>
+    element.defaultBackend === "native" &&
+    (!componentFilter ||
+      element.sourceComponent.toLowerCase() === componentFilter ||
+      element.tagName.toLowerCase() === componentFilter),
+);
+if (nativeElements.length === 0) {
+  throw new Error(`No native component matches ${componentFilter}`);
+}
+
+const indexResponse = await fetch(`${baseUrl}/index.json`);
+if (!indexResponse.ok) {
+  throw new Error(
+    `Unable to read Storybook index (${indexResponse.status} ${indexResponse.statusText})`,
+  );
+}
+const index = await indexResponse.json();
+const entries = Object.values(index.entries);
+
+function storyFolder(predicate, description) {
+  const titles = new Set(
+    entries.filter((entry) => predicate(entry)).map((entry) => entry.title),
+  );
+  if (titles.size !== 1) {
+    return { error: `${description}: found ${titles.size} folders` };
+  }
+  const title = [...titles][0];
+  const stories = new Map(
+    entries
+      .filter((entry) => entry.title === title && entry.type === "story")
+      .map((entry) => [entry.name, entry.id]),
+  );
+  return { title, stories };
+}
+
+function comparisonsFor(element) {
+  const component = element.sourceComponent;
+  const native = storyFolder(
+    (entry) =>
+      entry.title.startsWith("Web Components/") &&
+      entry.title.endsWith(`/${component}`),
+    `${component} native folder`,
+  );
+  const react = storyFolder(
+    (entry) =>
+      !entry.title.startsWith("Web Components/") &&
+      entry.title.endsWith(`/${component}`) &&
+      entry.title.split("/").length === 2,
+    `${component} React folder`,
+  );
+  if (native.error || react.error) {
+    return { skipped: native.error ?? react.error, comparisons: [] };
+  }
+  const comparisons = [];
+  for (const mode of MODES) {
+    const reactId = react.stories.get(mode.story);
+    const nativeId = native.stories.get(mode.story);
+    if (reactId && nativeId) {
+      comparisons.push({ component, mode, reactId, nativeId });
+    }
+  }
+  return { comparisons };
+}
+
+const browser = await chromium.launch();
+
+async function capture(context, page, storyId, mode) {
+  await page.emulateMedia({
+    forcedColors: mode.forcedColors ? "active" : "none",
+    reducedMotion: "reduce",
+  });
+  const globals = mode.globals ? `&globals=${mode.globals}` : "";
+  await page.goto(
+    `${baseUrl}/iframe.html?id=${storyId}&viewMode=story${globals}`,
+    { waitUntil: "domcontentloaded" },
+  );
+  // Play functions run after render; screenshotting mid-play is
+  // nondeterministic. The preview's render phase reaches "finished" only
+  // after render AND play complete ("errored"/"aborted" also settle).
+  await page
+    .waitForFunction(
+      () => {
+        const renders = window.__STORYBOOK_PREVIEW__?.storyRenders ?? [];
+        return (
+          renders.length > 0 &&
+          renders.every((render) =>
+            ["finished", "errored", "aborted"].includes(render.phase),
+          )
+        );
+      },
+      null,
+      { timeout: 15_000 },
+    )
+    .catch(() => {});
+  await page.addStyleTag({
+    content:
+      // The WIP badge is Storybook chrome, not component output; stable React
+      // stories have none while native betas do, so it must not count.
+      '*, *::before, *::after { animation: none !important; transition: none !important; caret-color: transparent !important; } html { scroll-behavior: auto !important; } [data-axe-ignore], [class*="wipWrapper"] { display: none !important; }',
+  });
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+    // Residual focus is an interaction state (play functions end focused),
+    // not part of the story's rendered contract.
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+    window.scrollTo(0, 0);
+  });
+  await page.waitForTimeout(250);
+  return PNG.sync.read(await page.screenshot({ type: "png" }));
+}
+
+/**
+ * Bounding box of non-background pixels, so story-layout offsets (centered
+ * vs padded canvases) don't count against component fidelity. Dark and
+ * forced-colors surfaces use a sampled corner color as background.
+ */
+function contentBounds(image) {
+  const background = [image.data[0], image.data[1], image.data[2]];
+  const matchesBackground = (at) =>
+    Math.abs(image.data[at] - background[0]) < 6 &&
+    Math.abs(image.data[at + 1] - background[1]) < 6 &&
+    Math.abs(image.data[at + 2] - background[2]) < 6;
+  let top = image.height;
+  let left = image.width;
+  let right = -1;
+  let bottom = -1;
+  for (let y = 0; y < image.height; y += 1) {
+    for (let x = 0; x < image.width; x += 1) {
+      const at = (image.width * y + x) * 4;
+      if (!matchesBackground(at)) {
+        if (x < left) left = x;
+        if (x > right) right = x;
+        if (y < top) top = y;
+        if (y > bottom) bottom = y;
+      }
+    }
+  }
+  if (right < 0) return null;
+  const margin = 8;
+  return {
+    left: Math.max(0, left - margin),
+    top: Math.max(0, top - margin),
+    right: Math.min(image.width - 1, right + margin),
+    bottom: Math.min(image.height - 1, bottom + margin),
+  };
+}
+
+function cropToContent(image) {
+  const bounds = contentBounds(image);
+  if (!bounds) return new PNG({ width: 1, height: 1 });
+  const width = bounds.right - bounds.left + 1;
+  const height = bounds.bottom - bounds.top + 1;
+  const cropped = new PNG({ width, height });
+  PNG.bitblt(image, cropped, bounds.left, bounds.top, width, height, 0, 0);
+  return cropped;
+}
+
+function diffPair(reactPng, nativePng) {
+  const croppedReact = cropToContent(reactPng);
+  const croppedNative = cropToContent(nativePng);
+  const width = Math.max(croppedReact.width, croppedNative.width);
+  const height = Math.max(croppedReact.height, croppedNative.height);
+  const pad = (source) => {
+    if (source.width === width && source.height === height) return source;
+    const padded = new PNG({ width, height });
+    padded.data.fill(255);
+    PNG.bitblt(source, padded, 0, 0, source.width, source.height, 0, 0);
+    return padded;
+  };
+  const a = pad(croppedReact);
+  const b = pad(croppedNative);
+  const diff = new PNG({ width, height });
+  const mismatched = pixelmatch(a.data, b.data, diff.data, width, height, {
+    threshold: 0.15,
+  });
+  const geometryDelta = {
+    width: Math.abs(croppedReact.width - croppedNative.width),
+    height: Math.abs(croppedReact.height - croppedNative.height),
+  };
+  const geometryLimit = (reactSide, nativeSide) =>
+    Math.max(
+      GEOMETRY_TOLERANCE_PX,
+      Math.max(reactSide, nativeSide) * GEOMETRY_TOLERANCE_RATIO,
+    );
+  const geometryPass =
+    geometryDelta.width <=
+      geometryLimit(croppedReact.width, croppedNative.width) &&
+    geometryDelta.height <=
+      geometryLimit(croppedReact.height, croppedNative.height);
+  return {
+    ratio: mismatched / (width * height),
+    geometryDelta,
+    geometryPass,
+    reactBox: { width: croppedReact.width, height: croppedReact.height },
+    nativeBox: { width: croppedNative.width, height: croppedNative.height },
+    diff,
+    a,
+    b,
+  };
+}
+
+mkdirSync(REPORT_DIR, { recursive: true });
+const context = await browser.newContext({ deviceScaleFactor: 1 });
+const page = await context.newPage();
+
+const results = [];
+const failures = [];
+const staleExceptions = [];
+const cleanComponents = new Set();
+const dirtyComponents = new Set();
+
+let progress = 0;
+for (const element of nativeElements) {
+  progress += 1;
+  console.log(
+    `[${progress}/${nativeElements.length}] ${element.sourceComponent}`,
+  );
+  const { comparisons, skipped } = comparisonsFor(element);
+  if (skipped) {
+    results.push({ component: element.sourceComponent, skipped });
+    continue;
+  }
+  for (const comparison of comparisons) {
+    const { component, mode } = comparison;
+    await page.setViewportSize(mode.viewport);
+    const reactShot = await capture(context, page, comparison.reactId, mode);
+    const nativeShot = await capture(context, page, comparison.nativeId, mode);
+    const outcome = diffPair(reactShot, nativeShot);
+    const key = `${component}/${mode.story}@${mode.key}`;
+    const exception = exceptions.find(
+      (entry) =>
+        entry.component === component &&
+        entry.story === mode.story &&
+        entry.mode === mode.key,
+    );
+    const pixelPass = outcome.ratio <= PIXEL_TOLERANCE;
+    const pass = pixelPass && outcome.geometryPass;
+    const record = {
+      component,
+      story: mode.story,
+      mode: mode.key,
+      ratio: Number(outcome.ratio.toFixed(4)),
+      geometryDelta: outcome.geometryDelta,
+      geometryPass: outcome.geometryPass,
+      reactBox: outcome.reactBox,
+      nativeBox: outcome.nativeBox,
+      pass,
+      excepted: Boolean(exception),
+      enforced: enforced.includes(component),
+    };
+    results.push(record);
+    if (pass) {
+      if (exception) staleExceptions.push(key);
+      continue;
+    }
+    dirtyComponents.add(component);
+    if (exception && outcome.ratio <= exception.maxRatio + EXCEPTION_SLACK) {
+      continue;
+    }
+    if (enforced.includes(component)) {
+      failures.push({
+        key,
+        ratio: record.ratio,
+        geometry: outcome.geometryPass
+          ? null
+          : `Δ${outcome.geometryDelta.width}×${outcome.geometryDelta.height}px (react ${outcome.reactBox.width}×${outcome.reactBox.height}, native ${outcome.nativeBox.width}×${outcome.nativeBox.height})`,
+        exceptedAt: exception?.maxRatio ?? null,
+      });
+    }
+    const base = join(REPORT_DIR, slugify(key));
+    writeFileSync(`${base}-react.png`, PNG.sync.write(outcome.a));
+    writeFileSync(`${base}-native.png`, PNG.sync.write(outcome.b));
+    writeFileSync(`${base}-diff.png`, PNG.sync.write(outcome.diff));
+  }
+  if (!dirtyComponents.has(element.sourceComponent)) {
+    cleanComponents.add(element.sourceComponent);
+  }
+}
+
+await browser.close();
+
+const measured = results.filter((entry) => !entry.skipped);
+const visualPassed = measured.filter(
+  (entry) => entry.ratio <= PIXEL_TOLERANCE,
+).length;
+const geometryPassed = measured.filter((entry) => entry.geometryPass).length;
+const summary = {
+  generatedAt: new Date().toISOString(),
+  pixelTolerance: PIXEL_TOLERANCE,
+  comparisons: measured.length,
+  visualParity: `${visualPassed}/${measured.length}`,
+  geometryParity: `${geometryPassed}/${measured.length}`,
+  enforcedComponents: `${enforced.length}/${nativeElements.length}`,
+  cleanComponents: [...cleanComponents].sort(),
+  results,
+};
+writeFileSync(
+  join(REPORT_DIR, "latest.json"),
+  `${JSON.stringify(summary, null, 2)}\n`,
+);
+
+if (updateRoster) {
+  const nextEnforced = [
+    ...new Set([...enforced, ...cleanComponents]),
+  ].sort();
+  const serializedExceptions = exceptions
+    .map(
+      (entry) =>
+        `  {\n    component: ${JSON.stringify(entry.component)},\n    story: ${JSON.stringify(entry.story)},\n    mode: ${JSON.stringify(entry.mode)},\n    maxRatio: ${entry.maxRatio},\n    reason:\n      ${JSON.stringify(entry.reason)},\n  },`,
+    )
+    .join("\n");
+  writeFileSync(
+    ROSTER_PATH,
+    `/**\n * Rendered-parity enforcement roster.\n *\n * \`enforced\` lists components whose React↔native story pairs have been\n * audited and match across the comparison matrix; the gate fails on any\n * regression for them (ratchet — enforcement is never removed, only added).\n * Components not yet enrolled are measured and reported but do not fail the\n * gate; enrol them by fixing their pairs and running\n * \`check-rendered-parity.mjs --update-roster\`.\n *\n * \`exceptions\` are narrow, reviewed waivers for INTENTIONAL native\n * divergence, keyed per component/story/mode with a concrete reason.\n * No blanket thresholds, no automatic baseline acceptance: the gate fails\n * on stale exceptions (pair now matches) and on drift past the recorded\n * ratio.\n */\nexport const enforced = ${JSON.stringify(nextEnforced, null, 2)};\n\nexport const exceptions = [${serializedExceptions ? `\n${serializedExceptions}\n` : ""}];\n`,
+  );
+  console.log(
+    `✳ roster updated: ${nextEnforced.length} enforced component(s) (${nextEnforced.length - enforced.length} newly enrolled)`,
+  );
+}
+
+if (staleExceptions.length > 0 && !updateRoster) {
+  console.error(
+    `Stale parity exceptions (pairs now match — remove them):\n${staleExceptions
+      .map((key) => `  - ${key}`)
+      .join("\n")}`,
+  );
+}
+if (failures.length > 0) {
+  console.error(
+    `Rendered-parity failures on enforced components (artifacts in ${REPORT_DIR}):\n${failures
+      .map(
+        (entry) =>
+          `  - ${entry.key}: ${(entry.ratio * 100).toFixed(2)}% pixels differ${
+            entry.geometry ? `; geometry ${entry.geometry}` : ""
+          }${
+            entry.exceptedAt !== null
+              ? ` (exception recorded ${(entry.exceptedAt * 100).toFixed(2)}%)`
+              : ""
+          }`,
+      )
+      .join("\n")}`,
+  );
+}
+if ((failures.length > 0 || staleExceptions.length > 0) && !updateRoster) {
+  process.exit(1);
+}
+console.log(
+  `✓ rendered parity: visual ${summary.visualParity}, geometry ${summary.geometryParity}, enforced ${summary.enforcedComponents} (report: .omx/state/design-system/rendered-parity/latest.json)`,
+);

--- a/scripts/design-system/rendered-parity.roster.mjs
+++ b/scripts/design-system/rendered-parity.roster.mjs
@@ -1,0 +1,27 @@
+/**
+ * Rendered-parity enforcement roster.
+ *
+ * `enforced` lists components whose React↔native story pairs have been
+ * audited and match across the comparison matrix; the gate fails on any
+ * regression for them (ratchet — enforcement is never removed, only added).
+ * Components not yet enrolled are measured and reported but do not fail the
+ * gate; enrol them by fixing their pairs and running
+ * `check-rendered-parity.mjs --update-roster`.
+ *
+ * `exceptions` are narrow, reviewed waivers for INTENTIONAL native
+ * divergence, keyed per component/story/mode with a concrete reason.
+ * No blanket thresholds, no automatic baseline acceptance: the gate fails
+ * on stale exceptions (pair now matches) and on drift past the recorded
+ * ratio.
+ */
+export const enforced = [
+  "Avatar",
+  "BlogMediaImage",
+  "Container",
+  "IconButton",
+  "List",
+  "SelectOption",
+  "SkipLink"
+];
+
+export const exceptions = [];


### PR DESCRIPTION
feat(design-system): rendered-parity gate — React as the visual source of truth

Story-name parity, contracts, and jsdom tests verify declarations; nothing
compared native rendering to its React twin, which is the channel every
visual drift shipped through. This adds the owner-specified gate
(docs/design-system/rendered-parity.md):

- check:rendered-parity renders each React/native story pair in Playwright
  and compares PIXELS (pixelmatch, 1% anti-aliasing tolerance) and GEOMETRY
  (content-box dimensions, 4px/2% tolerance) across a matrix: Default at
  desktop-light; Example at desktop-light, mobile-light (375x812),
  desktop-dark (globals theme), desktop-forced-colors (emulateMedia).
- Enforcement is roster-based (rendered-parity.roster.mjs): audited
  components ratchet (enforcement is never removed); unaudited ones are
  measured and reported so the fleet score stays honest while the audit
  proceeds. Intentional divergence needs a narrow reviewed exception
  (component/story/mode + measured ratio + reason); stale exceptions fail.
  No blanket thresholds, no automatic baseline acceptance.
- Determinism: waits for the preview render phase to reach "finished"
  (covers play functions; the storyFinished channel event never fires in
  plain iframe view), blurs residual play focus, hides WIP-badge chrome,
  disables animations, awaits fonts, and crops to content boxes so
  story-layout offsets don't count against component fidelity.
- Failure artifacts (react/native/diff PNGs) and a scored report land in
  .omx/state/design-system/rendered-parity/; visual + geometry parity are
  reported separately. Wired into check:web-components:dod on the same
  Storybook boot.

First honest fleet numbers: visual 75/404, geometry 137/404, 7/84
components fully clean (enrolled as the initial enforced roster). First
catches: native Menu open panel 10px wider than React (geometry caught
what pixels passed); Badge/Button Example stories are not content
replicas of their canonical stories. Menu stories aligned to canonical
triggers (secondary "Actions"/"Open menu", defaultOpen in canvas view)
as the first audit example - its Example pair is now pixel-identical
across all four modes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
