### PR TITLE
fix(storybook): theme-following docs container — HCB/dark docs pages legible again

### DIFF
--- a/.storybook/blocks/DtDocsContainer.tsx
+++ b/.storybook/blocks/DtDocsContainer.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useState } from "react";
+import type { PropsWithChildren } from "react";
+import { DocsContainer } from "@storybook/addon-docs/blocks";
+import type { DocsContainerProps } from "@storybook/addon-docs/blocks";
+import { addons } from "storybook/preview-api";
+import { GLOBALS_UPDATED } from "storybook/internal/core-events";
+import { create } from "storybook/theming";
+import type { ThemeVars } from "storybook/theming";
+
+const THEME_KEY = "storybook-theme";
+const DT_THEMES = ["light", "dark", "hcb", "hcw"] as const;
+type DtTheme = (typeof DT_THEMES)[number];
+
+const isDtTheme = (value: unknown): value is DtTheme =>
+  typeof value === "string" && DT_THEMES.includes(value as DtTheme);
+
+const readStoredTheme = (): DtTheme => {
+  if (typeof window === "undefined") return "light";
+  try {
+    const stored = window.localStorage.getItem(THEME_KEY);
+    return isDtTheme(stored) ? stored : "light";
+  } catch {
+    return "light";
+  }
+};
+
+const fontBase =
+  '"Satoshi", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+const fontCode = 'ui-monospace, "SF Mono", Menlo, monospace';
+
+/**
+ * Docs-container themes per DT theme global. The docs container renders
+ * outside the token cascade (Storybook paints its wrapper from an emotion
+ * theme, not from variables.css), so token values are copied as hex with
+ * their source token named alongside — the same documented exception to the
+ * no-hardcoded-colors rule as the manager theme in `.storybook/manager.ts`.
+ *
+ * Without this mapping the docs canvas stays light-theme white in every
+ * theme while the docs-frame blocks (DocHeader tabs, StatusPill) follow the
+ * `.themeHCB`/`.themeDark` tokens — white-on-white in HCB (regressed with
+ * the Astryx docs frame, #806).
+ */
+const DOCS_THEMES: Record<DtTheme, ThemeVars> = {
+  light: create({
+    base: "light",
+    fontBase,
+    fontCode,
+  }),
+  dark: create({
+    base: "dark",
+    fontBase,
+    fontCode,
+    colorPrimary: "#6fa8ff", // --color-primary (dark)
+    colorSecondary: "#6fa8ff", // --color-primary (dark)
+    appBg: "#181a1b", // --main-body-background-color (dark)
+    appContentBg: "#181a1b", // --main-body-background-color (dark)
+    appBorderColor: "#333333", // --color-border (dark)
+    textColor: "#e0e0e0", // --color-text (dark)
+    textInverseColor: "#041b23", // --color-primary (light)
+    textMutedColor: "#888888", // --color-muted (dark)
+    barBg: "#181a1b", // --main-body-background-color (dark)
+    inputBg: "#181a1b", // --main-body-background-color (dark)
+    inputBorder: "#444444", // --color-border-light (dark)
+    inputTextColor: "#e0e0e0", // --color-text (dark)
+  }),
+  hcb: create({
+    base: "dark",
+    fontBase,
+    fontCode,
+    colorPrimary: "#ffffff", // --color-primary (hcb)
+    colorSecondary: "#ffffff", // --color-primary (hcb)
+    appBg: "#000000", // --main-body-background-color (hcb)
+    appContentBg: "#000000", // --main-body-background-color (hcb)
+    appBorderColor: "#333333", // --color-border (hcb)
+    textColor: "#ffffff", // --color-text (hcb)
+    textInverseColor: "#000000", // --inverted-text-color (hcb)
+    textMutedColor: "#888888", // --color-muted (hcb)
+    barBg: "#000000", // --main-body-background-color (hcb)
+    inputBg: "#000000", // --main-body-background-color (hcb)
+    inputBorder: "#444444", // --color-border-light (hcb)
+    inputTextColor: "#ffffff", // --color-text (hcb)
+  }),
+  hcw: create({
+    base: "light",
+    fontBase,
+    fontCode,
+    colorPrimary: "#000000", // --color-primary (hcw)
+    colorSecondary: "#000000", // --color-primary (hcw)
+    appBg: "#ffffff", // --main-body-background-color (hcw)
+    appContentBg: "#ffffff", // --main-body-background-color (hcw)
+    appBorderColor: "#333333", // --color-border (hcw)
+    textColor: "#000000", // --color-text (hcw)
+    textInverseColor: "#ffffff", // --inverted-text-color (hcw)
+    textMutedColor: "#333333", // --color-muted (hcw)
+    barBg: "#ffffff", // --main-body-background-color (hcw)
+    inputBg: "#ffffff", // --main-body-background-color (hcw)
+    inputBorder: "#444444", // --color-border-light (hcw)
+    inputTextColor: "#000000", // --color-text (hcw)
+  }),
+};
+
+/**
+ * DocsContainer that follows the DT theme toolbar global. Initial value comes
+ * from the persisted `storybook-theme` key (written by the theme decorator in
+ * preview.tsx); toolbar switches arrive via GLOBALS_UPDATED without a reload.
+ */
+export function DtDocsContainer(
+  props: PropsWithChildren<DocsContainerProps>,
+) {
+  const [theme, setTheme] = useState<DtTheme>(readStoredTheme);
+
+  useEffect(() => {
+    const channel = addons.getChannel();
+    const onGlobalsUpdated = ({
+      globals,
+    }: {
+      globals?: { theme?: unknown };
+    }) => {
+      if (globals && isDtTheme(globals.theme)) {
+        setTheme(globals.theme);
+      }
+    };
+    channel.on(GLOBALS_UPDATED, onGlobalsUpdated);
+    return () => channel.off(GLOBALS_UPDATED, onGlobalsUpdated);
+  }, []);
+
+  return <DocsContainer {...props} theme={DOCS_THEMES[theme]} />;
+}

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -20,6 +20,7 @@ import { WipBadge } from "@dt/WipBadge";
 import { CookieConsentProvider } from "../nextjs-app/shared/lib/cookieConsent/CookieConsentContext";
 import { resolveDesignParameters } from "./lib/resolve-figma-from-contract";
 import { autogenArgTypes, autogenArgs } from "./lib/controls-autogen";
