### PR TITLE
fix(scripts): dogfood work-nav flow targets WorkNav's own label

### DIFF
--- a/scripts/design-system/check-site-package-dogfood.mjs
+++ b/scripts/design-system/check-site-package-dogfood.mjs
@@ -246,7 +246,10 @@ async function main() {
         },
         async ({ assert }) => {
           await gotoAndStabilize(page, WORK_ROUTE);
-          const back = tr(language, "projectBackToWork");
+          // Work detail routes render WorkNav (via NextWorkNav) since #1228;
+          // its back control is labeled workNavBackToWork, not the old
+          // ProjectNav projectBackToWork.
+          const back = tr(language, "workNavBackToWork");
           const prev = tr(language, "workNavPrev");
           const next = tr(language, "workNavNext");
           assert(


### PR DESCRIPTION
Stale check expectation from the #1228 nav swap (ProjectNav → WorkNav on work detail routes); the site-package-dogfood work-nav row now uses workNavBackToWork. Verified 27/27 green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)