### PR TITLE
feat(pricing): interactive duration × workload pricing calculator

### DIFF
--- a/docs/superpowers/specs/2026-07-18-pricing-calculator-design.md
+++ b/docs/superpowers/specs/2026-07-18-pricing-calculator-design.md
@@ -1,0 +1,66 @@
+# PricingCalculator — design spec (2026-07-18)
+
+Approved by owner 2026-07-18 (rate model, placement, badges, SelectableCard fix, overall design).
+
+## Goal
+
+A dynamically updating pricing calculator section for `/pricing`, modeled on the
+goodside.fi reference screenshot, composed exclusively from design-system
+components. Existing pricing sections stay untouched.
+
+## Placement
+
+New pattern `nextjs-app/shared/patterns/PricingCalculator/`, rendered inside
+`PricingPageContent` after the AaaS section and before the existing CTA row.
+
+## Composition (DS components only)
+
+Left column:
+
+- `Title` — "Adjust duration and workload to see your total investment."
+- Duration `SelectableCardGroup` (single-select): 2 weeks, 1, 2, 3, 6, 12 months
+  in a two-column grid. `Badge` "Partnership" on 6 and 12 months.
+- Workload `SelectableCardGroup` (single-select): 2, 3, 4, 5 days/week.
+- Allocation `Card` — percentage (days / 5), "Based on N days/week × 7 hours/day".
+- Totals `Card` — total hours and the standard rate.
+
+Right column:
+
+- "What's included in your investment:" `List`; first two items react to the
+  selection (duration phrase, days-per-week phrase), two static items.
+- "Your price" `Card` — effective (discounted) hourly rate.
+- "Total Investment" `Card` — locale-formatted total.
+- `Button` "Get in touch" → `/contact?mode=book`. No icon (owner deviation).
+
+## Pricing model (owner decision)
+
+- Standard rate: **€120/h**, 7 hours/day.
+- Weeks per duration: 2 weeks = 2; otherwise months × 52 / 12.
+- Total hours = round(weeks × daysPerWeek × 7).
+- Tier discounts on the hourly rate: 3 mo −5%, 6 mo −10%, 12 mo −15%.
+- Total investment = round(totalHours × effectiveRate).
+- Defaults: 2 months, 5 days/week.
+
+## i18n
+
+All copy keyed in EN / FI / SV `translation.json` (FI workload label "Työmäärä").
+Number formatting via `Intl.NumberFormat` on the active language.
+
+## Design-system change (owner-approved)
+
+`SelectableCard` declares `className` but drops it; fix by merging it onto the
+card label element. Additive, benefits all consumers.
+
+**Implementation note:** the app consumes `@digitaltableteur/react` 0.1.16 from
+the registry, which predates this fix, so the pattern must not rely on per-card
+`className`. The two-column option layout therefore lives on the group's
+options wrapper (`.optionGroup > div`), which works with the published package
+today; the SelectableCard fix ships with the next react publish.
+
+## Quality gates
+
+Contract (`status: beta`) + spec + stories (Default, Playground, Example,
+ForcedColors, plus an interaction play) + unit tests for the math and
+selection-driven updates + axe assertion. Local gate: typecheck, lint, test,
+build, `build:tokens`, `check:contract-props`, `check:consumers`,
+`validate:components`.

--- a/nextjs-app/shared/components/Badge/Badge.contract.json
+++ b/nextjs-app/shared/components/Badge/Badge.contract.json
@@ -93,6 +93,16 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/PricingPage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/PricingPage/PricingPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Pseo/PseoClusterBadges.tsx",
             "since": "2026-06-04"
         },
@@ -119,16 +129,6 @@
         {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Work/Illustrations/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts",
             "since": "2026-06-04"
         }
     ],

--- a/nextjs-app/shared/components/Card/Card.contract.json
+++ b/nextjs-app/shared/components/Card/Card.contract.json
@@ -82,6 +82,16 @@
     "consumers": [
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/PricingPage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/PricingPage/PricingPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
             "since": "2026-06-04"
         },
@@ -93,6 +103,26 @@
         {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/PricingCalculator/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/PricingPageContent/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx",
             "since": "2026-06-04"
         }
     ],

--- a/nextjs-app/shared/components/HelperText/HelperText.contract.json
+++ b/nextjs-app/shared/components/HelperText/HelperText.contract.json
@@ -84,22 +84,22 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/PricingPage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/PricingPage/PricingPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
             "since": "2026-06-04"
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/CVDownloadSection/CVDownloadSection.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/CVDownloadSection/index.ts",
             "since": "2026-06-04"
         }
     ],

--- a/nextjs-app/shared/components/List/List.contract.json
+++ b/nextjs-app/shared/components/List/List.contract.json
@@ -75,6 +75,16 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/PricingPage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/PricingPage/PricingPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/PrivacyPolicyPage/index.ts",
             "since": "2026-06-04"
         },
@@ -101,16 +111,6 @@
         {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Work/FinnishTransportAgency/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/GarageJunction/GarageJunctionPage.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/GarageJunction/index.ts",
             "since": "2026-06-04"
         }
     ],

