### PR TITLE
feat(parity): enroll SelectableCard in rendered-parity roster (19 -> 20)

### DIFF
--- a/nextjs-app/shared/stories/WebComponents/SelectableCard/SelectableCard.stories.tsx
+++ b/nextjs-app/shared/stories/WebComponents/SelectableCard/SelectableCard.stories.tsx
@@ -56,6 +56,62 @@ function Cards(args: Args) {
     </Stack>
   );
 }
+
+/* Single standalone card — mirrors the React SelectableCard Default (one
+   checkbox-style card in a 360px column) so the rendered-parity pair matches. */
+function SingleCard() {
+  return (
+    <div style={{ maxWidth: 360 }}>
+      <NativeElement
+        tagName="dt-selectable-card"
+        attributes={{ value: "starter" }}
+      >
+        <strong>Starter</strong>
+        <p>For solo work — 1 seat, community support.</p>
+      </NativeElement>
+    </div>
+  );
+}
+
+/* Single-select group — mirrors the React SelectableCard Example (three cards,
+   420px column, no helper line) so the rendered-parity pair matches. */
+function ExampleGroup() {
+  return (
+    <div style={{ maxWidth: 420 }}>
+      <NativeElement
+        tagName="dt-selectable-card-group"
+        attributes={{
+          type: "single",
+          legend: "Choose a plan",
+          name: "plan",
+          "default-value": "team",
+        }}
+      >
+        <NativeElement
+          tagName="dt-selectable-card"
+          attributes={{ value: "starter" }}
+        >
+          <strong>Starter</strong>
+          <p>1 seat, community support.</p>
+        </NativeElement>
+        <NativeElement
+          tagName="dt-selectable-card"
+          attributes={{ value: "team" }}
+        >
+          <strong>Team</strong>
+          <p>Up to 10 seats, priority support.</p>
+        </NativeElement>
+        <NativeElement
+          tagName="dt-selectable-card"
+          attributes={{ value: "scale" }}
+        >
+          <strong>Scale</strong>
+          <p>Unlimited seats, SLA.</p>
+        </NativeElement>
+      </NativeElement>
+    </div>
+  );
+}
 const meta = {
   title: "Web Components/Layout/SelectableCard",
   component: Cards,
@@ -82,10 +138,16 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 export const Default: Story = {
-  play: assertNative("dt-selectable-card-group"),
+  parameters: { layout: "padded" },
+  render: SingleCard,
+  play: assertNative("dt-selectable-card"),
 };
 export const Playground: Story = {};
-export const Example: Story = { ...exampleStory };
+export const Example: Story = {
+  ...exampleStory,
+  parameters: { layout: "padded" },
+  render: ExampleGroup,
+};
 export const MultiSelect: Story = { args: { type: "multiple" } };
 export const Horizontal: Story = { args: { orientation: "horizontal" } };
 export const Disabled: Story = { args: { disabled: true } };

--- a/packages/web-components/src/native/selectable-card.ts
+++ b/packages/web-components/src/native/selectable-card.ts
@@ -11,6 +11,11 @@ const ORIENTATIONS = ["vertical", "horizontal"] as const;
 export type DtSelectableCardSelectionType = (typeof TYPES)[number];
 export type DtSelectableCardOrientation = (typeof ORIENTATIONS)[number];
 
+// The app ships global document typography (p margin/line-height, strong
+// weight) that outranks plain ::slotted in the cascade. The slotted-content
+// rules use !important on exactly those colliding properties — the designed
+// escape hatch — so the surface matches React's Card, which neutralises the
+// same globals with component classes.
 const cardStyles = `
   :host { display: flex; position: relative; flex-direction: column; }
   /* The whole card is the control (no radio/checkbox glyph); the label is a
@@ -19,7 +24,12 @@ const cardStyles = `
   label { display: flex; position: relative; flex: 1 1 auto; flex-direction: column; cursor: pointer; }
   label.disabled { cursor: not-allowed; opacity: .55; }
   input { position: absolute; margin: -1px; inline-size: 1px; block-size: 1px; border: 0; clip-path: inset(50%); overflow: hidden; }
-  .surface { display: flex; position: relative; box-sizing: border-box; flex: 1 1 auto; flex-direction: column; justify-content: center; min-block-size: 4rem; padding: var(--space-internal-16); border: 1px solid var(--color-border-light); border-radius: var(--radius-lg, 8px); background: var(--color-surface); color: var(--color-text); }
+  .surface { display: flex; position: relative; box-sizing: border-box; flex: 1 1 auto; flex-direction: column; justify-content: center; gap: var(--space-internal-8); padding: var(--space-internal-16); border: 1px solid var(--color-border-light); border-radius: 12px; background: var(--color-surface); color: var(--color-text); }
+  /* Slotted title/description mirror @dt/Card Title(xxs)/Text(s); !important
+     defends the colliding props against the app's global p/strong typography,
+     which outranks plain ::slotted (see note above cardStyles). */
+  ::slotted(strong) { margin: 0; font-family: var(--font-title); font-size: var(--font-size-title-xxs); font-weight: 600 !important; line-height: var(--line-height-snug); color: var(--color-title); }
+  ::slotted(p) { margin: 0 !important; font-family: var(--font-text); font-size: var(--font-size-text-s); font-weight: var(--font-weight-text); line-height: 1.6 !important; color: var(--color-text-muted, var(--color-primary)); }
   /* Hover only affects unselected cards; a selected card keeps its look. */
   label:hover:not(.disabled):not(.selected) .surface { border-color: var(--color-border); }
   label.selected .surface { border-color: var(--color-primary); box-shadow: inset 0 0 0 1px var(--color-primary); }

--- a/scripts/design-system/check-web-components.mjs
+++ b/scripts/design-system/check-web-components.mjs
@@ -161,7 +161,11 @@ const maxPackedFiles = 40 + tags.length * 2;
 // +1 kB for the DT-1245 round (dt-badge xs size, dt-selectable-card redesign
 // port, 0.8.0 changelog entries): measured 1,851,032 bytes unpacked, ~0.4 kB
 // over the prior ceiling.
-const sharedBundleAndManifestCeiling = 1_314_000;
+// +1.5 kB for the dt-selectable-card rendered-parity pass (::slotted title/
+// description typography matching @dt/Card, !important escape hatch over the
+// app's global p/strong rules, surface radius/gap alignment): measured
+// 1,852,714 bytes unpacked, ~1.1 kB over the prior ceiling.
+const sharedBundleAndManifestCeiling = 1_315_500;
 // Attribute metadata and complete property-member metadata both scale with
 // each public element. Keep the member allowance explicit so fieldName never
 // points at an undeclared Custom Elements Manifest member.

--- a/scripts/design-system/native-stylelint-baseline.json
+++ b/scripts/design-system/native-stylelint-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "npm run lint:css:update",
   "templateCount": 84,
-  "warningCount": 574,
+  "warningCount": 575,
   "warnings": [
     {
       "column": 21,
@@ -3955,9 +3955,18 @@
       "id": "packages/web-components/src/native/selectable-card.ts::rhythmguard/prefer-token::Unexpected raw scale value \"-1px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::1"
     },
     {
+      "column": 263,
+      "file": "packages/web-components/src/native/selectable-card.ts",
+      "line": 22,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"12px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/selectable-card.ts::rhythmguard/prefer-token::Unexpected raw scale value \"12px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::1"
+    },
+    {
       "column": 118,
       "file": "packages/web-components/src/native/selectable-card.ts",
-      "line": 26,
+      "line": 35,
       "rule": "rhythmguard/prefer-token",
       "severity": "warning",
       "text": "Unexpected raw scale value \"2px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",

--- a/scripts/design-system/rendered-parity.roster.mjs
+++ b/scripts/design-system/rendered-parity.roster.mjs
@@ -29,6 +29,7 @@ export const enforced = [
   "Menu",
   "NavMenuList",
   "SelectOption",
+  "SelectableCard",
   "SkipLink",
   "SplitButton",
   "Testimonial",


### PR DESCRIPTION
## What

Enrolls **SelectableCard** in the rendered-parity roster (19 → 20 enforced). The native `dt-selectable-card` story pair now matches the React source of truth **pixel-for-pixel** across all five parity modes: `ratio=0.0000`, geometry delta `0` on desktop-light, mobile-light, desktop-dark, and forced-colors.

## Why it was the deepest of the queued three

Two independent gaps had to close together:

1. **Story scenes diverged.** Native `Default` rendered the full 3-card group in a 544px `Stack`; React `Default` is a single standalone card at 360px. Native `Example` carried a helper line React did not.
2. **Content typography diverged.** React passes `title`/`description` to `@dt/Card` (Title xxs / Text s, margin 0); native slotted raw `<strong>`/`<p>`, which the app global document typography (`p { margin-block-end; line-height }`, `strong` weight) overrode. `::slotted()` sits below the document tree in the cascade, so plain slotted rules lost.

## Changes

- **Native stories** mirror the React scenes: single card @360 (`Default`), 3-card single-select group @420 (`Example`), `layout: padded`, `Default` play asserts `dt-selectable-card`.
- **Surface box model** matches Card: `border-radius: 12px` (was `radius-lg` 8px), `gap: 8px`, dropped the stray `min-block-size: 4rem`.
- **`::slotted(strong)` / `::slotted(p)`** mirror Card Title(xxs)/Text(s). `!important` on exactly the three colliding properties (`p` margin + line-height, `strong` weight) is the designed escape hatch over the global document rules — the same globals React neutralises with Card component classes. Rationale documented in-source.
- **Budget bookkeeping:** web-components tarball ceiling +1.5 kB (measured 1,852,714 unpacked) and the single `12px` rhythmguard warning baselined (no 12px radius token exists; `@dt/Card` uses the same literal).

## Verification (local gate, CI is quota-dead)

typecheck ✓ · lint ✓ (0 errors) · 2705 tests ✓ · build ✓ · lint:css ✓ · check:web-components ✓ · check:contract-props ✓ · check:consumers ✓ · **rendered-parity 20/20 enforced, SelectableCard 5/5 (ratio 0, geometry 0)**

## Out of scope (flagged separately)

`build:tokens` deterministically re-dirties `typography.json` / `token-catalog.json` (vw→vi) and `app/tailwind.css` on main — pre-existing stale-token drift, left out of this PR and filed as its own chore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved Selectable Card layouts and examples, including standalone and single-selection group presentations.
  * Refined card spacing, corner rounding, and typography for more consistent rendering across applications.
* **Bug Fixes**
  * Corrected styling conflicts that could affect text appearance inside Selectable Cards.
* **Quality Improvements**
  * Added Selectable Card rendering checks to help prevent visual differences between supported implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->