### PR TITLE
fix(tokens): define --code-toolbar-text per theme — code-window chrome legible in HC themes

### DIFF
--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-18T16:45:03.901Z",
+  "generatedAt": "2026-07-19T13:28:10.929Z",
   "summary": {
     "componentCount": 164,
     "statusCounts": {
@@ -25,7 +25,7 @@
   },
   "tokens": {
     "source": "nextjs-app/shared/styles/variables.css",
-    "tokenCount": 185,
+    "tokenCount": 186,
     "usageCoverage": 151,
     "catalogPath": "nextjs-app/shared/foundations/token-catalog.json",
     "dtcgExport": "nextjs-app/shared/foundations/tokens/production/",

--- a/nextjs-app/shared/foundations/dist/tokens-manifest.json
+++ b/nextjs-app/shared/foundations/dist/tokens-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0",
   "source": "nextjs-app/shared/styles/variables.css",
-  "tokenCount": 185,
+  "tokenCount": 186,
   "usageCoverage": 151,
   "dtcgFiles": [
     "tokens/production/color.json",
@@ -131,6 +131,7 @@
     "--secondary-heading-font",
     "--secondary-text-color",
     "--inverted-text-color",
+    "--code-toolbar-text",
     "--shortcut-hint-color",
     "--wavy-underline-mask",
     "--storybook-blue",
@@ -214,5 +215,5 @@
     "--line-height-relaxed",
     "--line-height-loose"
   ],
-  "generatedAt": "2026-07-14T16:39:51.727Z"
+  "generatedAt": "2026-07-19T13:28:08.424Z"
 }

--- a/nextjs-app/shared/foundations/token-catalog.json
+++ b/nextjs-app/shared/foundations/token-catalog.json
@@ -1,7 +1,7 @@
 {
   "source": "nextjs-app/shared/styles/variables.css",
-  "generatedAt": "2026-07-19T11:18:13.166Z",
-  "tokenCount": 185,
+  "generatedAt": "2026-07-19T13:28:08.351Z",
+  "tokenCount": 186,
   "usageCoverage": 151,
   "themes": [
     {
@@ -1522,6 +1522,13 @@
         {
           "name": "--inverted-text-color",
           "value": "#fff",
+          "usage": "",
+          "category": "other",
+          "subgroup": "General"
+        },
+        {
+          "name": "--code-toolbar-text",
+          "value": "#2b3a45",
           "usage": "",
           "category": "other",
           "subgroup": "General"

--- a/nextjs-app/shared/foundations/tokens/production/other.json
+++ b/nextjs-app/shared/foundations/tokens/production/other.json
@@ -132,6 +132,22 @@
       }
     }
   },
+  "code": {
+    "toolbar": {
+      "text": {
+        "$value": "#2b3a45",
+        "$description": "Production token --code-toolbar-text",
+        "$type": "color",
+        "$extensions": {
+          "digitaltableteur": {
+            "cssVar": "--code-toolbar-text",
+            "category": "other",
+            "subgroup": "General"
+          }
+        }
+      }
+    }
+  },
   "shortcut": {
     "hint": {
       "color": {

--- a/nextjs-app/shared/styles/variables.css
+++ b/nextjs-app/shared/styles/variables.css
@@ -98,6 +98,14 @@
   --link-color: #041b23;
   --logo-text-color: var(--color-text); /* Logo wordmark text - theme-aware */
 
+  /* Code-window chrome text (CodeBlockWindow/CodeSnippet toolbar labels,
+     line-number gutter, status, caption). Was only a hardcoded fallback in
+     component CSS with a manual .themeDark override, so the HC themes
+     rendered dark slate on black. Defined here so React modules AND the
+     native shadow-DOM twins (custom props inherit through shadow roots)
+     resolve it per theme. */
+  --code-toolbar-text: #2b3a45; /* 10.9:1 on #fff */
+
   /* Chat composer keyboard hint. Was an undefined token whose #4b5563
      fallback applied in every theme (2.31:1 on the dark background). */
   --shortcut-hint-color: #4b5563;
@@ -359,6 +367,7 @@
   --main-body-copy-color: #e0e0e0; /* Body copy, was #6fa8ff; accent blue now reserved for interactive */
   --secondary-text-color: #aaa;
   --inverted-text-color: #181a1b;
+  --code-toolbar-text: #cbd5e0; /* matches the old .themeDark component override; 11.4:1 on #181a1b */
   --shortcut-hint-color: #9ca3af; /* 6.7:1 on #181a1b */
   --link-color: var(--color-primary); /* links use the interactive accent, not info-cyan; matches light theme where link == primary */
   --color-primary: #6fa8ff;
@@ -433,6 +442,7 @@
   --main-body-copy-color: #fff;
   --secondary-text-color: #fff;
   --inverted-text-color: #000;
+  --code-toolbar-text: #fff; /* max contrast on #000 chrome */
   --shortcut-hint-color: #fff;
   --link-color: #fff;
   --color-primary: #fff;
@@ -543,6 +553,7 @@
   --main-body-copy-color: #000;
   --secondary-text-color: #000;
   --inverted-text-color: #fff;
+  --code-toolbar-text: #000; /* max contrast on #fff chrome */
   --shortcut-hint-color: #000;
   --link-color: #000;
   --color-primary: #000;
@@ -634,6 +645,7 @@
     --color-border: CanvasText;
     --color-border-light: GrayText;
     --color-muted: CanvasText;
+    --code-toolbar-text: CanvasText;
     --color-disabled-placeholder: GrayText;
     --color-disabled-bg: Canvas;
     --color-disabled-bg-light: Canvas;


### PR DESCRIPTION
## Summary

Follow-up to #1274. With the docs canvas finally rendering in HCB, the CodeBlockWindow chrome showed the next layer of the regression: the `TSX` language label and line-number gutter stayed dark slate on the black surface.

**Why:** the code-window chrome text read `var(--code-toolbar-text, #2b3a45)` — a custom property **defined nowhere**, so the hardcoded dark fallback always won, with only a manual `.themeDark` component override (`#cbd5e0`). HCB/HCW never got overrides → `#2b3a45` on `#000` is ~1.6:1.

**Fix (root cause):** promote the phantom var to a real theme token in `variables.css`:

| Theme | `--code-toolbar-text` | Effect |
|-------|----------------------|--------|
| light | `#2b3a45` | pixel-identical to old fallback |
| dark | `#cbd5e0` | pixel-identical to old override |
| hcb | `#fff` | fixed (was `#2b3a45` on `#000`) |
| hcw | `#000` | max-contrast doctrine |
| forced-colors | `CanvasText` | consistent with the block's other tokens |

One definition fixes the React CSS Modules **and** both native shadow-DOM twins (`dt-code-block-window`, `dt-code-snippet`) — custom properties inherit through shadow roots, and the twins read the same var. No component CSS changed. Token pipeline regenerated (185 → 186 tokens).

## Verification

In-browser on the CodeBlockWindow docs page, computed styles per theme: light/dark unchanged; HCB language label, gutter numbers, and title all `#fff` on black; HCW all `#000` on white.

Local gate: check:contract-props ✅ check:consumers ✅ typecheck ✅ lint ✅ tests ✅ build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
