### PR TITLE
fix(tokens): emit blank line before tailwind DT-THEME:END marker

### DIFF
--- a/scripts/design-system/sync-tailwind-theme.mjs
+++ b/scripts/design-system/sync-tailwind-theme.mjs
@@ -60,7 +60,10 @@ function main() {
     lines.push(line);
   }
 
-  lines.push(END);
+  // Blank line before the END marker so the generated block satisfies
+  // stylelint's comment-empty-line-before rule (matches the committed,
+  // lint-valid form; otherwise every build:tokens re-dirties tailwind.css).
+  lines.push("", END);
 
   let css = readFileSync(TAILWIND_CSS, "utf8");
   const block = `${lines.join("\n")}\n`;


### PR DESCRIPTION
## What

Fixes the token generator so `npm run build:tokens` stops perpetually re-dirtying `app/tailwind.css`.

`sync-tailwind-theme.mjs` pushed the `/* DT-THEME:END */` comment directly after the last token alias, so the regenerated block had **no blank line before END**. That output is lint-invalid — stylelint's `comment-empty-line-before` rejects it — so the generated form could never be committed. The committed version (with the blank line) is the correct, lint-valid one, which is why PR #1271 had to exclude tailwind.css: every `build:tokens` (and the pre-push contract-gate hook) re-dirtied the file with output the pre-commit hook would then block.

## Fix

One line: push an empty string before the END marker so the emitted block matches the committed, lint-valid form (`lines.push("", END)`), with a comment explaining why.

## Verification (local, CI is quota-dead)

- `npm run build:tokens` → `app/tailwind.css` shows **no diff** ✓
- `npm run lint:css` ✓
- A second `build:tokens` leaves the tree clean (only this script change) ✓
- `check:contract-props` ✓ · `check:consumers` ✓ · pre-commit gate (contrast, lint:css, rhythmguard, typecheck, lint) ✓

## Out of scope (flagged separately)

`check:generated` also reports `nextjs-app/shared/foundations/dist/component-catalog.zod.ts` as stale on main (needs `npm run build:zod-catalog`). That is a distinct pre-existing generated-artifact drift, independent of this fix (`build:tokens` does not touch it), and is filed as its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
