### PR TITLE
style(storybook): soften story-frame dot grid across themes

### DIFF
--- a/.storybook/blocks/ShowcaseStage.module.css
+++ b/.storybook/blocks/ShowcaseStage.module.css
@@ -1,19 +1,25 @@
 .stage {
+  /* Decorative dot grid: half-strength border-light, resolved per theme.
+     HCW overrides this below to 25% — it pairs a deliberately bold dark
+     border-light (#444) with a white canvas, so a 50% mix still reads
+     near-solid; 25% lets the grid recede like the other themes. */
+  --stage-dot: color-mix(in srgb, var(--color-border-light) 50%, transparent);
+
   margin-block: var(--space-internal-24);
   border: 1px solid var(--color-border-light);
   border-radius: var(--radius-lg, 12px);
   background:
-    radial-gradient(
-      circle at 1px 1px,
-      var(--color-border-light) 1px,
-      transparent 0
-    );
+    radial-gradient(circle at 1px 1px, var(--stage-dot) 1px, transparent 0);
   background-size: 24px 24px;
   background-color: var(--main-body-background-color);
   padding: var(--space-layout-32) var(--space-internal-24);
   min-block-size: 160px;
   display: grid;
   align-items: center;
+}
+
+:global(.themeHCW) .stage {
+  --stage-dot: color-mix(in srgb, var(--color-border-light) 25%, transparent);
 }
 
 @media (width >= 768px) {


### PR DESCRIPTION
## Summary

The Storybook docs story-frame backdrop (the dotted grid behind each component preview in `ShowcaseStage`) drew its dots at full-strength `--color-border-light`, heavier than intended.

- Route the dot color through a `--stage-dot` local var set to `color-mix(in srgb, var(--color-border-light) 50%, transparent)`, so it halves per theme from the same token (no per-theme copies).
- **HCW special-cased to 25%:** it pairs a deliberately bold dark border-light (`#444`) with a white canvas, so a 50% mix (`≈#a1a1a1`) still reads near-solid. On black (HCB) that same `#444` at 50% already recedes; on white it doesn't. 25% brings HCW down to the same visual weight as the other themes.

Storybook-only chrome — no component or npm-package change, stylelint baseline untouched.

## Verification

In-browser on the CodeBlockWindow docs preview, computed `--stage-dot` per theme:

| Theme | border-light | dot alpha | resolves to |
|-------|-------------|-----------|-------------|
| light | `#ccc` | 50% | `srgb 0.8 / 0.5` |
| dark | `#ccc`* | 50% | halved |
| hcb | `#444` | 50% | `srgb 0.267 / 0.5` (subtle on black) |
| hcw | `#444` | 25% | `srgb 0.267 / 0.25` (recedes on white) |

Screenshotted light/HCB/HCW — grid is visibly softer, geometry unchanged.

Local gate: lint:css ✅ (baseline unchanged) typecheck ✅ lint ✅ tests ✅ build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
