### PR TITLE
chore(tokens): regenerate stale token output (vw→vi logical units)

### DIFF
--- a/nextjs-app/shared/foundations/token-catalog.json
+++ b/nextjs-app/shared/foundations/token-catalog.json
@@ -1,6 +1,6 @@
 {
   "source": "nextjs-app/shared/styles/variables.css",
-  "generatedAt": "2026-07-14T16:39:51.626Z",
+  "generatedAt": "2026-07-19T11:18:13.166Z",
   "tokenCount": 185,
   "usageCoverage": 151,
   "themes": [
@@ -1983,147 +1983,147 @@
       "tokens": [
         {
           "name": "--font-size-text",
-          "value": "clamp(1rem, 0.6vw + 0.9rem, 1.25rem)",
+          "value": "clamp(1rem, 0.6vi + 0.9rem, 1.25rem)",
           "usage": "Fluid type size token (text); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-text-xxs",
-          "value": "clamp(0.875rem, 0.1vw + 0.85rem, 0.9375rem)",
+          "value": "clamp(0.875rem, 0.1vi + 0.85rem, 0.9375rem)",
           "usage": "Fluid type size token (text-xxs); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-text-xs",
-          "value": "clamp(0.875rem, 0.2vw + 0.83rem, 1rem)",
+          "value": "clamp(0.875rem, 0.2vi + 0.83rem, 1rem)",
           "usage": "Fluid type size token (text-xs); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-text-s",
-          "value": "clamp(0.875rem, 0.35vw + 0.8rem, 1.05rem)",
+          "value": "clamp(0.875rem, 0.35vi + 0.8rem, 1.05rem)",
           "usage": "Fluid type size token (text-s); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-text-m",
-          "value": "clamp(1rem, 0.6vw + 0.9rem, 1.25rem)",
+          "value": "clamp(1rem, 0.6vi + 0.9rem, 1.25rem)",
           "usage": "Fluid type size token (text-m); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-text-l",
-          "value": "clamp(1.125rem, 0.8vw + 1rem, 1.5rem)",
+          "value": "clamp(1.125rem, 0.8vi + 1rem, 1.5rem)",
           "usage": "Fluid type size token (text-l); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-text-xl",
-          "value": "clamp(1.375rem, 1vw + 1.15rem, 1.875rem)",
+          "value": "clamp(1.375rem, 1vi + 1.15rem, 1.875rem)",
           "usage": "Fluid type size token (text-xl); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-text-xxl",
-          "value": "clamp(1.625rem, 1.4vw + 1.35rem, 2.25rem)",
+          "value": "clamp(1.625rem, 1.4vi + 1.35rem, 2.25rem)",
           "usage": "Fluid type size token (text-xxl); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-title",
-          "value": "clamp(2.25rem, 3.5vw + 1.5rem, 3.75rem)",
+          "value": "clamp(2.25rem, 3.5vi + 1.5rem, 3.75rem)",
           "usage": "Fluid type size token (title); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-title-xxs",
-          "value": "clamp(1.125rem, 0.4vw + 1.05rem, 1.375rem)",
+          "value": "clamp(1.125rem, 0.4vi + 1.05rem, 1.375rem)",
           "usage": "Fluid type size token (title-xxs); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-title-xs",
-          "value": "clamp(1.25rem, 0.9vw + 1.1rem, 1.75rem)",
+          "value": "clamp(1.25rem, 0.9vi + 1.1rem, 1.75rem)",
           "usage": "Fluid type size token (title-xs); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-title-s",
-          "value": "clamp(1.5rem, 2vw + 1.1rem, 2.25rem)",
+          "value": "clamp(1.5rem, 2vi + 1.1rem, 2.25rem)",
           "usage": "Fluid type size token (title-s); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-title-m",
-          "value": "clamp(2rem, 2.8vw + 1.3rem, 3rem)",
+          "value": "clamp(2rem, 2.8vi + 1.3rem, 3rem)",
           "usage": "Fluid type size token (title-m); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-title-l",
-          "value": "clamp(2.75rem, 4vw + 1.75rem, 4.25rem)",
+          "value": "clamp(2.75rem, 4vi + 1.75rem, 4.25rem)",
           "usage": "Fluid type size token (title-l); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-title-xl",
-          "value": "clamp(3.5rem, 6vw + 2.5rem, 5.5rem)",
+          "value": "clamp(3.5rem, 6vi + 2.5rem, 5.5rem)",
           "usage": "Fluid type size token (title-xl); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-title-xxl",
-          "value": "clamp(4.5rem, 8vw + 3rem, 7rem)",
+          "value": "clamp(4.5rem, 8vi + 3rem, 7rem)",
           "usage": "Fluid type size token (title-xxl); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-display",
-          "value": "clamp(\n    5rem,\n    10vw + 3rem,\n    8rem\n  )",
+          "value": "clamp(\n    5rem,\n    10vi + 3rem,\n    8rem\n  )",
           "usage": "Fluid type size token (display); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-display-xl",
-          "value": "clamp(\n    6rem,\n    14vw + 3rem,\n    12rem\n  )",
+          "value": "clamp(\n    6rem,\n    14vi + 3rem,\n    12rem\n  )",
           "usage": "Fluid type size token (display-xl); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-button-s",
-          "value": "clamp(0.875rem, 0.3vw + 0.8rem, 1rem)",
+          "value": "clamp(0.875rem, 0.3vi + 0.8rem, 1rem)",
           "usage": "Fluid type size token (button-s); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-button-m",
-          "value": "clamp(1rem, 0.35vw + 0.9rem, 1.125rem)",
+          "value": "clamp(1rem, 0.35vi + 0.9rem, 1.125rem)",
           "usage": "Fluid type size token (button-m); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"
         },
         {
           "name": "--font-size-button-l",
-          "value": "clamp(1.125rem, 0.45vw + 1rem, 1.25rem)",
+          "value": "clamp(1.125rem, 0.45vi + 1rem, 1.25rem)",
           "usage": "Fluid type size token (button-l); uses clamp().",
           "category": "typography",
           "subgroup": "Type scale"

--- a/nextjs-app/shared/foundations/tokens/production/typography.json
+++ b/nextjs-app/shared/foundations/tokens/production/typography.json
@@ -40,7 +40,7 @@
     "size": {
       "text": {
         "DEFAULT": {
-          "$value": "clamp(1rem, 0.6vw + 0.9rem, 1.25rem)",
+          "$value": "clamp(1rem, 0.6vi + 0.9rem, 1.25rem)",
           "$description": "Fluid type size token (text); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -52,7 +52,7 @@
           }
         },
         "xxs": {
-          "$value": "clamp(0.875rem, 0.1vw + 0.85rem, 0.9375rem)",
+          "$value": "clamp(0.875rem, 0.1vi + 0.85rem, 0.9375rem)",
           "$description": "Fluid type size token (text-xxs); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -64,7 +64,7 @@
           }
         },
         "xs": {
-          "$value": "clamp(0.875rem, 0.2vw + 0.83rem, 1rem)",
+          "$value": "clamp(0.875rem, 0.2vi + 0.83rem, 1rem)",
           "$description": "Fluid type size token (text-xs); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -76,7 +76,7 @@
           }
         },
         "s": {
-          "$value": "clamp(0.875rem, 0.35vw + 0.8rem, 1.05rem)",
+          "$value": "clamp(0.875rem, 0.35vi + 0.8rem, 1.05rem)",
           "$description": "Fluid type size token (text-s); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -88,7 +88,7 @@
           }
         },
         "m": {
-          "$value": "clamp(1rem, 0.6vw + 0.9rem, 1.25rem)",
+          "$value": "clamp(1rem, 0.6vi + 0.9rem, 1.25rem)",
           "$description": "Fluid type size token (text-m); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -100,7 +100,7 @@
           }
         },
         "l": {
-          "$value": "clamp(1.125rem, 0.8vw + 1rem, 1.5rem)",
+          "$value": "clamp(1.125rem, 0.8vi + 1rem, 1.5rem)",
           "$description": "Fluid type size token (text-l); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -112,7 +112,7 @@
           }
         },
         "xl": {
-          "$value": "clamp(1.375rem, 1vw + 1.15rem, 1.875rem)",
+          "$value": "clamp(1.375rem, 1vi + 1.15rem, 1.875rem)",
           "$description": "Fluid type size token (text-xl); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -124,7 +124,7 @@
           }
         },
         "xxl": {
-          "$value": "clamp(1.625rem, 1.4vw + 1.35rem, 2.25rem)",
+          "$value": "clamp(1.625rem, 1.4vi + 1.35rem, 2.25rem)",
           "$description": "Fluid type size token (text-xxl); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -138,7 +138,7 @@
       },
       "title": {
         "DEFAULT": {
-          "$value": "clamp(2.25rem, 3.5vw + 1.5rem, 3.75rem)",
+          "$value": "clamp(2.25rem, 3.5vi + 1.5rem, 3.75rem)",
           "$description": "Fluid type size token (title); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -150,7 +150,7 @@
           }
         },
         "xxs": {
-          "$value": "clamp(1.125rem, 0.4vw + 1.05rem, 1.375rem)",
+          "$value": "clamp(1.125rem, 0.4vi + 1.05rem, 1.375rem)",
           "$description": "Fluid type size token (title-xxs); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -162,7 +162,7 @@
           }
         },
         "xs": {
-          "$value": "clamp(1.25rem, 0.9vw + 1.1rem, 1.75rem)",
+          "$value": "clamp(1.25rem, 0.9vi + 1.1rem, 1.75rem)",
           "$description": "Fluid type size token (title-xs); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -174,7 +174,7 @@
           }
         },
         "s": {
-          "$value": "clamp(1.5rem, 2vw + 1.1rem, 2.25rem)",
+          "$value": "clamp(1.5rem, 2vi + 1.1rem, 2.25rem)",
           "$description": "Fluid type size token (title-s); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -186,7 +186,7 @@
           }
         },
         "m": {
-          "$value": "clamp(2rem, 2.8vw + 1.3rem, 3rem)",
+          "$value": "clamp(2rem, 2.8vi + 1.3rem, 3rem)",
           "$description": "Fluid type size token (title-m); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -198,7 +198,7 @@
           }
         },
         "l": {
-          "$value": "clamp(2.75rem, 4vw + 1.75rem, 4.25rem)",
+          "$value": "clamp(2.75rem, 4vi + 1.75rem, 4.25rem)",
           "$description": "Fluid type size token (title-l); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -210,7 +210,7 @@
           }
         },
         "xl": {
-          "$value": "clamp(3.5rem, 6vw + 2.5rem, 5.5rem)",
+          "$value": "clamp(3.5rem, 6vi + 2.5rem, 5.5rem)",
           "$description": "Fluid type size token (title-xl); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -222,7 +222,7 @@
           }
         },
         "xxl": {
-          "$value": "clamp(4.5rem, 8vw + 3rem, 7rem)",
+          "$value": "clamp(4.5rem, 8vi + 3rem, 7rem)",
           "$description": "Fluid type size token (title-xxl); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -236,7 +236,7 @@
       },
       "display": {
         "DEFAULT": {
-          "$value": "clamp(\n    5rem,\n    10vw + 3rem,\n    8rem\n  )",
+          "$value": "clamp(\n    5rem,\n    10vi + 3rem,\n    8rem\n  )",
           "$description": "Fluid type size token (display); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -248,7 +248,7 @@
           }
         },
         "xl": {
-          "$value": "clamp(\n    6rem,\n    14vw + 3rem,\n    12rem\n  )",
+          "$value": "clamp(\n    6rem,\n    14vi + 3rem,\n    12rem\n  )",
           "$description": "Fluid type size token (display-xl); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -262,7 +262,7 @@
       },
       "button": {
         "s": {
-          "$value": "clamp(0.875rem, 0.3vw + 0.8rem, 1rem)",
+          "$value": "clamp(0.875rem, 0.3vi + 0.8rem, 1rem)",
           "$description": "Fluid type size token (button-s); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -274,7 +274,7 @@
           }
         },
         "m": {
-          "$value": "clamp(1rem, 0.35vw + 0.9rem, 1.125rem)",
+          "$value": "clamp(1rem, 0.35vi + 0.9rem, 1.125rem)",
           "$description": "Fluid type size token (button-m); uses clamp().",
           "$type": "dimension",
           "$extensions": {
@@ -286,7 +286,7 @@
           }
         },
         "l": {
-          "$value": "clamp(1.125rem, 0.45vw + 1rem, 1.25rem)",
+          "$value": "clamp(1.125rem, 0.45vi + 1rem, 1.25rem)",
           "$description": "Fluid type size token (button-l); uses clamp().",
           "$type": "dimension",
           "$extensions": {


### PR DESCRIPTION
## What

Regenerates two stale generated token files so `npm run build:tokens` no longer re-dirties the tree with them.

Since the #1266 logical-CSS migration the token generator emits logical `vi` viewport units, but the committed JSON still carried physical `vw`. Every `build:tokens` (and the pre-push contract-gate hook) rewrote them, leaving spurious drift.

- `typography.json` / `token-catalog.json`: clamp() fluid type sizes `vw` → `vi`

After this change a second `build:tokens` leaves both files clean (the generator only rewrites on content change, so the `generatedAt` timestamp does not bump either).

## Deliberately excluded

- **`app/tailwind.css`** — `build:tokens` strips the blank line before the `/* DT-THEME:END */` marker, which stylelint (`comment-empty-line-before`) **rejects**. The committed version is the lint-valid one, so regenerating it is a regression (the pre-commit hook blocks it). The generator dropping that blank line is a separate bug, filed as a follow-up.

## Verification (local, CI is quota-dead)

`check:contract-props` ✓ · `check:consumers` ✓ · pre-commit gate (contrast, lint:css, rhythmguard, typecheck, lint) ✓ · second `build:tokens` leaves the two committed files clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