--- a/nextjs-app/shared/components/SelectableCard/SelectableCard.tsx
+++ b/nextjs-app/shared/components/SelectableCard/SelectableCard.tsx
@@ -184,7 +184,7 @@ export const SelectableCard: React.FC<SelectableCardProps> = ({
 
   return (
     <label
-      className={[styles.card, isDisabled ? styles.disabled : ""]
+      className={[styles.card, isDisabled ? styles.disabled : "", className]
         .filter(Boolean)
         .join(" ")}
       data-selected={checked ? "true" : "false"}

--- a/nextjs-app/shared/components/Skeleton/Skeleton.contract.json
+++ b/nextjs-app/shared/components/Skeleton/Skeleton.contract.json
@@ -51,6 +51,16 @@
     "consumers": [
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/PricingPage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/PricingPage/PricingPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Pseo/PseoIndexPage.tsx",
             "since": "2026-06-04"
         },
@@ -62,6 +72,26 @@
         {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Pseo/PseoPillarPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/PricingCalculator/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/PricingPageContent/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx",
             "since": "2026-06-04"
         }
     ],

--- a/nextjs-app/shared/components/StatusDot/StatusDot.contract.json
+++ b/nextjs-app/shared/components/StatusDot/StatusDot.contract.json
@@ -199,6 +199,16 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/PricingPage/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/PricingPage/PricingPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Pseo/PseoClusterBadges.tsx",
             "since": "2026-06-04"
         },
@@ -225,16 +235,6 @@
         {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Work/Illustrations/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts",
             "since": "2026-06-04"
         }
     ]

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,17 +1,17 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-17T14:13:44.419Z",
+  "generatedAt": "2026-07-18T06:07:34.935Z",
   "summary": {
-    "componentCount": 163,
+    "componentCount": 164,
     "statusCounts": {
-      "beta": 44,
+      "beta": 45,
       "stable": 97,
       "alpha": 21,
       "deprecated": 1
     },
     "honestBetaDocDebt": 0,
-    "catalogCompletenessPercent": 88.1,
-    "codebaseComponentCount": 185,
+    "catalogCompletenessPercent": 88.2,
+    "codebaseComponentCount": 186,
     "usageCoveragePercent": 94.5,
     "componentsWithProductionUsage": 35,
     "notReadyForStablePromotion": false
@@ -57,15 +57,15 @@
   },
   "catalogCoverage": {
     "description": "Catalog completeness across the codebase. componentCount above is the catalog count; this block reveals how much of the codebase that catalog actually represents.",
-    "totalComponentsInCodebase": 185,
-    "inCatalog": 163,
+    "totalComponentsInCodebase": 186,
+    "inCatalog": 164,
     "outOfCatalog": 22,
-    "catalogCompletenessPercent": 88.1,
+    "catalogCompletenessPercent": 88.2,
     "artifactCoverage": {
-      "stories": 147,
-      "tests": 149,
+      "stories": 148,
+      "tests": 150,
       "mdx": 3,
-      "spec": 163
+      "spec": 164
     },
     "outOfCatalogByBucket": {
       "catalog-gap": 0,
@@ -77,13 +77,13 @@
   },
   "usageCoverage": {
     "description": "Auto-detected import evidence from app/** and nextjs-app/**. Separate from contract.consumers[], which remains the stable-promotion gate for shipping-product proof.",
-    "catalogedComponents": 163,
-    "withAnyUsage": 154,
+    "catalogedComponents": 164,
+    "withAnyUsage": 155,
     "withProductionUsage": 35,
-    "uniqueImportedComponents": 154,
-    "totalEvidenceRows": 767,
+    "uniqueImportedComponents": 155,
+    "totalEvidenceRows": 768,
     "aliasImportFiles": 395,
-    "relativeImportFiles": 405,
+    "relativeImportFiles": 406,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
   },
@@ -102,12 +102,12 @@
   "dsharpParity": {
     "description": "Comparison against DSharp as of 2026-05-26. Breadth is close, maturity is not. This block walks back the earlier parity overclaim.",
     "contractCount": {
-      "digitaltableteur": 163,
+      "digitaltableteur": 164,
       "dsharp": 112
     },
     "statusMix": {
       "digitaltableteur": {
-        "beta": 44,
+        "beta": 45,
         "stable": 97,
         "alpha": 21,
         "deprecated": 1
@@ -16976,7 +16976,7 @@
           }
         }
       },
-      "spec": "# Label\n\n## Intent\nProvide the visible, accessible-name-bearing label for a single form\ncontrol. Label is intentionally narrow — it owns text + required indicator\n+ disabled muted style, and explicitly does not own grouping (use a\nfieldset) or help text (use HelperText).\n\n## Interaction contract\n- Keyboard: clicking the label moves focus to the associated input via\n  native `htmlFor` resolution. No custom handler.\n- Pointer: click activates / focuses the associated input. The\n  `title`/`tooltipText` attribute fires a native tooltip on hover.\n- Screen readers: the label text becomes the accessible name of the\n  associated input. The required asterisk is hidden from SR; the\n  `<span className=\"srOnly\">(required)</span>` is announced instead.\n\n## Do / don't\n- Do: pass `htmlFor` for every Label. Implicit association by wrapping\n  works in browsers but is fragile under DOM reordering.\n- Do: pair `Label required` with `Input required` — visible state and\n  ARIA state must agree.\n- Don't: place validation errors inside Label. Errors belong to the\n  input's described-by region, not the label.\n- Don't: use a Label as a section heading. Headings carry navigation\n  semantics that Label does not.\n\n## Design notes\n- Tokens: drives from `--color-text` (default), `--color-text-muted`\n  (disabled), and `--color-required` (asterisk). Forced-colors mode\n  overrides the disabled muted colour with the system `GrayText` keyword.\n- Figma: https://www.figma.com/design/digitaltableteur/forms — keep\n  required-marker styling aligned with the Figma form-field component.\n- The translation surface is implicit: consumers pass already-translated\n  strings via `children`. The \"(required)\" SR text is hardcoded in EN\n  because the asterisk semantics are universally understood; if a locale\n  needs a different SR convention, override via the consumer.\n",
+      "spec": "# Label\n\n## Intent\nProvide the visible, accessible-name-bearing label for a single form\ncontrol. Label is intentionally narrow — it owns text + required indicator\n+ disabled muted style, and explicitly does not own grouping (use a\nfieldset) or help text (use HelperText).\n\n## Interaction contract\n- Keyboard: clicking the label moves focus to the associated input via\n  native `htmlFor` resolution. No custom handler.\n- Pointer: click activates / focuses the associated input. The\n  `title`/`tooltipText` attribute fires a native tooltip on hover.\n- Screen readers: the label text becomes the accessible name of the\n  associated input. The required asterisk is hidden from SR; the\n  `<span className=\"srOnly\">(required)</span>` is announced instead.\n\n## Do / don't\n- Do: pass `htmlFor` for every Label. Implicit association by wrapping\n  works in browsers but is fragile under DOM reordering.\n- Do: pair `Label required` with `Input required` — visible state and\n  ARIA state must agree.\n- Don't: place validation errors inside Label. Errors belong to the\n  input's described-by region, not the label.\n- Don't: use a Label as a section heading. Headings carry navigation\n  semantics that Label does not.\n\n## Design notes\n- Tokens: drives from `--color-text` (default), `--color-text-muted`\n  (disabled), and `--color-required` (asterisk). Forced-colors mode\n  overrides the disabled muted colour with the system `GrayText` keyword.\n- Axe exemption (documented): the disabled label colour is intentionally\n  sub-AA (3.19:1 on white). WCAG 1.4.3 exempts text that is part of an\n  inactive user interface component, and a label of a disabled control is\n  part of that component — axe cannot infer the association, so the\n  Disabled stories (React and dt-label) disable the color-contrast rule\n  with a pointer to this note. Do not reuse the muted colour for active\n  text.\n- Figma: https://www.figma.com/design/digitaltableteur/forms — keep\n  required-marker styling aligned with the Figma form-field component.\n- The translation surface is implicit: consumers pass already-translated\n  strings via `children`. The \"(required)\" SR text is hardcoded in EN\n  because the asterisk semantics are universally understood; if a locale\n  needs a different SR convention, override via the consumer.\n",
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Label",
@@ -30701,7 +30701,7 @@
           }
         }
       },
-      "spec": "# Switch\n\n## Intent\nRender a two-state setting toggle with the right semantic role for\n\"on/off\" controls. Switch is distinct from Checkbox: it implies\n\"applied immediately\" and is announced by screen readers as a switch,\nnot a checkbox.\n\n## Interaction contract\n- Keyboard: Space and Enter toggle. Tab follows DOM order.\n- Pointer: click toggles. Loading state suppresses click.\n- Screen readers: `<button role=\"switch\">` with `aria-checked` reflecting\n  the value. Loading sets `aria-busy`; disabled sets `aria-disabled`.\n\n## Do / don't\n- Do: use Switch for \"apply-on-toggle\" settings.\n- Do: set `isLoading` during async commits to prevent double-flips.\n- Don't: use Switch inside a form whose values are submitted in a batch.\n  Use Checkbox there so the choose-then-Submit affordance is honest.\n- Don't: rely on colour alone to convey state — the position of the\n  thumb is the primary visual cue, and forced-colors fallbacks preserve\n  that position semantic.\n\n## Design notes\n- Tokens: on-state surface is `--color-primary`; off-state is\n  `--color-surface-2`. Thumb is `--color-on-primary` against the surface.\n  Loading spinner uses the focus ring colour for clarity.\n- Figma: https://www.figma.com/design/digitaltableteur/switch — variants\n  for placement (right / left / top label) and loading state aligned with\n  the Figma component set.\n- Label and HelperText composition is internal — the consumer passes\n  strings, the component owns the layout. Different from Checkbox, where\n  the consumer composes the surrounding atoms manually.\n",
+      "spec": "# Switch\n\n## Intent\nRender a two-state setting toggle with the right semantic role for\n\"on/off\" controls. Switch is distinct from Checkbox: it implies\n\"applied immediately\" and is announced by screen readers as a switch,\nnot a checkbox.\n\n## Interaction contract\n- Keyboard: Space and Enter toggle. Tab follows DOM order.\n- Pointer: click toggles. Loading state suppresses click.\n- Screen readers: `<button role=\"switch\">` with `aria-checked` reflecting\n  the value. Loading sets `aria-busy`; disabled sets `aria-disabled`.\n\n## Do / don't\n- Do: use Switch for \"apply-on-toggle\" settings.\n- Do: set `isLoading` during async commits to prevent double-flips.\n- Don't: use Switch inside a form whose values are submitted in a batch.\n  Use Checkbox there so the choose-then-Submit affordance is honest.\n- Don't: rely on colour alone to convey state — the position of the\n  thumb is the primary visual cue, and forced-colors fallbacks preserve\n  that position semantic.\n\n## Design notes\n- Tokens: on-state surface is `--color-primary`; off-state is\n  `--color-surface-2`. Thumb is `--color-on-primary` against the surface.\n  Loading spinner uses the focus ring colour for clarity.\n- Figma: https://www.figma.com/design/digitaltableteur/switch — variants\n  for placement (right / left / top label) and loading state aligned with\n  the Figma component set.\n- Label and HelperText composition is internal — the consumer passes\n  strings, the component owns the layout. Different from Checkbox, where\n  the consumer composes the surrounding atoms manually.\n- Axe exemption (documented): while `loading` the control is inert\n  (interaction blocked, `aria-busy`) and its label takes the muted\n  disabled colour, intentionally sub-AA (3.19:1). WCAG 1.4.3 exempts\n  text that is part of an inactive control; axe cannot infer the label's\n  association, so the Loading story disables the color-contrast rule with\n  a pointer to this note. Do not reuse the muted colour for active text.\n",
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Switch",
@@ -41355,6 +41355,173 @@
         "composesWith": [],
         "prefersOver": [],
         "declaredPropCount": 11
