### PR TITLE
refactor(codesnippet): toolbar copy control uses the sm button size

### DIFF
--- a/nextjs-app/shared/components/CodeSnippet/CodeSnippet.tsx
+++ b/nextjs-app/shared/components/CodeSnippet/CodeSnippet.tsx
@@ -224,7 +224,7 @@ export const CodeSnippet: React.FC<CodeSnippetProps> = ({
           <div className={styles.actions}>
             {variant === "single" ? (
               <Button
-                size="md"
+                size="sm"
                 variant="secondary"
                 onClick={() => void copyToClipboard("raw")}
                 aria-label="Copy code to clipboard"
@@ -233,7 +233,7 @@ export const CodeSnippet: React.FC<CodeSnippetProps> = ({
               </Button>
             ) : (
               <SplitButton
-                size="md"
+                size="sm"
                 variant="secondary"
                 label="Copy"
                 onPrimaryClick={() => void copyToClipboard("raw")}


### PR DESCRIPTION
## Summary

CodeSnippet's toolbar copy control rendered at `size="md"` (40px), one step larger than the compact toolbar warrants. Drop the copy control to `size="sm"` (32px) in both variants:

- menu variant: `SplitButton size="sm"` (the control the request named)
- single variant: the plain `Button size="sm"` for the same toolbar slot, so the copy control is the same height regardless of variant

The full-width "Show more" expand button is a separate control and stays `md`.

At sm the React control (32px) also matches the native `dt-code-snippet` twin's hand-rolled copy chrome (`min-block-size: 2rem`), which md never lined up with.

## Verification

In-browser, computed styles: Single and Multi stories both render the copy control as `Button-module__sm` at 32px.

Local gate: typecheck / lint / 2705 tests / build all green.

Note: source change only — registry-consuming contexts pick it up on the next ds-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
