### PR TITLE
feat(figma): backfill batch 2 — stable navigation components, ratchet 59 → 55

### DIFF
--- a/nextjs-app/shared/components/CategoryFilter/CategoryFilter.contract.json
+++ b/nextjs-app/shared/components/CategoryFilter/CategoryFilter.contract.json
@@ -5,7 +5,7 @@
     "group": "navigation",
     "status": "stable",
     "description": "Filter pill row for list pages (blog archive, work index). Multiple visual treatments (pills, underline, minimal) for different surface densities.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-category-filter",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1429-2346",
     "radixPrimitive": null,
     "element": "div",
     "variants": {

--- a/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.contract.json
+++ b/nextjs-app/shared/components/LanguageSwitcher/LanguageSwitcher.contract.json
@@ -5,7 +5,7 @@
     "group": "navigation",
     "status": "stable",
     "description": "Compact language selector: a current-language trigger that fans out the other locales as a button group.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-language-switcher",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1430-2164",
     "radixPrimitive": null,
     "element": "div",
     "variants": {},

--- a/nextjs-app/shared/components/Pagination/Pagination.contract.json
+++ b/nextjs-app/shared/components/Pagination/Pagination.contract.json
@@ -5,7 +5,7 @@
     "group": "navigation",
     "status": "stable",
     "description": "Pagination controls for paged lists (article archive, search results). Renders a `<nav>` landmark with previous/next buttons and a numbered list; supports ellipsis truncation for long page ranges.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-pagination",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1430-2182",
     "radixPrimitive": null,
     "element": "nav",
     "variants": {},

--- a/nextjs-app/shared/components/SiteTree/SiteTree.contract.json
+++ b/nextjs-app/shared/components/SiteTree/SiteTree.contract.json
@@ -5,7 +5,7 @@
     "group": "navigation",
     "status": "stable",
     "description": "Hierarchical sitemap with collapsible folder branches and page leaves.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-site-tree",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1430-2200",
     "radixPrimitive": null,
     "element": "nav",
     "variants": {},

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-18T15:37:20.093Z",
+  "generatedAt": "2026-07-18T15:45:05.369Z",
   "summary": {
     "componentCount": 164,
     "statusCounts": {
@@ -5916,7 +5916,7 @@
         "group": "navigation",
         "status": "stable",
         "description": "Filter pill row for list pages (blog archive, work index). Multiple visual treatments (pills, underline, minimal) for different surface densities.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-category-filter",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1429-2346",
         "radixPrimitive": null,
         "element": "div",
         "variants": {
@@ -17167,7 +17167,7 @@
         "group": "navigation",
         "status": "stable",
         "description": "Compact language selector: a current-language trigger that fans out the other locales as a button group.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-language-switcher",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1430-2164",
         "radixPrimitive": null,
         "element": "div",
         "variants": {},
@@ -22100,7 +22100,7 @@
         "group": "navigation",
         "status": "stable",
         "description": "Pagination controls for paged lists (article archive, search results). Renders a `<nav>` landmark with previous/next buttons and a numbered list; supports ellipsis truncation for long page ranges.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-pagination",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1430-2182",
         "radixPrimitive": null,
         "element": "nav",
         "variants": {},
@@ -27362,7 +27362,7 @@
         "group": "navigation",
         "status": "stable",
         "description": "Hierarchical sitemap with collapsible folder branches and page leaves.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-site-tree",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1430-2200",
         "radixPrimitive": null,
         "element": "nav",
         "variants": {},

--- a/scripts/design-system/figma-component-index.json
+++ b/scripts/design-system/figma-component-index.json
@@ -456,6 +456,26 @@
       "name": "PhoneInput",
       "type": "COMPONENT",
       "page": "Atoms"
+    },
+    "1429-2346": {
+      "name": "CategoryFilter",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1430-2164": {
+      "name": "LanguageSwitcher",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "1430-2182": {
+      "name": "Pagination",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "1430-2200": {
+      "name": "SiteTree",
+      "type": "COMPONENT",
+      "page": "Atoms"
     }
   }
 }

--- a/scripts/design-system/figma-links.baseline.json
+++ b/scripts/design-system/figma-links.baseline.json
@@ -1,4 +1,4 @@
 {
-  "stablePlaceholderCeiling": 59,
-  "note": "Ratchet for BETA and STABLE contracts whose figma link does not resolve to a real component in figma-component-index.json. Tightened 64 -> 59 on 2026-07-18 (full-backfill program, batch wiring FormField, FormFieldEditorial, ContactFormEditorial, MultiCombobox, PhoneInput). Lower this in the PR that wires a real component. See docs/design-system/figma-parity-audit.md"
+  "stablePlaceholderCeiling": 55,
+  "note": "Ratchet for BETA and STABLE contracts whose figma link does not resolve to a real component in figma-component-index.json. Tightened 59 -> 55 on 2026-07-18 (full-backfill program, batch wiring CategoryFilter, LanguageSwitcher, Pagination, SiteTree). Lower this in the PR that wires a real component. See docs/design-system/figma-parity-audit.md"
 }


### PR DESCRIPTION
Second batch of the Figma backfill program. CategoryFilter required extending the FilterChip Figma set in place with the Size axis its contract already has (6 → 18 variants: sm 6/12 @12px, md 8/16 @14px, lg 8/24 @16px per FilterChip.module.css) plus a code-truth repair (underline chips carry padding-inline 0); CategoryFilter then composes real chip instances across its 9 Variant×Size combinations with per-variant group chrome (pills gap-8, underline gap-24 + bottom rail, minimal gap-16). LanguageSwitcher modeled in the open state (FI/SV fan + bordered EN trigger), Pagination with active/disabled/ellipsis anatomy, SiteTree with open/closed branches and the color/border/light indent rail. All variable-bound, forced-Dark verified. Ceiling 59 → 55.

Verification: check:figma-links 55/55; all contract gates + typecheck/lint/lint:css/test (2693)/build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)