### PR TITLE
fix(design-system): AT snapshot capture includes role=menu/listbox portals

### DIFF
--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--alignments.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--alignments.yaml
@@ -1,0 +1,3 @@
+- button "Start"
+- button "Center"
+- button "End"

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--as-links.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--as-links.yaml
@@ -1,1 +1,6 @@
 - button "Account" [expanded]
+- menu "Account":
+  - menuitem "Profile"
+  - menuitem "Settings"
+  - separator
+  - menuitem "Sign out"

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--default.dark.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--default.dark.yaml
@@ -1,1 +1,6 @@
 - button "Actions" [expanded]
+- menu "Actions":
+  - menuitem "Edit ⌘E"
+  - menuitem "Duplicate"
+  - separator
+  - menuitem "Delete"

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--default.forced-colors.yaml
@@ -1,1 +1,6 @@
 - button "Actions" [expanded]
+- menu "Actions":
+  - menuitem "Edit ⌘E"
+  - menuitem "Duplicate"
+  - separator
+  - menuitem "Delete"

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--default.light.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--default.light.yaml
@@ -1,1 +1,6 @@
 - button "Actions" [expanded]
+- menu "Actions":
+  - menuitem "Edit ⌘E"
+  - menuitem "Duplicate"
+  - separator
+  - menuitem "Delete"

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--default.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--default.yaml
@@ -1,1 +1,6 @@
 - button "Actions" [expanded]
+- menu "Actions":
+  - menuitem "Edit ⌘E"
+  - menuitem "Duplicate"
+  - separator
+  - menuitem "Delete"

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--disabled.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--disabled.yaml
@@ -1,1 +1,5 @@
 - button "Actions" [expanded]
+- menu "Actions":
+  - menuitem "Rename"
+  - menuitem "Archive (unavailable)" [disabled]
+  - menuitem "Delete"

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--forced-colors.dark.yaml
@@ -1,1 +1,6 @@
 - button "Actions" [expanded]
+- menu "Actions":
+  - menuitem "Edit"
+  - menuitem "Duplicate"
+  - separator
+  - menuitem "Delete (unavailable)" [disabled]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--forced-colors.forced-colors.yaml
@@ -1,1 +1,6 @@
 - button "Actions" [expanded]
+- menu "Actions":
+  - menuitem "Edit"
+  - menuitem "Duplicate"
+  - separator
+  - menuitem "Delete (unavailable)" [disabled]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--forced-colors.light.yaml
@@ -1,1 +1,6 @@
 - button "Actions" [expanded]
+- menu "Actions":
+  - menuitem "Edit"
+  - menuitem "Duplicate"
+  - separator
+  - menuitem "Delete (unavailable)" [disabled]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--forced-colors.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--forced-colors.yaml
@@ -1,1 +1,6 @@
 - button "Actions" [expanded]
+- menu "Actions":
+  - menuitem "Edit"
+  - menuitem "Duplicate"
+  - separator
+  - menuitem "Delete (unavailable)" [disabled]

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--playground.dark.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--playground.dark.yaml
@@ -1,1 +1,6 @@
 - button "Actions" [expanded]
+- menu "Actions":
+  - menuitem "Edit ⌘E"
+  - menuitem "Duplicate"
+  - separator
+  - menuitem "Delete"

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--playground.forced-colors.yaml
@@ -1,1 +1,6 @@
 - button "Actions" [expanded]
+- menu "Actions":
+  - menuitem "Edit ⌘E"
+  - menuitem "Duplicate"
+  - separator
+  - menuitem "Delete"

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--playground.light.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--playground.light.yaml
@@ -1,1 +1,6 @@
 - button "Actions" [expanded]
+- menu "Actions":
+  - menuitem "Edit ⌘E"
+  - menuitem "Duplicate"
+  - separator
+  - menuitem "Delete"

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--playground.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--playground.yaml
@@ -1,1 +1,6 @@
 - button "Actions" [expanded]
+- menu "Actions":
+  - menuitem "Edit ⌘E"
+  - menuitem "Duplicate"
+  - separator
+  - menuitem "Delete"

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--with-icons.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--with-icons.yaml
@@ -1,1 +1,6 @@
 - button "File" [expanded]
