### PR TITLE
fix(design-system): clear remaining story-suite failures (contrast + plays)

### DIFF
--- a/nextjs-app/shared/components/Button/Button.stories.tsx
+++ b/nextjs-app/shared/components/Button/Button.stories.tsx
@@ -1,6 +1,6 @@
 import contract from "./Button.contract.json";
 import { action } from "storybook/actions";
-import { userEvent, within, expect } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 import React from "react";
 import { Meta, StoryFn, type StoryObj } from "@storybook/react-vite";
 import Button from "@dt/Button";
@@ -227,12 +227,18 @@ export const Default = Primary;
 Primary.args = {
   variant: "primary",
   children: <Label tKey="buttonPrimary" />,
+  // fn() spy: the play asserts toHaveBeenCalled(), which throws
+  // "not a spy" on a plain action-logger arg in Storybook 10.
+  onClick: fn(),
 };
 Primary.play = async ({ canvasElement, args }) => {
   const canvas = within(canvasElement);
   const button = canvas.getByRole("button");
   await userEvent.click(button);
   expect(args.onClick).toHaveBeenCalled();
+  // Keyboard reachability: the click leaves the button focused, so reset
+  // focus first — tab() would otherwise move focus OFF the button.
+  button.blur();
   await userEvent.tab();
   expect(button).toHaveFocus();
 };

--- a/nextjs-app/shared/components/Label/Label.spec.md
+++ b/nextjs-app/shared/components/Label/Label.spec.md
@@ -29,6 +29,13 @@ fieldset) or help text (use HelperText).
 - Tokens: drives from `--color-text` (default), `--color-text-muted`
   (disabled), and `--color-required` (asterisk). Forced-colors mode
   overrides the disabled muted colour with the system `GrayText` keyword.
+- Axe exemption (documented): the disabled label colour is intentionally
+  sub-AA (3.19:1 on white). WCAG 1.4.3 exempts text that is part of an
+  inactive user interface component, and a label of a disabled control is
+  part of that component — axe cannot infer the association, so the
+  Disabled stories (React and dt-label) disable the color-contrast rule
+  with a pointer to this note. Do not reuse the muted colour for active
+  text.
 - Figma: https://www.figma.com/design/digitaltableteur/forms — keep
   required-marker styling aligned with the Figma form-field component.
 - The translation surface is implicit: consumers pass already-translated

--- a/nextjs-app/shared/components/Label/Label.stories.tsx
+++ b/nextjs-app/shared/components/Label/Label.stories.tsx
@@ -159,6 +159,12 @@ Disabled.args = {
   children: "storyLabelDisabled",
   disabled: true,
 };
+// Documented axe exemption (see Label.spec.md): the muted disabled-label
+// color is intentionally sub-AA — WCAG 1.4.3 exempts text that is part of
+// an inactive control, but axe cannot tell a label belongs to one.
+Disabled.parameters = {
+  a11y: { options: { rules: [{ id: "color-contrast", enabled: false }] } },
+};
 
 Default.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);

--- a/nextjs-app/shared/components/PersonCard/PersonCard.module.css
+++ b/nextjs-app/shared/components/PersonCard/PersonCard.module.css
@@ -117,6 +117,12 @@
   font-family: var(--font-text);
   color: var(--color-white);
 }
+
+.personGrid:global(.custom-person-card) a {
+  /* The demo darkens the card surface (--color-muted); links must flip to
+     white with the rest of the text or they fall to 3.2:1 contrast. */
+  color: var(--color-white);
+}
 /* stylelint-enable selector-pseudo-class-no-unknown, selector-class-pattern */
 
 @media (width <= 768px) {

--- a/nextjs-app/shared/components/Switch/Switch.spec.md
+++ b/nextjs-app/shared/components/Switch/Switch.spec.md
@@ -31,3 +31,9 @@ not a checkbox.
 - Label and HelperText composition is internal — the consumer passes
   strings, the component owns the layout. Different from Checkbox, where
   the consumer composes the surrounding atoms manually.
+- Axe exemption (documented): while `loading` the control is inert
+  (interaction blocked, `aria-busy`) and its label takes the muted
+  disabled colour, intentionally sub-AA (3.19:1). WCAG 1.4.3 exempts
+  text that is part of an inactive control; axe cannot infer the label's
+  association, so the Loading story disables the color-contrast rule with
+  a pointer to this note. Do not reuse the muted colour for active text.

--- a/nextjs-app/shared/components/Switch/Switch.stories.tsx
+++ b/nextjs-app/shared/components/Switch/Switch.stories.tsx
@@ -168,6 +168,11 @@ export const Loading: Story = {
           "loading blocks double flips and sets aria-busy while an async toggle is in flight.",
       },
     },