+      }
+    },
+    {
+      "name": "PricingCalculator",
+      "contract": {
+        "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+        "schemaVersion": 2,
+        "name": "PricingCalculator",
+        "tier": "pattern",
+        "group": "marketing",
+        "status": "beta",
+        "description": "Interactive duration × workload pricing calculator for the pricing page.",
+        "dense": "Pricing calculator section: duration and workload SelectableCard groups drive a live summary (allocation, hours, effective rate, total investment) with a booking CTA.",
+        "keywords": [
+          "pricing",
+          "calculator",
+          "estimator",
+          "investment",
+          "marketing"
+        ],
+        "usage": {
+          "description": "PricingCalculator is the custom-engagement estimator on the pricing page: two single-select SelectableCardGroups (duration: 2 weeks to 12 months; workload: 2–5 days/week) recompute total hours, allocation, the tier-discounted hourly rate, and the total investment on every change. Longer commitments (6/12 months) carry a Partnership badge and the deepest rate discounts. It complements the fixed packages; it does not replace them.",
+          "bestPractices": [
+            {
+              "guidance": true,
+              "description": "Keep the pricing model in pricingMath.ts as the single source of truth; the component only renders its output."
+            },
+            {
+              "guidance": false,
+              "description": "Don't use it for fixed-scope package pricing; that's the packages section of PricingPageContent."
+            },
+            {
+              "guidance": false,
+              "description": "Don't hardcode currency formatting; totals format via Intl.NumberFormat on the active language."
+            }
+          ]
+        },
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-pricing-calculator",
+        "radixPrimitive": null,
+        "element": "section",
+        "variants": {},
+        "slots": [],
+        "asChild": false,
+        "subParts": [],
+        "requiredStories": [
+          "Default",
+          "Playground",
+          "Example",
+          "ForcedColors"
+        ],
+        "a11y": {
+          "keyboard": [
+            "Tab",
+            "Arrow keys",
+            "Space",
+            "Enter"
+          ],
+          "ariaRequirements": [
+            "section labelled by the calculator title",
+            "native fieldset/legend + radio semantics from SelectableCardGroup",
+            "CTA is a real link to /contact"
+          ],
+          "reducedMotion": true,
+          "reviewed": true,
+          "reviewedNote": "2026-07-18 — Initial beta: native radio groups via SelectableCardGroup (keyboard + AT from the platform), axe assertion in unit tests, ForcedColors story added.",
+          "forcedColorsVerified": true
+        },
+        "tokens": {
+          "colors": [
+            "--color-surface",
+            "--color-border-light",
+            "--color-muted",
+            "--color-primary"
+          ],
+          "spacing": []
+        },
+        "lightDarkVerified": true,
+        "props": {
+          "className": {
+            "optional": true,
+            "type": "string",
+            "description": "Optional wrapper class."
+          }
+        },
+        "composesWith": [
+          "PricingPageContent",
+          "CTASection"
+        ],
+        "forbiddenUse": [
+          "use for fixed-scope package pricing",
+          "duplicate the pricing model outside pricingMath.ts"
+        ],
+        "consumers": [
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx",
+            "since": "2026-07-18"
+          }
+        ]
+      },
+      "spec": "# PricingCalculator\n\n## Intent\nInteractive duration × workload pricing calculator for the pricing page: two\nselectable option groups drive a live summary of total hours, allocation,\neffective hourly rate, and total investment, closing with a booking CTA.\n\n## Pricing model\n- Standard rate 120 €/h, 7 hours/day (owner-approved 2026-07-18).\n- Weeks per duration: 2 weeks = 2; months × 52/12 otherwise.\n- Hourly-rate tier discounts: 3 mo −5%, 6 mo −10%, 12 mo −15%; 6 and 12 months\n  carry the Partnership badge.\n- Total investment = round(weeks × days × 7) × discounted rate.\n- Model lives in `pricingMath.ts`; the component only renders its output.\n\n## Interaction contract\n- Keyboard: Tab into each group; Arrow keys/Space change the native radio\n  selection (SelectableCardGroup); Enter activates the CTA link\n- Pointer: whole option cards are labels for their radios\n- Screen readers: fieldset/legend names each group; the summary re-renders as\n  static text (no live region — values update on user action within the group)\n\n## Do / don't\n- Do: keep all price maths in `pricingMath.ts`\n- Do: format totals via `Intl.NumberFormat` on the active language\n- Don't: use for fixed-scope package pricing (packages section owns that)\n- Don't: duplicate the pricing model in other components\n\n## Design notes\n- Tokens: `--color-surface`, `--color-border-light`, `--color-muted`,\n  `--color-primary`, layout/internal space tokens, text/title size tokens\n- Figma: none yet (code-first pattern, 2026-07-18)\n",
+      "documentationDebt": false,
+      "usage": {
+        "publicImport": "@dt/PricingCalculator",
+        "importCount": 1,
+        "productionImportCount": 0,
+        "patternImportCount": 1,
+        "componentImportCount": 0,
+        "evidence": [
+          {
+            "path": "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx",
+            "importKind": "relative",
+            "importPath": "../PricingCalculator",
+            "context": "pattern"
+          }
+        ]
+      },
+      "agent": {
+        "preferredImport": "@dt/PricingCalculator",
+        "intent": "Interactive duration × workload pricing calculator for the pricing page: two selectable option groups drive a live summary of total hours, allocation, effective hourly rate, and total investment, closing with a booking …",
+        "props": {
+          "className": {
+            "optional": true,
+            "type": "string",
+            "description": "Optional wrapper class."
+          }
+        },
+        "propRelationships": [],
+        "variants": {},
+        "cvaVariants": {},
+        "variantsFnName": null,
+        "useWhen": [
+          "keep all price maths in `pricingMath.ts`",
+          "format totals via `Intl.NumberFormat` on the active language"
+        ],
+        "avoidWhen": [
+          "use for fixed-scope package pricing (packages section owns that)",
+          "duplicate the pricing model in other components"
+        ],
+        "requiredA11y": [
+          "section labelled by the calculator title",
+          "native fieldset/legend + radio semantics from SelectableCardGroup",
+          "CTA is a real link to /contact"
+        ],
+        "keyboard": [
+          "Tab",
+          "Arrow keys",
+          "Space",
+          "Enter"
+        ],
+        "compositionRules": [
+          "duplicate the pricing model in other components"
+        ],
+        "canonicalExamples": [
+          "Default",
+          "Playground",
+          "Example",
+          "ForcedColors"
+        ],
+        "replacementFor": [],
+        "forbiddenUse": [
+          "use for fixed-scope package pricing (packages section owns that)",
+          "duplicate the pricing model in other components"
+        ],
+        "composesWith": [],
+        "prefersOver": [],
+        "declaredPropCount": 1
       }
     },
     {

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-17T14:13:09.993Z",
+  "generatedAt": "2026-07-18T06:07:34.644Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -13407,6 +13407,57 @@
       "composesWith": [],
       "prefersOver": [],
       "declaredPropCount": 11
+    },
+    "PricingCalculator": {
+      "preferredImport": "@dt/PricingCalculator",
+      "intent": "Interactive duration × workload pricing calculator for the pricing page: two selectable option groups drive a live summary of total hours, allocation, effective hourly rate, and total investment, closing with a booking …",
+      "props": {
+        "className": {
+          "optional": true,
+          "type": "string",
+          "description": "Optional wrapper class."
+        }
+      },
+      "propRelationships": [],
+      "variants": {},
+      "cvaVariants": {},
+      "variantsFnName": null,
+      "useWhen": [
+        "keep all price maths in `pricingMath.ts`",
+        "format totals via `Intl.NumberFormat` on the active language"
+      ],
+      "avoidWhen": [
+        "use for fixed-scope package pricing (packages section owns that)",
+        "duplicate the pricing model in other components"
+      ],
+      "requiredA11y": [
+        "section labelled by the calculator title",
+        "native fieldset/legend + radio semantics from SelectableCardGroup",
+        "CTA is a real link to /contact"
+      ],
+      "keyboard": [
+        "Tab",
+        "Arrow keys",
+        "Space",
+        "Enter"
+      ],
+      "compositionRules": [
+        "duplicate the pricing model in other components"
+      ],
+      "canonicalExamples": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+      ],
+      "replacementFor": [],
+      "forbiddenUse": [
+        "use for fixed-scope package pricing (packages section owns that)",
+        "duplicate the pricing model in other components"
+      ],
+      "composesWith": [],
+      "prefersOver": [],
+      "declaredPropCount": 1
     },
     "PricingPageContent": {
       "preferredImport": "@dt/PricingPageContent",

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -8263,7 +8263,7 @@
         {
           "story": "Disabled",
           "description": "Visual mute for a disabled field; the input must also be disabled.",
-          "source": "export const Disabled = Template.bind({});\nDisabled.args = {\n  htmlFor: \"input-id\",\n  children: \"storyLabelDisabled\",\n  disabled: true,\n};\n\nDefault.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement);\n  await canvas.findByText(/default label/i);\n};\n\nWithTooltip.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement);\n  const label = await canvas.findByText(/label with tooltip/i);\n  await userEvent.hover(label);\n  // Optionally, check for tooltip appearance if implemented\n};\n\nRequired.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement);\n  await canvas.findByText(/required label/i);\n};\n\nDisabled.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement);\n  const label = await canvas.findByText(/disabled label/i);\n  // Optionally, check for disabled state if implemented\n};\n\nDisabled.tags = [\"example\"];\nDisabled.parameters = {\n  ...(Disabled as { parameters?: object }).parameters,\n  docs: { description: { story: \"Visual mute for a disabled field; the input must also be disabled.\" } },\n};"
+          "source": "export const Disabled = Template.bind({});\nDisabled.args = {\n  htmlFor: \"input-id\",\n  children: \"storyLabelDisabled\",\n  disabled: true,\n};\n// Documented axe exemption (see Label.spec.md): the muted disabled-label\n// color is intentionally sub-AA — WCAG 1.4.3 exempts text that is part of\n// an inactive control, but axe cannot tell a label belongs to one.\nDisabled.parameters = {\n  a11y: { options: { rules: [{ id: \"color-contrast\", enabled: false }] } },\n};\n\nDefault.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement);\n  await canvas.findByText(/default label/i);\n};\n\nWithTooltip.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement);\n  const label = await canvas.findByText(/label with tooltip/i);\n  await userEvent.hover(label);\n  // Optionally, check for tooltip appearance if implemented\n};\n\nRequired.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement);\n  await canvas.findByText(/required label/i);\n};\n\nDisabled.play = async ({ canvasElement }) => {\n  const canvas = within(canvasElement);\n  const label = await canvas.findByText(/disabled label/i);\n  // Optionally, check for disabled state if implemented\n};\n\nDisabled.tags = [\"example\"];\nDisabled.parameters = {\n  ...(Disabled as { parameters?: object }).parameters,\n  docs: { description: { story: \"Visual mute for a disabled field; the input must also be disabled.\" } },\n};"
         }
       ]
     },
