### PR TITLE
feat(parity): batch enroll VisuallyHidden + Divider + Text (roster 16 -> 19) + Switch partial

### DIFF
--- a/nextjs-app/shared/stories/WebComponents/Divider/Divider.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/Divider/Divider.stories.tsx
@@ -44,7 +44,14 @@ const meta = {
 } satisfies Meta<typeof NativeDivider>;
 export default meta;
 type Story = StoryObj<typeof meta>;
-export const Default: Story = { play: assertNative("dt-divider") };
+// Mirror the React Divider Default: a full-width horizontal rule under the
+// `padded` layout. The meta's centered Stage (24rem) made the native rule
+// shorter than React's, which was the entire Default pixel/geometry gap.
+export const Default: Story = {
+  parameters: { layout: "padded" },
+  render: () => <NativeElement tagName="dt-divider" />,
+  play: assertNative("dt-divider"),
+};
 export const Playground: Story = {};
 export const Vertical: Story = {
   ...exampleStory,
@@ -84,5 +91,20 @@ export const VerticalInRow: Story = {
     </div>
   ),
 };
-export const Example: Story = { ...exampleStory };
+// Mirror the React Divider Example byte-for-byte (same wrapper width, font,
+// and the two paragraphs around the rule). The old `...exampleStory` rendered
+// the meta's single 24rem Stage divider — nothing like the React pair.
+export const Example: Story = {
+  ...exampleStory,
+  parameters: { layout: "padded", controls: { disable: true } },
+  render: () => (
+    <div
+      style={{ inlineSize: "min(24rem, 100%)", fontFamily: "var(--font-text)" }}
+    >
+      <p>Section one</p>
+      <NativeElement tagName="dt-divider" />
+      <p>Section two</p>
+    </div>
+  ),
+};
 export const ForcedColors: Story = { ...forcedColorsStory };

--- a/nextjs-app/shared/stories/WebComponents/Switch/Switch.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/Switch/Switch.stories.tsx
@@ -116,8 +116,13 @@ export const WithError: Story = {
   args: { error: "Could not update this preference." },
 };
 export const Playground: Story = {};
+// Mirror the React Switch Example: an unchecked switch with the same label and
+// helper text (React renders a ControlledTemplate starting unchecked).
 export const Example: Story = {
   ...exampleStory,
-  args: { label: "Dark mode", checked: true },
+  args: {
+    label: "Enable email notifications",
+    helperText: "You'll receive updates about your account activity",
+  },
 };
 export const ForcedColors: Story = { ...forcedColorsStory };

--- a/nextjs-app/shared/stories/WebComponents/Text/Text.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/Text/Text.stories.tsx
@@ -162,8 +162,28 @@ export const LineHeights: Story = {
     </Stack>
   ),
 };
+// Mirror the React Text Example: an <h1>-sized dt-title above an l-size body
+// dt-text, using the same English strings the React story resolves from i18n
+// (storyTitlePlayground / storyTextDefault). The old single dt-text with
+// unrelated copy diffed on both content and composition height.
 export const Example: Story = {
   ...exampleStory,
-  args: { content: "Body copy for a marketing section.", size: "l" },
+  parameters: { a11y: { disable: true }, controls: { disable: true } },
+  render: () => (
+    <>
+      <NativeElement
+        tagName="dt-title"
+        attributes={{
+          level: 1,
+          size: "l",
+          content: "Play with the Title component!",
+        }}
+      />
+      <NativeElement
+        tagName="dt-text"
+        attributes={{ size: "l", as: "p", content: "This is default text." }}
+      />
+    </>
+  ),
 };
 export const ForcedColors: Story = { ...forcedColorsStory };