+import { DtDocsContainer } from "./blocks/DtDocsContainer";
 import { DtDocsPage } from "./blocks/DtDocsPage";
 import { dtSourceTransform } from "./blocks/sourceTransform";
 
@@ -492,6 +493,10 @@ const preview: Preview = {
     // the 11-block DT template; others fall back to classic autodocs inside
     // DtDocsPage. Source transform strips story scaffolding from code panels.
     docs: {
+      // Theme-following docs container: paints the docs canvas from the DT
+      // theme global so docs-frame blocks styled with theme tokens stay
+      // legible in dark/HCB/HCW (see DtDocsContainer for the regression note).
+      container: DtDocsContainer,
       page: DtDocsPage,
       source: { transform: dtSourceTransform },
     },


### PR DESCRIPTION
## Summary

Storybook docs pages regressed when the Astryx docs frame landed (#806, 2026-07-03): the docs container always painted the **light theme's white canvas**, while the docs-frame blocks (DocHeader implementation tabs, StatusPill consuming Badge tones) follow the `.themeHCB` / `.themeDark` token cascade. Result: pure white-on-white in HCB (stable pill and active tab invisible), ~1.5:1 gray-on-white tab labels in dark. Pre-#806 docs survived because classic autodocs used Storybook's own dark-on-white typography and legacy MDX pages forced `--inverted-text-color` inside the wrapper.

Fix: `DtDocsContainer` wraps addon-docs `DocsContainer` with a docs theme per DT theme global.

- Token values are documented hex copies (same exception as the manager theme in `.storybook/manager.ts` — the docs container renders from an emotion theme, outside the `variables.css` cascade).
- Initial theme from the persisted `storybook-theme` key (written by the theme decorator); toolbar switches arrive live via `GLOBALS_UPDATED`, no reload.
- Wired via `parameters.docs.container` in `.storybook/preview.tsx`.

## Verification

In-browser on the CodeBlockWindow docs page (computed styles inside the preview iframe):

| Theme | Docs canvas | StatusPill | Active tab |
|-------|-------------|------------|------------|
| light | `#fff` (unchanged) | `#068338` green | `#041b23` |
| dark | `#181a1b` | `#4fd18b` | `#e0e0e0` |
| hcb | `#000` | `#fff` on black | `#fff` on black |
| hcw | `#fff` | `#000` | `#000` |

No-reload toolbar switch confirmed by emitting `updateGlobals` (light → hcb flips the canvas immediately).

Local gate: typecheck ✅ lint ✅ tests 332 files / 2705 passed ✅ build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Storybook documentation now automatically follows the selected DT theme, including light, dark, and high-contrast modes.
  * Theme preferences persist across sessions and update when changed in Storybook.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->