### PR TITLE
feat(figma): backfill batch 4 — stable patterns wave 1, ratchet 47 → 41

### DIFF
--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-18T15:53:47.165Z",
+  "generatedAt": "2026-07-18T16:00:33.728Z",
   "summary": {
     "componentCount": 164,
     "statusCounts": {
@@ -37797,7 +37797,7 @@
         "usage": {
           "description": "ContactHero opens a contact page with a headline and supporting copy; compact tightens vertical rhythm for shorter pages. Copy arrives via props (title, subtitle), so route-level i18n stays in the page component. The current editorial contact layout owns its own heading, so check ContactPageContentEditorial before reaching for this."
         },
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-contact-hero",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1435-135",
         "radixPrimitive": null,
         "element": "div",
         "variants": {},
@@ -39605,7 +39605,7 @@
         "usage": {
           "description": "HeroSection is the layout shell under heroes: a full-bleed section with min-height, align/justify, and background/backgroundImage variants, rendering whatever children you pass (HomeHero builds on it). Use it when a bespoke hero needs the shell but not Hero's fixed content model. Pass ariaLabel when the section needs its own landmark name."
         },
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-hero-section",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1434-139",
         "radixPrimitive": null,
         "element": "div",
         "variants": {
@@ -40256,7 +40256,7 @@
         "usage": {
           "description": "HighlightSection is the emphasized marketing band: overline, title, description, and a CTA slot over stronger visual variants and sm/md/lg sizes. The homepage uses it for the featured message between section bands. Use CTASection when the band's whole job is the closing call to action; HighlightSection is for mid-page emphasis."
         },
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-highlight-section",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1434-312",
         "radixPrimitive": null,
         "element": "div",
         "variants": {
@@ -40553,7 +40553,7 @@
         "usage": {
           "description": "HomeHero is the bespoke landing hero for the homepage: a kinetic headline randomized per visit, background treatment, and a primary CTA that scrolls to scrollTargetId. Copy and variants live inside the component by design; it is not a configurable hero. For prop-driven heroes on other routes use Hero, or HeroSection for a bare shell."
         },
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-home-hero",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1435-131",
         "radixPrimitive": null,
         "element": "div",
         "variants": {},
@@ -41819,7 +41819,7 @@
         "usage": {
           "description": "ProcessBlock presents a project's process as titled phase cards in a grid, under an optional section title and description. Work case-study pages use it to walk through discovery-to-delivery phases between StoryBlock sections. Phases are data props, so pages keep copy colocated with the page."
         },
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-process-block",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1435-160",
         "radixPrimitive": null,
         "element": "div",
         "variants": {},
@@ -44680,7 +44680,7 @@
         "usage": {
           "description": "StoryBlock is the workhorse narrative section of Work case studies: a subtitle/title pair, rich text content, and images arranged by imageLayout, over background and spacing knobs. Chain several StoryBlocks (with GridBlock mosaics and ProcessBlock) to build a project page's spine."
         },
-        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-story-block",
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1435-143",
         "radixPrimitive": null,
         "element": "div",
         "variants": {},

--- a/nextjs-app/shared/patterns/ContactHero/ContactHero.contract.json
+++ b/nextjs-app/shared/patterns/ContactHero/ContactHero.contract.json
@@ -15,7 +15,7 @@
     "usage": {
         "description": "ContactHero opens a contact page with a headline and supporting copy; compact tightens vertical rhythm for shorter pages. Copy arrives via props (title, subtitle), so route-level i18n stays in the page component. The current editorial contact layout owns its own heading, so check ContactPageContentEditorial before reaching for this."
     },
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-contact-hero",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1435-135",
     "radixPrimitive": null,
     "element": "div",
     "variants": {},

--- a/nextjs-app/shared/patterns/HeroSection/HeroSection.contract.json
+++ b/nextjs-app/shared/patterns/HeroSection/HeroSection.contract.json
@@ -16,7 +16,7 @@
     "usage": {
         "description": "HeroSection is the layout shell under heroes: a full-bleed section with min-height, align/justify, and background/backgroundImage variants, rendering whatever children you pass (HomeHero builds on it). Use it when a bespoke hero needs the shell but not Hero's fixed content model. Pass ariaLabel when the section needs its own landmark name."
     },
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-hero-section",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1434-139",
     "radixPrimitive": null,
     "element": "div",
     "variants": {

--- a/nextjs-app/shared/patterns/HighlightSection/HighlightSection.contract.json
+++ b/nextjs-app/shared/patterns/HighlightSection/HighlightSection.contract.json
@@ -16,7 +16,7 @@
     "usage": {
         "description": "HighlightSection is the emphasized marketing band: overline, title, description, and a CTA slot over stronger visual variants and sm/md/lg sizes. The homepage uses it for the featured message between section bands. Use CTASection when the band's whole job is the closing call to action; HighlightSection is for mid-page emphasis."
     },
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-highlight-section",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1434-312",
     "radixPrimitive": null,
     "element": "div",
     "variants": {

--- a/nextjs-app/shared/patterns/HomeHero/HomeHero.contract.json
+++ b/nextjs-app/shared/patterns/HomeHero/HomeHero.contract.json
@@ -16,7 +16,7 @@
     "usage": {
         "description": "HomeHero is the bespoke landing hero for the homepage: a kinetic headline randomized per visit, background treatment, and a primary CTA that scrolls to scrollTargetId. Copy and variants live inside the component by design; it is not a configurable hero. For prop-driven heroes on other routes use Hero, or HeroSection for a bare shell."
     },
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-home-hero",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1435-131",
     "radixPrimitive": null,
     "element": "div",
     "variants": {},

--- a/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.contract.json
+++ b/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.contract.json
@@ -16,7 +16,7 @@
     "usage": {
         "description": "ProcessBlock presents a project's process as titled phase cards in a grid, under an optional section title and description. Work case-study pages use it to walk through discovery-to-delivery phases between StoryBlock sections. Phases are data props, so pages keep copy colocated with the page."
     },
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-process-block",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1435-160",
     "radixPrimitive": null,
     "element": "div",
     "variants": {},

--- a/nextjs-app/shared/patterns/StoryBlock/StoryBlock.contract.json
+++ b/nextjs-app/shared/patterns/StoryBlock/StoryBlock.contract.json
@@ -16,7 +16,7 @@
     "usage": {
         "description": "StoryBlock is the workhorse narrative section of Work case studies: a subtitle/title pair, rich text content, and images arranged by imageLayout, over background and spacing knobs. Chain several StoryBlocks (with GridBlock mosaics and ProcessBlock) to build a project page's spine."
     },
-    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=dt-story-block",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1435-143",
     "radixPrimitive": null,
     "element": "div",
     "variants": {},

--- a/scripts/design-system/dogfood-ratchet.baseline.json
+++ b/scripts/design-system/dogfood-ratchet.baseline.json
@@ -553,6 +553,10 @@
       "rawElements": 1,
       "utilityLines": 0
     },
+    "nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.tsx": {
+      "rawElements": 0,
+      "utilityLines": 2
+    },
     "nextjs-app/shared/patterns/PricingPageContent/PricingPageContent.tsx": {
       "rawElements": 4,
       "utilityLines": 0

--- a/scripts/design-system/figma-component-index.json
+++ b/scripts/design-system/figma-component-index.json
@@ -516,6 +516,36 @@
       "name": "ValueCard",
       "type": "COMPONENT_SET",
       "page": "Atoms"
+    },
+    "1434-139": {
+      "name": "HeroSection",
+      "type": "COMPONENT_SET",
+      "page": "Patterns"
+    },
+    "1434-312": {
+      "name": "HighlightSection",
+      "type": "COMPONENT_SET",
+      "page": "Patterns"
+    },
+    "1435-131": {
+      "name": "HomeHero",
+      "type": "COMPONENT",
+      "page": "Patterns"
+    },
+    "1435-135": {
+      "name": "ContactHero",
+      "type": "COMPONENT",
+      "page": "Patterns"
+    },
+    "1435-143": {
+      "name": "StoryBlock",
+      "type": "COMPONENT",
+      "page": "Patterns"
+    },
+    "1435-160": {
+      "name": "ProcessBlock",
+      "type": "COMPONENT",
+      "page": "Patterns"
     }
   }
 }

--- a/scripts/design-system/figma-links.baseline.json
+++ b/scripts/design-system/figma-links.baseline.json
@@ -1,4 +1,4 @@
 {
-  "stablePlaceholderCeiling": 47,
-  "note": "Ratchet for BETA and STABLE contracts whose figma link does not resolve to a real component in figma-component-index.json. Tightened 55 -> 47 on 2026-07-18 (full-backfill program, batch wiring AuthorBio, ExpandableSection, SecureCVDownload, SocialShare, EnhancedProjectCard, ServiceCard, ReadingProgress, ValueCard). Lower this in the PR that wires a real component. See docs/design-system/figma-parity-audit.md"
+  "stablePlaceholderCeiling": 41,
+  "note": "Ratchet for BETA and STABLE contracts whose figma link does not resolve to a real component in figma-component-index.json. Tightened 47 -> 41 on 2026-07-18 (full-backfill program, batch wiring HeroSection, HighlightSection, HomeHero, ContactHero, StoryBlock, ProcessBlock). Lower this in the PR that wires a real component. See docs/design-system/figma-parity-audit.md"
 }


### PR DESCRIPTION
Fourth backfill batch, first pattern wave. HeroSection (Align start|center|end variants), HighlightSection (Variant solid|gradient|pattern|dots — gradient uses the code's hardcoded #ddf→#eef literals; the compact|comfortable|spacious size axis is padding-only geometry, recorded as a usage note per the owner bar), HomeHero, ContactHero, StoryBlock, ProcessBlock. Patterns page at 1200 width, Button lg instances + variable-bound Satoshi text, forced-Dark verified. Ceiling 47 → 41.

Second commit trues the **dogfood-ratchet baseline**: PricingCalculator.tsx (merged #1244) was never baselined, leaving the pre-push dogfood step latently red — the third guard-drift case found today after the figma-links slippage and the templates/ scan-root blind spot.

Process note: this PR's first push attempts surfaced a tooling hazard — pre-commit/pre-push typecheck races the running dev server's .next/dev type regeneration (transient TS syntax errors in generated files), and a recovery amend accidentally rewrote local main's tip (never pushed; local main was hard-reset to origin/main and verified byte-identical). Full local gate ran green for the exact pushed tree.

Verification: check:figma-links 41/41; all contract gates + typecheck/lint/lint:css/test (2693)/build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)