--- a/nextjs-app/shared/stories/WebComponents/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import {
   NativeElement,
-  TriggerButton,
   assertNative,
   exampleStory,
   forcedColorsStory,
@@ -30,13 +29,23 @@ export const Playground: Story = {};
 export const Default: Story = { play: assertNative("dt-visually-hidden") };
 export const Example: Story = {
   ...exampleStory,
+  // Mirror the React VisuallyHidden Example byte-for-byte: the same bare
+  // <button> (identical inline style) wrapping the component under test. The
+  // rendered-parity gate compares this pair; TriggerButton's own chrome
+  // (padding/border/radius) diverged from React's plain button.
   render: () => (
-    <TriggerButton>
+    <button
+      type="button"
+      style={{
+        fontFamily: "var(--font-text)",
+        padding: "var(--space-internal-12)",
+      }}
+    >
       Save
       <NativeElement tagName="dt-visually-hidden">
-        Saves your profile changes
+        {" — saves your profile changes"}
       </NativeElement>
-    </TriggerButton>
+    </button>
   ),
 };
 export const ForcedColors: Story = { ...forcedColorsStory };

--- a/packages/web-components/src/native/divider.ts
+++ b/packages/web-components/src/native/divider.ts
@@ -14,6 +14,17 @@ const styles = `
   hr { margin: 0; border: 0; background: var(--color-border); }
   .horizontal { inline-size: 100%; block-size: 1px; }
   .vertical { inline-size: 1px; block-size: 100%; min-block-size: var(--space-layout-24); }
+  /*
+   * The React Divider's line is a light-DOM <hr>, so in forced-colors it
+   * survives via Tailwind preflight's border-style:solid + border-top-width.
+   * The shadow-DOM twin never sees that preflight, so its background line is
+   * forced to Canvas and the rule vanishes (an a11y regression, not a waiver).
+   * Redraw it with a system color so high-contrast mode keeps the separator,
+   * matching React's rendered output.
+   */
+  @media (forced-colors: active) {
+    hr { background: CanvasText; }
+  }
 `;
 
 export class DtDividerElement extends DigitaltableteurElement {

--- a/packages/web-components/src/native/switch.ts
+++ b/packages/web-components/src/native/switch.ts
@@ -24,10 +24,10 @@ const styles = `
   button[aria-checked="true"] { background: var(--switch-track-on, var(--color-primary)); }
   button:focus-visible { outline: var(--focus-ring-width, 2px) solid var(--focus-ring-color, var(--color-primary)); outline-offset: var(--focus-ring-offset, 2px); }
   button:disabled { opacity: 0.55; cursor: not-allowed; }
-  .handle { position: absolute; inset-block-start: 50%; inset-inline-start: 0.15rem; translate: 0 -50%; aspect-ratio: 1; block-size: calc(var(--switch-height) - 0.3rem); border-radius: 50%; background: var(--switch-handle-bg, white); transition: translate var(--duration-fast, 160ms) ease; }
+  .handle { position: absolute; inset-block-start: 50%; inset-inline-start: 0.15rem; translate: 0 -50%; aspect-ratio: 1; block-size: calc(var(--switch-height) - 0.3rem); border-radius: 50%; background: var(--switch-handle-bg, white); box-shadow: 0 2px 6px rgb(15 23 42 / 18%); transition: translate var(--duration-fast, 160ms) ease; }
   button[aria-checked="true"] .handle { translate: calc(var(--switch-width) - var(--switch-height)) -50%; }
   .loading .handle::after { content: ""; position: absolute; inset: 20%; border: 1px solid currentcolor; border-inline-end-color: transparent; border-radius: 50%; animation: spin 700ms linear infinite; }
-  .message { margin: 0.375rem 0 0; font-size: 0.875rem; }
+  .message { margin: 0.5rem 0 0; font-size: 0.875rem; color: var(--color-primary); }
   .error { color: var(--color-error-text, var(--color-error)); }
   @keyframes spin { to { rotate: 1turn; } }
   @media (prefers-reduced-motion: reduce) { button, .handle { transition: none; } .loading .handle::after { animation: none; } }

--- a/scripts/design-system/rendered-parity.roster.mjs
+++ b/scripts/design-system/rendered-parity.roster.mjs
@@ -21,6 +21,7 @@ export const enforced = [
   "BlogMediaImage",
   "Container",
   "CookieConsent",
+  "Divider",
   "GroupLabel",
   "IconButton",
   "List",
@@ -30,7 +31,9 @@ export const enforced = [
   "SelectOption",
   "SkipLink",
   "SplitButton",
-  "Testimonial"
+  "Testimonial",
+  "Text",
+  "VisuallyHidden"
 ];
 
 export const exceptions = [];


### PR DESCRIPTION
## Rendered-parity batch — roster 16 → 19

Next batch off the parity queue. Triaged all 9 remaining queued components, landed the tractable ones to 0.0000, and diagnosed the rest.

### Enrolled (3) — all 5/5 visual + geometry, 0.0000 across the matrix

| Component | Root cause | Fix |
|-----------|-----------|-----|
| **VisuallyHidden** | Native Example used `TriggerButton` (own padding/border/radius); React uses a bare `<button>` | Mirrored React's exact `<button>` markup |
| **Divider** | Native Default was a 24rem centered `Stage` vs React's padded full-width; Example was the meta divider vs React's two-paragraph composition; **forced-colors line vanished** on the shadow-DOM `<hr>` | Stories mirror React's layout; added `@media(forced-colors){ hr{background:CanvasText} }` — a real a11y fix (line was disappearing in high-contrast) |
| **Text** | Native Example was a single `dt-text` with unrelated copy; React composes `Title` + `Text` | Native Example now renders `dt-title` + `dt-text` with the same i18n-resolved strings (`dt-title` matched `Title` exactly, 939×127) |

### Partial — Switch (real fixes landed, **enrollment deferred**)

Fixed genuine drift: the native handle lacked React's `box-shadow` (flat vs raised thumb), and the helper text used `margin:0.375rem` + inherited color vs `HelperText`'s `0.5rem` + `--color-primary`. **Example desktop-light is now 0.0000.**

**Not enrolled — owner call needed:** in forced-colors the **React Switch is invisible** (no forced-colors handling: track→Canvas, handle→white, no border), while the native twin correctly renders a visible handle via its own forced-colors block. Matching React would regress native high-contrast a11y, and the roster doctrine says React is source of truth. Options: fix React's forced-colors (preferred — fixes a real a11y bug and achieves parity), or record a narrow exception.

### Deferred with diagnosis (deeper audits, not fixture swaps)

- **NavLink** — `dt-nav-link` composes `dt-link`; Default "Work" drifts on color/size/weight vs React `Link`; Example adds a nav of 4 links + wavy-underline active state.
- **CodeSnippet** — code block **line-height** much looser in native (rows ~2× taller); Copy button chrome differs (React outlined split button vs native filled-grey).
- **Combobox** — fixture values already match; residual is real field/trigger rendering drift (border/height/padding/chevron).
- **SelectableCard** — known component approximations (surface radius `--radius-lg` vs 12px, min-block-size 4rem vs content-height, padding 16 vs Card prop).
- **Gallery** — architectural: native CSS grid vs React JS column distribution (owner-noted intentional). Needs a documented exception or a native rework — an owner call.

### Verification (local — CI is dead)

| Gate | Result |
|------|--------|
| Full rendered-parity fleet gate | ✓ **19/85 enrolled pass, no regression**; fleet visual 112→129, geometry 173→190 |
| typecheck / lint | ✓ / ✓ (0 errors) |
| test | ✓ 329 files / 2693 tests |
| build | ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