@@ -14849,7 +14849,7 @@
         {
           "story": "Loading",
           "description": "loading blocks double flips and sets aria-busy while an async toggle is in flight.",
-          "source": "export const Loading: Story = {\n  tags: [\"example\"],\n  parameters: {\n    docs: {\n      description: {\n        story:\n          \"loading blocks double flips and sets aria-busy while an async toggle is in flight.\",\n      },\n    },\n  },\n  args: { loading: true, checked: true },\n  render: (args) => <ControlledTemplate {...args} />,\n};"
+          "source": "export const Loading: Story = {\n  tags: [\"example\"],\n  parameters: {\n    docs: {\n      description: {\n        story:\n          \"loading blocks double flips and sets aria-busy while an async toggle is in flight.\",\n      },\n    },\n    // Documented axe exemption (see Switch.spec.md): while loading the\n    // control is inactive and its label takes the muted disabled color —\n    // WCAG 1.4.3 exempts inactive-control text, but axe cannot tell the\n    // label belongs to one.\n    a11y: { options: { rules: [{ id: \"color-contrast\", enabled: false }] } },\n  },\n  args: { loading: true, checked: true },\n  render: (args) => <ControlledTemplate {...args} />,\n};"
         },
         {
           "story": "LabelOnTop",
@@ -19619,6 +19619,72 @@
       },
       "tokens": {
         "colors": [],
+        "spacing": []
+      },
+      "examples": []
+    },
+    "PricingCalculator": {
+      "name": "PricingCalculator",
+      "group": "marketing",
+      "tier": 2,
+      "status": "beta",
+      "description": "Interactive duration × workload pricing calculator for the pricing page.",
+      "dense": "Pricing calculator section: duration and workload SelectableCard groups drive a live summary (allocation, hours, effective rate, total investment) with a booking CTA.",
+      "keywords": [
+        "pricing",
+        "calculator",
+        "estimator",
+        "investment",
+        "marketing"
+      ],
+      "importLine": "import { PricingCalculator } from \"@dt/PricingCalculator\";",
+      "keyProps": [
+        {
+          "name": "className",
+          "type": "string",
+          "required": false
+        }
+      ],
+      "props": {
+        "className": {
+          "optional": true,
+          "type": "string",
+          "description": "Optional wrapper class."
+        }
+      },
+      "composesWith": [
+        "PricingPageContent",
+        "CTASection"
+      ],
+      "prefersOver": [],
+      "forbiddenUse": [
+        "use for fixed-scope package pricing",
+        "duplicate the pricing model outside pricingMath.ts"
+      ],
+      "usage": {
+        "description": "PricingCalculator is the custom-engagement estimator on the pricing page: two single-select SelectableCardGroups (duration: 2 weeks to 12 months; workload: 2–5 days/week) recompute total hours, allocation, the tier-discounted hourly rate, and the total investment on every change. Longer commitments (6/12 months) carry a Partnership badge and the deepest rate discounts. It complements the fixed packages; it does not replace them.",
+        "bestPractices": [
+          {
+            "guidance": true,
+            "description": "Keep the pricing model in pricingMath.ts as the single source of truth; the component only renders its output."
+          },
+          {
+            "guidance": false,
+            "description": "Don't use it for fixed-scope package pricing; that's the packages section of PricingPageContent."
+          },
+          {
+            "guidance": false,
+            "description": "Don't hardcode currency formatting; totals format via Intl.NumberFormat on the active language."
+          }
+        ]
+      },
+      "tokens": {
+        "colors": [
+          "--color-surface",
+          "--color-border-light",
+          "--color-muted",
+          "--color-primary"
+        ],
         "spacing": []
       },
       "examples": []

--- a/nextjs-app/shared/locales/en/translation.json
+++ b/nextjs-app/shared/locales/en/translation.json
@@ -1352,5 +1352,26 @@
   "splitButton": {
     "moreOptions": "More options"
   },
-  "storyCheckboxGroupMasterLabel": "Select all"
+  "storyCheckboxGroupMasterLabel": "Select all",
+  "pricingCalcTitle": "Adjust duration and workload to see your total investment.",
+  "pricingCalcDurationLegend": "Duration",
+  "pricingCalcWorkloadLegend": "Workload",
+  "pricingCalcUnitWeeks": "weeks",
+  "pricingCalcUnitMonth": "month",
+  "pricingCalcUnitMonths": "months",
+  "pricingCalcUnitDaysPerWeek": "days/week",
+  "pricingCalcPartnershipBadge": "Partnership",
+  "pricingCalcAllocationLabel": "Allocation",
+  "pricingCalcAllocationBasis": "Based on {{days}} days/week × {{hours}} hours/day",
+  "pricingCalcTotalHoursLabel": "Total hours:",
+  "pricingCalcStandardRateLabel": "Standard rate:",
+  "pricingCalcRatePerHour": "{{rate}}€/hour",
+  "pricingCalcIncludedTitle": "What's included in your investment:",
+  "pricingCalcIncludedDuration": "{{duration}} design partnership",
+  "pricingCalcIncludedWorkload": "Dedicated design expertise for {{days}} days per week",
+  "pricingCalcIncludedProcess": "Complete end-to-end design process and deliverables",
+  "pricingCalcIncludedCollaboration": "Direct collaboration and strategic design guidance",
+  "pricingCalcYourPriceLabel": "Your price",
+  "pricingCalcTotalInvestmentLabel": "Total Investment:",
+  "pricingCalcCta": "Get in touch"
 }

