### PR TITLE
fix(tokens): promote phantom CSS vars to real per-theme tokens — HC legibility

### DIFF
--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -135,12 +135,17 @@
   --color-dt-gray-medium: var(--color-gray-medium);
   --color-dt-header-bg: var(--color-header-bg);
   --color-dt-info: var(--color-info);
+  --color-dt-info-bg: var(--color-info-bg);
+  --color-dt-info-text: var(--color-info-text);
   --color-dt-light-bg: var(--color-light-bg);
   --color-dt-muted: var(--color-muted);
   --color-dt-muted-light: var(--color-muted-light);
   --color-dt-neutral-bg: var(--color-neutral-bg);
   --color-dt-neutral-text: var(--color-neutral-text);
+  --color-dt-placeholder-dark: var(--color-placeholder-dark);
+  --color-dt-placeholder-dark-fg: var(--color-placeholder-dark-fg);
   --color-dt-primary: var(--color-primary);
+  --color-dt-primary-dark: var(--color-primary-dark);
   --color-dt-primary-disabled: var(--color-primary-disabled);
   --color-dt-react: var(--color-react);
   --color-dt-success: var(--color-success);

--- a/nextjs-app/shared/components/ImagePlaceholder/ImagePlaceholder.module.css
+++ b/nextjs-app/shared/components/ImagePlaceholder/ImagePlaceholder.module.css
@@ -49,8 +49,11 @@
 }
 
 .dark {
-  background-color: var(--color-gray-dark);
-  color: var(--color-text-inverse, #fff);
+  background-color: var(--color-placeholder-dark);
+
+  /* --color-placeholder-dark stays dark in every theme (unlike --color-gray-dark,
+     which inverts to a light value in dark/HCW and left the white text invisible). */
+  color: var(--color-placeholder-dark-fg);
 }
 
 .gradient {

--- a/nextjs-app/shared/components/Switch/Switch.module.css
+++ b/nextjs-app/shared/components/Switch/Switch.module.css
@@ -117,7 +117,14 @@
   align-items: center;
   border-radius: 999px;
   background-color: var(--switch-handle-bg, #fff);
-  box-shadow: 0 2px 6px rgb(15 23 42 / 18%);
+
+  /* Soft drop shadow + a hairline ring. The ring is transparent in most themes
+     and only becomes visible in HCB (via --switch-handle-ring-color), where the
+     on-state track is #fff and a plain #fff handle would otherwise vanish. A
+     box-shadow ring follows the circle and adds no box-model shift. */
+  box-shadow:
+    0 2px 6px rgb(15 23 42 / 18%),
+    0 0 0 1px var(--switch-handle-ring-color, transparent);
   transition:
     transform var(--duration-fast) var(--ease-out-cubic),
     background-color var(--duration-fast) var(--ease-out-cubic),

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-19T13:28:10.929Z",
+  "generatedAt": "2026-07-19T15:36:35.444Z",
   "summary": {
     "componentCount": 164,
     "statusCounts": {
@@ -25,8 +25,8 @@
   },
   "tokens": {
     "source": "nextjs-app/shared/styles/variables.css",
-    "tokenCount": 186,
-    "usageCoverage": 151,
+    "tokenCount": 192,
+    "usageCoverage": 156,
     "catalogPath": "nextjs-app/shared/foundations/token-catalog.json",
     "dtcgExport": "nextjs-app/shared/foundations/tokens/production/",
     "tailwindBridge": "app/tailwind.css (DT-THEME block)",

--- a/nextjs-app/shared/foundations/dist/tokens-manifest.json
+++ b/nextjs-app/shared/foundations/dist/tokens-manifest.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": "1.0",
   "source": "nextjs-app/shared/styles/variables.css",
-  "tokenCount": 186,
-  "usageCoverage": 151,
+  "tokenCount": 192,
+  "usageCoverage": 156,
   "dtcgFiles": [
     "tokens/production/color.json",
     "tokens/production/elevation.json",
@@ -46,6 +46,7 @@
     "--color-disabled-placeholder",
     "--color-primary-disabled",
     "--color-primary",
+    "--color-primary-dark",
     "--color-title",
     "--color-text",
     "--color-focus-ring",
@@ -54,10 +55,14 @@
     "--color-border-light",
     "--color-switch-track-off",
     "--color-light-bg",
+    "--color-placeholder-dark",
+    "--color-placeholder-dark-fg",
     "--color-react",
     "--color-header-bg",
     "--color-success",
     "--color-info",
+    "--color-info-bg",
+    "--color-info-text",
     "--color-error",
     "--color-error-bg",
     "--color-error-text",
@@ -133,6 +138,7 @@
     "--inverted-text-color",
     "--code-toolbar-text",
     "--shortcut-hint-color",
+    "--switch-handle-ring-color",
     "--wavy-underline-mask",
     "--storybook-blue",
     "--storybook-cyan",
@@ -215,5 +221,5 @@
     "--line-height-relaxed",
     "--line-height-loose"
   ],
-  "generatedAt": "2026-07-19T13:28:08.424Z"
+  "generatedAt": "2026-07-19T15:36:32.501Z"
 }

--- a/nextjs-app/shared/foundations/token-catalog.json
+++ b/nextjs-app/shared/foundations/token-catalog.json
@@ -1,8 +1,8 @@
 {
   "source": "nextjs-app/shared/styles/variables.css",
-  "generatedAt": "2026-07-19T13:28:08.351Z",
-  "tokenCount": 186,
-  "usageCoverage": 151,
+  "generatedAt": "2026-07-19T15:36:32.450Z",
+  "tokenCount": 192,
+  "usageCoverage": 156,
   "themes": [
     {
       "id": "light",
@@ -967,6 +967,27 @@
           "subgroup": "Semantic"
         },
         {
+          "name": "--color-primary-dark",
+          "value": "#0046b8",
+          "usage": "Color token (primary-dark).",
+          "category": "color",
+          "subgroup": "Semantic"
+        },
+        {
+          "name": "--color-placeholder-dark",
+          "value": "#222",
+          "usage": "Color token (placeholder-dark).",
+          "category": "color",
+          "subgroup": "Semantic"
+        },
+        {
+          "name": "--color-placeholder-dark-fg",
+          "value": "#fff",
+          "usage": "Color token (placeholder-dark-fg).",
+          "category": "color",
+          "subgroup": "Semantic"
+        },
+        {
           "name": "--color-react",
           "value": "#61dafb",
           "usage": "Color token (react).",
@@ -1005,6 +1026,20 @@
           "name": "--color-info",
           "value": "#0c7a8b",
           "usage": "Informational alerts and neutral-positive emphasis.",
+          "category": "color",
+          "subgroup": "Status & feedback"
+        },
+        {
+          "name": "--color-info-bg",
+          "value": "#e6f4ff",
+          "usage": "Color token (info-bg).",
+          "category": "color",
+          "subgroup": "Status & feedback"
+        },
+        {
+          "name": "--color-info-text",
+          "value": "#0c5460",
+          "usage": "Color token (info-text).",
           "category": "color",
           "subgroup": "Status & feedback"
         },
@@ -1536,6 +1571,13 @@
         {
           "name": "--shortcut-hint-color",
           "value": "#4b5563",
+          "usage": "",
+          "category": "other",
+          "subgroup": "General"
+        },
+        {
+          "name": "--switch-handle-ring-color",
+          "value": "transparent",
           "usage": "",
           "category": "other",
           "subgroup": "General"

--- a/nextjs-app/shared/foundations/tokens/production/color.json
+++ b/nextjs-app/shared/foundations/tokens/production/color.json
@@ -227,6 +227,18 @@
             "subgroup": "Semantic"
           }
         }
+      },
+      "dark": {
+        "$value": "#0046b8",
+        "$description": "Color token (primary-dark).",
+        "$type": "color",
+        "$extensions": {
+          "digitaltableteur": {
+            "cssVar": "--color-primary-dark",
+            "category": "color",
+            "subgroup": "Semantic"
+          }
+        }
       }
     },
     "title": {
@@ -335,6 +347,34 @@
         }
       }
     },
+    "placeholder": {
+      "dark": {
+        "DEFAULT": {
+          "$value": "#222",
+          "$description": "Color token (placeholder-dark).",
+          "$type": "color",
+          "$extensions": {
+            "digitaltableteur": {
+              "cssVar": "--color-placeholder-dark",
+              "category": "color",
+              "subgroup": "Semantic"
+            }
+          }
+        },
+        "fg": {
+          "$value": "#fff",
+          "$description": "Color token (placeholder-dark-fg).",
+          "$type": "color",
+          "$extensions": {
+            "digitaltableteur": {
+              "cssVar": "--color-placeholder-dark-fg",
+              "category": "color",
+              "subgroup": "Semantic"
+            }
+          }
+        }
+      }
+    },
     "react": {
       "$value": "#61dafb",
       "$description": "Color token (react).",
@@ -374,14 +414,40 @@
       }
     },
     "info": {
-      "$value": "#0c7a8b",
-      "$description": "Informational alerts and neutral-positive emphasis.",
-      "$type": "color",
-      "$extensions": {
-        "digitaltableteur": {
-          "cssVar": "--color-info",
-          "category": "color",
-          "subgroup": "Status & feedback"
+      "DEFAULT": {
+        "$value": "#0c7a8b",
+        "$description": "Informational alerts and neutral-positive emphasis.",
+        "$type": "color",
+        "$extensions": {
+          "digitaltableteur": {
+            "cssVar": "--color-info",
+            "category": "color",
+            "subgroup": "Status & feedback"
+          }
+        }
+      },
+      "bg": {
+        "$value": "#e6f4ff",
+        "$description": "Color token (info-bg).",
+        "$type": "color",
+        "$extensions": {
+          "digitaltableteur": {
+            "cssVar": "--color-info-bg",
+            "category": "color",
+            "subgroup": "Status & feedback"
+          }
+        }
+      },
+      "text": {
+        "$value": "#0c5460",
+        "$description": "Color token (info-text).",
+        "$type": "color",
+        "$extensions": {
+          "digitaltableteur": {
+            "cssVar": "--color-info-text",
+            "category": "color",
+            "subgroup": "Status & feedback"
+          }
         }
       }
     },

--- a/nextjs-app/shared/foundations/tokens/production/other.json
+++ b/nextjs-app/shared/foundations/tokens/production/other.json
@@ -164,6 +164,24 @@
       }
     }
   },
