### PR TITLE
fix(scripts): unwedge wc publish verification — bounded parity fetch + fresh server per phase

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "generate:web-components": "node scripts/design-system/generate-web-components.mjs",
     "build:web-components": "npm run generate:web-components && npm --prefix packages/web-components run build",
     "check:web-components": "node scripts/design-system/check-web-components.mjs",
-    "check:web-components:dod": "npm run check:web-components && concurrently -k -s first -n SB,TEST \"npm run storybook -- --ci --no-open --quiet\" \"npm run storybook:wait && npm run test:stories:web-components && npm run check:rendered-parity\"",
+    "check:web-components:dod": "npm run check:web-components && npm run test:stories:web-components:ci && npm run check:rendered-parity:ci",
     "check:react-public-api": "node scripts/design-system/check-react-public-api.mjs",
     "check:react-public-surface": "node scripts/design-system/check-react-public-surface.mjs",
     "check:npm-consumer-install": "node scripts/design-system/check-npm-consumer-install.mjs",

--- a/scripts/design-system/check-rendered-parity.mjs
+++ b/scripts/design-system/check-rendered-parity.mjs
@@ -104,7 +104,12 @@ if (nativeElements.length === 0) {
   throw new Error(`No native component matches ${componentFilter}`);
 }
 
-const indexResponse = await fetch(`${baseUrl}/index.json`);
+// Bounded: after the wc story sweep the shared dev server can be wedged
+// (accepted socket, no response); an untimed fetch here turned that into an
+// infinite CI hang (2026-07-18 publish runs). Fail loudly instead.
+const indexResponse = await fetch(`${baseUrl}/index.json`, {
+  signal: AbortSignal.timeout(60_000),
+});
 if (!indexResponse.ok) {
   throw new Error(
     `Unable to read Storybook index (${indexResponse.status} ${indexResponse.statusText})`,


### PR DESCRIPTION
Root cause of today's hung/failed ds-publish runs (first ever to execute the #1231 rendered-parity gate in CI): the wc story sweep wedges the shared Storybook dev server, and parity's untimed `fetch(index.json)` converts that into an infinite hang. Evidence: orphaned parity+chrome processes at cancellation, 11 min of log silence after the sweep's last line, and attempt-1's collected 'Error loading story index: Failed to fetch'.

- `check-rendered-parity.mjs`: index fetch bounded with `AbortSignal.timeout(60_000)`
- `check:web-components:dod`: sweep and parity now run as their own `:ci` phases, each booting a fresh dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI validation reliability by preventing rendered-parity checks from hanging when the development server becomes unresponsive.
  * Updated web component checks to use CI-optimized test and parity validation workflows executed sequentially.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->