--- a/nextjs-app/shared/locales/fi/translation.json
+++ b/nextjs-app/shared/locales/fi/translation.json
@@ -1356,5 +1356,26 @@
     "moreOptions": "Lisää vaihtoehtoja"
   },
   "mermaidErrorTitle": "Kaaviovirhe",
-  "storyCheckboxGroupMasterLabel": "Valitse kaikki"
+  "storyCheckboxGroupMasterLabel": "Valitse kaikki",
+  "pricingCalcTitle": "Säädä kestoa ja työmäärää, niin näet kokonaisinvestointisi.",
+  "pricingCalcDurationLegend": "Kesto",
+  "pricingCalcWorkloadLegend": "Työmäärä",
+  "pricingCalcUnitWeeks": "viikkoa",
+  "pricingCalcUnitMonth": "kuukausi",
+  "pricingCalcUnitMonths": "kuukautta",
+  "pricingCalcUnitDaysPerWeek": "päivää/vko",
+  "pricingCalcPartnershipBadge": "Kumppanuus",
+  "pricingCalcAllocationLabel": "Allokaatio",
+  "pricingCalcAllocationBasis": "Perustuu: {{days}} päivää/vko × {{hours}} tuntia/päivä",
+  "pricingCalcTotalHoursLabel": "Tunnit yhteensä:",
+  "pricingCalcStandardRateLabel": "Normaalihinta:",
+  "pricingCalcRatePerHour": "{{rate}} €/tunti",
+  "pricingCalcIncludedTitle": "Mitä investointisi sisältää:",
+  "pricingCalcIncludedDuration": "{{duration}} kestävä designkumppanuus",
+  "pricingCalcIncludedWorkload": "Omistettu designasiantuntemus {{days}} päivänä viikossa",
+  "pricingCalcIncludedProcess": "Kattava design-prosessi ja toimitukset alusta loppuun",
+  "pricingCalcIncludedCollaboration": "Suora yhteistyö ja strateginen designohjaus",
+  "pricingCalcYourPriceLabel": "Hintasi",
+  "pricingCalcTotalInvestmentLabel": "Kokonaisinvestointi:",
+  "pricingCalcCta": "Ota yhteyttä"
 }

--- a/nextjs-app/shared/locales/sv/translation.json
+++ b/nextjs-app/shared/locales/sv/translation.json
@@ -1366,5 +1366,26 @@
     "moreOptions": "Fler alternativ"
   },
   "mermaidErrorTitle": "Diagramfel",
-  "storyCheckboxGroupMasterLabel": "Välj alla"
+  "storyCheckboxGroupMasterLabel": "Välj alla",
+  "pricingCalcTitle": "Justera längd och arbetsmängd för att se din totala investering.",
+  "pricingCalcDurationLegend": "Längd",
+  "pricingCalcWorkloadLegend": "Arbetsmängd",
+  "pricingCalcUnitWeeks": "veckor",
+  "pricingCalcUnitMonth": "månad",
+  "pricingCalcUnitMonths": "månader",
+  "pricingCalcUnitDaysPerWeek": "dagar/vecka",
+  "pricingCalcPartnershipBadge": "Partnerskap",
+  "pricingCalcAllocationLabel": "Allokering",
+  "pricingCalcAllocationBasis": "Baserat på {{days}} dagar/vecka × {{hours}} timmar/dag",
+  "pricingCalcTotalHoursLabel": "Timmar totalt:",
+  "pricingCalcStandardRateLabel": "Standardpris:",
+  "pricingCalcRatePerHour": "{{rate}} €/timme",
+  "pricingCalcIncludedTitle": "Vad din investering inkluderar:",
+  "pricingCalcIncludedDuration": "Designpartnerskap i {{duration}}",
+  "pricingCalcIncludedWorkload": "Dedikerad designexpertis {{days}} dagar i veckan",
+  "pricingCalcIncludedProcess": "Komplett designprocess och leveranser från början till slut",
+  "pricingCalcIncludedCollaboration": "Direkt samarbete och strategisk designrådgivning",
+  "pricingCalcYourPriceLabel": "Ditt pris",
+  "pricingCalcTotalInvestmentLabel": "Total investering:",
+  "pricingCalcCta": "Kontakta oss"
 }

