### PR TITLE
feat(design-system): controls honesty — un-seed controlled props, audit hidden-by-design, 100% operability

### DIFF
--- a/.storybook/controls-autogen.json
+++ b/.storybook/controls-autogen.json
@@ -99,7 +99,6 @@
     "FormFieldEditorial",
     "LocationCard",
     "ServiceCard",
-    "SkillsGrid",
     "SocialShare",
     "ValueCard",
     "VisuallyHidden",

--- a/.storybook/lib/controls-autogen.ts
+++ b/.storybook/lib/controls-autogen.ts
@@ -25,6 +25,10 @@
  */
 import type { ArgTypesEnhancer, ArgsEnhancer } from "storybook/internal/types";
 import registry from "../controls-autogen.json";
+import {
+  PLUMBING,
+  controlledPairPartner,
+} from "../../scripts/design-system/controls-hidden-by-design.mjs";
 
 type ContractProp = {
   optional?: boolean;
@@ -46,17 +50,10 @@ for (const [path, mod] of Object.entries(contractModules)) {
 
 const AUTOGEN = new Set<string>(registry.components);
 
-// Plumbing a human never sets from a panel — hidden, same set audit:controls skips.
-const HIDDEN = new Set([
-  "ref",
-  "style",
-  "key",
-  "asChild",
-  "as",
-  "data-role",
-  "aria-label",
-  "id",
-]);
+// Plumbing a human never sets from a panel — hidden. Shared with
+// audit:controls via scripts/design-system/controls-hidden-by-design.mjs so
+// the enhancer and the audit can never drift apart again.
+const HIDDEN: Set<string> = PLUMBING;
 
 const componentNameFor = (title?: string) => title?.split("/").pop() ?? "";
 
@@ -106,6 +103,7 @@ function deriveEntry(
   prop: string,
   spec: ContractProp,
   inherited: AnyArgType | undefined,
+  allProps: string[],
 ): AnyArgType {
   const type = spec.type ?? "";
   const table = { category: categoryFor(prop), ...(inherited?.table ?? {}) };
@@ -113,6 +111,14 @@ function deriveEntry(
   if (HIDDEN.has(prop)) return { table: { ...table, disable: true } };
   if (/^on[A-Z]/.test(prop) || isFunction(type)) {
     return { action: prop, table: { ...table, disable: true } };
+  }
+  // The controlled half of a value/defaultValue-style pair is hidden: "" is a
+  // legitimate controlled value, so it cannot be seeded as a no-op — a seeded
+  // "" locks the canvas into controlled-empty (defaultValue ignored, typing
+  // dead; TransformingActionInput #1242). Drive the playground through the
+  // default* sibling instead.
+  if (controlledPairPartner(prop, allProps)) {
+    return { table: { ...table, disable: true } };
   }
 
   const unionValues =
@@ -195,7 +201,10 @@ export const autogenArgTypes: ArgTypesEnhancer = (context) => {
         (existing.table as { disable?: boolean } | undefined)?.disable ===
           true);
     if (authored) continue;
-    out[prop] = { ...existing, ...deriveEntry(prop, spec, existing) };
+    out[prop] = {
+      ...existing,
+      ...deriveEntry(prop, spec, existing, Object.keys(contract.props)),
+    };
   }
   return out;
 };
@@ -209,10 +218,13 @@ export const autogenArgs: ArgsEnhancer = (context) => {
   const contract = contracts.get(name);
   if (!contract?.props) return context.initialArgs;
 
+  const allProps = Object.keys(contract.props);
   const seeds: Record<string, unknown> = {};
   for (const [prop, spec] of Object.entries(contract.props)) {
     if (HIDDEN.has(prop) || /^on[A-Z]/.test(prop) || prop === "children")
       continue;
+    // Controlled-pair halves are hidden AND unseeded — see deriveEntry.
+    if (controlledPairPartner(prop, allProps)) continue;
     const argType = (context.argTypes as Record<string, AnyArgType>)[prop];
     if (argType && "mapping" in argType) continue; // preset selects stay unset
     const seed = seedFor(spec, argType);

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -420,6 +420,24 @@ const config: TestRunnerConfig = {
     ];
     const betaMatrix = storyTags.includes("beta-matrix");
 
+    // Deterministic AT capture for stories with React.lazy content: a cold
+    // page loses the race between the lazy chunk and the capture, a warmed
+    // worker wins it, and the snapshot flips run-to-run (NextLayout's chat
+    // toggle). Stories declare the late element; capture waits for it.
+    const atWaitSelector = (
+      storyContext?.parameters as
+        | { atSnapshot?: { waitForSelector?: string } }
+        | undefined
+    )?.atSnapshot?.waitForSelector;
+    if (atWaitSelector) {
+      await page
+        .waitForSelector(atWaitSelector, { state: "visible", timeout: 5_000 })
+        .catch(() => {
+          // Capture proceeds; a genuinely missing element then surfaces as a
+          // visible snapshot mismatch instead of a silent skip.
+        });
+    }
+
     // AT-tree snapshots are the DSharp-style gate for Phase 2.
     await captureAccessibilityTree(page, context.id, { betaMatrix });
 

--- a/nextjs-app/shared/components/BlogNav/BlogNav.stories.tsx
+++ b/nextjs-app/shared/components/BlogNav/BlogNav.stories.tsx
@@ -43,6 +43,9 @@ const meta: Meta<typeof BlogNav> = {
   },
   args: {
     currentPath: "/blog/digital-craftsmanship",
+    // Seeded so the boolean control renders a toggle instead of a dead
+    // "Set boolean" button (the component's no-op default).
+    disabled: false,
   },
 };
 

--- a/nextjs-app/shared/components/Checkbox/__a11y-snapshots__/forms-checkbox--default.yaml
+++ b/nextjs-app/shared/components/Checkbox/__a11y-snapshots__/forms-checkbox--default.yaml
@@ -1,2 +1,2 @@
-- checkbox "Default Checkbox"
+- checkbox "Default Checkbox" [checked]
 - text: Default Checkbox

--- a/nextjs-app/shared/components/Grid/Grid.stories.tsx
+++ b/nextjs-app/shared/components/Grid/Grid.stories.tsx
@@ -76,6 +76,15 @@ const meta = {
       table: { category: "Content", type: { summary: "ReactNode" } },
     },
     columns: { control: "number", description: "Column count or template" },
+    // Responsive rungs are viewport-dependent: a panel knob at the default
+    // viewport looks inert (tracks only change past 768/1024/1440/1920px),
+    // and the default canvas stays deliberately scalar. Hidden by design —
+    // the ResponsiveColumns story demos them; audit:controls carries the
+    // matching HIDDEN_EXEMPT entry.
+    tabletColumns: { table: { disable: true } },
+    desktopColumns: { table: { disable: true } },
+    wideColumns: { table: { disable: true } },
+    ultraColumns: { table: { disable: true } },
   },
   args: defaultArgs,
 } satisfies Meta<typeof Grid>;

--- a/nextjs-app/shared/components/ListItem/ListItem.stories.tsx
+++ b/nextjs-app/shared/components/ListItem/ListItem.stories.tsx
@@ -23,6 +23,9 @@ const meta = {
     selected: false,
     disabled: false,
     highlighted: false,
+    // Seeded so the text control renders an input instead of a dead
+    // "Set string" button ("" is the no-op default).
+    className: "",
   },
   argTypes: {
     tone: {

--- a/nextjs-app/shared/components/NextLayout/NextLayout.stories.tsx
+++ b/nextjs-app/shared/components/NextLayout/NextLayout.stories.tsx
@@ -29,6 +29,10 @@ const meta = {
     contractStatus: contract.status,
     a11y: { test: "error" },
     docs: { description: { component: contract.description } },
+    // The chat toggle is a React.lazy chunk: AT capture must wait for it or
+    // the snapshot flips with worker cache warmth (cold page = no button,
+    // warmed page = button). See test-runner.ts atSnapshot handling.
+    atSnapshot: { waitForSelector: "button[aria-label^=\"Chat\"]" },
   },
   // Controls are contract-derived at runtime (.storybook/lib/controls-autogen.ts).
   args: {},

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--default.dark.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--default.dark.yaml
@@ -75,4 +75,5 @@
   - link "Dribbble":
     - /url: https://dribbble.com/digitaltableteur
   - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
 - status

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--default.forced-colors.yaml
@@ -75,4 +75,5 @@
   - link "Dribbble":
     - /url: https://dribbble.com/digitaltableteur
   - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
 - status

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--default.light.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--default.light.yaml
@@ -75,4 +75,5 @@
   - link "Dribbble":
     - /url: https://dribbble.com/digitaltableteur
   - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
 - status

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--default.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--default.yaml
@@ -75,4 +75,5 @@
   - link "Dribbble":
     - /url: https://dribbble.com/digitaltableteur
   - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
 - status

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--playground.forced-colors.yaml
@@ -73,4 +73,5 @@
   - link "Dribbble":
     - /url: https://dribbble.com/digitaltableteur
   - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
 - status

--- a/nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.stories.tsx
+++ b/nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.stories.tsx
@@ -38,10 +38,7 @@ export const Default: Story = {
 };
 
 export const StartAsInput: Story = {
-  // value: undefined un-seeds the autogen's value:"" — `value` is the
-  // CONTROLLED prop, and a seeded "" locks the input to controlled-empty
-  // (defaultValue ignored, typing dead).
-  args: { initialMode: "input", defaultValue: "Intent prompt", value: undefined },
+  args: { initialMode: "input", defaultValue: "Intent prompt" },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByRole("textbox");

--- a/nextjs-app/shared/components/TransformingActionInput/__a11y-snapshots__/site-transformingactioninput--start-as-input.yaml
+++ b/nextjs-app/shared/components/TransformingActionInput/__a11y-snapshots__/site-transformingactioninput--start-as-input.yaml
@@ -2,5 +2,6 @@
 - text: Adaptive surface Input state Intent
 - textbox "Intent":
   - /placeholder: Type your intent…
+  - text: New text
 - button "Cancel"
 - button "Submit"

--- a/nextjs-app/shared/components/WorkNav/WorkNav.stories.tsx
+++ b/nextjs-app/shared/components/WorkNav/WorkNav.stories.tsx
@@ -45,6 +45,9 @@ const meta: Meta<typeof WorkNav> = {
   },
   args: {
     currentPath: "/work/new-things-co",
+    // Seeded so the boolean control renders a toggle instead of a dead
+    // "Set boolean" button (the component's no-op default).
+    disabled: false,
   },
 };
 

--- a/scripts/design-system/audit-controls.mjs
+++ b/scripts/design-system/audit-controls.mjs
@@ -14,6 +14,7 @@
  *   node scripts/design-system/audit-controls.mjs [--url http://127.0.0.1:6010] [--json] [--only Name]
  */
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { PLUMBING, hiddenByDesign } from './controls-hidden-by-design.mjs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { chromium } from 'playwright'
@@ -156,11 +157,22 @@ const ROOTS = [
     resolve(__dirname, '../../nextjs-app/shared/patterns'),
 ]
 
-// Public props worth a control (skip pure DOM/React plumbing a human never sets).
-// Keep in sync with HIDDEN in .storybook/lib/controls-autogen.ts — `id` is
-// plumbing of the same class as aria-label: contracts expose it, no human
-// drives a canvas from an id text field.
-const SKIP = new Set(['ref', 'style', 'key', 'asChild', 'as', 'data-role', 'aria-label', 'id'])
+// Public props worth a control (skip pure DOM/React plumbing a human never
+// sets). Single source of truth shared with the enhancer:
+// scripts/design-system/controls-hidden-by-design.mjs.
+const SKIP = PLUMBING
+
+// Props with NO Controls row by a documented per-component decision that the
+// shared hiddenByDesign() predicate cannot express. Every entry carries its
+// justification, mirroring EFFECT_EXEMPT.
+const HIDDEN_EXEMPT = {
+    Grid: {
+        tabletColumns: 'viewport-dependent: only changes tracks past 768px, so a panel knob at the default viewport looks inert; demoed by the ResponsiveColumns story',
+        desktopColumns: 'viewport-dependent (1024px rung); demoed by the ResponsiveColumns story',
+        wideColumns: 'viewport-dependent (1440px rung); demoed by the ResponsiveColumns story',
+        ultraColumns: 'viewport-dependent (1920px rung); demoed by the ResponsiveColumns story',
+    },
+}
 
 function contractProps(dir, root) {
     const p = `${root}/${dir}/${dir}.contract.json`
@@ -173,7 +185,10 @@ function contractProps(dir, root) {
         const props = Object.keys(c.props ?? {}).filter(
             (k) => !SKIP.has(k) && !/^(React\.)?(Ref|RefObject|MutableRefObject)\b/.test(c.props[k]?.type ?? ''),
         )
-        return { status: c.status, props }
+        const propTypes = Object.fromEntries(
+            props.map((k) => [k, c.props[k]?.type ?? '']),
+        )
+        return { status: c.status, props, propTypes }
     } catch { return null }
 }
 
@@ -365,15 +380,24 @@ for (const comp of components) {
         return out
     })
     const perProp = {}
-    let operable = 0, dead = 0, missing = 0, handlers = 0
+    let operable = 0, dead = 0, missing = 0, handlers = 0, hidden = 0
     for (const prop of comp.props) {
         if (/^on[A-Z]/.test(prop)) { perProp[prop] = 'handler'; handlers++; continue }
         const kind = widgets[prop]
         if (kind && FUNCTIONAL.has(kind)) { perProp[prop] = kind; operable++ }
         else if (kind === 'dead') { perProp[prop] = 'DEAD'; dead++ }
+        else if (
+            // No row at all AND deliberately so: either the shared predicate
+            // (ReactNode/arrays/Records/controlled-pair halves — the same
+            // classification the enhancer hides by) or a documented
+            // per-component exemption. A DEAD row (visible Set-button) never
+            // qualifies — a rendered dead widget is a defect regardless.
+            hiddenByDesign(prop, comp.propTypes?.[prop] ?? '', comp.props) ||
+            HIDDEN_EXEMPT[comp.name]?.[prop]
+        ) { perProp[prop] = 'hidden'; hidden++ }
         else { perProp[prop] = 'MISSING'; missing++ }
     }
-    const denom = comp.props.length - handlers
+    const denom = comp.props.length - handlers - hidden
     let effects = null
     if (EFFECTS) {
         effects = { effect: 0, inert: [], exempt: [], skipped: [], unstable: [] }
@@ -389,7 +413,7 @@ for (const comp of components) {
     }
     results.push({
         name: comp.name, status: comp.status,
-        total: denom, operable, dead, missing, handlers,
+        total: denom, operable, dead, missing, handlers, hidden,
         coverage: denom ? Math.round((operable / denom) * 100) : 100,
         failing: Object.entries(perProp).filter(([, v]) => v === 'DEAD' || v === 'MISSING').map(([k, v]) => `${k}:${v}`),
         ...(effects ? { effects } : {}),
@@ -401,18 +425,18 @@ await browser.close()
 if (JSON_OUT) { console.log(JSON.stringify(results, null, 2)); process.exit(0) }
 
 results.sort((a, b) => (a.coverage ?? -1) - (b.coverage ?? -1))
-let totalProps = 0, totalOperable = 0, fullyOperable = 0
+let totalProps = 0, totalOperable = 0, fullyOperable = 0, totalHidden = 0
 console.log('\nHuman-Simulated Controls audit — operable = human can select/toggle/check/input/slide\n')
 for (const r of results) {
     if (r.error) { console.log(`  ${r.name.padEnd(24)} — ${r.error}`); continue }
-    totalProps += r.total; totalOperable += r.operable
+    totalProps += r.total; totalOperable += r.operable; totalHidden += r.hidden ?? 0
     if (r.coverage === 100) { fullyOperable++; continue }
     const bar = '█'.repeat(Math.round(r.coverage / 5)).padEnd(20, '░')
     console.log(`  ${r.name.padEnd(24)} [${r.status.padEnd(6)}] ${bar} ${String(r.coverage).padStart(3)}%  ${r.operable}/${r.total}  ✗ ${r.failing.join(', ')}`)
 }
 const pct = Math.round((totalOperable / totalProps) * 100)
 console.log(`\n${fullyOperable}/${results.filter((r) => !r.error).length} components fully operable`)
-console.log(`${totalOperable}/${totalProps} value props operable (${pct}%)`)
+console.log(`${totalOperable}/${totalProps} value props operable (${pct}%), ${totalHidden} hidden by design`)
 console.log(`CONTROLS_OPERABLE_PCT=${pct}`)
 
 if (EFFECTS) {

--- a/scripts/design-system/controls-hidden-by-design.d.ts
+++ b/scripts/design-system/controls-hidden-by-design.d.ts
@@ -1,0 +1,10 @@
+export declare const PLUMBING: Set<string>;
+export declare function controlledPairPartner(
+  prop: string,
+  allPropNames: string[],
+): string | null;
+export declare function hiddenByDesign(
+  prop: string,
+  type: string,
+  allPropNames: string[],
+): string | null;

--- a/scripts/design-system/controls-hidden-by-design.mjs
+++ b/scripts/design-system/controls-hidden-by-design.mjs
@@ -1,0 +1,65 @@
+/**
+ * Single source of truth for "this contract prop deliberately has no
+ * Controls-panel row". Consumed by BOTH sides of the controls system:
+ *
+ *   - .storybook/lib/controls-autogen.ts derives argTypes from contracts and
+ *     hides these props (table.disable) instead of rendering dead widgets.
+ *   - scripts/design-system/audit-controls.mjs excludes them from the
+ *     operability denominator (a deliberately hidden row is not "missing").
+ *
+ * Categories:
+ *   plumbing         — DOM/React wiring a human never sets from a panel.
+ *   ref              — Ref-typed props, same class as `ref` itself.
+ *   handler          — event callbacks; the actions pane covers them.
+ *   react-node       — ReactNode/Element slots: a "Set object" button helps
+ *                      nobody. (`children` is exempt — the enhancer gives it
+ *                      a text control or stories map presets onto it.)
+ *   composite        — arrays / Record types: same "Set object" problem, and
+ *                      a seeded "" scalar actively breaks components
+ *                      (Accordion openIds: "" = controlled-empty, #1238).
+ *   controlled-pair  — the controlled half of a value/defaultValue-style
+ *                      pair. "" is a LEGITIMATE controlled value, so it can
+ *                      never be seeded as a no-op; a seeded "" locks the
+ *                      canvas into controlled-empty (dead typing,
+ *                      TransformingActionInput #1242). Drive the playground
+ *                      via the default* sibling instead.
+ */
+
+export const PLUMBING = new Set([
+  "ref",
+  "style",
+  "key",
+  "asChild",
+  "as",
+  "data-role",
+  "aria-label",
+  "id",
+]);
+
+/** The `defaultX` sibling name for a controlled prop `x`, if the contract has one. */
+export function controlledPairPartner(prop, allPropNames) {
+  const partner = `default${prop.charAt(0).toUpperCase()}${prop.slice(1)}`;
+  return allPropNames.includes(partner) ? partner : null;
+}
+
+/**
+ * @param {string} prop      contract prop name
+ * @param {string} type      contract prop type string
+ * @param {string[]} allPropNames all prop names on the same contract
+ * @returns {string|null} the hidden-by-design category, or null (needs a row)
+ */
+export function hiddenByDesign(prop, type, allPropNames) {
+  if (PLUMBING.has(prop)) return "plumbing";
+  if (/^(React\.)?(Ref|RefObject|MutableRefObject)\b/.test(type)) return "ref";
+  if (/^on[A-Z]/.test(prop) || type.includes("=>") || /^\(/.test(type)) {
+    return "handler";
+  }
+  if (prop !== "children" && /ReactNode|Element|Children/i.test(type)) {
+    return "react-node";
+  }
+  if (type.includes("[]") || /\bArray</.test(type) || /\bRecord</.test(type)) {
+    return "composite";
+  }
+  if (controlledPairPartner(prop, allPropNames)) return "controlled-pair";
+  return null;
+}

--- a/tests/storybook/controls-autogen.test.ts
+++ b/tests/storybook/controls-autogen.test.ts
@@ -13,11 +13,24 @@ function checkboxArgs(initialArgs: Record<string, unknown>) {
 }
 
 describe("contract-driven Storybook args", () => {
-  it("seeds controlled and uncontrolled rows so both controls stay operable", () => {
+  it("seeds the uncontrolled row and leaves the controlled half unseeded", () => {
     const args = checkboxArgs({});
 
-    expect(args).toHaveProperty("checked", false);
+    // `checked` is the controlled half of the checked/defaultChecked pair:
+    // seeding it locks the canvas into controlled mode (defaultChecked
+    // ignored, clicking dead) — it stays unseeded and its panel row hidden.
+    expect(args).not.toHaveProperty("checked");
     expect(args).toHaveProperty("defaultChecked", false);
+  });
+
+  it("hides the controlled half's panel row", () => {
+    const argTypes = autogenArgTypes({
+      title: "Forms/Checkbox",
+      argTypes: {},
+    } as never) as Record<string, { table?: { disable?: boolean } }>;
+
+    expect(argTypes.checked?.table?.disable).toBe(true);
+    expect(argTypes.defaultChecked?.table?.disable).not.toBe(true);
   });
 
   it("preserves an explicitly authored uncontrolled default", () => {


### PR DESCRIPTION
## Summary
Executes both open owner calls from #1238/#1242 as one coherent package. Headline: **audit:controls now reports 143/143 components fully operable, 853/853 value props (100%), 23 hidden by design — `--min 100` is green**, which makes the farm's always-failing controls step satisfiable.

### Decision 1 — stop seeding controlled props
The autogen seeded `""`/`false` into the **controlled half** of value/defaultValue-style pairs. `""` is a legitimate controlled value, so it can never be a no-op — the seed silently locked canvases into controlled mode: **Checkbox clicks were dead, form typing was dead** across the registered components. Controlled halves are now unseeded and their panel rows hidden; `default*` siblings drive the playground, and canvases are interactive again. (TransformingActionInput's per-story workaround from #1242 reverted.)

### Decision 2 — hidden-by-design category in the audit
New shared module [controls-hidden-by-design.mjs](scripts/design-system/controls-hidden-by-design.mjs) is the single source of truth for "this contract prop deliberately has no Controls row" (plumbing / refs / handlers / ReactNode / arrays / Records / controlled halves) — imported by **both** the enhancer and audit-controls, so they can never drift again (they previously shared only a "keep in sync" comment). The audit excludes these from the operability denominator; a **rendered** dead Set-button never qualifies. `HIDDEN_EXEMPT` carries documented per-component exemptions (Grid's viewport-dependent responsive rungs, demoed by the ResponsiveColumns story).

### Reaching the bar
Grid's four responsive-column rows hidden (inert knobs at a fixed viewport), BlogNav/WorkNav seed `disabled: false`, ListItem seeds `className: ""`, stale SkillsGrid registry entry removed (deleted in #1145).

### Bonus root-cause: deterministic AT capture for lazy content
Chasing a full-suite flake surfaced a real capture race: NextLayout's chat toggle is a `React.lazy` chunk — cold pages captured **without** it, warmed workers **with** it, so the snapshot flipped with worker cache warmth. `postVisit` now honors `parameters.atSnapshot.waitForSelector`; NextLayout declares the toggle and all 16 of its yamls are rebaselined to include it.

### Snapshot re-trues (now-honest canvases)
Checkbox default shows `[checked]` (its play's click actually works now); TransformingActionInput shows the play's typed text.

## Verification
Full story suite **273/273, exit 0** after the wait fix (previous three runs flaked on the NextLayout race — root-caused, not retried away); audit-controls `--min 100` green; typecheck, lint, 2,680 unit tests (one updated to the new convention, one added), build all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Storybook controls by hiding implementation-only properties and avoiding conflicting controlled-value controls.
  * Added support for waiting on dynamically loaded elements before accessibility snapshots are captured.
  * Added the Chat button to NextLayout accessibility coverage.

* **Bug Fixes**
  * Corrected default control values for checkbox, navigation, and text inputs.
  * Updated accessibility snapshots to reflect checked states and newly available content.

* **Tests**
  * Expanded coverage for generated controls and accessibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->