### PR TITLE
fix(design-system): harden accessible-name fallbacks against empty strings

### DIFF
--- a/nextjs-app/shared/components/Card/Card.tsx
+++ b/nextjs-app/shared/components/Card/Card.tsx
@@ -196,8 +196,10 @@ export const Card: React.FC<CardProps> = ({
               )}
             </div>
           )}
+          {/* || not ??: Storybook's seeded text controls pass "", and an
+              empty accessible name is never valid — fall back to the href. */}
           {effectiveLink && !title && (
-            <a href={effectiveLink} className={styles.cardLink} aria-label={linkLabel ?? effectiveLink} />
+            <a href={effectiveLink} className={styles.cardLink} aria-label={linkLabel || effectiveLink} />
           )}
         </>
       )}

--- a/nextjs-app/shared/components/ChatWidget/ChatComposer.tsx
+++ b/nextjs-app/shared/components/ChatWidget/ChatComposer.tsx
@@ -72,8 +72,10 @@ const ChatComposer = React.forwardRef<ChatComposerHandle, ChatComposerProps>(
     const resolvedPlaceholder =
       placeholder ??
       t("chatPlaceholder", "Ask about a project, service, or approach…");
-    const resolvedLabel = label ?? t("chatInputLabel", "Ask Donny a question");
-    const resolvedSendLabel = sendLabel ?? t("chatSend", "Send message");
+    // || not ??: Storybook's seeded text controls pass "", and an empty
+    // accessible name is never valid — fall back to the translations.
+    const resolvedLabel = label || t("chatInputLabel", "Ask Donny a question");
+    const resolvedSendLabel = sendLabel || t("chatSend", "Send message");
     // Visible label; resolvedSendLabel stays the accessible name and
     // contains it, satisfying WCAG 2.5.3 Label in Name.
     const sendButtonText = t("chatSendLabel", "Send");

--- a/nextjs-app/shared/components/ChatWidget/ChatToolResultSection.tsx
+++ b/nextjs-app/shared/components/ChatWidget/ChatToolResultSection.tsx
@@ -17,7 +17,12 @@ const ChatToolResultSection: React.FC<ChatToolResultSectionProps> = ({
   }
 
   return (
-    <section className={styles.toolResultSection} aria-label={meta.sectionTitle ?? meta.toolLabel}>
+    <section
+      className={styles.toolResultSection}
+      /* || not ??: an empty sectionTitle must not blank the region's
+         accessible name — fall back to the tool label. */
+      aria-label={meta.sectionTitle || meta.toolLabel}
+    >
       <div className={styles.toolResultMeta}>
         <Icon name="Wrench" size="xs" decorative />
         <span className={styles.toolResultMetaLabel}>

--- a/nextjs-app/shared/components/ChatWidget/ChatWidget.tsx
+++ b/nextjs-app/shared/components/ChatWidget/ChatWidget.tsx
@@ -438,9 +438,11 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({
     emailWorkflowReducer,
     initialEmailWorkflowState,
   );
-  const resolvedTitle = title ?? t("chatTitle", "Chat with Donny");
+  // || not ??: Storybook's seeded text controls pass "", and an empty
+  // dialog title/description is never valid — fall back to the translations.
+  const resolvedTitle = title || t("chatTitle", "Chat with Donny");
   const resolvedDescription =
-    description ?? t("chatDescription", "Brand-specific answers, no fluff.");
+    description || t("chatDescription", "Brand-specific answers, no fluff.");
   const placeholderText = t("chatPlaceholder", "Ask me anything…");
   const inputLabelText = t("chatInputLabel", "Ask Donny a question");
   const sendLabelText = t("chatSend", "Send message");

--- a/nextjs-app/shared/components/Lightbox/Lightbox.tsx
+++ b/nextjs-app/shared/components/Lightbox/Lightbox.tsx
@@ -102,7 +102,9 @@ export function Lightbox({
         className={styles.panel}
         role="dialog"
         aria-modal="true"
-        aria-label={currentImage?.alt ?? "Image gallery"}
+        /* || not ??: alt="" is a valid decorative-image value, but the
+           dialog itself must always carry an accessible name. */
+        aria-label={currentImage?.alt || "Image gallery"}
       >
         <button
           type="button"

--- a/nextjs-app/shared/components/MCPActionButton/MCPActionButton.tsx
+++ b/nextjs-app/shared/components/MCPActionButton/MCPActionButton.tsx
@@ -132,7 +132,9 @@ export const MCPActionButton: React.FC<MCPActionButtonProps> = (props) => {
 
       return (
         <Button href={href} {...rest} {...commonProps}>
-          {children ?? t("mcpActionButton.label")}
+          {/* || not ??: an empty children string must not blank the button
+              label — fall back to the translated default. */}
+          {children || t("mcpActionButton.label")}
         </Button>
       );
     }
@@ -152,7 +154,9 @@ export const MCPActionButton: React.FC<MCPActionButtonProps> = (props) => {
 
     return (
       <Button {...rest} {...commonProps}>
-        {children ?? t("mcpActionButton.label")}
+        {/* || not ??: an empty children string must not blank the button
+            label — fall back to the translated default. */}
+        {children || t("mcpActionButton.label")}
       </Button>
     );
   };

--- a/packages/web-components/src/native/cookie-consent.ts
+++ b/packages/web-components/src/native/cookie-consent.ts
@@ -1014,7 +1014,9 @@ export class DtCookieConsentElement extends DigitaltableteurElement {
       input.type = "checkbox";
       input.checked = this.draftValue[category.id] === true;
       input.disabled = category.required === true;
-      input.setAttribute("aria-label", category.toggleLabel ?? category.label);
+      // || not ??: an empty toggleLabel from consumer data must not blank
+      // the checkbox's accessible name — fall back to the category label.
+      input.setAttribute("aria-label", category.toggleLabel || category.label);
       input.addEventListener("change", () => {
         this.draftValue = this.normalizeValue({
           ...this.draftValue,


### PR DESCRIPTION
## Summary
Completes the empty-string aria fallback audit (the seeded-`""` leak class — SocialShare #852 and Tabs #1238 precedents). `?? fallback` on an accessible-name source keeps an empty string and blanks the name; `||` lets it fall through to the fallback. Seven sites across six files, each with the one-line comment from the Tabs pattern:

| Site | Fix |
|---|---|
| [Card.tsx](nextjs-app/shared/components/Card/Card.tsx) | link-overlay anchor: `linkLabel \|\| effectiveLink` |
| [ChatToolResultSection.tsx](nextjs-app/shared/components/ChatWidget/ChatToolResultSection.tsx) | section label: `sectionTitle \|\| toolLabel` |
| [Lightbox.tsx](nextjs-app/shared/components/Lightbox/Lightbox.tsx) | dialog label: `alt \|\| "Image gallery"` (alt="" is valid for an image, never for a dialog name) |
| [ChatWidget.tsx](nextjs-app/shared/components/ChatWidget/ChatWidget.tsx) | title/description `\|\|` translations |
| [ChatComposer.tsx](nextjs-app/shared/components/ChatWidget/ChatComposer.tsx) | input + send-button labels `\|\|` translations |
| [MCPActionButton.tsx](nextjs-app/shared/components/MCPActionButton/MCPActionButton.tsx) | `children \|\|` translated label (both render paths) |
| [cookie-consent.ts](packages/web-components/src/native/cookie-consent.ts) (WC) | toggle input label: `toggleLabel \|\| label` |

**Deliberately unchanged:** visible-text fallback chains (Combobox placeholder, HelsinkiClock timezone, SplitButton keys, native combobox option labels) — an empty string there is cosmetic, not an accessible-name violation.

## Verification
No current story renders the affected empty paths (Card stories always pair link+title; ChatWidget stories pass explicit titles; MCPActionButton stories set children), so these are hardening fixes with **zero AT snapshot churn** — confirmed by scoped suite runs: Card, ChatWidget (all subcomponent suites), Lightbox, MCPActionButton, WC CookieConsent, WC Card — 12 suites, 75/75, no yaml delta. Local gate: typecheck, lint, 2679 tests, build all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)