### PR TITLE
chore(app): consume @digitaltableteur/react@0.1.17 — retire calculator shims, Badge xs

### DIFF
--- a/.rhythmguard-baseline.json
+++ b/.rhythmguard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "createdAt": "2026-07-18T09:11:44.565Z",
+  "createdAt": "2026-07-18T12:41:18.390Z",
   "directory": "nextjs-app/shared",
   "findings": [
     {
@@ -5865,8 +5865,8 @@
     {
       "column": 25,
       "file": "nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.module.css",
-      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/PricingCalculator/PricingCalculator.module.css\u001f127\u001f25\u001f-50%\u001fUnexpected raw scale value \"-50%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
-      "line": 127,
+      "key": "rhythmguard/prefer-token\u001ftoken-opportunity\u001fnextjs-app/shared/patterns/PricingCalculator/PricingCalculator.module.css\u001f90\u001f25\u001f-50%\u001fUnexpected raw scale value \"-50%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "line": 90,
       "rule": "rhythmguard/prefer-token",
       "text": "Unexpected raw scale value \"-50%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
       "type": "token-opportunity",

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.16
+  - definition: 0.1.17
   - term: tokens
   - definition: 0.1.2
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.forced-colors.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.16
+  - definition: 0.1.17
   - term: tokens
   - definition: 0.1.2
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.16
+  - definition: 0.1.17
   - term: tokens
   - definition: 0.1.2
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.16
+  - definition: 0.1.17
   - term: tokens
   - definition: 0.1.2
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.16
+  - definition: 0.1.17
   - term: tokens
   - definition: 0.1.2
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.forced-colors.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.16
+  - definition: 0.1.17
   - term: tokens
   - definition: 0.1.2
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.16
+  - definition: 0.1.17
   - term: tokens
   - definition: 0.1.2
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.16
+  - definition: 0.1.17
   - term: tokens
   - definition: 0.1.2
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.16
+  - definition: 0.1.17
   - term: tokens
   - definition: 0.1.2
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.forced-colors.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.16
+  - definition: 0.1.17
   - term: tokens
   - definition: 0.1.2
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.16
+  - definition: 0.1.17
   - term: tokens
   - definition: 0.1.2
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.16
+  - definition: 0.1.17
   - term: tokens
   - definition: 0.1.2
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.16
+  - definition: 0.1.17
   - term: tokens
   - definition: 0.1.2
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.forced-colors.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.16
+  - definition: 0.1.17
   - term: tokens
   - definition: 0.1.2
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.16
+  - definition: 0.1.17
   - term: tokens
   - definition: 0.1.2
   - term: tokens-css

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
@@ -69,7 +69,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.16
+  - definition: 0.1.17
   - term: tokens
   - definition: 0.1.2
   - term: tokens-css

--- a/nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.module.css
+++ b/nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.module.css
@@ -58,42 +58,10 @@
   row-gap: var(--space-internal-16);
 }
 
-/* Registry SelectableCard (react 0.1.16) still draws its radio indicator,
-   reserves trailing padding for it, lets the surface sit content-height
-   inside a stretched label, and swaps the selected border on hover; the DS
-   source has fixed all four (the whole card is the control, content centers,
-   selected look survives hover). Neutralize here until the next react
-   publish. */
-
-.optionGroup label {
-  display: flex;
-  flex-direction: column;
-}
-
-.optionGroup label span[data-type] {
-  display: none;
-}
-
-.optionGroup label > div {
-  display: flex;
-  padding-inline-end: var(--space-internal-12);
-  flex: 1 1 auto;
-  flex-direction: column;
-  justify-content: center;
-}
-
-.calculator .optionGroup label[data-selected="true"]:hover > div {
-  border-color: var(--color-primary);
-}
-
-/* Windows High Contrast strips author box-shadows, so the published selected
-   ring vanishes; border-width survives forced colors and restores a non-color
-   selected cue on the whole-card control. */
-@media (forced-colors: active) {
-  .calculator .optionGroup label[data-selected="true"] > div {
-    border-width: 3px;
-  }
-}
+/* The registry SelectableCard (react >= 0.1.17) owns the whole-card control
+   behavior natively: no indicator glyph, flex-column centering, selected look
+   surviving hover, and the forced-colors border cue. The 0.1.16-era reach-in
+   shims that reproduced those from here are retired. */
 
 .optionContent {
   display: flex;
@@ -111,18 +79,13 @@
   color: var(--color-muted);
 }
 
-/* Badge straddles the card's top edge (half above, half on the card).
-   pointer-events: none so it never steals clicks from this or nearby cards.
-   The 24px height mirrors the DS Badge size="xs" added on this branch; the
-   registry package (0.1.16) predates it, so keep size="sm" + this override
-   until the next react publish, then switch to size="xs" and delete the
-   block-size line. Scoped under .calculator to outrank Badge's sm=32px at
-   equal load order. */
+/* Badge (size="xs") straddles the card's top edge (half above, half on the
+   card). pointer-events: none so it never steals clicks from this or nearby
+   cards. */
 
 .calculator .partnershipBadge {
   position: absolute;
   z-index: 1;
-  block-size: 24px;
   pointer-events: none;
   transform: translateY(-50%);
   inset-block-start: 0;

--- a/nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.tsx
+++ b/nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.tsx
@@ -240,7 +240,7 @@ export function PricingCalculator({ className }: PricingCalculatorProps) {
                     {unitLabel(option)}
                   </Text>{" "}
                   {option.partnership ? (
-                    <Badge size="sm" className={styles.partnershipBadge}>
+                    <Badge size="xs" className={styles.partnershipBadge}>
                       {t("pricingCalcPartnershipBadge", "Partnership")}
                     </Badge>
                   ) : null}
@@ -267,7 +267,7 @@ export function PricingCalculator({ className }: PricingCalculatorProps) {
                       {t("pricingCalcUnitDays", "days")}
                     </Text>{" "}
                     {duration.partnership && days >= PARTNERSHIP_MIN_DAYS ? (
-                      <Badge size="sm" className={styles.partnershipBadge}>
+                      <Badge size="xs" className={styles.partnershipBadge}>
                         {t("pricingCalcPartnershipBadge", "Partnership")}
                       </Badge>
                     ) : null}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ai-sdk/openai": "^4.0.11",
         "@ai-sdk/react": "^4.0.23",
         "@calcom/embed-react": "^1.5.3",
-        "@digitaltableteur/react": "^0.1.16",
+        "@digitaltableteur/react": "^0.1.17",
         "@digitaltableteur/tokens": "^0.1.2",
         "@digitaltableteur/tokens-css": "^0.1.3",
         "@emailjs/browser": "^4.4.1",
@@ -3402,9 +3402,9 @@
       "license": "MIT"
     },
     "node_modules/@digitaltableteur/react": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.16.tgz",
-      "integrity": "sha512-g240qbVfi7XVY3sSpEKZA+sHjStSvlDPjTwiK/XcIit/yWVO9pPCRS+J7BViFzc4C0FbIKa9nZoXGMujzhENFg==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.17.tgz",
+      "integrity": "sha512-8Tr/iwufm0heSw9bwrums6Ps1668O01Yi8dOnC6PHk+3LA2qQsEkBotLB80/XWVFxHw8PkuDEBDP2hLuvh8ftQ==",
       "license": "UNLICENSED",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "@ai-sdk/openai": "^4.0.11",
     "@ai-sdk/react": "^4.0.23",
     "@calcom/embed-react": "^1.5.3",
-    "@digitaltableteur/react": "^0.1.16",
+    "@digitaltableteur/react": "^0.1.17",
     "@digitaltableteur/tokens": "^0.1.2",
     "@digitaltableteur/tokens-css": "^0.1.3",
     "@emailjs/browser": "^4.4.1",

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -1,6 +1,6 @@
 {
   "generatedBy": "npm run lint:css:update",
-  "warningCount": 437,
+  "warningCount": 436,
   "warnings": [
     {
       "id": "app/blog/NextBlogNav.module.css::7::3::order/properties-order::Expected \"margin-inline\" to come before \"max-width\" (order/properties-order)",
@@ -3216,31 +3216,22 @@
       "text": "Expected variable, function or keyword for \"CanvasText\" of \"color\" (scale-unlimited/declaration-strict-value)"
     },
     {
-      "id": "nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.module.css::290::1::no-descending-specificity::Expected selector \".calculator .priceLabel\" to come before selector \".priceCard.priceCardDiscounted .priceLabel\", at line 243 (no-descending-specificity)",
+      "id": "nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.module.css::253::1::no-descending-specificity::Expected selector \".calculator .priceLabel\" to come before selector \".priceCard.priceCardDiscounted .priceLabel\", at line 206 (no-descending-specificity)",
       "file": "nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.module.css",
-      "line": 290,
+      "line": 253,
       "column": 1,
       "rule": "no-descending-specificity",
       "severity": "warning",
-      "text": "Expected selector \".calculator .priceLabel\" to come before selector \".priceCard.priceCardDiscounted .priceLabel\", at line 243 (no-descending-specificity)"
+      "text": "Expected selector \".calculator .priceLabel\" to come before selector \".priceCard.priceCardDiscounted .priceLabel\", at line 206 (no-descending-specificity)"
     },
     {
-      "id": "nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.module.css::294::1::no-descending-specificity::Expected selector \".calculator .priceValue\" to come before selector \".priceCard.priceCardDiscounted .priceValue\", at line 247 (no-descending-specificity)",
+      "id": "nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.module.css::257::1::no-descending-specificity::Expected selector \".calculator .priceValue\" to come before selector \".priceCard.priceCardDiscounted .priceValue\", at line 210 (no-descending-specificity)",
       "file": "nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.module.css",
-      "line": 294,
+      "line": 257,
       "column": 1,
       "rule": "no-descending-specificity",
       "severity": "warning",
-      "text": "Expected selector \".calculator .priceValue\" to come before selector \".priceCard.priceCardDiscounted .priceValue\", at line 247 (no-descending-specificity)"
-    },
-    {
-      "id": "nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.module.css::85::1::selector-max-specificity::Too high specificity in \".calculator .optionGroup label[data-selected=\"true\"]:hover > div\", maximum \"0,4,0\" (selector-max-specificity)",
-      "file": "nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.module.css",
-      "line": 85,
-      "column": 1,
-      "rule": "selector-max-specificity",
-      "severity": "warning",
-      "text": "Too high specificity in \".calculator .optionGroup label[data-selected=\"true\"]:hover > div\", maximum \"0,4,0\" (selector-max-specificity)"
+      "text": "Expected selector \".calculator .priceValue\" to come before selector \".priceCard.priceCardDiscounted .priceValue\", at line 210 (no-descending-specificity)"
     },
     {
       "id": "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.module.css::11::3::order/properties-order::Expected \"padding-inline\" to come before \"max-width\" (order/properties-order)",


### PR DESCRIPTION
## Summary
- Bump `@digitaltableteur/react` ^0.1.16 → ^0.1.17 (published today: SelectableCard redesign incl. the className merge fix, Badge `xs`=24px, ListItem export).
- Retire every 0.1.16-era reach-in shim from PricingCalculator.module.css: the `padding-inline-end` time bomb is deleted, the dead `span[data-type]` rule and the duplicate label-flex / hover / forced-colors rules are pruned.
- Partnership badges switch from `size="sm"` + 24px override to the real `size="xs"`.
- AboutPageContent's 16 AT yaml react `definition:` lines trued to 0.1.17.

## Verification
- Registry install/resolution/storybook-registry checks green against the live registry; 48 targeted tests against the installed 0.1.17; full local gate green; live /pricing probe confirms package-owned behavior (no indicator spans, centered content, 12px padding, 24px xs badge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)