### PR TITLE
fix(design-system): rendered-parity audit wave 1 — CookieConsent, Menu, SplitButton, NavMenuList pixel-identical + enrolled

### DIFF
--- a/nextjs-app/shared/components/CookieConsent/CookieConsent.stories.tsx
+++ b/nextjs-app/shared/components/CookieConsent/CookieConsent.stories.tsx
@@ -39,6 +39,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   tags: ["beta-matrix"],
   globals: { forcedColors: "none" },
+  decorators: [withOpenBanner],
 };
 export const Playground: Story = {
   tags: ["beta-matrix"],
@@ -55,10 +56,12 @@ export const Example: Story = {
   tags: ["beta-matrix"],
   globals: { forcedColors: "none" },
   parameters: { controls: { disable: true }, layout: "fullscreen" },
+  decorators: [withOpenBanner],
   render: () => <CookieConsent />,
 };
 
 export const ForcedColors: Story = {
   tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
+  decorators: [withOpenBanner],
 };

--- a/nextjs-app/shared/components/CookieConsent/__a11y-snapshots__/site-cookieconsent--default.light.yaml
+++ b/nextjs-app/shared/components/CookieConsent/__a11y-snapshots__/site-cookieconsent--default.light.yaml
@@ -1,1 +1,9 @@
 - status: Work in progress (beta)
+- region "Cookie preferences":
+  - paragraph:
+    - text: Cookies improve your experience. Read our
+    - link "cookie policy":
+      - /url: /privacy-policy
+  - button "Customize settings"
+  - button "Only essential"
+  - button "Accept all"

--- a/nextjs-app/shared/components/CookieConsent/__a11y-snapshots__/site-cookieconsent--example.light.yaml
+++ b/nextjs-app/shared/components/CookieConsent/__a11y-snapshots__/site-cookieconsent--example.light.yaml
@@ -1,1 +1,9 @@
 - status: Work in progress (beta)
+- region "Cookie preferences":
+  - paragraph:
+    - text: Cookies improve your experience. Read our
+    - link "cookie policy":
+      - /url: /privacy-policy
+  - button "Customize settings"
+  - button "Only essential"
+  - button "Accept all"

--- a/nextjs-app/shared/components/CookieConsent/__a11y-snapshots__/site-cookieconsent--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/CookieConsent/__a11y-snapshots__/site-cookieconsent--forced-colors.light.yaml
@@ -1,1 +1,9 @@
 - status: Work in progress (beta)
+- region "Cookie preferences":
+  - paragraph:
+    - text: Cookies improve your experience. Read our
+    - link "cookie policy":
+      - /url: /privacy-policy
+  - button "Customize settings"
+  - button "Only essential"
+  - button "Accept all"

--- a/nextjs-app/shared/components/SplitButton/SplitButton.stories.tsx
+++ b/nextjs-app/shared/components/SplitButton/SplitButton.stories.tsx
@@ -308,8 +308,11 @@ export const DisabledState: Story = {
 export const Example: Story = {
   tags: ["beta-matrix"],
   globals: { forcedColors: "none" },
-  name: "Example (document toolbar)",
-  parameters: { controls: { disable: true }, layout: "padded" },
+  parameters: {
+    controls: { disable: true },
+    layout: "padded",
+    docs: { description: { story: "Document toolbar composition." } },
+  },
   render: () => (
     <div
       style={{

--- a/nextjs-app/shared/stories/WebComponents/CookieConsent/CookieConsent.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/CookieConsent/CookieConsent.stories.tsx
@@ -84,7 +84,7 @@ const meta = {
     categories,
     value:
       "{\"essential\":true,\"analytics\":false,\"marketing\":false,\"functional\":false}",
-    summary: "We use cookies to improve your experience.",
+    summary: "Cookies improve your experience.",
     policyHref: "/privacy-policy",
     autoShow: "false",
   },

--- a/nextjs-app/shared/stories/WebComponents/NavMenuList/NavMenuList.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/NavMenuList/NavMenuList.stories.tsx
@@ -40,8 +40,10 @@ function NativeNavMenuList(args: Args) {
     if (nav) nav.items = items;
   }, [items]);
 
+  // Full-width, no wrapper: the React NavMenuList stories render the bare
+  // list, and the rendered-parity gate compares against them 1:1.
   return (
-    <div ref={rootRef} style={{ inlineSize: "min(20rem, 90vw)" }}>
+    <div ref={rootRef}>
       <NativeElement
         tagName="dt-nav-menu-list"
         attributes={{ "current-path": args.currentPath }}
@@ -56,6 +58,9 @@ const meta = {
   tags: ["autodocs", "beta", "web-components"],
   parameters: {
     ...nativeStoryParameters,
+    // The React stories use the default padded canvas, where the list fills
+    // the container width; centered would shrink-wrap it.
+    layout: "padded",
     docs: {
       description: {
         component:
@@ -63,7 +68,9 @@ const meta = {
       },
     },
   },
-  args: { items: "site", currentPath: "/work/case-study" },
+  // "/" matches the React stories, whose useNavigationPathname() falls back
+  // to "/" in Storybook (Home active via exact match).
+  args: { items: "site", currentPath: "/" },
   argTypes: {
     items: { control: "inline-radio", options: ["site", "three"] },
     currentPath: { control: "text" },
@@ -82,7 +89,7 @@ export const Default: Story = {
     expect(host?.shadowRoot?.querySelectorAll("a")).toHaveLength(5);
     expect(
       host?.shadowRoot?.querySelector("a[aria-current=page]"),
-    ).toHaveTextContent("Work");
+    ).toHaveTextContent("Home");
   },
 };
 

--- a/nextjs-app/shared/stories/WebComponents/SplitButton/SplitButton.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/SplitButton/SplitButton.stories.tsx
@@ -261,20 +261,47 @@ export const Surfaces: Story = {
   ),
 };
 
+// Replica of the React Example (document toolbar): Save primary + Export
+// secondary in a flex row; the rendered-parity gate compares them 1:1.
 export const Example: Story = {
   ...exampleStory,
+  // Same canvas layout as the React Example: centered canvases start the
+  // content on fractional x, changing glyph rasterization vs the pair.
+  parameters: { layout: "padded" },
   render: () => (
-    <Stage height="15rem">
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "0.75rem",
+        padding: "0.5rem",
+      }}
+    >
+      <NativeElement
+        tagName="dt-split-button"
+        attributes={{
+          label: "Save",
+          variant: "primary",
+          options: JSON.stringify([
+            { id: "save-as", label: "Save as", icon: "pencil" },
+            { id: "save-cloud", label: "Save to cloud", icon: "download" },
+            { id: "save-copy", label: "Save a copy", icon: "copy-simple" },
+          ]),
+        }}
+      />
       <NativeElement
         tagName="dt-split-button"
         attributes={{
           label: "Export",
           variant: "secondary",
           "toggle-label": "Choose export format",
-          options: exportOptions,
+          options: JSON.stringify([
+            { id: "pdf", label: "Export as PDF", trailingIcon: "file-text" },
+            { id: "csv", label: "Export CSV", trailingIcon: "download" },
+          ]),
         }}
       />
-    </Stage>
+    </div>
   ),
 };
 

--- a/packages/web-components/src/native/cookie-consent.ts
+++ b/packages/web-components/src/native/cookie-consent.ts
@@ -80,27 +80,59 @@ const styles = `
     background: color-mix(in srgb, var(--main-body-background-color, Canvas) 94%, transparent);
     backdrop-filter: blur(10px);
   }
-  .bar { display: flex; margin-inline: auto; inline-size: 100%; max-inline-size: var(--container-lg, 72rem); align-items: center; gap: var(--space-layout-24, 1.5rem); }
-  .copy { min-inline-size: 0; flex: 1 1 auto; }
-  .summary { margin: 0; color: var(--color-text, CanvasText); font-size: var(--font-size-text-m, 1rem); line-height: var(--line-height-normal, 1.5); }
-  .policy { color: var(--color-primary, LinkText); text-underline-offset: 0.2em; }
+  .bar { display: flex; margin-inline: auto; inline-size: 100%; min-block-size: 2.5rem; max-inline-size: var(--container-lg, 72rem); align-items: center; gap: var(--space-layout-24, 1.5rem); }
+  /* Optical vertical center, mirroring CookieConsentBanner.module.css: the
+     wavy underline hangs below the link, so the copy is nudged down half the
+     underline depth to center on cap height. */
+  .copy {
+    --underline-depth: 6px;
+    --optical-shift: calc(var(--underline-depth) / 2 - 2px);
+
+    display: flex;
+    min-inline-size: 0;
+    min-block-size: 2.5rem;
+    flex: 1 1 auto;
+    align-items: center;
+    overflow: visible;
+  }
+  .summary { margin: 0; color: var(--color-text, CanvasText); font-size: var(--font-size-text-m, 1rem); line-height: var(--line-height-normal, 1.5); transform: translateY(var(--optical-shift)); }
+  /* The site link treatment (variables.css .wavyUnderline) with the banner's
+     out-of-flow underline geometry, exactly as the React banner renders it. */
+  /* inline-flex mirrors the React Link: the label is an atomic inline box,
+     so it wraps as one unit and the wave spans the whole link. */
+  .policy { display: inline-flex; position: relative; align-items: center; color: var(--link-color, LinkText); text-decoration: none; }
+  .policy::after {
+    position: absolute;
+    right: 0;
+    bottom: calc(-1 * var(--underline-depth));
+    left: 0;
+    height: var(--underline-depth);
+    background-color: var(--underline-accent-color, currentcolor);
+    opacity: 0.9;
+    content: "";
+    mask-image: var(--wavy-underline-mask);
+    mask-repeat: repeat-x;
+    mask-size: 16px 6px;
+  }
   .actions { display: flex; flex-shrink: 0; flex-wrap: wrap; justify-content: flex-end; align-items: center; gap: var(--space-layout-16, 1rem); }
   button, .button {
     display: inline-flex;
+    box-sizing: border-box;
     min-block-size: 2.5rem;
     padding: var(--space-internal-8, 0.5rem) var(--space-internal-16, 1rem);
     align-items: center;
     justify-content: center;
-    border: 1px solid transparent;
+    border: none;
     border-radius: var(--radius-lg, 0.5rem);
-    font: inherit;
-    font-weight: 600;
-    line-height: 1.25;
+    font-family: var(--primary-body-font, inherit);
+    font-size: var(--font-size-button-m, 1rem);
+    font-weight: 400;
+    line-height: 1;
     cursor: pointer;
   }
   button:focus-visible, .button:focus-visible, input:focus-visible + .switchTrack { outline: var(--focus-ring-width, 2px) solid var(--focus-ring-color, var(--color-primary, Highlight)); outline-offset: var(--focus-ring-offset, 2px); }
   .primary { background: var(--color-primary, ButtonText); color: var(--color-white, ButtonFace); }
-  .secondary { border-color: var(--color-primary, ButtonText); background: transparent; color: var(--color-primary, ButtonText); }
+  .secondary { border: 0.125rem solid var(--color-primary, ButtonText); background: transparent; color: var(--color-primary, ButtonText); }
   .tertiary { background: transparent; color: var(--color-primary, ButtonText); }
   .overlay { position: fixed; z-index: 9100; inset: 0; display: grid; padding: var(--space-layout-16, 1rem); place-items: center; background: rgb(0 0 0 / 55%); }
   .dialog { box-sizing: border-box; inline-size: min(51.25rem, 100%); max-block-size: min(46rem, calc(100dvh - 2rem)); overflow: auto; border: 1px solid var(--color-border, #767676); border-radius: var(--radius-lg, 0.5rem); background: var(--main-body-background-color, Canvas); color: var(--color-text, CanvasText); box-shadow: 0 24px 80px rgb(0 0 0 / 30%); }
@@ -127,8 +159,15 @@ const styles = `
   .footerActions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: var(--space-layout-16, 1rem); }
   @media (width >= 768px) { .banner { padding-inline: max(var(--page-margin-tablet, 2rem), env(safe-area-inset-left)) max(var(--page-margin-tablet, 2rem), env(safe-area-inset-right)); } }
   @media (width >= 1024px) { .banner { padding-inline: max(var(--page-margin-desktop, 3rem), env(safe-area-inset-left)) max(var(--page-margin-desktop, 3rem), env(safe-area-inset-right)); } }
+  /* Touch targets: >= 44px on small viewports, matching Button.module.css. */
+  @media (width <= 768px) {
+    button, .button { min-block-size: 2.75rem; }
+  }
   @media (width <= 767px) {
+    .banner { padding-block: var(--space-layout-24, 1.5rem) max(var(--space-layout-16, 1rem), env(safe-area-inset-bottom)); }
     .bar { align-items: stretch; flex-direction: column; gap: var(--space-layout-16, 1rem); }
+    .copy { min-block-size: auto; padding-block-end: var(--underline-depth); }
+    .summary { font-size: var(--font-size-text-s, 0.875rem); line-height: var(--line-height-snug, 1.375); }
     .actions { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: var(--space-internal-8, 0.5rem); }
     .actions > * { inline-size: 100%; }
     .actions > :first-child { order: 3; grid-column: 1 / -1; }
@@ -141,9 +180,10 @@ const styles = `
   @media (prefers-reduced-motion: reduce) { .banner { animation: none; } .switchTrack, .switchTrack::before { transition: none; } }
   @keyframes banner-in { from { translate: 0 100%; opacity: 0; } to { translate: 0 0; opacity: 1; } }
   @media (forced-colors: active) {
-    .banner, .dialog { border-color: CanvasText; background: Canvas; color: CanvasText; forced-color-adjust: none; }
+    /* The banner and its buttons get NO overrides: the React banner has none,
+       so forced-colors must strip both implementations identically. */
+    .dialog { border-color: CanvasText; background: Canvas; color: CanvasText; forced-color-adjust: none; }
     .overlay { background: Canvas; }
-    .primary, .secondary, .tertiary, .close { border: 1px solid ButtonText; background: ButtonFace; color: ButtonText; }
     .switchTrack { border-color: CanvasText; background: Canvas; }
     .switch input:checked + .switchTrack { background: Highlight; }
     .switchTrack::before { background: CanvasText; }
@@ -856,7 +896,6 @@ export class DtCookieConsentElement extends DigitaltableteurElement {
       }),
       ` ${this.text("read-our-text", { en: "Read our", fi: "Lue", sv: "Läs vår" })} `,
       this.policyLink(),
-      ".",
     );
     copy.append(summary);
     bar.append(copy);

--- a/packages/web-components/src/native/menu.ts
+++ b/packages/web-components/src/native/menu.ts
@@ -59,6 +59,9 @@ const styles = `
     position: absolute;
     z-index: 6000;
     display: flex;
+    /* React's global reset makes the panel border-box, so its 11rem minimum
+       includes padding and border; shadow DOM gets no reset. */
+    box-sizing: border-box;
     min-inline-size: 11rem;
     padding: var(--space-internal-4);
     flex-direction: column;

--- a/packages/web-components/src/native/nav-menu-list.ts
+++ b/packages/web-components/src/native/nav-menu-list.ts
@@ -34,6 +34,9 @@ const styles = `
     padding: 0;
     flex-direction: column;
     gap: var(--dt-nav-menu-gap, var(--space-internal-8, 0.5rem));
+    /* The site's global typography (typography.css ul rule) doesn't cross
+       the shadow boundary; the React list inherits it. */
+    line-height: var(--line-height-relaxed, 1.625);
     list-style: none;
   }
   .navItem { margin: 0; padding: 0; }
@@ -81,18 +84,16 @@ const styles = `
       border-color: color-mix(in srgb, var(--color-primary, #111) 45%, transparent);
     }
   }
+  /* Parent-driven active outline, exactly as NavMenuList.module.css. */
+  @supports selector(:has(*)) {
+    .navItem:has(> .navLink[aria-current="page"]) {
+      outline: 2px solid
+        color-mix(in srgb, var(--color-primary, #111) 100%, transparent);
+      outline-offset: 2px;
+    }
+  }
   @media (prefers-reduced-motion: reduce) {
     .navLink { transition: none; }
-  }
-  @media (forced-colors: active) {
-    .navLink { color: LinkText; forced-color-adjust: none; }
-    .navLink:hover { background: Canvas; }
-    .navLinkActive {
-      border-color: Highlight;
-      background: Highlight;
-      color: HighlightText;
-    }
-    .navLinkActive::after { border-color: HighlightText; }
   }
 `;
 

--- a/packages/web-components/src/native/split-button.ts
+++ b/packages/web-components/src/native/split-button.ts
@@ -63,6 +63,9 @@ const styles = `
     border-radius: var(--radius-lg);
     font: inherit;
     font-family: var(--primary-body-font);
+    /* React Button wraps its label in a line-height:1 span, so min-block-size
+       (not the inherited body line box) decides the control height. */
+    line-height: 1;
     text-decoration: none;
     white-space: nowrap;
     cursor: pointer;
@@ -138,6 +141,13 @@ const styles = `
     padding-inline: var(--space-internal-24);
     font-size: var(--font-size-button-l);
   }
+  /* After the size rules, as in Button.module.css: the toggle's narrow
+     padding must beat the per-size padding-inline. */
+  .toggle { padding-inline: var(--space-internal-12); }
+  /* Touch targets: >= 44px on small viewports, matching Button.module.css. */
+  @media (width <= 768px) {
+    .sm, .md { min-block-size: 2.75rem; }
+  }
   .rounded { border-radius: 9999px; }
   .rounded.primary { border-end-end-radius: 0; border-start-end-radius: 0; }
   .rounded.toggle { border-end-start-radius: 0; border-start-start-radius: 0; }
@@ -171,27 +181,23 @@ const styles = `
     background: color-mix(in srgb, var(--color-muted) 50%, transparent);
   }
   .labelFallback { display: inline-flex; }
+  /* 1.5rem matches the React caret Icon box; with md padding it is exactly
+     what makes the secondary segments 44px tall (React parity). */
   .caret {
     display: inline-flex;
-    inline-size: 1rem;
-    block-size: 1rem;
+    inline-size: 1.5rem;
+    block-size: 1.5rem;
     align-items: center;
     justify-content: center;
-  }
-  .caret::before {
-    content: "";
-    inline-size: 0.5rem;
-    block-size: 0.5rem;
-    border-inline-end: 2px solid currentcolor;
-    border-block-end: 2px solid currentcolor;
-    rotate: 45deg;
-    translate: 0 -15%;
   }
   .menu {
     position: absolute;
     inset-block-start: calc(100% + 0.375rem);
     z-index: 6000;
     display: flex;
+    /* React's global reset makes the panel border-box, so its 11rem minimum
+       includes padding and border; shadow DOM gets no reset. */
+    box-sizing: border-box;
     min-inline-size: 11rem;
     padding: var(--space-internal-4);
     flex-direction: column;
@@ -265,8 +271,8 @@ const styles = `
     .toggle:active:not(:disabled) { transform: none; }
   }
   @media (forced-colors: active) {
-    .primary,
-    .toggle,
+    /* The buttons get NO forced-color-adjust: the React Button has none, so
+       forced-colors must strip both implementations identically. */
     .menu {
       forced-color-adjust: none;
     }
@@ -983,6 +989,11 @@ export class DtSplitButtonElement extends DigitaltableteurElement {
     const caret = this.ownerDocument.createElement("span");
     caret.className = "caret";
     caret.setAttribute("aria-hidden", "true");
+    // The same Phosphor glyph the React caret renders (<Icon name="caret-down">).
+    const caretGlyph = this.ownerDocument.createElement("dt-icon");
+    caretGlyph.setAttribute("name", "caret-down");
+    caretGlyph.setAttribute("aria-hidden", "true");
+    caret.append(caretGlyph);
     toggle.append(caret);
 
     wrapper.append(primary, toggle);

--- a/packages/web-components/web-components.config.mjs
+++ b/packages/web-components/web-components.config.mjs
@@ -1451,9 +1451,7 @@ const elementDefinitions = [
     nativeClassName: "DtSplitButtonElement",
     description:
       "Primary action paired with an accessible menu of related actions.",
-    storyParity: storyParity({
-      equivalents: [{ react: "Example (document toolbar)", native: "Example" }],
-    }),
+    storyParity: storyParity(),
     props: [
       stringProp("label"),
       {

--- a/scripts/design-system/rendered-parity.roster.mjs
+++ b/scripts/design-system/rendered-parity.roster.mjs
@@ -18,10 +18,14 @@ export const enforced = [
   "Avatar",
   "BlogMediaImage",
   "Container",
+  "CookieConsent",
   "IconButton",
   "List",
+  "Menu",
+  "NavMenuList",
   "SelectOption",
-  "SkipLink"
+  "SkipLink",
+  "SplitButton"
 ];
 
 export const exceptions = [];


### PR DESCRIPTION
## Summary

First component-by-component wave of the rendered-parity audit (gate shipped in #1231). All four targets are now **pixel-identical (ratio 0.0000) to their React twins across the full comparison matrix** and enrolled in the enforcement roster. Fleet score moves from visual 75/404 → 91/408, geometry 137/404 → 152/408, enforced 7/84 → 11/84.

## CookieConsent (was the worst offender at 95.6%)

The headline finding: the React `Default`/`Example` stories rendered **null** (global preview decorator mounts `autoShow={false}`; only Playground opted back in), so every prior comparison ran against a blank canvas. The React stories now force-show the banner, and their a11y snapshots capture the real banner tree instead of the WIP-badge line.

Native banner trued to the React render:
- Canonical copy ("Cookies improve your experience."), no trailing period after the policy link.
- The site wavy-underline link treatment, with the banner's out-of-flow underline geometry and React Link's atomic `inline-flex` wrapping (this is what makes the text wrap at the same point).
- Button md typography (`--font-size-button-m`, weight 400, `line-height: 1`), `border: none` base with the secondary 2px border, `box-sizing: border-box`.
- Optical-shift copy centering, `min-block-size` on bar/copy, mobile top padding `--space-layout-24`, mobile text-s/snug summary, 44px touch targets at ≤768px.
- Forced-colors overrides on the banner/buttons **removed**: React has none, so forced-colors must strip both implementations identically.

## Menu

`box-sizing: border-box` on the native panel. React's global reset makes the panel border-box, so its 11rem minimum includes padding and border; the shadow DOM gets no reset — that was the whole 10px-wider-panel geometry finding.

## SplitButton

- React `Example` had display name "Example (document toolbar)" so the exact-name pairing never compared it — renamed to canonical `Example` (story ID unchanged, snapshots unaffected; stale `equivalents` entry removed from the config).
- Native Example now replicates the React document-toolbar composition (Save primary + Export secondary) on a padded canvas.
- Native fixes: `line-height: 1` labels (React wraps labels in a line-height-1 span so `min-block-size` decides control height), real Phosphor `caret-down` via `dt-icon` at the 1.5rem React icon box (this also reproduces React's 44px secondary-segment height), toggle `padding-inline` re-asserted after the size rules (was losing to `.md`), panel `border-box`, ≤768px touch-target rule, no `forced-color-adjust` on the buttons.

## NavMenuList

- Native story is now a replica: bare full-width list on a padded canvas with `currentPath: "/"` (React's `useNavigationPathname()` falls back to `/` in Storybook, so Home is active).
- Native styles: the global `ul { line-height: 1.625 }` from typography.css doesn't cross the shadow boundary — added to `.nav`; the `:has()` active-item outline added; native-only forced-colors block removed (same rationale as above).

## Verification

- `check:rendered-parity`: all four components 5/5 visual + 5/5 geometry (0.0000 in every mode); full sweep green with 0 enforced failures; `--update-roster` enrolled exactly these four.
- Local gate: typecheck, lint, 2658 tests, `check:contract-props`, `check:consumers`, build — all exit 0.
- `check:web-components` + story-name parity: 84 tags, 100% declared parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved cookie consent banner layout, typography, button styling, policy-link presentation, mobile responsiveness, and touch targets.
  - Improved cookie consent behavior and appearance in high-contrast mode.
  - Updated split buttons with refined sizing, spacing, typography, and a clearer caret icon.
  - Improved navigation active-state outlines and line-height consistency.
  - Added broader visual consistency coverage across related component variants.

- **Documentation**
  - Updated component examples to better demonstrate cookie consent, navigation, and split-button layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->