+- menu "File":
+  - menuitem "Edit ⌘E"
+  - menuitem "Duplicate ⌘D"
+  - separator
+  - menuitem "Delete"

--- a/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--with-submenu.yaml
+++ b/nextjs-app/shared/components/Menu/__a11y-snapshots__/actions-menu--with-submenu.yaml
@@ -1,1 +1,6 @@
 - button "Share" [expanded]
+- menu "Share":
+  - menuitem "Copy link"
+  - menuitem "Invite people"
+  - separator
+  - menuitem "Export"

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--keyboard-multi-select.dark.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--keyboard-multi-select.dark.yaml
@@ -2,3 +2,5 @@
 - button "Remove badge"
 - combobox "Disciplines" [expanded]: acc
 - button "Toggle options" [expanded]
+- listbox "Disciplines":
+  - option "Accessibility" [selected]

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--keyboard-multi-select.forced-colors.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--keyboard-multi-select.forced-colors.yaml
@@ -2,3 +2,5 @@
 - button "Remove badge"
 - combobox "Disciplines" [expanded]: acc
 - button "Toggle options" [expanded]
+- listbox "Disciplines":
+  - option "Accessibility" [selected]

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--keyboard-multi-select.light.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--keyboard-multi-select.light.yaml
@@ -2,3 +2,5 @@
 - button "Remove badge"
 - combobox "Disciplines" [expanded]: acc
 - button "Toggle options" [expanded]
+- listbox "Disciplines":
+  - option "Accessibility" [selected]

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--keyboard-multi-select.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--keyboard-multi-select.yaml
@@ -2,3 +2,5 @@
 - button "Remove badge"
 - combobox "Disciplines" [expanded]: acc
 - button "Toggle options" [expanded]
+- listbox "Disciplines":
+  - option "Accessibility" [selected]

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--max-items.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--max-items.yaml
@@ -1,0 +1,5 @@
+- text: Disciplines (max 2) Research
+- button "Remove badge"
+- combobox "Disciplines (max 2)"
+- button "Toggle options"
+- paragraph: Pick up to two.

--- a/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--overflow.yaml
+++ b/nextjs-app/shared/components/MultiCombobox/__a11y-snapshots__/forms-multicombobox--overflow.yaml
@@ -1,0 +1,11 @@
+- text: Disciplines Research
+- button "Remove badge"
+- text: Design
+- button "Remove badge"
+- text: Frontend
+- button "Remove badge"
+- text: Accessibility
+- button "Remove badge"
+- combobox "Disciplines"
+- button "Toggle options"
+- paragraph: The field grows with every chip.

--- a/nextjs-app/shared/components/SelectableCard/SelectableCardGroup.stories.tsx
+++ b/nextjs-app/shared/components/SelectableCard/SelectableCardGroup.stories.tsx
@@ -54,9 +54,9 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-export const Playground: Story = {};
-export const Example: Story = {};
+export const Default: Story = { tags: ["beta-matrix"] };
+export const Playground: Story = { tags: ["beta-matrix"] };
+export const Example: Story = { tags: ["beta-matrix"] };
 export const MultiSelect: Story = { args: { type: "multiple" } };
 export const Horizontal: Story = { args: { orientation: "horizontal" } };
 export const Disabled: Story = { args: { disabled: true } };
@@ -64,5 +64,6 @@ export const WithError: Story = {
   args: { error: "Choose at least one plan." },
 };
 export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
 };

--- a/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--nested-submenus.yaml
+++ b/nextjs-app/shared/components/SplitButton/__a11y-snapshots__/actions-splitbutton--nested-submenus.yaml
@@ -1,2 +1,8 @@
 - button "Publish"
 - button "More options" [expanded]
+- menu "More options":
+  - menuitem "Environment" [expanded]
+  - menuitem "Notify"
+- menu "Environment":
+  - menuitem "Production"
+  - menuitem "Staging"