+  "switch": {
+    "handle": {
+      "ring": {
+        "color": {
+          "$value": "transparent",
+          "$description": "Production token --switch-handle-ring-color",
+          "$type": "color",
+          "$extensions": {
+            "digitaltableteur": {
+              "cssVar": "--switch-handle-ring-color",
+              "category": "other",
+              "subgroup": "General"
+            }
+          }
+        }
+      }
+    }
+  },
   "wavy": {
     "underline": {
       "mask": {

--- a/nextjs-app/shared/patterns/Hero/Hero.module.css
+++ b/nextjs-app/shared/patterns/Hero/Hero.module.css
@@ -18,14 +18,14 @@
 
 .background-dark {
   background: var(--color-primary);
-  color: var(--color-text-inverse, #fff);
+  color: var(--inverted-text-color);
 }
 
 .background-gradient {
   background: linear-gradient(
     135deg,
     var(--color-primary) 0%,
-    var(--color-primary-dark, #0046b8) 100%
+    var(--color-primary-dark) 100%
   );
   color: var(--color-white);
 }

--- a/nextjs-app/shared/styles/variables.css
+++ b/nextjs-app/shared/styles/variables.css
@@ -158,6 +158,19 @@
   --color-primary-disabled: #041b2350;
   --color-success: #068338;
   --color-info: #0c7a8b;
+
+  /* Info surface + on-info text (e.g. native CookieConsent "required" badge).
+     Previously phantom vars whose #hex fallbacks left the badge illegible in
+     HCB. --color-primary-dark is the Hero gradient end; --color-placeholder-dark
+     (+ -fg) is ImagePlaceholder's genuinely-dark variant surface (dark in every
+     theme so its light text stays legible). --switch-handle-ring-color is a
+     hairline ring shown only where the on-track matches the handle colour. */
+  --color-info-bg: #e6f4ff;
+  --color-info-text: #0c5460;
+  --color-primary-dark: #0046b8;
+  --color-placeholder-dark: #222;
+  --color-placeholder-dark-fg: #fff;
+  --switch-handle-ring-color: transparent;
   --color-error: #dc3545;
   --color-warning: #ffc107;
   --color-warning-contrast: #8d5a00;
@@ -374,6 +387,12 @@
   --color-primary-disabled: #6fa8ff50;
   --color-success: #4fd18b;
   --color-info: #71efff;
+  --color-info-bg: #0e2a33;
+  --color-info-text: #71efff;
+  --color-primary-dark: #0046b8;
+  --color-placeholder-dark: #2a2c2d;
+  --color-placeholder-dark-fg: #fff;
+  --switch-handle-ring-color: transparent;
   --color-error: #ff6b6b;
   --color-warning: #ffb366;
   --color-warning-contrast: #ffb366;
@@ -449,6 +468,12 @@
   --color-primary-disabled: color-mix(in srgb, #fff 60%, #000);
   --color-success: #fff;
   --color-info: #fff;
+  --color-info-bg: #000;
+  --color-info-text: #fff;
+  --color-primary-dark: #fff;
+  --color-placeholder-dark: #2a2a2a;
+  --color-placeholder-dark-fg: #fff;
+  --switch-handle-ring-color: var(--color-border);
   --color-error: #fff;
   --color-warning: #fff;
   --color-warning-contrast: #fff;
@@ -560,6 +585,12 @@
   --color-primary-disabled: color-mix(in srgb, #fff 60%, #000);
   --color-success: #000;
   --color-info: #000;
+  --color-info-bg: #fff;
+  --color-info-text: #000;
+  --color-primary-dark: #000;
+  --color-placeholder-dark: #1a1a1a;
+  --color-placeholder-dark-fg: #fff;
+  --switch-handle-ring-color: transparent;
   --color-error: #000;
   --color-warning: #000;
   --color-warning-contrast: #000;
@@ -660,6 +691,12 @@
     --color-warning: CanvasText;
     --color-warning-contrast: CanvasText;
     --color-info: CanvasText;
+    --color-info-bg: Canvas;
+    --color-info-text: CanvasText;
+    --color-primary-dark: Canvas;
+    --color-placeholder-dark: Canvas;
+    --color-placeholder-dark-fg: CanvasText;
+    --switch-handle-ring-color: transparent;
   }
 }
 

--- a/packages/web-components/src/native/switch.ts
+++ b/packages/web-components/src/native/switch.ts
@@ -24,7 +24,7 @@ const styles = `
   button[aria-checked="true"] { background: var(--switch-track-on, var(--color-primary)); }
   button:focus-visible { outline: var(--focus-ring-width, 2px) solid var(--focus-ring-color, var(--color-primary)); outline-offset: var(--focus-ring-offset, 2px); }
   button:disabled { opacity: 0.55; cursor: not-allowed; }
-  .handle { position: absolute; top: 50%; inset-inline-start: 0.15rem; translate: 0 -50%; aspect-ratio: 1; block-size: calc(var(--switch-height) - 0.3rem); border-radius: 50%; background: var(--switch-handle-bg, white); box-shadow: 0 2px 6px rgb(15 23 42 / 18%); transition: translate var(--duration-fast, 160ms) ease; }
+  .handle { position: absolute; top: 50%; inset-inline-start: 0.15rem; translate: 0 -50%; aspect-ratio: 1; block-size: calc(var(--switch-height) - 0.3rem); border-radius: 50%; background: var(--switch-handle-bg, white); box-shadow: 0 2px 6px rgb(15 23 42 / 18%), 0 0 0 1px var(--switch-handle-ring-color, transparent); transition: translate var(--duration-fast, 160ms) ease; }
   button[aria-checked="true"] .handle { translate: calc(var(--switch-width) - var(--switch-height)) -50%; }
   .loading .handle::after { content: ""; position: absolute; inset: 20%; border: 1px solid currentcolor; border-inline-end-color: transparent; border-radius: 50%; animation: spin 700ms linear infinite; }
   .message { margin: var(--space-internal-8, 0.5rem) 0 0; font-size: 0.875rem; color: var(--color-primary); }


### PR DESCRIPTION
## Summary

Follow-up sweep to #1274/#1275. Scanned all CSS under `nextjs-app/shared/` and `packages/web-components/src/native/` for `var(--X, #hex)` where `--X` is defined nowhere (so the hex fallback wins in every theme, and only `.themeDark` ever got a manual override — illegible in HCB/HCW).

**Most flagged vars were false positives**, which is why this is a small, targeted fix rather than a big sweep:
- Defined locally in the component (NewsBulletin's `--bulletin-*`, with per-theme overrides).
- Covered by explicit `.themeHCB`/`.themeHCW` overrides (ChatWidget's `--shortcut-hint-strong-color` — verified white in HCB).
- Dark-only, never rendered in HCB/HCW (`--code-toolbar-text-dark`).

**Four were genuine high-contrast bugs**, fixed token-first:

| # | Component | Bug (HCB/HCW) | Fix |
|---|-----------|---------------|-----|
| 1 | Hero `background="dark"` | `var(--color-text-inverse, #fff)` on `--color-primary`; the token doesn't exist, so `#fff` won everywhere — in HCB `--color-primary` is `#fff` → white-on-white **invisible** | use `--inverted-text-color` (correct per theme; also fixes the pre-existing ~2:1 white-on-`#6fa8ff` fail in dark). Gradient end `--color-primary-dark` is now a real token. |
| 2 | ImagePlaceholder `variant="dark"` | `#fff` text on `--color-gray-dark`, which **inverts** to light in dark/HCW → white-on-light-gray **invisible** | new `--color-placeholder-dark` (+`-fg`) token, genuinely dark in every theme |
| 3 | Switch handle | `#fff` handle on the `#fff` on-track in HCB → **invisible** when ON | new `--switch-handle-ring-color` token adds a hairline `box-shadow` ring, transparent except HCB — applied to the React module **and** the native `dt-switch` twin (the custom prop inherits into the shadow root, so both render identically) |
| 4 | CookieConsent "required" badge (native) | `--color-info-bg` + `--color-info-text` phantom → illegible in class-based HCB | both are now real per-theme tokens; the native `var()` references resolve through the shadow boundary unchanged |

**Intentional / left documented:** `--color-linkedin`/`--color-linkedin-hover` (LinkedIn brand blue), `--gallery-bg` (page-only illustration canvas), two dev-only Storybook story helpers.

Six new tokens across all four themes + forced-colors; `build:tokens` regenerated (186 → 192). Light/dark rendering is preserved except two deliberate a11y improvements (Hero dark text; ImagePlaceholder light bg `#333`→`#222`, negligible).

## Verification

In-browser, computed styles per theme:
- ImagePlaceholder `.dark` HCW → `#1a1a1a` bg + `#fff` text (was invisible).
- Hero `background-dark` HCB → `#000` text on `#fff` primary (was white-on-white).
- Switch handle HCB → `#333` ring on the white handle — confirmed in **both** the React module and the native `dt-switch` shadow DOM.
- CookieConsent badge: verified by construction — the native reads the now-defined `--color-info-bg`/`--color-info-text` (I could not render the badge to screenshot it).

Local gate: lint:css (baseline unchanged) / typecheck / lint / 2705 tests / build / check:contract-props / check:consumers — all green.

## Caveats

- Hero `background="dark"` text changes from white to near-black **in dark theme** — an a11y improvement (was a contrast fail) but a visible change.
- The CookieConsent badge fix is verified by construction, not a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added semantic color options for information states, dark primary accents, and dark image placeholders.
  - Added switch handle ring color support across themes and high-contrast modes.

- **Improvements**
  - Updated dark image placeholders for clearer text visibility.
  - Enhanced switch handles with a subtle focus ring.
  - Refined hero gradient colors and theme consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->