### PR TITLE
fix(wc): button-group seam collapse lost to light-DOM context; ::slotted audit

### DIFF
--- a/packages/web-components/src/native/button-group.ts
+++ b/packages/web-components/src/native/button-group.ts
@@ -8,7 +8,11 @@ const styles = `
   :host { display: inline-flex; }
   .group { display: inline-flex; align-items: stretch; }
   .spaced { gap: var(--space-internal-8); }
-  ::slotted([data-dt-group-position]:not([data-dt-group-position="first"])) { margin-inline-start: -1px; }
+  /* !important: on pages with a global reset the normal ::slotted declaration
+     loses to the outer document context (same trap as dt-menu, #1237) and the
+     attached buttons render a 2px double-border seam instead of collapsing
+     to 1px. Verified: the normal declaration computes to 0 in Storybook. */
+  ::slotted([data-dt-group-position]:not([data-dt-group-position="first"])) { margin-inline-start: -1px !important; }
 `;
 
 export class DtButtonGroupElement extends DigitaltableteurElement {


### PR DESCRIPTION
## Summary
Completes the ::slotted reset-stomp audit chip (follow-up to #1237). Every candidate was verified **live** in Storybook (computed value vs declared value), and only one real fix was needed.

| Component | Verdict | Detail |
|---|---|---|
| **button-group** | **FIXED** | `-1px` seam collapse computed to 0 → attached buttons showed a 2px double border. Only an `!important` shadow declaration applies (verified with injected test rules); now marked `!important` with a comment. |
| avatar-group | Safe | The `-8px` overlap is stamped as an **inline style** during adoption ([avatar-group.ts:93](packages/web-components/src/native/avatar-group.ts:93)) — already immune; the `::slotted` rule is belt-and-braces. |
| list | Safe | `::slotted(li)` margin applies correctly (9px computed). |
| accordion | Dead selectors | `.title::slotted` / `.content::slotted` never match — the class is on the wrapper div, not the slot. Reset-independent; left as-is since making them match would change visuals locked by parity gates. |
| expandable-section | Dead selector | Same pattern (`.inner` is the wrapper). Left as-is. |
| modal | No-op | Icon `margin: 0` equals the reset value either way. |

## Mechanism refinement over #1237
The `@layer`'d preflight `* { margin/padding: 0 }` does **not** stomp `::slotted` (avatar/list apply fine). The observed stompers are the unlayered button/element-specific preflight rules (the menu case) and an unidentified context effect on `dt-button` (no matching outer rule found in document or adopted stylesheets, yet only `!important` applies). Practical rule: audit by computed-vs-declared per component, not by blanket theory.

## Verification
- ButtonGroup scoped rendered-parity passes (geometry 4/5 gated) with the seam restored.
- Full rendered-parity roster passes: visual 112/413, geometry 173/413, enforced 15/85.
- Scoped WC story check ok; typecheck, lint, 2679 tests, build all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)