### PR TITLE
fix(modal): stop content reset from blanking nested switch handles

### DIFF
--- a/nextjs-app/shared/components/Modal/Modal.module.css
+++ b/nextjs-app/shared/components/Modal/Modal.module.css
@@ -99,13 +99,13 @@
   margin: 0;
 }
 
-.content :is(p, span, div) {
+.content > :is(p, span, div) {
   background-color: transparent;
   color: inherit;
 }
 
 .loading .content,
-.loading .content :is(p, span, div) {
+.loading .content > :is(p, span, div) {
   background-color: var(--main-body-background-color, var(--color-white));
   color: var(--color-primary);
 }


### PR DESCRIPTION
The Modal content reset `.content :is(p, span, div) { background-color: transparent }` used a descendant selector whose specificity (0,1,1) outranks a component's own single-class rule like `.Switch-module__handle` (0,1,0). Every Switch rendered inside a Modal — the CookieConsent preferences dialog — lost its white handle fill and rendered a transparent knob (only its drop shadow visible) in all themes, while the same Switch was correct standalone.

Fix: scope the reset and its `.loading` counterpart to **direct children** (`.content > :is(p, span, div)`), so they normalize the modal's own content wrapper without reaching into nested component internals.

Verified in-browser: all four CookieConsent switch handles now render solid white (rgb(255,255,255)). Local gate green (lint:css baseline unchanged, typecheck, lint, 2705 tests, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal styling so theme colors apply only to direct content elements, preventing unintended styling of nested elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->