### PR TITLE
fix(design-system): WC landmark-unique + stale-node pagination play

### DIFF
--- a/nextjs-app/shared/stories/WebComponents/Breadcrumb/Breadcrumb.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/Breadcrumb/Breadcrumb.stories.tsx
@@ -197,8 +197,20 @@ export const Comparison: Story = {
   tags: ["example"],
   render: () => (
     <Row>
-      <NativeBreadcrumb items={site} underline="always" homeIcon={false} />
-      <NativeBreadcrumb items={deep} underline="hover" homeIcon={true} />
+      {/* Distinct labels keep the two nav landmarks distinguishable
+          (axe landmark-unique), same as UnderlineModes above. */}
+      <NativeBreadcrumb
+        items={site}
+        underline="always"
+        ariaLabel="Site trail"
+        homeIcon={false}
+      />
+      <NativeBreadcrumb
+        items={deep}
+        underline="hover"
+        ariaLabel="Deep trail"
+        homeIcon={true}
+      />
     </Row>
   ),
 };

--- a/nextjs-app/shared/stories/WebComponents/Pagination/Pagination.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/Pagination/Pagination.stories.tsx
@@ -106,9 +106,26 @@ export const SiblingCount: Story = {
   tags: ["example"],
   render: () => (
     <Stack>
-      <ControlledPagination currentPage={10} totalPages={20} siblingCount={0} />
-      <ControlledPagination currentPage={10} totalPages={20} siblingCount={1} />
-      <ControlledPagination currentPage={10} totalPages={20} siblingCount={2} />
+      {/* Distinct labels keep the three nav landmarks distinguishable
+          (axe landmark-unique). */}
+      <ControlledPagination
+        currentPage={10}
+        totalPages={20}
+        siblingCount={0}
+        ariaLabel="Pagination, no siblings"
+      />
+      <ControlledPagination
+        currentPage={10}
+        totalPages={20}
+        siblingCount={1}
+        ariaLabel="Pagination, one sibling"
+      />
+      <ControlledPagination
+        currentPage={10}
+        totalPages={20}
+        siblingCount={2}
+        ariaLabel="Pagination, two siblings"
+      />
     </Stack>
   ),
 };
@@ -124,7 +141,12 @@ export const Interactive: Story = {
     if (!pageTwo) throw new Error("Could not find page 2 button.");
     await userEvent.click(pageTwo);
     await waitFor(() => {
-      expect(pageTwo).toHaveAttribute("aria-current", "page");
+      // Re-query: the page-change round-trip re-renders the shadow list, so
+      // the pre-click node reference can go stale.
+      const current = element.shadowRoot?.querySelector(
+        "button[aria-label=\"Page 2\"]",
+      );
+      expect(current).toHaveAttribute("aria-current", "page");
     });
   },
 };


### PR DESCRIPTION
## Summary
- **WC Breadcrumb `Comparison`**: both `dt-breadcrumb` navs carried the default aria-label "Breadcrumb" → axe `landmark-unique` failure. Now labelled "Site trail" / "Deep trail", following the pattern `UnderlineModes` already uses in the same file.
- **WC Pagination `SiblingCount`**: three identical nav landmarks → distinct per-instance labels.
- **WC Pagination `Interactive` play** (bonus, from the pre-existing-failures list): the play asserted `aria-current` on the button reference held from before the click; in the runner environment the page-change round-trip re-renders the shadow list and the held node goes stale (reads null). The assertion now re-queries inside `waitFor`. Verified the component itself was always correct (fresh node carries `aria-current="page"`).

## Sweep
Checked the remaining nav-producing stories for the duplicate-landmark pattern: WC BlogNav / WorkNav / NavMenuList are single-instance; React Breadcrumb multi-instance stories already use distinct labels; React Pagination stories are single-instance. Menu/SplitButton/Badge comparison stories don't produce landmarks, so the rule can't fire there. No AT snapshots exist for WC story dirs — no yaml churn.

## Verification
WC Breadcrumb + Pagination suites 19/19 against a live Storybook; typecheck, lint, 2679 tests, build all exit 0.

Note for the "pre-existing story-suite failures" chip: Pagination Interactive is fixed here — remaining items there are the 4 color-contrast stories, WC FileUpload/CodeSnippet plays, Button/TransformingActionInput runner errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added distinct accessible labels to breadcrumb and pagination examples, making navigation landmarks easier to distinguish.
  * Improved pagination interaction checks to accurately verify the current page after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->