### PR TITLE
fix(design-system): rendered-parity audit wave 2 — Badge, Testimonial, GroupLabel pixel-identical + enrolled

### DIFF
--- a/nextjs-app/shared/components/Testimonial/Testimonial.stories.tsx
+++ b/nextjs-app/shared/components/Testimonial/Testimonial.stories.tsx
@@ -148,13 +148,16 @@ export const Playground: Story = {
     linkedinUrl: "https://linkedin.com/in/sarahjohnson",
   },
 };
+// Default is a StoryFn (a function): spreading it copies nothing, so
+// `...Default` produced render-less stories that mounted an empty
+// Testimonial. Use it as the render function instead.
 export const Example = {
   tags: ["beta-matrix"],
   parameters: { controls: { disable: true } },
-  ...Default,
+  render: Default,
 };
 export const ForcedColors = {
   tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
-  ...Default,
+  render: Default,
 };

--- a/nextjs-app/shared/stories/WebComponents/Badge/Badge.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/Badge/Badge.stories.tsx
@@ -11,7 +11,7 @@ import {
 type Args = {
   label: string;
   variant: "primary" | "secondary";
-  tone: "neutral" | "info" | "success" | "warning" | "error";
+  tone: "" | "neutral" | "info" | "success" | "warning" | "error";
   size: "sm" | "md" | "lg";
   removable: boolean;
   dot: boolean;
@@ -25,12 +25,17 @@ const meta = {
   tags: ["autodocs", "beta", "web-components"],
   parameters: {
     ...nativeStoryParameters,
+    // The React stories use the default padded canvas; centered starts
+    // content on fractional x and shifts glyph rasterization.
+    layout: "padded",
     docs: { description: { component: "Native dt-badge custom element." } },
   },
+  // Mirrors the React Playground/Default args (children "Badge", no tone —
+  // distinct from "neutral", exactly like the React optional tone prop).
   args: {
-    label: "Beta",
+    label: "Badge",
     variant: "primary",
-    tone: "warning",
+    tone: "",
     size: "md",
     removable: false,
     dot: false,
@@ -39,7 +44,7 @@ const meta = {
     variant: { control: "inline-radio", options: ["primary", "secondary"] },
     tone: {
       control: "select",
-      options: ["neutral", "info", "success", "warning", "error"],
+      options: ["", "neutral", "info", "success", "warning", "error"],
     },
     size: { control: "inline-radio", options: ["sm", "md", "lg"] },
     removable: { control: "boolean" },
@@ -127,8 +132,38 @@ export const AsCount: Story = {
   ...exampleStory,
   args: { label: "3", tone: "info", size: "sm" },
 };
+// Replica of the React Example (TonesContent): all variants and tones in a
+// wrapping flex row; the rendered-parity gate compares them 1:1.
 export const Example: Story = {
   ...exampleStory,
-  args: { label: "New", tone: "info" },
+  render: () => (
+    <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+      <NativeElement tagName="dt-badge" attributes={{ label: "Primary" }} />
+      <NativeElement
+        tagName="dt-badge"
+        attributes={{ label: "Secondary", variant: "secondary" }}
+      />
+      <NativeElement
+        tagName="dt-badge"
+        attributes={{ label: "Success", tone: "success" }}
+      />
+      <NativeElement
+        tagName="dt-badge"
+        attributes={{ label: "Error", tone: "error" }}
+      />
+      <NativeElement
+        tagName="dt-badge"
+        attributes={{ label: "Warning", tone: "warning" }}
+      />
+      <NativeElement
+        tagName="dt-badge"
+        attributes={{ label: "Info", tone: "info" }}
+      />
+      <NativeElement
+        tagName="dt-badge"
+        attributes={{ label: "Neutral", tone: "neutral" }}
+      />
+    </div>
+  ),
 };
 export const ForcedColors: Story = { ...forcedColorsStory };

--- a/nextjs-app/shared/stories/WebComponents/GroupLabel/GroupLabel.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/GroupLabel/GroupLabel.stories.tsx
@@ -93,36 +93,29 @@ export const AboveCompoundWidget: Story = {
   ),
 };
 
+// Replica of the React Example (same markup, classes, and padded canvas);
+// the rendered-parity gate compares them 1:1.
 export const Example: Story = {
   ...exampleStory,
+  parameters: { layout: "padded" },
   render: () => (
-    <fieldset
-      id="native-contact-topic"
-      style={{
-        border: 0,
-        padding: 0,
-        margin: 0,
-        display: "grid",
-        gap: "0.75rem",
-        minWidth: "18rem",
-      }}
-    >
+    <fieldset style={{ border: 0, padding: 0, margin: 0 }}>
       <NativeElement
         tagName="dt-group-label"
         attributes={{
           content: "What can we help with?",
           for: "native-contact-topic",
-          hint: "Pick one or more topics. The label names the group rather than any single checkbox.",
         }}
       />
-      <label style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
-        <input type="checkbox" />
-        Strategy
-      </label>
-      <label style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
-        <input type="checkbox" />
-        Design
-      </label>
+      <div
+        id="native-contact-topic"
+        role="group"
+        aria-labelledby="contact-topic-label"
+      >
+        <p className="text-sm text-muted-foreground">
+          Checkbox group slots here
+        </p>
+      </div>
     </fieldset>
   ),
 };

--- a/nextjs-app/shared/stories/WebComponents/Testimonial/Testimonial.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/Testimonial/Testimonial.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import {
   NativeElement,
-  Stage,
   assertNative,
   exampleStory,
   forcedColorsStory,
@@ -17,21 +16,21 @@ type Args = {
   avatarUrl: string;
 };
 
+// No width Stage: the React stories render the bare full-width testimonial
+// on the padded canvas, and the rendered-parity gate compares them 1:1.
 function Testimonial(args: Args) {
   return (
-    <Stage width="40rem">
-      <NativeElement
-        tagName="dt-testimonial"
-        attributes={{
-          quote: args.quote,
-          name: args.name,
-          "person-title": args.title,
-          company: args.company,
-          "linkedin-url": args.linkedinUrl,
-          "avatar-url": args.avatarUrl,
-        }}
-      />
-    </Stage>
+    <NativeElement
+      tagName="dt-testimonial"
+      attributes={{
+        quote: args.quote,
+        name: args.name,
+        "person-title": args.title,
+        company: args.company,
+        "linkedin-url": args.linkedinUrl,
+        "avatar-url": args.avatarUrl,
+      }}
+    />
   );
 }
 

--- a/packages/web-components/src/native/badge.ts
+++ b/packages/web-components/src/native/badge.ts
@@ -16,13 +16,15 @@ export type DtBadgeSize = (typeof SIZES)[number];
 
 const toneIcons: Partial<Record<DtBadgeTone, string>> = {
   error: "x-circle",
-  warning: "warning-circle",
+  warning: "warning",
   success: "check-circle",
   info: "info",
 };
 
 const styles = `
-  :host { display: inline-block; vertical-align: middle; }
+  /* inline-flex like the React badge root: inline-block wraps the badge in a
+     line box whose leading adds a half pixel around icon content. */
+  :host { display: inline-flex; vertical-align: middle; }
   :host([hidden]) { display: none; }
   .badge { box-sizing: border-box; display: inline-flex; width: fit-content; height: 40px; padding: 0 var(--space-internal-16); align-items: center; gap: 0.25em; border: 2px solid transparent; border-radius: 999px; font-family: var(--primary-body-font); font-size: 1rem; font-weight: 600; letter-spacing: 0.02em; white-space: nowrap; overflow: hidden; }
   .sm { height: 32px; padding-inline: var(--space-internal-12); font-size: 0.75rem; }
@@ -76,11 +78,15 @@ export class DtBadgeElement extends DigitaltableteurElement {
   set variant(value: DtBadgeVariant) {
     reflectAttribute(this, "variant", value);
   }
-  get tone(): DtBadgeTone {
-    return enumAttribute(this, "tone", TONES, "neutral");
+  /**
+   * Tri-state like the React Badge's optional tone: an absent attribute means
+   * NO tone (the plain variant treatment), which is distinct from "neutral".
+   */
+  get tone(): DtBadgeTone | "" {
+    return enumAttribute<DtBadgeTone | "">(this, "tone", TONES, "");
   }
-  set tone(value: DtBadgeTone) {
-    reflectAttribute(this, "tone", value);
+  set tone(value: DtBadgeTone | "") {
+    reflectAttribute(this, "tone", value || null);
   }
   get size(): DtBadgeSize {
     return enumAttribute(this, "size", SIZES, "md");
@@ -128,7 +134,8 @@ export class DtBadgeElement extends DigitaltableteurElement {
     const explicitIcon = stringAttribute(this, "icon");
     const slottedIcon = hasNamedSlot(this, "icon");
     const iconName =
-      explicitIcon || (!this.dot ? toneIcons[this.tone] || "" : "");
+      explicitIcon ||
+      (!this.dot && this.tone ? toneIcons[this.tone] || "" : "");
     if (slottedIcon || iconName || this.dot) {
       const iconWrapper = this.ownerDocument.createElement("span");
       iconWrapper.className = "icon";

--- a/packages/web-components/src/native/group-label.ts
+++ b/packages/web-components/src/native/group-label.ts
@@ -22,16 +22,17 @@ const styles = `
     gap: var(--space-internal-4, 0.25rem);
   }
 
+  /* Mirrors GroupLabel.module.css exactly: fixed 1rem, weight 500, primary
+     color, 0.5rem gap, inherited line-height. */
   .label {
     display: inline-flex;
     align-items: center;
-    gap: var(--space-internal-4, 0.25rem);
+    gap: 0.5rem;
     margin: 0;
-    color: var(--color-text, var(--color-primary, currentColor));
-    font-family: var(--font-text, var(--primary-body-font));
-    font-size: var(--font-size-text-m, 1rem);
-    font-weight: 600;
-    line-height: var(--line-height-snug, 1.3);
+    color: var(--color-primary, currentColor);
+    font-family: var(--font-body, sans-serif);
+    font-size: 1rem;
+    font-weight: 500;
     cursor: pointer;
   }
 

--- a/packages/web-components/src/native/testimonial.ts
+++ b/packages/web-components/src/native/testimonial.ts
@@ -10,15 +10,33 @@ const styles = `
   :host([hidden]) { display: none; }
   blockquote { box-sizing: border-box; margin: 0; padding: 1.5rem; border: 1px solid var(--color-gray-light); border-radius: .5rem; background: var(--color-white); color: var(--color-text); box-shadow: 0 2px 4px rgb(0 0 0 / 10%); transition: box-shadow .2s ease-in-out; }
   blockquote:hover { box-shadow: 0 4px 8px rgb(0 0 0 / 15%); }
-  .quote { margin: 0 0 1rem; font-family: var(--font-text); font-style: italic; line-height: 1.6; }
+  /* The React card composes the Text component (quote + name = Text M, title
+     row = Text S) whose sizing and trailing margin live in Text.module.css;
+     shadow DOM must restate them. */
+  .quote { margin: 0 0 var(--space-layout-16, 1rem); font-family: var(--font-text); font-size: var(--font-size-text-m, 1rem); font-style: italic; line-height: 1.6; }
   footer { display: flex; align-items: flex-start; gap: .75rem; }
   img { inline-size: 3rem; block-size: 3rem; flex: none; border-radius: 50%; object-fit: cover; }
   .info { min-inline-size: 0; flex: 1; }
   .nameRow { display: flex; margin-block-end: .25rem; align-items: center; gap: .5rem; }
-  cite { font-family: var(--font-text); font-weight: 600; font-style: normal; }
-  a { display: inline-flex; align-items: center; color: var(--color-linkedin, #0077b5); text-decoration: none; transition: color .2s ease-in-out; }
+  cite { margin-block-end: var(--space-layout-16, 1rem); font-family: var(--font-text); font-size: var(--font-size-text-m, 1rem); font-weight: 600; font-style: normal; line-height: 1.6; }
+  /* The React LinkedIn link is the DS Link, which carries the site's global
+     wavy-underline treatment (variables.css). */
+  a { display: inline-flex; position: relative; padding-block-end: 6px; align-items: center; color: var(--color-linkedin, #0077b5); text-decoration: none; transition: color .2s ease-in-out; }
+  a::after {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    height: 6px;
+    background-color: var(--underline-accent-color, currentcolor);
+    opacity: 0.9;
+    content: "";
+    mask-image: var(--wavy-underline-mask);
+    mask-repeat: repeat-x;
+    mask-size: 16px 6px;
+  }
   a:hover { color: var(--color-linkedin-hover, #005885); }
-  .meta { margin: 0; color: var(--color-gray-medium); font-family: var(--font-text); font-size: var(--font-size-text-s, .875rem); line-height: 1.4; }
+  .meta { margin: 0 0 var(--space-layout-16, 1rem); color: var(--color-gray-medium); font-family: var(--font-text); font-size: var(--font-size-text-s, .875rem); font-style: italic; line-height: 1.4; }
   @media (prefers-reduced-motion: reduce) { blockquote, a { transition: none; } }
   @media (forced-colors: active) { blockquote { border-color: CanvasText; background: Canvas; color: CanvasText; box-shadow: none; } a { color: LinkText; } }
 `;

--- a/scripts/design-system/rendered-parity.roster.mjs
+++ b/scripts/design-system/rendered-parity.roster.mjs
@@ -16,16 +16,19 @@
  */
 export const enforced = [
   "Avatar",
+  "Badge",
   "BlogMediaImage",
   "Container",
   "CookieConsent",
+  "GroupLabel",
   "IconButton",
   "List",
   "Menu",
   "NavMenuList",
   "SelectOption",
   "SkipLink",
-  "SplitButton"
+  "SplitButton",
+  "Testimonial"
 ];
 
 export const exceptions = [];


### PR DESCRIPTION
## Summary

Wave 2 of the rendered-parity audit: **Badge, Testimonial, and GroupLabel are pixel-identical (0.0000) to their React twins across the full comparison matrix** and enrolled in the enforcement roster. Fleet score moves from visual 91/408 → 106/408, geometry 152/408 → 167/408, enforced 11/84 → 14/84.

## Badge

- Native Example replicates the React TonesContent showcase (all variants and tones in a wrapping row); native Default mirrors the React args (label "Badge", no tone).
- **API drift fixed:** `dt-badge` tone was defaulted to `neutral`, so the native badge could not render React's plain primary treatment at all. Tone is now tri-state like React's optional prop — absent attribute = plain variant, distinct from `tone="neutral"`.
- Warning tone renders the Phosphor `warning` triangle (was `warning-circle`).
- Host is `inline-flex` like the React badge root — `inline-block` wrapped the badge in a line box whose leading added a half pixel around icon content (visible as row-wrap drift at mobile width).

## Testimonial

- **Broken React showcase found:** `Example`/`ForcedColors` spread the `Default` StoryFn (`{ ...Default }`) — spreading a function copies no properties, so both stories mounted an **empty** `<Testimonial>`; the fleet report was comparing a 31px sliver of quote marks. They now use the showcase as their `render` function.
- Native story drops its 40rem Stage (React renders the bare full-width card).
- Native stylesheet restates what the React card gets from the Text component and global styles, which the shadow boundary filters out: text-m quote and name with Text's trailing margin, text-s italic title row at line-height 1.4, and the site wavy-underline treatment on the LinkedIn link.

## GroupLabel

- Native Example replicates the React Example markup (bare fieldset + group placeholder on a padded canvas) instead of an invented checkbox composition.
- Native label mirrors GroupLabel.module.css exactly: fixed 1rem, weight 500, `--font-body`, `--color-primary`, 0.5rem gap, inherited line-height (was text-m 20px, weight 600, `--font-text`, `--color-text` — which also diverged in dark mode).

## Verification

- `check:rendered-parity`: all three components 5/5 visual + 5/5 geometry; full sweep green, 0 enforced failures, `--update-roster` enrolled exactly these three.
- Local gate: typecheck, lint, 2658 tests, `check:contract-props`, `check:consumers`, build — all exit 0.
- `check:web-components` + story-name parity: 84 tags, 100% declared parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Badges now support an unstyled tone and display all available tone variants in examples.
  - Badge warning icons and layout have been refined for improved consistency.
  - Group labels and testimonials now use updated spacing, typography, and accessibility-focused examples.
  - Testimonial links feature enhanced underline styling.

- **Bug Fixes**
  - Corrected Storybook examples so testimonial stories render reliably.

- **Tests**
  - Added Badge, Group Label, and Testimonial examples to rendered parity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->