--- a/scripts/design-system/a11y-snapshot-capture-lib.mjs
+++ b/scripts/design-system/a11y-snapshot-capture-lib.mjs
@@ -1,5 +1,14 @@
 /**
- * Storybook AT snapshot capture — includes portaled overlays (Modal, etc.).
+ * Storybook AT snapshot capture — includes portaled overlays: dialogs (Modal,
+ * etc.) plus Radix dropdown menus (role="menu") and select popovers
+ * (role="listbox"), which portal to <body> and were invisible to the snapshot
+ * before. Menu/listbox capture is guarded so content already present in
+ * another captured part is not captured twice: :not(#storybook-root *)
+ * excludes inline menus (in the root snapshot), and :not([role="dialog"] *)
+ * / :not([role="alertdialog"] *) excludes ones nested inside a portaled
+ * dialog (e.g. CommandPalette's listbox, already in the dialog part).
+ * Dialogs keep the historical unguarded selector so existing snapshots stay
+ * byte-stable.
  * @param {import('@playwright/test').Page} page
  */
 export async function captureStoryAccessibilityTree(page) {
@@ -7,7 +16,12 @@ export async function captureStoryAccessibilityTree(page) {
   const rootSnap = await page.locator("#storybook-root").ariaSnapshot();
   parts.push(typeof rootSnap === "string" ? rootSnap : String(rootSnap));
 
-  const portaled = page.locator('[role="alertdialog"], [role="dialog"]');
+  const portaledOverlayGuard =
+    ':not(#storybook-root *):not([role="dialog"] *):not([role="alertdialog"] *)';
+  const portaled = page.locator(
+    '[role="alertdialog"], [role="dialog"], ' +
+      `[role="menu"]${portaledOverlayGuard}, [role="listbox"]${portaledOverlayGuard}`,
+  );
   const count = await portaled.count();
   for (let i = 0; i < count; i++) {
     const snap = await portaled.nth(i).ariaSnapshot();


### PR DESCRIPTION
## Summary
- Closes the a11y-capture blind spot: the snapshot lib only appended `role=dialog/alertdialog` portals, so Radix dropdown menus (`role=menu`) and portaled listboxes were invisible to the AT gate — Menu/SplitButton item content (including the new ListItem meta slot from #1234) never appeared in any snapshot.
- `a11y-snapshot-capture-lib.mjs` now also captures `role=menu` and `role=listbox` portals, guarded with `:not(#storybook-root *)` and `:not([role=dialog] *)/:not([role=alertdialog] *)` so inline menus and dialog-hosted listboxes (CommandPalette) are not captured twice.
- Bootstrapped the newly visible content: 16 Menu yamls across plain/light/dark/forced-colors, SplitButton `nested-submenus` (parent + nested submenu portals), and MultiCombobox `keyboard-multi-select` (its listbox portals to body — a second blind spot found in passing).
- New coverage: `actions-menu--alignments` (new story from #1234, closed menus so buttons only), MultiCombobox `max-items`/`overflow` plain yamls.
- SelectableCardGroup lifecycle stories gain the `beta-matrix` tag (tagger straggler that would resurface on every matrix run).

## Deliberately NOT included
Update runs surfaced unrelated drift which was reverted, not committed:
- Stale `- status: Work in progress (beta)` lines in ~50 yamls of components since promoted to stable (Switch, Breadcrumb, DonnyAvatar, WorkNav, BlogNav, Timestamp, …).
- ~200 missing themed yamls (never-bootstrapped modes, tracked as backfill debt).
Both are separate concerns; happy to sweep them in a follow-up.

## Verification
- Scoped runner passes in all four modes in update mode with zero residual drift after the final capture; CommandPalette snapshots byte-stable under the new guard (double-capture bug caught and fixed during review).
- Local gate: typecheck, lint, full tests (2679), build — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved accessibility coverage for menus, nested submenus, split buttons, and multi-select controls.
  * Expanded snapshots now include opened menu items, separators, disabled options, listboxes, and selected values.
  * Added coverage for menu alignment, overflow, and maximum-selection states.

* **Tests**
  * Accessibility validation now captures portaled menus and listboxes, improving verification across themes and forced-colors mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->