--- a/nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.contract.json
+++ b/nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.contract.json
@@ -1,0 +1,90 @@
+{
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "schemaVersion": 2,
+    "name": "PricingCalculator",
+    "tier": "pattern",
+    "group": "marketing",
+    "status": "beta",
+    "description": "Interactive duration × workload pricing calculator for the pricing page.",
+    "dense": "Pricing calculator section: duration and workload SelectableCard groups drive a live summary (allocation, hours, effective rate, total investment) with a booking CTA.",
+    "keywords": [
+        "pricing",
+        "calculator",
+        "estimator",
+        "investment",
+        "marketing"
+    ],
+    "usage": {
+        "description": "PricingCalculator is the custom-engagement estimator on the pricing page: two single-select SelectableCardGroups (duration: 2 weeks to 12 months; workload: 2–5 days/week) recompute total hours, allocation, the tier-discounted hourly rate, and the total investment on every change. Longer commitments (6/12 months) carry a Partnership badge and the deepest rate discounts. It complements the fixed packages; it does not replace them.",
+        "bestPractices": [
+            {
+                "guidance": true,
+                "description": "Keep the pricing model in pricingMath.ts as the single source of truth; the component only renders its output."
+            },
+            {
+                "guidance": false,
+                "description": "Don't use it for fixed-scope package pricing; that's the packages section of PricingPageContent."
+            },
+            {
+                "guidance": false,
+                "description": "Don't hardcode currency formatting; totals format via Intl.NumberFormat on the active language."
+            }
+        ]
+    },
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-pricing-calculator",
+    "radixPrimitive": null,
+    "element": "section",
+    "variants": {},
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [
+            "Tab",
+            "Arrow keys",
+            "Space",
+            "Enter"
+        ],
+        "ariaRequirements": [
+            "section labelled by the calculator title",
+            "native fieldset/legend + radio semantics from SelectableCardGroup",
+            "CTA is a real link to /contact"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-07-18 — Initial beta: native radio groups via SelectableCardGroup (keyboard + AT from the platform), axe assertion in unit tests, ForcedColors story added.",
+        "forcedColorsVerified": true
+    },
+    "tokens": {
+        "colors": [
+            "--color-surface",
+            "--color-border-light",
+            "--color-muted",
+            "--color-primary"
+        ],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "props": {
+        "className": {
+            "optional": true,
+            "type": "string",
+            "description": "Optional wrapper class."
+        }
+    },
+    "composesWith": [
+        "PricingPageContent",
+        "CTASection"
+    ],
+    "forbiddenUse": [
+        "use for fixed-scope package pricing",
+        "duplicate the pricing model outside pricingMath.ts"
+    ],
+    "consumers": []
+}

--- a/nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.module.css
+++ b/nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.module.css
@@ -1,0 +1,178 @@
+/* PricingCalculator — duration × workload → total investment.
+   Two-column section: selection controls on the left, live summary on the
+   right; collapses to a single column below the content breakpoint. */
+
+.calculator {
+  display: grid;
+  padding: var(--space-layout-24);
+  grid-template-columns: 1fr;
+  gap: var(--space-layout-32);
+  border: 1px solid var(--color-border-light);
+  border-radius: 16px;
+  background-color: var(--color-surface);
+}
+
+@media (width >= 900px) {
+  .calculator {
+    padding: var(--space-layout-32);
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+    gap: var(--space-layout-48);
+  }
+}
+
+/* Left column — controls */
+
+.controls {
+  display: flex;
+  min-inline-size: 0;
+  flex-direction: column;
+  gap: var(--space-layout-24);
+}
+
+.title {
+  max-inline-size: 24ch;
+}
+
+/* Option groups: two columns of equal cards. The group renders a fieldset
+   with an options wrapper div; the layout lives here (not on the cards) so it
+   also holds for the registry-published SelectableCard, which drops per-card
+   className until the next @digitaltableteur/react release. */
+
+.optionGroup {
+  inline-size: 100%;
+}
+
+.optionGroup > div {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.optionContent {
+  display: flex;
+  justify-content: center;
+  align-items: baseline;
+  gap: var(--space-internal-8);
+}
+
+.optionAmount {
+  font-weight: 600;
+}
+
+.optionUnit {
+  color: var(--color-muted);
+}
+
+.partnershipBadge {
+  position: absolute;
+  z-index: 1;
+  inset-block-start: calc(-1 * var(--space-internal-8));
+  inset-inline-end: var(--space-internal-12);
+}
+
+/* Meta cards under the controls */
+
+.metaRow {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-internal-12);
+}
+
+@media (width >= 600px) {
+  .metaRow {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.metaCard {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--space-internal-8);
+}
+
+.metaHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-internal-8);
+}
+
+.metaLabel {
+  color: var(--color-muted);
+}
+
+.metaValue {
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.metaFootnote {
+  color: var(--color-muted);
+}
+
+.metaLine {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-internal-8);
+}
+
+.metaFigure {
+  font-weight: 600;
+}
+
+/* Right column — summary */
+
+.summary {
+  display: flex;
+  min-inline-size: 0;
+  flex-direction: column;
+  gap: var(--space-layout-16);
+}
+
+.includedTitle {
+  margin-block-end: var(--space-internal-12);
+  font-weight: 600;
+}
+
+.includedList {
+  color: var(--color-muted);
+}
+
+.priceCard {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-internal-8);
+}
+
+.priceLabel {
+  color: var(--color-muted);
+}
+
+.priceValue {
+  font-size: var(--font-size-text-xxl);
+  font-weight: 600;
+  line-height: 1.1;
+}
+
+.totalCard {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-internal-12);
+  flex-flow: row wrap;
+}
+
+.totalLabel {
+  font-weight: 600;
+}
+
+.totalValue {
+  font-size: var(--font-size-title-s);
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.cta {
+  inline-size: 100%;
+}

--- a/nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.spec.md
+++ b/nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.spec.md
@@ -1,0 +1,32 @@
+# PricingCalculator
+
+## Intent
+Interactive duration × workload pricing calculator for the pricing page: two
+selectable option groups drive a live summary of total hours, allocation,
+effective hourly rate, and total investment, closing with a booking CTA.
+
+## Pricing model
+- Standard rate 120 €/h, 7 hours/day (owner-approved 2026-07-18).
+- Weeks per duration: 2 weeks = 2; months × 52/12 otherwise.
+- Hourly-rate tier discounts: 3 mo −5%, 6 mo −10%, 12 mo −15%; 6 and 12 months
+  carry the Partnership badge.
+- Total investment = round(weeks × days × 7) × discounted rate.
+- Model lives in `pricingMath.ts`; the component only renders its output.
+
+## Interaction contract
+- Keyboard: Tab into each group; Arrow keys/Space change the native radio
+  selection (SelectableCardGroup); Enter activates the CTA link
+- Pointer: whole option cards are labels for their radios
+- Screen readers: fieldset/legend names each group; the summary re-renders as
+  static text (no live region — values update on user action within the group)
+
+## Do / don't
+- Do: keep all price maths in `pricingMath.ts`
+- Do: format totals via `Intl.NumberFormat` on the active language
+- Don't: use for fixed-scope package pricing (packages section owns that)
+- Don't: duplicate the pricing model in other components
+
+## Design notes
+- Tokens: `--color-surface`, `--color-border-light`, `--color-muted`,
+  `--color-primary`, layout/internal space tokens, text/title size tokens
+- Figma: none yet (code-first pattern, 2026-07-18)

--- a/nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.stories.tsx
+++ b/nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+import { PricingCalculator } from "./PricingCalculator";
+import { computePricing } from "./pricingMath";
+import contract from "./PricingCalculator.contract.json";
+
+const meta = {
+  title: "Patterns/PricingCalculator",
+  component: PricingCalculator,
+  tags: ["beta", "autodocs"],
+  parameters: {
+    layout: "padded",
+    contractStatus: contract.status,
+    a11y: { test: "error" },
+    docs: { description: { component: contract.description } },
+  },
+  argTypes: {
+    className: {
+      control: "text",
+      description: "Optional wrapper class.",
+      table: { category: "Advanced", type: { summary: "string" } },
+    },
+  },
+} satisfies Meta<typeof PricingCalculator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  tags: ["beta-matrix"],
+};
+
+export const Playground: Story = {
+  tags: ["beta-matrix"],
+  args: {
+    className: "",
+  },
+};
+
+/** Selecting a different duration and workload recomputes the totals live. */
+export const Interactive: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const format = new Intl.NumberFormat("en", { maximumFractionDigits: 0 });
+
+    // Defaults: 2 months × 5 days/week.
+    const defaults = computePricing("2m", 5);
+    await expect(
+      canvas.getByText(format.format(defaults.totalHours)),
+    ).toBeInTheDocument();
+
+    // Move to the 12-month partnership tier at 3 days/week.
+    await userEvent.click(canvas.getByRole("radio", { name: /12\s*months/i }));
+    await userEvent.click(canvas.getByRole("radio", { name: /3\s*days/i }));
+
+    const next = computePricing("12m", 3);
+    await expect(
+      canvas.getByText(format.format(next.totalHours)),
+    ).toBeInTheDocument();
+    await expect(next.effectiveRate).toBe(102);
+    await expect(
+      canvas.getByText(new RegExp(`^${next.effectiveRate}\\s?€/`)),
+    ).toBeInTheDocument();
+  },
+};
+
+/** In-context composition: the section as it sits on the pricing page. */
+export const Example: Story = {
+  render: () => (
+    <div style={{ maxWidth: 1120, marginInline: "auto" }}>
+      <PricingCalculator />
+    </div>
+  ),
+};
+
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
+  globals: { forcedColors: "active" },
+};

