### PR TITLE
fix(switch): forced-colors visibility (a11y) + React/WC control-surface parity

### DIFF
--- a/nextjs-app/shared/components/Switch/Switch.module.css
+++ b/nextjs-app/shared/components/Switch/Switch.module.css
@@ -77,8 +77,29 @@
   outline-offset: var(--focus-ring-offset, 2px);
 }
 
-/* Forced colors mode (Windows High Contrast) */
+/* Forced colors mode (Windows High Contrast).
+   Without explicit system colors the track background is forced to Canvas and
+   the handle to Canvas — the whole control disappears (white on white). Keep it
+   perceivable: outline the track (CanvasText, no box-model shift), fill the
+   handle (CanvasText), and use Highlight for the on-state track. `outline` is
+   used rather than `border` so the handle's absolute position is unaffected.
+   Mirrors the native dt-switch twin so both render identically. */
 @media (forced-colors: active) {
+  .switch {
+    outline: 1px solid CanvasText;
+    background-color: Canvas;
+    forced-color-adjust: none;
+  }
+
+  .switch[data-checked="true"] {
+    background-color: Highlight;
+  }
+
+  .handle {
+    background-color: CanvasText;
+    box-shadow: none;
+  }
+
   .switch:focus-visible {
     outline: 3px solid Highlight;
     outline-offset: 2px;

--- a/nextjs-app/shared/components/Switch/Switch.stories.tsx
+++ b/nextjs-app/shared/components/Switch/Switch.stories.tsx
@@ -90,6 +90,24 @@ const meta: Meta<typeof Switch> = {
   // label is ReactNode on the contract (autogen hides those) but accepts plain
   // text, so it keeps an authored text control.
   argTypes: {
+    // `checked` is the controlled half of the checked/defaultChecked pair, so
+    // the autogen force-hides it (an unwired controlled prop would lock the
+    // canvas). These stories DO wire it through ControlledTemplate, so expose
+    // an on/off toggle here to match the dt-switch web-component story — an
+    // authored argType wins over the autogen, and the contract-based
+    // audit:controls predicate still counts it hidden-by-design (no drift).
+    checked: {
+      control: { type: "boolean" },
+      description: "Whether the switch is on. Toggling flips the control.",
+      table: { category: "State", type: { summary: "boolean" } },
+    },
+    // Keep the control surface equal to the dt-switch web-component twin (the
+    // 8 meaningful knobs). `defaultChecked` is mount-only — React's useState
+    // ignores prop changes after mount, so toggling it does nothing live; the
+    // real on/off is `checked` above. `className` is a react-docgen leak (not a
+    // contract prop) that renders a useless "Set object" widget.
+    defaultChecked: { table: { disable: true } },
+    className: { table: { disable: true } },
     label: {
       control: { type: "text" },
       description: "Label text displayed next to the switch",

--- a/nextjs-app/shared/stories/WebComponents/Switch/Switch.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/Switch/Switch.stories.tsx
@@ -51,6 +51,8 @@ const meta = {
     loading: false,
     size: "md",
     labelPlacement: "right",
+    helperText: "",
+    error: "",
   },
   argTypes: {
     size: { control: "inline-radio", options: ["sm", "md", "lg"] },
@@ -58,6 +60,9 @@ const meta = {
       control: "inline-radio",
       options: ["left", "right", "top"],
     },
+    // Match the React Switch control surface (the 8 meaningful knobs).
+    helperText: { control: "text" },
+    error: { control: "text" },
   },
 } satisfies Meta<typeof NativeSwitch>;
 export default meta;

--- a/packages/web-components/src/native/switch.ts
+++ b/packages/web-components/src/native/switch.ts
@@ -31,7 +31,7 @@ const styles = `
   .error { color: var(--color-error-text, var(--color-error)); }
   @keyframes spin { to { rotate: 1turn; } }
   @media (prefers-reduced-motion: reduce) { button, .handle { transition: none; } .loading .handle::after { animation: none; } }
-  @media (forced-colors: active) { button { forced-color-adjust: none; background: Canvas; border-color: CanvasText; } button[aria-checked="true"] { background: Highlight; } .handle { background: CanvasText; } }
+  @media (forced-colors: active) { button { forced-color-adjust: none; background: Canvas; outline: 1px solid CanvasText; } button[aria-checked="true"] { background: Highlight; } .handle { background: CanvasText; box-shadow: none; } }
 `;
 
 export class DtSwitchElement extends DigitaltableteurElement {

--- a/scripts/design-system/audit-controls.mjs
+++ b/scripts/design-system/audit-controls.mjs
@@ -166,6 +166,9 @@ const SKIP = PLUMBING
 // shared hiddenByDesign() predicate cannot express. Every entry carries its
 // justification, mirroring EFFECT_EXEMPT.
 const HIDDEN_EXEMPT = {
+    Switch: {
+        defaultChecked: 'mount-only in Storybook: React useState ignores prop changes after mount, so a defaultChecked knob is inert. The live on/off is the controlled `checked` prop (driven by ControlledTemplate), matching the dt-switch web-component surface.',
+    },
     Grid: {
         tabletColumns: 'viewport-dependent: only changes tracks past 768px, so a panel knob at the default viewport looks inert; demoed by the ResponsiveColumns story',
         desktopColumns: 'viewport-dependent (1024px rung); demoed by the ResponsiveColumns story',


### PR DESCRIPTION
## Switch: forced-colors a11y fix + control-surface parity

Rebased onto the #1266 logical-CSS baseline (merged first, as directed).

### 1. Forced-colors visibility (a11y bug)

Both twins were effectively **invisible in Windows High Contrast**: the React Switch had only a focus-ring forced-colors rule, so the unfocused track and handle were forced to Canvas/white and the whole control disappeared; the native twin showed only a bare handle. Both now render identically: an **outlined track** (CanvasText, via `outline` so the handle's absolute position doesn't shift), a **CanvasText handle**, and a **Highlight** on-state track. forced-colors Example parity improved 0.09 → 0.01.

### 2. Control-surface parity (React 10 vs WC 6 → both 8)

The React Storybook exposed **no `checked` control** (the controls-autogen force-hides the controlled half of the checked/defaultChecked pair) while the `dt-switch` twin did, and the two showed different totals. Both now expose the same **8 meaningful controls**: `checked, disabled, loading, size, labelPlacement, label, helperText, error`.

- **React**: authors a live `checked` boolean toggle (wired through `ControlledTemplate`); hides `defaultChecked` (mount-only — `useState` ignores prop changes, so a knob is inert) and `className` (a react-docgen leak rendering a dead "Set object").
- **WC**: gains `helperText` + `error` text controls.
- **audit-controls**: `Switch.defaultChecked` added to `HIDDEN_EXEMPT` with a documented reason; the 100% controls audit is unchanged.

### Not enrolled in rendered-parity (yet)

Desktop-light is `0.0000`, but Example mobile-light (0.0206), desktop-dark (0.0128), and desktop-forced-colors (0.0109) sit just over the 0.01 tolerance — incidental subpixel AA (light-DOM vs shadow-DOM handle) and a 1px helper-text baseline at 375px, geometry passing. Left unenrolled rather than papered over with exceptions (the roster reserves those for *intentional* divergence).

### Verification (local — CI is dead)

| Gate | Result |
|------|--------|
| lint:css (logical-CSS enforcement) | ✓ |
| audit:controls | ✓ 100% (144/144 components, 854/854 props) |
| typecheck / lint | ✓ / ✓ |
| test | ✓ 332 files / 2705 tests |
| build | ✓ |

Verified live in Storybook: React `checked` control flips the switch on; forced-colors renders a visible outlined switch in both states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved Switch visibility and interaction in Windows High Contrast and other forced-colors modes.
  - Added clearer outlines, system-compatible colors, and improved handle rendering for checked and unchecked states.

- **Documentation**
  - Updated Switch Storybook controls to accurately expose checked, helper text, and error states.
  - Clarified how controlled and default switch values behave in interactive examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->