### PR TITLE
feat(parity): enroll AspectRatio in rendered-parity roster (15 -> 16)

### DIFF
--- a/nextjs-app/shared/components/AspectRatio/AspectRatio.stories.tsx
+++ b/nextjs-app/shared/components/AspectRatio/AspectRatio.stories.tsx
@@ -2,6 +2,14 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { AspectRatio } from "./AspectRatio";
 import contract from "./AspectRatio.contract.json";
 
+// Deterministic hero fixture, byte-identical to the native dt-aspect-ratio
+// Example story (shared/stories/WebComponents/AspectRatio). A network image
+// (picsum) is non-deterministic and can never pixel-match a twin; the
+// rendered-parity gate compares this fixture on both sides, so it must be an
+// inline data URI shared verbatim.
+const dataUriHero =
+  "data:image/svg+xml;utf8,%3Csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20viewBox=%270%200%20640%20360%27%3E%3Cdefs%3E%3ClinearGradient%20id=%27g%27%20x1=%270%27%20x2=%271%27%20y1=%270%27%20y2=%271%27%3E%3Cstop%20offset=%270%25%27%20stop-color=%27%23dbeafe%27/%3E%3Cstop%20offset=%27100%25%27%20stop-color=%27%23bfdbfe%27/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect%20width=%27640%27%20height=%27360%27%20fill=%27url(%23g)%27/%3E%3Crect%20x=%2740%27%20y=%2740%27%20width=%27560%27%20height=%27280%27%20rx=%2728%27%20fill=%27%23eff6ff%27/%3E%3Ccircle%20cx=%27184%27%20cy=%27146%27%20r=%2750%27%20fill=%27%2393c5fd%27/%3E%3Cpath%20d=%27M132%20240c34-46%2092-46%20126%200%27%20fill=%27none%27%20stroke=%27%233b82f6%27%20stroke-width=%2718%27%20stroke-linecap=%27round%27/%3E%3Crect%20x=%27296%27%20y=%27118%27%20width=%27220%27%20height=%2718%27%20rx=%279%27%20fill=%27%233b82f6%27/%3E%3Crect%20x=%27296%27%20y=%27154%27%20width=%27176%27%20height=%2718%27%20rx=%279%27%20fill=%27%2360a5fa%27/%3E%3Crect%20x=%27296%27%20y=%27190%27%20width=%22136%22%20height=%2218%22%20rx=%229%22%20fill=%22%2393c5fd%22/%3E%3C/svg%3E";
+
 const defaultArgs = {
   ratio: "16:9" as const,
   children: (
@@ -67,7 +75,7 @@ export const Example: Story = {
     <div style={{ width: 320 }}>
       <AspectRatio ratio="16:9">
         <img
-          src="https://picsum.photos/640/360"
+          src={dataUriHero}
           alt="Case study hero frame"
           className="h-full w-full object-cover"
         />

--- a/scripts/design-system/rendered-parity.roster.mjs
+++ b/scripts/design-system/rendered-parity.roster.mjs
@@ -15,6 +15,7 @@
  * ratio.
  */
 export const enforced = [
+  "AspectRatio",
   "Avatar",
   "Badge",
   "BlogMediaImage",


### PR DESCRIPTION
## What

Enrolls **AspectRatio** in the rendered-parity enforcement roster (15 → 16), the next component off the owner's parity queue.

## Why it was failing

The React `AspectRatio` Example story pulled a **random network image** (`picsum.photos/640/360`); the native `dt-aspect-ratio` Example ships a deterministic data-URI hero. The twin pair diffed **57–85%** across the Example modes even though frame **geometry was already pixel-perfect** (416×241 / 336×196 identical on both sides). This is the story-side fixture trap (drift-class #5) — and the network image is non-deterministic, so the story could never pixel-match a twin regardless.

## Fix

Align the React Example fixture to the same inline data-URI hero the native story already uses (byte-identical), so the gate compares the same content on both sides. **No component behaviour changed** — only the story fixture.

## Verification (local — CI is dead)

| Gate | Result |
|------|--------|
| `check:rendered-parity --component=AspectRatio` | **visual 5/5, geometry 5/5** (Example modes 0.0000, Default 0.0015) |
| Roster | AspectRatio enrolled → 16 enforced |
| typecheck | ✓ |
| lint | ✓ (0 errors) |
| test | ✓ 329 files / 2693 tests |
| build | ✓ |

AT snapshots unaffected (img `alt` unchanged; no snapshot referenced picsum). Visually confirmed the React Example now renders the deterministic blue-card hero, correctly clipped to 16:9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved visual consistency for the AspectRatio component’s Storybook example by using a deterministic image fixture.
  * Added AspectRatio to rendered-parity enforcement checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->