### PR TITLE
fix(ci): ds-publish runs the wc build check, not the storybook dod gate

### DIFF
--- a/.github/workflows/ds-publish.yml
+++ b/.github/workflows/ds-publish.yml
@@ -71,8 +71,13 @@ jobs:
       - name: Build and verify React package
         run: npm run check:react-package
 
+      # Build + vitest verification only. The Storybook story sweep and
+      # rendered-parity pixel gate (check:web-components:dod) are development
+      # gates enforced by the local publish preflight, whose clearance record
+      # this workflow verifies below; running them here made publish runs take
+      # 20-60 minutes instead of ~10 and wedged twice on 2026-07-18.
       - name: Build and verify Web Components package
-        run: npm run check:web-components:dod
+        run: npm run check:web-components
 
       - name: Verify package metadata
         run: npm run check:package-release-notes


### PR DESCRIPTION
Publish runs ballooned to 20-60 min (and wedged twice today) because the transport ran the full Storybook sweep + rendered-parity dod chain on every dispatch. Those gates live in the local publish preflight (whose clearance record the workflow verifies). The transport now builds and vitest-verifies the wc package only — publish runs return to ~10 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)