### PR TITLE
feat(footer): order nav links Home/Work/About/Pricing/Blog/Contact

### DIFF
--- a/nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx
+++ b/nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx
@@ -146,11 +146,11 @@ export function SiteFooter({ className }: SiteFooterProps) {
               <DtLink underline="hover" href="/about" size="sm">
                 {t("navAbout")}
               </DtLink>
-              <DtLink underline="hover" href="/blog" size="sm">
-                {t("navBlog")}
-              </DtLink>
               <DtLink underline="hover" href="/pricing" size="sm">
                 {t("navPricing")}
+              </DtLink>
+              <DtLink underline="hover" href="/blog" size="sm">
+                {t("navBlog")}
               </DtLink>
               <DtLink underline="hover" href="/contact" size="sm">
                 {t("navContact")}

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--default.dark.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--default.dark.yaml
@@ -14,10 +14,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--default.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--default.forced-colors.yaml
@@ -14,10 +14,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--default.light.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--default.light.yaml
@@ -14,10 +14,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--default.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--default.yaml
@@ -14,10 +14,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--example.dark.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--example.dark.yaml
@@ -14,10 +14,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--example.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--example.forced-colors.yaml
@@ -14,10 +14,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--example.light.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--example.light.yaml
@@ -14,10 +14,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--example.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--example.yaml
@@ -14,10 +14,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--forced-colors.dark.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--forced-colors.dark.yaml
@@ -14,10 +14,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--forced-colors.forced-colors.yaml
@@ -14,10 +14,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--forced-colors.light.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--forced-colors.light.yaml
@@ -14,10 +14,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--forced-colors.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--forced-colors.yaml
@@ -14,10 +14,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--playground.dark.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--playground.dark.yaml
@@ -14,10 +14,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--playground.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--playground.forced-colors.yaml
@@ -14,10 +14,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--playground.light.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--playground.light.yaml
@@ -14,10 +14,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--playground.yaml
+++ b/nextjs-app/shared/patterns/SiteFooter/__a11y-snapshots__/patterns-sitefooter--playground.yaml
@@ -14,10 +14,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal


### PR DESCRIPTION
Swap Pricing above Blog in SiteFooter; regenerate the 16 a11y snapshots. Local gate green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Reordered the footer’s Explore links so **Pricing** appears before **Blog**.
  - Link destinations remain unchanged.

- **Tests**
  - Updated accessibility coverage across footer variants and color modes to reflect the new link order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->