+    // Documented axe exemption (see Switch.spec.md): while loading the
+    // control is inactive and its label takes the muted disabled color —
+    // WCAG 1.4.3 exempts inactive-control text, but axe cannot tell the
+    // label belongs to one.
+    a11y: { options: { rules: [{ id: "color-contrast", enabled: false }] } },
   },
   args: { loading: true, checked: true },
   render: (args) => <ControlledTemplate {...args} />,

--- a/nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.stories.tsx
+++ b/nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.stories.tsx
@@ -38,7 +38,10 @@ export const Default: Story = {
 };
 
 export const StartAsInput: Story = {
-  args: { initialMode: "input", defaultValue: "Intent prompt" },
+  // value: undefined un-seeds the autogen's value:"" — `value` is the
+  // CONTROLLED prop, and a seeded "" locks the input to controlled-empty
+  // (defaultValue ignored, typing dead).
+  args: { initialMode: "input", defaultValue: "Intent prompt", value: undefined },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByRole("textbox");

--- a/nextjs-app/shared/stories/WebComponents/CodeSnippet/CodeSnippet.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/CodeSnippet/CodeSnippet.stories.tsx
@@ -204,7 +204,11 @@ export const WithMaxLines: Story = {
       element?.shadowRoot?.querySelector<HTMLButtonElement>(".expandButton");
     await userEvent.click(expandButton!);
     await waitFor(() => {
-      expect(expandButton?.textContent).toMatch(/show less/i);
+      // Re-query: the toggle re-renders the shadow tree, so the pre-click
+      // node reference goes stale (same trap as WC Pagination, #1239).
+      const toggled =
+        element?.shadowRoot?.querySelector<HTMLButtonElement>(".expandButton");
+      expect(toggled?.textContent).toMatch(/show less/i);
     });
   },
 };

--- a/nextjs-app/shared/stories/WebComponents/FileUpload/FileUpload.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/FileUpload/FileUpload.stories.tsx
@@ -202,11 +202,14 @@ export const SelectAndClear: Story = {
     }
     await userEvent.click(clear);
 
-    await waitFor(() =>
+    await waitFor(() => {
+      // Re-query: clearing re-renders the shadow summary, so the pre-click
+      // node reference goes stale (same trap as WC Pagination, #1239).
+      const cleared = summaryField(canvasElement);
       expect(
-        summary instanceof HTMLInputElement ? summary.value : summary.textContent,
-      ).not.toMatch(/brief\.pdf/),
-    );
+        cleared instanceof HTMLInputElement ? cleared.value : cleared.textContent,
+      ).not.toMatch(/brief\.pdf/);
+    });
   },
 };
 

--- a/nextjs-app/shared/stories/WebComponents/Label/Label.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/Label/Label.stories.tsx
@@ -52,7 +52,16 @@ export const WithTooltip: Story = {
   args: { tooltipText: "Used in proposals and invoices." },
 };
 export const Required: Story = { ...exampleStory, args: { required: true } };
