### PR TITLE
fix(scripts): i18n visual matrix targets WorkNav's own back label

### DIFF
--- a/scripts/design-system/run-i18n-visual-matrix.mjs
+++ b/scripts/design-system/run-i18n-visual-matrix.mjs
@@ -199,7 +199,9 @@ async function main() {
           assert(page.url().endsWith("/work"), "SiteHeader Work link routes to /work");
 
           await gotoAndStabilize(page, "/work/helsinki-design-system");
-          const workBack = tr(language, "projectBackToWork");
+          // Work detail routes render WorkNav (via NextWorkNav) since #1228;
+          // its back control is labeled workNavBackToWork.
+          const workBack = tr(language, "workNavBackToWork");
           assert(
             (await page.getByRole("button", { name: textPattern(workBack) }).count()) > 0,
             `WorkNav back label is localized: ${workBack}`,


### PR DESCRIPTION
Companion to #1249: run-i18n-visual-matrix.mjs still expected ProjectNav's projectBackToWork on work detail routes; now workNavBackToWork. Verified 27/27 checks / 24 screenshots green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)