--- a/nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.test.tsx
+++ b/nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { PricingCalculator } from "./PricingCalculator";
+import {
+  DURATION_OPTIONS,
+  STANDARD_RATE,
+  computePricing,
+} from "./pricingMath";
+
+expect.extend(toHaveNoViolations);
+
+describe("pricingMath", () => {
+  it("matches the reference default: 2 months × 5 days/week = 303 hours at the standard rate", () => {
+    const pricing = computePricing("2m", 5);
+    expect(pricing.totalHours).toBe(303);
+    expect(pricing.effectiveRate).toBe(STANDARD_RATE);
+    expect(pricing.discount).toBe(0);
+    expect(pricing.allocationPercent).toBe(100);
+    expect(pricing.total).toBe(303 * STANDARD_RATE);
+  });
+
+  it("applies tier discounts to the hourly rate only on 3/6/12 month commitments", () => {
+    expect(computePricing("2w", 5).effectiveRate).toBe(120);
+    expect(computePricing("1m", 5).effectiveRate).toBe(120);
+    expect(computePricing("3m", 5).effectiveRate).toBe(114);
+    expect(computePricing("6m", 5).effectiveRate).toBe(108);
+    expect(computePricing("12m", 5).effectiveRate).toBe(102);
+  });
+
+  it("scales hours with days per week and reports allocation as a share of 5 days", () => {
+    const pricing = computePricing("2w", 3);
+    expect(pricing.totalHours).toBe(Math.round(2 * 3 * 7));
+    expect(pricing.allocationPercent).toBe(60);
+    expect(pricing.total).toBe(pricing.totalHours * 120);
+  });
+
+  it("marks exactly the 6 and 12 month tiers as partnerships", () => {
+    expect(
+      DURATION_OPTIONS.filter((option) => option.partnership).map(
+        (option) => option.id,
+      ),
+    ).toEqual(["6m", "12m"]);
+  });
+});
+
+describe("PricingCalculator", () => {
+  it("renders both selection groups with the defaults selected", () => {
+    render(<PricingCalculator />);
+
+    expect(
+      screen.getByRole("group", { name: "Duration" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: "Workload" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /^2\s*months$/i })).toBeChecked();
+    expect(screen.getByRole("radio", { name: /5\s*days/i })).toBeChecked();
+    expect(screen.getByText("303")).toBeInTheDocument();
+    expect(screen.getByText(/2 months design partnership/i)).toBeInTheDocument();
+  });
+
+  it("recomputes hours, rate, and included copy when the selection changes", async () => {
+    const user = userEvent.setup();
+    render(<PricingCalculator />);
+
+    await user.click(screen.getByRole("radio", { name: /12\s*months/i }));
+    await user.click(screen.getByRole("radio", { name: /3\s*days/i }));
+
+    const next = computePricing("12m", 3);
+    const formatted = new Intl.NumberFormat("en", {
+      maximumFractionDigits: 0,
+    }).format(next.totalHours);
+    expect(screen.getByText(formatted)).toBeInTheDocument();
+    expect(screen.getByText(/102€\/hour/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/12 months design partnership/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/expertise for 3 days per week/i),
+    ).toBeInTheDocument();
+  });
+
+  it("links the CTA to contact booking without an icon", () => {
+    render(<PricingCalculator />);
+    const cta = screen.getByRole("link", { name: "Get in touch" });
+    expect(cta).toHaveAttribute("href", "/contact?mode=book");
+    expect(cta.querySelector("svg")).toBeNull();
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(<PricingCalculator />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.tsx
+++ b/nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useId, useMemo, useState } from "react";
+import {
+  Badge,
+  Button,
+  Card,
+  List,
+  SelectableCard,
+  SelectableCardGroup,
+  Text,
+  Title,
+} from "@digitaltableteur/react";
+import { useLocalization } from "../../lib/translation";
+import { cn } from "../../lib/cn";
+import {
+  DAYS_PER_WEEK_OPTIONS,
+  DURATION_OPTIONS,
+  HOURS_PER_DAY,
+  computePricing,
+  getDurationOption,
+  type DurationId,
+  type DurationOption,
+} from "./pricingMath";
+import styles from "./PricingCalculator.module.css";
+
+export interface PricingCalculatorProps {
+  /** Optional wrapper class. */
+  className?: string;
+}
+
+/**
+ * PricingCalculator — duration × workload → total investment. Selections are
+ * two single-select SelectableCardGroups; the summary column recomputes the
+ * effective hourly rate, total hours, and total investment on every change.
+ */
+export function PricingCalculator({ className }: PricingCalculatorProps) {
+  const { translate: t, resolvedLanguage } = useLocalization();
+  const titleId = useId();
+  const [durationId, setDurationId] = useState<DurationId>("2m");
+  const [daysPerWeek, setDaysPerWeek] = useState(5);
+
+  const duration = getDurationOption(durationId);
+  const pricing = computePricing(durationId, daysPerWeek);
+
+  const numberFormat = useMemo(
+    () =>
+      new Intl.NumberFormat(resolvedLanguage || "en", {
+        maximumFractionDigits: 0,
+      }),
+    [resolvedLanguage],
+  );
+
+  const unitLabel = (option: DurationOption): string => {
+    if (option.unit === "weeks") {
+      return t("pricingCalcUnitWeeks", "weeks");
+    }
+    return option.amount === 1
+      ? t("pricingCalcUnitMonth", "month")
+      : t("pricingCalcUnitMonths", "months");
+  };
+
+  const durationPhrase = `${duration.amount} ${unitLabel(duration)}`;
+  const ratePhrase = t("pricingCalcRatePerHour", "{{rate}}€/hour", {
+    rate: pricing.effectiveRate,
+  });
+  const standardRatePhrase = t("pricingCalcRatePerHour", "{{rate}}€/hour", {
+    rate: pricing.standardRate,
+  });
+
+  return (
+    <section
+      className={cn(styles.calculator, className)}
+      aria-labelledby={titleId}
+    >
+      <div className={styles.controls}>
+        <Title
+          level={3}
+          size="m"
+          lineHeight="tight"
+          id={titleId}
+          className={styles.title}
+        >
+          {t(
+            "pricingCalcTitle",
+            "Adjust duration and workload to see your total investment.",
+          )}
+        </Title>
+
+        <SelectableCardGroup
+          legend={t("pricingCalcDurationLegend", "Duration")}
+          value={durationId}
+          onValueChange={(value) => setDurationId(value as DurationId)}
+          orientation="horizontal"
+          className={styles.optionGroup}
+        >
+          {DURATION_OPTIONS.map((option) => (
+            <SelectableCard
+              key={option.id}
+              value={option.id}
+              padding="sm"
+            >
+              <span className={styles.optionContent}>
+                <Text as="span" size="m" className={styles.optionAmount}>
+                  {option.amount}
+                </Text>
+                <Text as="span" size="m" className={styles.optionUnit}>
+                  {unitLabel(option)}
+                </Text>
+              </span>
+              {option.partnership ? (
+                <Badge size="sm" className={styles.partnershipBadge}>
+                  {t("pricingCalcPartnershipBadge", "Partnership")}
+                </Badge>
+              ) : null}
+            </SelectableCard>
+          ))}
+        </SelectableCardGroup>
+
+        <SelectableCardGroup
+          legend={t("pricingCalcWorkloadLegend", "Workload")}
+          value={String(daysPerWeek)}
+          onValueChange={(value) => setDaysPerWeek(Number(value))}
+          orientation="horizontal"
+          className={styles.optionGroup}
+        >
+          {DAYS_PER_WEEK_OPTIONS.map((days) => (
+            <SelectableCard
+              key={days}
+              value={String(days)}
+              padding="sm"
+            >
+              <span className={styles.optionContent}>
+                <Text as="span" size="m" className={styles.optionAmount}>
+                  {days}
+                </Text>
+                <Text as="span" size="m" className={styles.optionUnit}>
+                  {t("pricingCalcUnitDaysPerWeek", "days/week")}
+                </Text>
+              </span>
+            </SelectableCard>
+          ))}
+        </SelectableCardGroup>
+
+        <div className={styles.metaRow}>
+          <Card variant="muted" padding="md" className={styles.metaCard}>
+            <div className={styles.metaHeader}>
+              <Text as="span" size="s" className={styles.metaLabel}>
+                {t("pricingCalcAllocationLabel", "Allocation")}
+              </Text>
+              <Text as="span" size="l" className={styles.metaValue}>
+                {pricing.allocationPercent}%
+              </Text>
+            </div>
+            <Text as="p" size="s" className={styles.metaFootnote}>
+              {t(
+                "pricingCalcAllocationBasis",
+                "Based on {{days}} days/week × {{hours}} hours/day",
+                { days: daysPerWeek, hours: HOURS_PER_DAY },
+              )}
+            </Text>
+          </Card>
+          <Card variant="muted" padding="md" className={styles.metaCard}>
+            <div className={styles.metaLine}>
+              <Text as="span" size="s" className={styles.metaLabel}>
+                {t("pricingCalcTotalHoursLabel", "Total hours:")}
+              </Text>
+              <Text as="span" size="s" className={styles.metaFigure}>
+                {numberFormat.format(pricing.totalHours)}
+              </Text>
+            </div>
+            <div className={styles.metaLine}>
+              <Text as="span" size="s" className={styles.metaLabel}>
+                {t("pricingCalcStandardRateLabel", "Standard rate:")}
+              </Text>
+              <Text as="span" size="s" className={styles.metaFigure}>
+                {standardRatePhrase}
+              </Text>
+            </div>
+          </Card>
+        </div>
+      </div>
+
+      <div className={styles.summary}>
+        <div className={styles.included}>
+          <Text as="p" size="m" className={styles.includedTitle}>
+            {t("pricingCalcIncludedTitle", "What's included in your investment:")}
+          </Text>
+          <List
+            size="m"
+            spacing="normal"
+            className={styles.includedList}
+            items={[
+              t("pricingCalcIncludedDuration", "{{duration}} design partnership", {
+                duration: durationPhrase,
+              }),
+              t(
+                "pricingCalcIncludedWorkload",
+                "Dedicated design expertise for {{days}} days per week",
+                { days: daysPerWeek },
+              ),
+              t(
+                "pricingCalcIncludedProcess",
+                "Complete end-to-end design process and deliverables",
+              ),
+              t(
+                "pricingCalcIncludedCollaboration",
+                "Direct collaboration and strategic design guidance",
+              ),
+            ]}
+          />
+        </div>
+
+        <Card variant="muted" padding="lg" className={styles.priceCard}>
+          <Text as="p" size="s" className={styles.priceLabel}>
+            {t("pricingCalcYourPriceLabel", "Your price")}
+          </Text>
+          <Text as="p" size="l" className={styles.priceValue}>
+            {ratePhrase}
+          </Text>
+        </Card>
+
+        <Card variant="muted" padding="lg" className={styles.totalCard}>
+          <Text as="span" size="m" className={styles.totalLabel}>
+            {t("pricingCalcTotalInvestmentLabel", "Total Investment:")}
+          </Text>
+          <Text as="span" size="l" className={styles.totalValue}>
+            {numberFormat.format(pricing.total)}&nbsp;€
+          </Text>
+        </Card>
+
+        <Button
+          href="/contact?mode=book"
+          variant="primary"
+          size="lg"
+          className={styles.cta}
+        >
+          {t("pricingCalcCta", "Get in touch")}
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+PricingCalculator.displayName = "PricingCalculator";
+
+export default PricingCalculator;

--- a/nextjs-app/shared/patterns/PricingCalculator/index.ts
+++ b/nextjs-app/shared/patterns/PricingCalculator/index.ts
@@ -1,0 +1,16 @@
+export { PricingCalculator, default } from "./PricingCalculator";
+export type { PricingCalculatorProps } from "./PricingCalculator";
+export {
+  DAYS_PER_WEEK_OPTIONS,
+  DURATION_OPTIONS,
+  FULL_WEEK_DAYS,
+  HOURS_PER_DAY,
+  STANDARD_RATE,
+  computePricing,
+  getDurationOption,
+} from "./pricingMath";
+export type {
+  DurationId,
+  DurationOption,
+  PricingBreakdown,
+} from "./pricingMath";

--- a/nextjs-app/shared/patterns/PricingCalculator/pricingMath.ts
+++ b/nextjs-app/shared/patterns/PricingCalculator/pricingMath.ts
@@ -1,0 +1,68 @@
+/**
+ * Pricing model for the /pricing calculator (owner-approved 2026-07-18):
+ * standard rate 120 €/h at 7 h/day, with hourly-rate discounts on longer
+ * commitments (3 mo −5%, 6 mo −10%, 12 mo −15%).
+ */
+
+export const STANDARD_RATE = 120;
+export const HOURS_PER_DAY = 7;
+export const FULL_WEEK_DAYS = 5;
+
+const WEEKS_PER_MONTH = 52 / 12;
+
+export type DurationId = "2w" | "1m" | "2m" | "3m" | "6m" | "12m";
+
+export interface DurationOption {
+  id: DurationId;
+  /** Displayed quantity (2 weeks, 1 month, …). */
+  amount: number;
+  unit: "weeks" | "months";
+  weeks: number;
+  /** Fractional discount applied to the hourly rate. */
+  discount: number;
+  /** Marks the long-commitment partnership tiers. */
+  partnership: boolean;
+}
+
+export const DURATION_OPTIONS: DurationOption[] = [
+  { id: "2w", amount: 2, unit: "weeks", weeks: 2, discount: 0, partnership: false },
+  { id: "1m", amount: 1, unit: "months", weeks: WEEKS_PER_MONTH, discount: 0, partnership: false },
+  { id: "2m", amount: 2, unit: "months", weeks: 2 * WEEKS_PER_MONTH, discount: 0, partnership: false },
+  { id: "3m", amount: 3, unit: "months", weeks: 3 * WEEKS_PER_MONTH, discount: 0.05, partnership: false },
+  { id: "6m", amount: 6, unit: "months", weeks: 6 * WEEKS_PER_MONTH, discount: 0.1, partnership: true },
+  { id: "12m", amount: 12, unit: "months", weeks: 12 * WEEKS_PER_MONTH, discount: 0.15, partnership: true },
+];
+
+export const DAYS_PER_WEEK_OPTIONS = [2, 3, 4, 5] as const;
+
+export interface PricingBreakdown {
+  totalHours: number;
+  standardRate: number;
+  /** Standard rate after the duration tier discount, rounded to whole euros. */
+  effectiveRate: number;
+  discount: number;
+  /** Share of a full 5-day week, as a whole percentage. */
+  allocationPercent: number;
+  total: number;
+}
+
+export function getDurationOption(id: DurationId): DurationOption {
+  return DURATION_OPTIONS.find((option) => option.id === id) ?? DURATION_OPTIONS[0];
+}
+
+export function computePricing(
+  durationId: DurationId,
+  daysPerWeek: number,
+): PricingBreakdown {
+  const duration = getDurationOption(durationId);
+  const totalHours = Math.round(duration.weeks * daysPerWeek * HOURS_PER_DAY);
+  const effectiveRate = Math.round(STANDARD_RATE * (1 - duration.discount));
+  return {
+    totalHours,
+    standardRate: STANDARD_RATE,
+    effectiveRate,
+    discount: duration.discount,
+    allocationPercent: Math.round((daysPerWeek / FULL_WEEK_DAYS) * 100),
+    total: Math.round(totalHours * effectiveRate),
+  };
+}

--- a/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.module.css
+++ b/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.module.css
@@ -442,6 +442,12 @@
   }
 }
 
+/* Calculator — custom-engagement estimator between AaaS and the CTAs */
+
+.calculatorSection {
+  margin-block-start: var(--space-layout-48);
+}
+
 /* CTAs */
 
 .ctaRow {

--- a/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx
+++ b/nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx
@@ -5,6 +5,7 @@ import { useId, useState } from "react";
 import { useTranslate } from "../../lib/translation";
 import { cn } from "../../lib/cn";
 import { Button, Icon, Text, Title } from "@digitaltableteur/react";
+import { PricingCalculator } from "../PricingCalculator";
 import styles from "./PricingPageContent.module.css";
 
 const PRICING_HERO_IMAGE = "/images/pricing/dsharp3-hero.png";
@@ -475,6 +476,13 @@ export function PricingPageContent({ className }: PricingPageContentProps) {
                 ))}
               </ul>
             </div>
+          </div>
+
+          <div
+            className={styles.calculatorSection}
+            data-donny-target="pricing.calculator"
+          >
+            <PricingCalculator />
           </div>
 
           <div className={styles.ctaRow}>


### PR DESCRIPTION
## Summary
- New `PricingCalculator` pattern on /pricing (after AaaS, before the CTA row): duration (2 wks / 1 / 2 / 3 / 6 / 12 mo) × workload (2–5 days/week) SelectableCardGroups drive a live summary — total hours, allocation, tier-discounted hourly rate and total investment — with Partnership badges on 6/12 mo and a "Get in touch" booking CTA (no icon, per owner deviation).
- Pricing model (owner-approved): 120 €/h standard at 7 h/day; rate discounts 3 mo −5 %, 6 mo −10 %, 12 mo −15 %; model isolated in `pricingMath.ts`. Defaults 2 mo × 5 d/wk = 303 h, 36 360 €.
- EN/FI/SV copy; totals via `Intl.NumberFormat` on the active language.
- DS fix (owner-approved): `SelectableCard` declared `className` but dropped it — now merged onto the card label. The pattern does not depend on the fix (app consumes registry react 0.1.16); the 2-column option layout lives on the group's options wrapper.
- Existing pricing sections untouched. Consumer-audit regeneration included.

## Verification
- Local gate green: typecheck, lint, full tests (2688), build, validate:components, build:tokens, check:contract-props, check:consumers.
- Live-verified in the browser (light + dark): defaults render 303 h / 120€/hour / 36,360 €; selecting 12 mo × 3 d/wk recomputes to 1 092 h / 102€/hour / 111,384 € / 60 % allocation.
- Known pre-existing gap (chip filed): Storybook doesn't load `@digitaltableteur/react/style.css`, so npm-consumed components render unstyled in stories (affects PricingPageContent too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive pricing calculator to the pricing page.
  * Users can select engagement duration and weekly workload to view updated hours, rates, discounts, and total investment.
  * Added localized calculator content in English, Finnish, and Swedish.
  * Added a “Get in touch” call-to-action linking to the contact page.

* **Bug Fixes**
  * Improved selectable card styling so custom styles are applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->