### PR TITLE
feat(figma): backfill batch 3 — stable display/structure components, ratchet 55 → 47

### DIFF
--- a/nextjs-app/shared/components/AuthorBio/AuthorBio.contract.json
+++ b/nextjs-app/shared/components/AuthorBio/AuthorBio.contract.json
@@ -5,7 +5,7 @@
     "group": "structure",
     "status": "stable",
     "description": "Author byline card for blog articles: avatar, name, and markdown bio, resolved from the authors data by slug.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-author-bio",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1432-2568",
     "radixPrimitive": null,
     "element": "div",
     "variants": {},

--- a/nextjs-app/shared/components/EnhancedProjectCard/EnhancedProjectCard.contract.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/EnhancedProjectCard.contract.json
@@ -5,7 +5,7 @@
     "group": "marketing",
     "status": "stable",
     "description": "Portfolio project card with image, video hover, and metadata.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-enhanced-project-card",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1433-2257",
     "radixPrimitive": null,
     "element": "a",
     "variants": {

--- a/nextjs-app/shared/components/ExpandableSection/ExpandableSection.contract.json
+++ b/nextjs-app/shared/components/ExpandableSection/ExpandableSection.contract.json
@@ -5,7 +5,7 @@
     "group": "structure",
     "status": "stable",
     "description": "Collapsible content region with a trigger header. Lighter than `Accordion` (which manages a group of expandables) — used standalone for a single 'show more' or detail-disclosure section.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-expandable-section",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1433-2206",
     "radixPrimitive": null,
     "element": "div",
     "variants": {},

--- a/nextjs-app/shared/components/ReadingProgress/ReadingProgress.contract.json
+++ b/nextjs-app/shared/components/ReadingProgress/ReadingProgress.contract.json
@@ -5,7 +5,7 @@
     "group": "feedback",
     "status": "stable",
     "description": "Scroll-linked reading progress indicator for long content.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-reading-progress",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1433-2212",
     "radixPrimitive": null,
     "element": "div",
     "variants": {},

--- a/nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.contract.json
+++ b/nextjs-app/shared/components/SecureCVDownload/SecureCVDownload.contract.json
@@ -5,7 +5,7 @@
     "group": "structure",
     "status": "stable",
     "description": "Gated CV download whose trigger opens a verification modal before the file is served.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-secure-cvdownload",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1432-2635",
     "radixPrimitive": null,
     "element": "div",
     "variants": {},

--- a/nextjs-app/shared/components/ServiceCard/ServiceCard.contract.json
+++ b/nextjs-app/shared/components/ServiceCard/ServiceCard.contract.json
@@ -5,7 +5,7 @@
     "group": "marketing",
     "status": "stable",
     "description": "Service tile with icon, title, description, and optional link.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-service-card",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1431-2225",
     "radixPrimitive": null,
     "element": "div",
     "variants": {

--- a/nextjs-app/shared/components/SocialShare/SocialShare.contract.json
+++ b/nextjs-app/shared/components/SocialShare/SocialShare.contract.json
@@ -5,7 +5,7 @@
     "group": "structure",
     "status": "stable",
     "description": "Row of social share targets: per-network deep links plus a native-share or copy-link button, with an optional labelled article-footer variant.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-social-share",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1432-2609",
     "radixPrimitive": null,
     "element": "section",
     "variants": {

--- a/nextjs-app/shared/components/ValueCard/ValueCard.contract.json
+++ b/nextjs-app/shared/components/ValueCard/ValueCard.contract.json
@@ -5,7 +5,7 @@
     "group": "display",
     "status": "stable",
     "description": "Card variant for values / principles grids — icon + title + short description, with the same three visual treatments as `LocationCard`.",
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-value-card",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1431-2190",
     "radixPrimitive": null,
     "element": "article",
     "variants": {

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-18T15:45:05.369Z",
+  "generatedAt": "2026-07-18T15:53:47.165Z",
   "summary": {
     "componentCount": 164,
     "statusCounts": {
@@ -1916,7 +1916,7 @@
         "group": "structure",
         "status": "stable",
         "description": "Author byline card for blog articles: avatar, name, and markdown bio, resolved from the authors data by slug.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-author-bio",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1432-2568",
         "radixPrimitive": null,
         "element": "div",
         "variants": {},
@@ -11905,7 +11905,7 @@
         "group": "marketing",
         "status": "stable",
         "description": "Portfolio project card with image, video hover, and metadata.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-enhanced-project-card",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1433-2257",
         "radixPrimitive": null,
         "element": "a",
         "variants": {
@@ -12261,7 +12261,7 @@
         "group": "structure",
         "status": "stable",
         "description": "Collapsible content region with a trigger header. Lighter than `Accordion` (which manages a group of expandables) — used standalone for a single 'show more' or detail-disclosure section.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-expandable-section",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1433-2206",
         "radixPrimitive": null,
         "element": "div",
         "variants": {},
@@ -25284,7 +25284,7 @@
         "group": "feedback",
         "status": "stable",
         "description": "Scroll-linked reading progress indicator for long content.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-reading-progress",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1433-2212",
         "radixPrimitive": null,
         "element": "div",
         "variants": {},
@@ -25887,7 +25887,7 @@
         "group": "structure",
         "status": "stable",
         "description": "Gated CV download whose trigger opens a verification modal before the file is served.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-secure-cvdownload",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1432-2635",
         "radixPrimitive": null,
         "element": "div",
         "variants": {},
@@ -26982,7 +26982,7 @@
         "group": "marketing",
         "status": "stable",
         "description": "Service tile with icon, title, description, and optional link.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-service-card",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1431-2225",
         "radixPrimitive": null,
         "element": "div",
         "variants": {
@@ -28366,7 +28366,7 @@
         "group": "structure",
         "status": "stable",
         "description": "Row of social share targets: per-network deep links plus a native-share or copy-link button, with an optional labelled article-footer variant.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-social-share",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1432-2609",
         "radixPrimitive": null,
         "element": "section",
         "variants": {
@@ -35184,7 +35184,7 @@
         "group": "display",
         "status": "stable",
         "description": "Card variant for values / principles grids — icon + title + short description, with the same three visual treatments as `LocationCard`.",
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-value-card",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1431-2190",
         "radixPrimitive": null,
         "element": "article",
         "variants": {

--- a/scripts/design-system/figma-component-index.json
+++ b/scripts/design-system/figma-component-index.json
@@ -476,6 +476,46 @@
       "name": "SiteTree",
       "type": "COMPONENT",
       "page": "Atoms"
+    },
+    "1432-2568": {
+      "name": "AuthorBio",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "1433-2206": {
+      "name": "ExpandableSection",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "1432-2635": {
+      "name": "SecureCVDownload",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "1432-2609": {
+      "name": "SocialShare",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1433-2257": {
+      "name": "EnhancedProjectCard",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1431-2225": {
+      "name": "ServiceCard",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1433-2212": {
+      "name": "ReadingProgress",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "1431-2190": {
+      "name": "ValueCard",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
     }
   }
 }

--- a/scripts/design-system/figma-links.baseline.json
+++ b/scripts/design-system/figma-links.baseline.json
@@ -1,4 +1,4 @@
 {
-  "stablePlaceholderCeiling": 55,
-  "note": "Ratchet for BETA and STABLE contracts whose figma link does not resolve to a real component in figma-component-index.json. Tightened 59 -> 55 on 2026-07-18 (full-backfill program, batch wiring CategoryFilter, LanguageSwitcher, Pagination, SiteTree). Lower this in the PR that wires a real component. See docs/design-system/figma-parity-audit.md"
+  "stablePlaceholderCeiling": 47,
+  "note": "Ratchet for BETA and STABLE contracts whose figma link does not resolve to a real component in figma-component-index.json. Tightened 55 -> 47 on 2026-07-18 (full-backfill program, batch wiring AuthorBio, ExpandableSection, SecureCVDownload, SocialShare, EnhancedProjectCard, ServiceCard, ReadingProgress, ValueCard). Lower this in the PR that wires a real component. See docs/design-system/figma-parity-audit.md"
 }


### PR DESCRIPTION
Third backfill batch: eight stable components with full contract variant sets. ValueCard (default/bordered/elevated; 10% primary icon-tile wash via node-opacity rects), ServiceCard (default/bordered/elevated/minimal; per-variant chrome incl. 30% bottom rail), SocialShare (inline/article; DS Icon placeholders for runtime react-icons glyphs, recorded in description), EnhancedProjectCard (video/square/portrait/landscape image ratios), plus AuthorBio (2px primary frame + Avatar instance), SecureCVDownload (trigger + open email-gate dialog composed from TextInput/Button instances), ExpandableSection (open state), ReadingProgress (track/bar/percentage chip). All variable-bound and forced-Dark verified. Ceiling 55 → 47.

Verification: check:figma-links 47/47; all contract gates + typecheck/lint/lint:css/test (2693)/build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)