-export const Disabled: Story = { ...exampleStory, args: { disabled: true } };
+export const Disabled: Story = {
+  ...exampleStory,
+  args: { disabled: true },
+  // Documented axe exemption (see Label.spec.md): same rationale as the
+  // React Label Disabled story — WCAG 1.4.3 inactive-control exemption.
+  parameters: {
+    ...exampleStory.parameters,
+    a11y: { options: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+};
 export const Example: Story = {
   ...exampleStory,
   render: () => (

--- a/packages/web-components/src/native/file-upload.ts
+++ b/packages/web-components/src/native/file-upload.ts
@@ -131,7 +131,10 @@ const styles = `
   }
 
   .summaryField::placeholder {
-    color: var(--color-muted-light, GrayText);
+    /* --color-muted, not muted-light: active placeholder text is real text
+       (no WCAG inactive-control exemption) and must meet 4.5:1 — matches the
+       React shared-field placeholder convention. */
+    color: var(--color-muted, GrayText);
     opacity: 1;
   }
 
@@ -160,7 +163,10 @@ const styles = `
   .summaryField:disabled,
   .editorialTrigger:disabled {
     background: var(--color-disabled-bg-light, #eee);
-    color: var(--color-muted-light, GrayText);
+    /* Canonical disabled pair (project convention): disabled controls use the
+       --color-disabled-* tokens; contrast is intentionally sub-AA per the
+       WCAG 1.4.3 inactive-control exemption. */
+    color: var(--color-disabled-placeholder, GrayText);
   }
 
   .editorialTrigger {
@@ -173,7 +179,8 @@ const styles = `
   }
 
   .editorialPlaceholder {
-    color: var(--color-muted-light, GrayText);
+    /* --color-muted, not muted-light: see .summaryField::placeholder. */
+    color: var(--color-muted, GrayText);
   }
 
   .actions {


### PR DESCRIPTION
## Summary
Closes the last chip from the 2026-07-17 sweep series. **The full test-storybook suite is now green: 273 suites / 1,882 tests, exit 0.**

### Play fixes
- **Button `Primary`/`Default`** (alias, so both failed): `expect(args.onClick).toHaveBeenCalled()` threw *'not a spy'* on the action-logger arg (Storybook 10 requires `fn()` spies) — and this thrown play **poisoned the preview page, cascading `__getContext` errors across the entire suite** (the mystery runner-infra class). Args now provide `fn()`. A second latent bug surfaced behind it: the play asserted `toHaveFocus()` after `tab()` had moved focus OFF the just-clicked button — now blurs first, preserving the keyboard-reachability intent.
- **WC CodeSnippet `WithMaxLines` + WC FileUpload `SelectAndClear`**: stale shadow-node assertions, re-queried inside `waitFor` (the #1239 pattern — 3rd and 4th instances).
- **TransformingActionInput `StartAsInput`**: autogen seeds `value: ""` and `value` is the **controlled** prop → controlled-empty (defaultValue ignored, typing dead). The story un-seeds with `value: undefined`. ⚠️ **Systemic note for owner**: every registered component with a controlled `value` prop has a dead-typing canvas under the seeded `""` (TextInput, Select, Combobox, …) — `""` is a legitimate controlled value so neither the component nor the lib can safely treat it as absent. Options: stop seeding props named `value` when a `defaultValue` sibling exists, or accept per-story un-seeding. Left for your call given the ~19-component blast radius.

### Contrast fixes
- **PersonCard `WithCustomClass`**: the demo class darkens the surface and flips name/title to white but left the email link dark (3.2:1) — links now white too (≈5.4:1).
- **WC FileUpload**: *active* placeholder text used `--color-muted-light` (3.19:1) → now `--color-muted` per the React shared-field convention (real text has no inactive-control exemption); disabled field colors moved to the canonical `--color-disabled-placeholder` token per the disabled-unification convention.
- **Label `Disabled` (React + dt-label), Switch `Loading`**: labels of inactive controls keep the intentional muted color. Story-level `color-contrast` rule disables with justification prose in [Label.spec.md](nextjs-app/shared/components/Label/Label.spec.md) / [Switch.spec.md](nextjs-app/shared/components/Switch/Switch.spec.md): WCAG 1.4.3 exempts text that is part of an inactive control; axe cannot infer a label's association with one. Mirrors the documented forced-colors rule-disable precedent in preview.tsx.

## Verification
Affected suites 125/125; **full story suite 273/273**; FileUpload is not pixel-gated (scoped parity trivially passes); zero AT snapshot churn; typecheck, lint, 2,679 unit tests, build all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated file upload placeholder and disabled-state colors for improved visual consistency and clearer contrast.
  * Refined Storybook styling so links in dark person-card demos remain readable.

* **Accessibility**
  * Documented intentional contrast exceptions for disabled and loading labels in accessibility examples.

* **Tests**
  * Improved interaction checks for buttons, file uploads, expandable code snippets, and focus behavior across Storybook examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->