### PR TITLE
feat(ds): adopt DSDS documentation semantics + fix spec.md bullet truncation

### DIFF
--- a/content/drafts/projecting-165-components-into-dsds.mdx
+++ b/content/drafts/projecting-165-components-into-dsds.mdx
@@ -1,0 +1,153 @@
+---
+title: "We Projected a 165-Component System Into DSDS. Here's What the Schema Couldn't Express."
+slug: "projecting-165-components-into-dsds"
+publishedAt: "2026-07-21T00:00:00.000Z"
+readTime: "11 min read"
+excerpt: "A documentation schema is a claim about what design system knowledge looks like. Running ours through one found gaps in both directions."
+authorName: "Petri Lahdelma"
+authorSlug: "petri-lahdelma"
+---
+
+The Design System Doc Spec turned up in my reading last week: a JSON schema for design system documentation, deliberately layered above the W3C token format and Custom Elements Manifest. It documents eight entity types, holds them in typed blocks with a `kind` tag, and refuses to duplicate anything the formats below it already own.
+
+I did not adopt it. It is version 0.15.2, five months old, and 211 of its 212 commits come from one person. What I did instead was project our system into it: 165 components, generated from the contracts and agent blocks we already maintain, written out as DSDS documents and validated against the spec's own bundled schema.
+
+The projection is throwaway. The residue is not. A schema someone else designed is a claim about what design system knowledge looks like, and running your own documentation through it tells you where your model and theirs disagree. Every disagreement is either a gap in yours or a gap in theirs, and you have to look at each one to find out which.
+
+Here is what fell out.
+
+## The Setup
+
+Our documentation lives in two places. Each component has a `contract.json` carrying structural facts (props, variants, a11y state, tokens consumed, story requirements) and a `spec.md` carrying human guidance under a "Do / don't" heading. A build step compiles both into `component-agent-blocks.json`, which is what coding agents actually read.
+
+The projection maps that onto DSDS entities. Props become an `api` block, Do/don't lines become `guidelines`, accessibility state becomes an `accessibility` block with criteria, and anything with no home goes into a residue report rather than getting quietly dropped. The residue is the output I cared about.
+
+First run: 9,191 validation errors across 25 classes. That number is not interesting on its own, because most of it was me writing the projection from the prose documentation instead of the schema files. Reading the actual JSON Schema took the count to 2,807, then 1,020, then 19, then zero. All 165 entities validate.
+
+The interesting part is the four things that never validated cleanly, and had to be worked around.
+
+## What the Schema Could Not Express
+
+### An accessibility requirement that nothing verifies
+
+This is the one that mattered most, because it is the one where our data was better than the schema's vocabulary.
+
+Our contracts carried eight accessibility booleans: `reviewed`, `forcedColorsVerified`, `accessibilityTreeVerified`, `realBrowserForcedColorsVerified`, `screenReaderVerified`, and three more. Each asserts that something was checked. None records by what. A claim that CI proves on every push and a claim a human made once in March have the same shape on disk, which means neither can be trusted more than the other.
+
+DSDS fixes exactly this with `verification` on a criterion: `automated` (with a named check), `assisted`, or `manual`. I built the same thing into our contracts, deriving criteria from the booleans using the check names that were already sitting in our schema descriptions as prose. That produced 783 criteria across the system: 473 automated, 195 manual, and 115 that nothing verifies at all.
+
+Those 115 have no representation in DSDS. The enum has no member for them. The spec's answer is to omit `verification` entirely, and its description instructs tools to treat a missing value as no evidence of automatability. That is a reasonable default, but it means *automatability unknown*, which is a weaker claim than *we know that nothing proves this*. One is an absence of information. The other is a finding.
+
+Worse, I could not record it in a vendor extension either. Document blocks gained `$extensions` in 0.15.2, but `criterion` is a closed object that never got one. So the marker had to be hoisted up to the parent `accessibility` block as a list of criterion ids, which technically preserves the data and breaks the link between the gap and the requirement it belongs to.
+
+That count of 115 is now a ratcheted gate in our repo. It can go down and it cannot go up. It was not a number we could have written down a week ago, because we had no field capable of holding it.
+
+### Documentation that a rule set derived
+
+DSDS's `docOrigin` distinguishes how documentation came to exist: `authored`, `generated`, `extracted`, or `reconstructed`. It is a genuinely good idea and I stole it, because our agent blocks mix machine-read props with hand-written intent in one object, and an agent has no way to tell which is which. That matters: an agent that "corrects" a human-authored intent line toward what the code appears to do has destroyed the only part of the file that says what the code was *for*.
+
+But our provenance has three states and theirs has four that do not include ours. Props read from the TypeScript AST are `generated`. Intent written by a person is `authored`. And then there is a third kind: our forbidden-use list, our composition rules, our accessibility criteria. Those are computed by a rule set from human-authored input. No machine read them off the source, and no human wrote them.
+
+`generated` implies read from source. `extracted` means a person or agent read the existing code after the fact. Neither is right, and collapsing to `generated` loses the distinction between "a machine read this" and "a machine inferred this from what a human wrote." The second is much less trustworthy than the first, which is the whole reason to record provenance. 165 blocks hit this.
+
+### The MAY level
+
+DSDS's `conformanceLevel` is `must`, `should`, `should-not`, `must-not`. RFC 2119, which the field is explicitly named for, also defines MAY: truly optional, no recommendation either way.
+
+Omitting it is defensible. A documentation rule that says "you may do this" is arguably not a rule. But it means a genuinely optional allowance has to be written as `should`, which recommends it, and the difference between "this is permitted" and "we suggest this" is exactly the kind of thing an agent reads literally.
+
+### The component-to-token edge
+
+Every one of our contracts records which design tokens the component consumes, in a typed `tokens` object split by colors, spacing, radii, shadows, z-index, and typography. It is how we answer "what breaks if this token changes."
+
+DSDS documents tokens as first-class entities, and documents components as first-class entities, and provides no typed edge from a component to the tokens it uses. You can mention tokens in prose inside an anatomy or design-specifications block. You cannot query it. All 165 components carry that data into `$extensions`, where no DSDS consumer will look for it.
+
+This is the residue table in full. Each row is data our contracts hold that the schema has no typed home for:
+
+```
+ 165  docOrigin: derived        165  cvaVariants
+ 165  requiredStories           165  subParts
+ 165  tier                      165  tokens
+ 165  lightDarkVerified         138  consumers
+ 165  declaredPropCount         119  api prop: no description
+ 115  a11y criterion: unverified  2  content.maxLength
+   2  radixPrimitive
+```
+
+Some of those are fair. `tier`, `requiredStories`, and `declaredPropCount` are our build system's business, not a documentation standard's. But `tokens` and `consumers` are the two edges that make our graph queryable, and both fall out.
+
+## What the Schema Expressed Better Than We Did
+
+An honest projection cuts both ways, and this direction produced the more useful findings.
+
+### Rules and facts are different things
+
+I had designed a `content` field for UX writing guidance, holding voice, capitalization, terminology, and length limits together. Then I read DSDS's `content` block and found it is a label dictionary plus localization notes, with an explicit instruction that general content guidance belongs in `guidelines` with category `content` instead.
+
+The spec's line is sharp: a guideline says "use sentence case," which is a rule. A content entry says "Add: takes an existing object and uses it in a new context," which is a fact. I had merged two kinds of thing because they were both about words. Splitting them is correct, and the projection now emits voice and capitalization as guidelines and terminology as labels.
+
+I was also wrong in the other direction. I had written in my own notes that DSDS has no localization surface, so our FI and SV constraints had nowhere to go. It has `localizationEntry`, with `text-expansion` and `truncation` as named concerns, which is precisely our problem. What is genuinely lost is narrower than I claimed: the concern survives, but a per-slot integer ceiling becomes prose, and no gate can fail a build on a sentence.
+
+### Unresolvable references are defects
+
+DSDS's conformance model says a conforming consumer "MUST treat unresolvable references as defects, not silently drop them." Schema validity is explicitly not enough; there is a semantic layer covering identifier uniqueness and reference resolution.
+
+So I checked. Our 165 components produce 440 relationship edges from the `composesWith`, `prefersOver`, and `replacementFor` fields. **58 of them point at nothing**, across 35 distinct targets. And the targets explain why:
+
+```
+raw-<button>
+@/components/ui/button
+toast-for-persistent-page-level-status
+custom-div-alert
+```
+
+Those are prose fragments and an import path sitting in fields meant to hold component names. Nothing in our repo checks that the graph resolves, so they had been accumulating quietly. That is a real bug, found by taking someone else's conformance requirement seriously for an afternoon.
+
+### Deprecation needs a forwarding address
+
+One entity failed validation on status alone. DSDS accepts a bare string for status, except for `deprecated`, which must use the object form because deprecation requires a `deprecationNotice` saying what to use instead. Our contracts had `deprecatedReason` sitting there unused by anything, so the mapping was free. But the constraint is right and we were not enforcing it.
+
+## The Bug I Found on the Way
+
+The most valuable thing in this whole exercise had nothing to do with DSDS.
+
+To emit RFC 2119 levels I had to rewrite the parser that reads the Do/don't sections. Our spec.md bullets wrap at the prose margin, like this:
+
+```markdown
+- Do: compose destructive actions as `variant` + `tone="error"` rather than a
+  bespoke variant.
+```
+
+The old parser read line by line and took only the line starting with `- Do`. So what agents actually received was:
+
+```
+compose destructive actions as `variant` + `tone="error"` rather than a
+```
+
+Guidance truncated mid-clause, for as long as that parser has existed. Eleven contracts had the truncated text baked into their stored `forbiddenUse` arrays, which means the corruption had already propagated from the parser into committed data. One of them told agents not to "mount more than one SiteFooter. AT users encounter two", stopping there, dropping the part that explains the landmark conflict.
+
+I would not have found it by reading the parser. I found it because projecting into a foreign schema made me look closely at data I had stopped seeing.
+
+## What We Kept
+
+Five things, none of them the format itself:
+
+Guidance now carries an RFC 2119 level and a rationale. `- Don't (must): nest a Button inside another interactive control -- nested interactive elements produce an ambiguous accessibility tree and swallow clicks.` Unmarked lines still parse and default to `should`, so all 166 spec files kept working. Six hard rules are marked so far, against 555 still sitting at the default, which is an honest picture of how much of our guidance has ever had its severity decided.
+
+Rationale extraction is labelled by provenance. The reason usually exists already, as the sentence after the rule, so the parser infers it. Sampling put that at roughly 80% precision: sometimes the trailing sentence is the remedy, not the reason. So each rationale records whether it was `explicit` or `inferred`, and the gate counts them separately. 8 explicit, 94 inferred.
+
+Provenance per field, so an agent knows what not to rewrite.
+
+Accessibility criteria with a declared verification mode, and the 115-item ratchet that came with it.
+
+`governance.lastReviewed`, because 165 components and no record of when a human last read any of them is its own kind of debt.
+
+## Should You Adopt It
+
+Not as a source of truth, not at 0.15.2, not with one author. Pinned schema URLs are immutable and the stability page is unusually honest about pre-1.0 risk, so the downside is bounded, but there is no second implementer and nothing else in your toolchain reads DSDS today.
+
+Steal from it instead. The RFC 2119 levels, the provenance model, and the verification modes are all ideas that improved our own schema without coupling us to theirs. Then run the projection once, throw it away, and read the residue.
+
+The exercise is worth an afternoon even if you delete the output. A foreign schema will not tell you what your documentation says. It will tell you what your documentation is *shaped* like, and where that shape is an accident. We found 58 broken graph edges, 115 unverifiable accessibility claims, and one parser that had been truncating guidance mid-sentence into committed files.
+
+None of those were in the residue table. They were in the process of building it.

--- a/nextjs-app/shared/components/Badge/Badge.contract.json
+++ b/nextjs-app/shared/components/Badge/Badge.contract.json
@@ -167,7 +167,8 @@
             "values": [
                 "sm",
                 "md",
-                "lg"
+                "lg",
+                "xs"
             ],
             "description": "Size."
         },

--- a/nextjs-app/shared/components/Button/Button.contract.json
+++ b/nextjs-app/shared/components/Button/Button.contract.json
@@ -389,5 +389,39 @@
         "TextInput",
         "CheckboxGroup",
         "Modal"
-    ]
+    ],
+    "governance": {
+        "owner": "design-system",
+        "lastReviewed": "2026-07-21",
+        "note": "Contract, spec.md and props re-read against implementation during the DSDS doc-semantics pass. Hard rules promoted to must/must-not with rationale."
+    },
+    "content": {
+        "voice": "Imperative and specific. A button label names the action it performs, not the object it acts on.",
+        "capitalization": "sentence",
+        "terminology": [
+            {
+                "prefer": "Save",
+                "over": [
+                    "Submit",
+                    "OK"
+                ],
+                "rationale": "Names the outcome rather than the mechanism."
+            },
+            {
+                "prefer": "Delete",
+                "over": [
+                    "Remove",
+                    "Trash"
+                ],
+                "rationale": "Reserved for irreversible destruction; Remove implies a reversible detach."
+            }
+        ],
+        "doNotTranslate": [
+            "Digitaltableteur"
+        ],
+        "maxLength": {
+            "children": 24
+        },
+        "notes": "FI and SV labels run 20-30% longer than EN. The 24-char ceiling is measured on the longest locale, not on EN."
+    }
 }

--- a/nextjs-app/shared/components/Button/Button.spec.md
+++ b/nextjs-app/shared/components/Button/Button.spec.md
@@ -24,11 +24,12 @@ visual weight (primary / secondary / tertiary) and `tone` sets semantic colour
   is a URL, not a handler.
 - Do: compose destructive actions as `variant` + `tone="error"` rather than a
   bespoke variant.
-- Do: provide `accessibleName` on icon-only buttons. The dev-mode warning
-  catches missing names locally; production must not ship without one.
-- Don't: pair an icon-only button with a tooltip as the *only* accessible name
-  on mobile; tooltips don't fire on touch. Use `accessibleName` too.
-- Don't: nest a Button inside another interactive control. Buttons are terminal.
+- Do (must): provide `accessibleName` on icon-only buttons -- a control with no
+  accessible name is announced as "button" with no purpose, which fails WCAG 4.1.2.
+- Don't (must): pair an icon-only button with a tooltip as the *only* accessible
+  name -- tooltips don't fire on touch, so the name does not exist on mobile at all.
+- Don't (must): nest a Button inside another interactive control -- nested
+  interactive elements produce an ambiguous accessibility tree and swallow clicks.
 - Don't: use a Button for inline navigation in body copy. Use **Link**.
 
 ## Design notes

--- a/nextjs-app/shared/components/Icon/Icon.contract.json
+++ b/nextjs-app/shared/components/Icon/Icon.contract.json
@@ -159,9 +159,9 @@
                 "sm",
                 "md",
                 "lg",
+                "xs",
                 "xl",
                 "2xs",
-                "xs",
                 "2xl"
             ],
             "description": "Tokenized or explicit pixel size."

--- a/nextjs-app/shared/components/List/List.contract.json
+++ b/nextjs-app/shared/components/List/List.contract.json
@@ -139,9 +139,9 @@
             "optional": true,
             "type": "union",
             "values": [
+                "xs",
                 "s",
                 "xl",
-                "xs",
                 "xxs",
                 "m",
                 "l",

--- a/nextjs-app/shared/components/Modal/Modal.contract.json
+++ b/nextjs-app/shared/components/Modal/Modal.contract.json
@@ -112,8 +112,8 @@
                 "sm",
                 "md",
                 "lg",
-                "xl",
                 "xs",
+                "xl",
                 "xxs",
                 "xxl",
                 "XXS",
@@ -310,5 +310,28 @@
             "children": "Your edits will be applied immediately.",
             "showCloseIcon": true
         }
+    },
+    "governance": {
+        "owner": "design-system",
+        "lastReviewed": "2026-07-21",
+        "note": "Re-read after the #1280 content-reset fix. Nesting and aria-live rules promoted to must-not."
+    },
+    "content": {
+        "voice": "Direct and calm. State what will happen, then let the actions carry the verbs.",
+        "capitalization": "sentence",
+        "terminology": [
+            {
+                "prefer": "Cancel",
+                "over": [
+                    "Nevermind",
+                    "Back"
+                ],
+                "rationale": "Cancel is the conventional dismissal label and is already translated in all three locales."
+            }
+        ],
+        "maxLength": {
+            "title": 48
+        },
+        "notes": "Title is the AT announcement. Keep it a noun phrase naming what opened, never a full sentence."
     }
 }

--- a/nextjs-app/shared/components/Modal/Modal.spec.md
+++ b/nextjs-app/shared/components/Modal/Modal.spec.md
@@ -19,8 +19,8 @@ route.
   role implies announcement — no extra `aria-live` is wired.
 
 ## Do / don't
-- Do: always pass a `title`. Title-less modals are a bad AT experience;
-  the user lands on "Dialog" with no context.
+- Do (must): always pass a `title` -- a title-less dialog is announced as
+  "Dialog" with no context, leaving the user no way to know what opened.
 - Do: pass `description` for supporting copy (maps to `aria-describedby`,
   shadcn `DialogDescription` parity). Prefer `description` over a lone
   `<p>` child when the body is a single sentence.
@@ -30,16 +30,16 @@ route.
 - Do: use `severity="error"` for destructive confirmations, render the
   destructive action with `tone="error"`, and pair it with a secondary
   Cancel. The dialog chrome and action must communicate the same risk.
-- Don't: nest a Modal inside another Modal. AT focus order becomes
-  ambiguous and the `inert` attribute applies once. If you need a
-  second confirmation step, swap content in place inside the existing
-  modal.
+- Don't (must): nest a Modal inside another Modal -- AT focus order becomes
+  ambiguous and the `inert` attribute applies once, so the outer dialog stays
+  reachable. If you need a second confirmation step, swap content in place
+  inside the existing modal.
 - Don't: render a Modal lazily (e.g. only mount it when `isOpen`).
   Mount it always; control via `isOpen`. Lazy mounting breaks focus
   restoration because the unmount happens before the focus restore.
-- Don't: add `aria-live` to the dialog root. The role implies
-  announcement; doubling it causes "dialog dialog" or double message
-  reads.
+- Don't (must): add `aria-live` to the dialog root -- the role already implies
+  announcement, and doubling it makes AT read "dialog dialog" or repeat the
+  message.
 
 ## Design notes
 - Tokens: surface uses `--color-surface`; overlay uses

--- a/nextjs-app/shared/components/Spacer/Spacer.contract.json
+++ b/nextjs-app/shared/components/Spacer/Spacer.contract.json
@@ -63,8 +63,8 @@
                 "sm",
                 "md",
                 "lg",
-                "xl",
                 "xs",
+                "xl",
                 "2xl"
             ],
             "description": "Tokenized gap size."

--- a/nextjs-app/shared/components/Stack/Stack.contract.json
+++ b/nextjs-app/shared/components/Stack/Stack.contract.json
@@ -116,9 +116,9 @@
                 "sm",
                 "md",
                 "lg",
+                "xs",
                 "none",
-                "xl",
-                "xs"
+                "xl"
             ],
             "description": "Gap token between items."
         },

--- a/nextjs-app/shared/components/Text/Text.contract.json
+++ b/nextjs-app/shared/components/Text/Text.contract.json
@@ -141,9 +141,9 @@
             "optional": true,
             "type": "union",
             "values": [
+                "xs",
                 "s",
                 "xl",
-                "xs",
                 "xxs",
                 "m",
                 "l",

--- a/nextjs-app/shared/components/Timestamp/Timestamp.contract.json
+++ b/nextjs-app/shared/components/Timestamp/Timestamp.contract.json
@@ -115,8 +115,8 @@
             "optional": true,
             "type": "union",
             "values": [
-                "s",
                 "xs",
+                "s",
                 "xxs",
                 "m"
             ],

--- a/nextjs-app/shared/components/Title/Title.contract.json
+++ b/nextjs-app/shared/components/Title/Title.contract.json
@@ -147,9 +147,9 @@
             "optional": true,
             "type": "union",
             "values": [
+                "xs",
                 "s",
                 "xl",
-                "xs",
                 "xxs",
                 "m",
                 "l",

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-18T08:48:17.550Z",
+  "generatedAt": "2026-07-21T09:17:45.736Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -76,14 +76,14 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "keep `item.id` stable across renders. Re-using ids between",
-        "phrase the `title` as the question or the topic, not the action.",
-        "use `type=\"multiple\"` when readers compare sections; keep the"
+        "keep `item.id` stable across renders. Re-using ids between different accordions on the same page collides on the `aria-controls` / `aria-labelledby` reference.",
+        "phrase the `title` as the question or the topic, not the action. \"Pricing\" reads better than \"Click to see pricing\".",
+        "use `type=\"multiple\"` when readers compare sections; keep the default `type=\"single\"` for FAQs and settings."
       ],
       "avoidWhen": [
-        "put primary navigation inside an accordion. AT users land on",
-        "nest accordions more than one level deep. Two-level",
-        "put a single short paragraph behind a section — the click"
+        "put primary navigation inside an accordion. AT users land on a closed panel and assume the link is gone.",
+        "nest accordions more than one level deep. Two-level disclosure becomes unreadable in screen reader linear mode.",
+        "put a single short paragraph behind a section — the click costs more than it saves; show the text directly."
       ],
       "requiredA11y": [
         "aria-expanded on triggers",
@@ -95,8 +95,8 @@
         "Tab"
       ],
       "compositionRules": [
-        "put primary navigation inside an accordion. AT users land on",
-        "nest accordions more than one level deep. Two-level"
+        "put primary navigation inside an accordion. AT users land on a closed panel and assume the link is gone.",
+        "nest accordions more than one level deep. Two-level disclosure becomes unreadable in screen reader linear mode."
       ],
       "canonicalExamples": [
         "Default",
@@ -106,13 +106,177 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "put primary navigation inside an accordion. AT users land on",
-        "nest accordions more than one level deep. Two-level",
-        "put a single short paragraph behind a section — the click"
+        "put primary navigation inside an accordion. AT users land on a closed panel and assume the link is gone.",
+        "nest accordions more than one level deep. Two-level disclosure becomes unreadable in screen reader linear mode.",
+        "put a single short paragraph behind a section — the click costs more than it saves; show the text directly."
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "keep `item.id` stable across renders",
+          "rationale": "Re-using ids between different accordions on the same page collides on the `aria-controls` / `aria-labelledby` reference.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "phrase the `title` as the question or the topic, not the action. \"Pricing\" reads better than \"Click to see pricing\".",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "use `type=\"multiple\"` when readers compare sections; keep the default `type=\"single\"` for FAQs and settings.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "put primary navigation inside an accordion",
+          "rationale": "AT users land on a closed panel and assume the link is gone.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "nest accordions more than one level deep",
+          "rationale": "Two-level disclosure becomes unreadable in screen reader linear mode.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "put a single short paragraph behind a section — the click costs more than it saves; show the text directly.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-26 — production behavior verified in Storybook; argTypes and required stories aligned with validate:components."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Accordion.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Accordion.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Accordion.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Accordion.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "AlertBanner": {
       "preferredImport": "@dt/AlertBanner",
@@ -185,13 +349,13 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "pass `aria-live=\"assertive\"` for `tone=\"error\"` so the AT user is",
-        "keep the description short — banners that scroll vertically lose"
+        "pass `aria-live=\"assertive\"` for `tone=\"error\"` so the AT user is interrupted. The default `polite` is correct for `info` and `success`.",
+        "keep the description short — banners that scroll vertically lose the user's attention. If the message needs paragraphs, link out to a docs page from the description."
       ],
       "avoidWhen": [
-        "make errors dismissable. Letting the user hide a blocking",
-        "stack more than one banner on the same page. Two competing",
-        "animate the banner in on every render. AlertBanner is for"
+        "make errors dismissable. Letting the user hide a blocking problem leads to confused support tickets.",
+        "stack more than one banner on the same page. Two competing announcements collide in the AT queue.",
+        "animate the banner in on every render. AlertBanner is for persistent state, not transient feedback."
       ],
       "requiredA11y": [
         "role=alert + assertive for error tone; role=status + polite otherwise",
@@ -204,7 +368,7 @@
         "Space"
       ],
       "compositionRules": [
-        "stack more than one banner on the same page. Two competing"
+        "stack more than one banner on the same page. Two competing announcements collide in the AT queue."
       ],
       "canonicalExamples": [
         "Playground",
@@ -217,9 +381,9 @@
       ],
       "forbiddenUse": [
         "Pair AlertBanner with blocking Modal for the same user outcome — pick one surface",
-        "make errors dismissable. Letting the user hide a blocking",
-        "stack more than one banner on the same page. Two competing",
-        "animate the banner in on every render. AlertBanner is for"
+        "make errors dismissable. Letting the user hide a blocking problem leads to confused support tickets.",
+        "stack more than one banner on the same page. Two competing announcements collide in the AT queue.",
+        "animate the banner in on every render. AlertBanner is for persistent state, not transient feedback."
       ],
       "composesWith": [
         "Button",
@@ -228,7 +392,166 @@
       "prefersOver": [
         "Toast for non-persistent status"
       ],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "pass `aria-live=\"assertive\"` for `tone=\"error\"` so the AT user is interrupted",
+          "rationale": "The default `polite` is correct for `info` and `success`.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "keep the description short — banners that scroll vertically lose the user's attention",
+          "rationale": "If the message needs paragraphs, link out to a docs page from the description.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "make errors dismissable",
+          "rationale": "Letting the user hide a blocking problem leads to confused support tickets.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "stack more than one banner on the same page",
+          "rationale": "Two competing announcements collide in the AT queue.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "animate the banner in on every render",
+          "rationale": "AlertBanner is for persistent state, not transient feedback.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-26 — tones and dismiss control reviewed in Storybook. 2026-07-03 (batch 4) — action slot + icon override added; dismiss strings moved to i18next (en/fi/sv, EN output unchanged). 2026-07-08 — promoted after Mermaid adopted AlertBanner for persistent diagram errors; check:beta-promotion-readiness verifies production consumers, snapshots, forced colors, and real Figma evidence."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AlertBanner.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AlertBanner.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AlertBanner.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AlertBanner.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ArticleCard": {
       "preferredImport": "@dt/ArticleCard",
@@ -292,7 +615,132 @@
         "TextInput"
       ],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on ArticleCard pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleCard.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleCard.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleCard.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleCard.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ArticleContent": {
       "preferredImport": "@dt/ArticleContent",
@@ -365,7 +813,153 @@
         "MdxImage"
       ],
       "prefersOver": [],
-      "declaredPropCount": 3
+      "declaredPropCount": 3,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "wrap MDX/article body markup; choose `size` for the reading measure (sm/md/lg)",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "use `ArticleProse` (and `not-prose`) to scope the prose typography",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "put page chrome inside — this is the reading column only",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-06 alpha->beta: axe clean via test-storybook a11y test:error across base + light + dark + forced-colors on all stories (sm/md/lg measures); 4-mode AT snapshots captured and compare-clean. Pure layout/typography wrapper (Container + prose classes); semantics come from the wrapped MDX. No own animation. 2026-07-08 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified on a non-6010 Storybook; accessibility tree and real-browser forced-colors confirmed."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleContent.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleContent.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleContent.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleContent.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ArticleShareSection": {
       "preferredImport": "@dt/ArticleShareSection",
@@ -451,7 +1045,159 @@
         "MdxImage"
       ],
       "prefersOver": [],
-      "declaredPropCount": 5
+      "declaredPropCount": 5,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "pass the article `url` and `title`; choose `layout` (horizontal | vertical)",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "hide the heading with `showTitle={false}` for compact rails",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use for arbitrary pages — this is the blog article template slot",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-06 alpha->beta: axe clean via test-storybook a11y test:error across base + light + dark + forced-colors on all stories (horizontal + vertical, with/without heading); 4-mode AT snapshots captured and compare-clean. Every icon-only control carries an aria-label; the copied-state confirmation uses green-800 ink (green-600 is only ~3:1 on white, below AA). Figma composes cloned on-page Phosphor icon instances. Tailwind className styling retained as an intentional per-surface owner call. 2026-07-08 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified on a non-6010 Storybook; accessibility tree and real-browser forced-colors confirmed."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleShareSection.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleShareSection.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleShareSection.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleShareSection.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "AspectRatio": {
       "preferredImport": "@dt/AspectRatio",
@@ -518,7 +1264,151 @@
         "ui"
       ],
       "prefersOver": [],
-      "declaredPropCount": 3
+      "declaredPropCount": 3,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Wrap a single media-shaped child (img, video, iframe, illustration).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "Use the canonical ratios (16:9 for video, 1:1 for square thumbs) so the catalog stays small.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Use this as a generic flex/grid item — pick a layout primitive instead.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Add padding or margin via className — children will overlap their own padding",
+          "rationale": "the wrapper is `position: relative`.",
+          "rationaleSource": "explicit",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AspectRatio.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AspectRatio.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AspectRatio.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AspectRatio.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Author": {
       "preferredImport": "@dt/Author",
@@ -568,7 +1458,132 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on Author pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Author.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Author.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Author.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Author.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "AuthorBio": {
       "preferredImport": "@dt/AuthorBio",
@@ -627,7 +1642,139 @@
         "MdxImage"
       ],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on AuthorBio pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-06 — beta→stable: AT snapshots bootstrapped across base/light/dark/forced-colors (all beta-matrix stories green, deterministic); axe color-contrast passed in light+dark+forced for the bordered color surface; stale compliance story removed. Tagline renders as plain Text; the author-data `[@](url)` was a content error (the `@` is a handle mention, not a link) corrected in content/authors to `@digitaltableteur`, so no markdown link renders in the byline."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AuthorBio.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AuthorBio.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AuthorBio.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AuthorBio.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Avatar": {
       "preferredImport": "@dt/Avatar",
@@ -711,12 +1858,12 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "pass `name` even when an image is set — the initials fallback and",
-        "pass `menuLabel` whenever you set `menuItems`. The trigger has no"
+        "pass `name` even when an image is set — the initials fallback and alt text both flow from it.",
+        "pass `menuLabel` whenever you set `menuItems`. The trigger has no visible text in menu mode."
       ],
       "avoidWhen": [
-        "render two interactive children inside Avatar (link plus menu);",
-        "nest an Avatar inside a Button. Pick one — Avatar already owns"
+        "render two interactive children inside Avatar (link plus menu); the contract is exactly one interaction mode per instance.",
+        "nest an Avatar inside a Button. Pick one — Avatar already owns the click affordance when clickable, and Button owns it when not."
       ],
       "requiredA11y": [
         "menu trigger needs accessible name",
@@ -724,16 +1871,16 @@
       ],
       "keyboard": [],
       "compositionRules": [
-        "render two interactive children inside Avatar (link plus menu);",
-        "nest an Avatar inside a Button. Pick one — Avatar already owns"
+        "render two interactive children inside Avatar (link plus menu); the contract is exactly one interaction mode per instance.",
+        "nest an Avatar inside a Button. Pick one — Avatar already owns the click affordance when clickable, and Button owns it when not."
       ],
       "canonicalExamples": [
         "Default"
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "render two interactive children inside Avatar (link plus menu);",
-        "nest an Avatar inside a Button. Pick one — Avatar already owns"
+        "render two interactive children inside Avatar (link plus menu); the contract is exactly one interaction mode per instance.",
+        "nest an Avatar inside a Button. Pick one — Avatar already owns the click affordance when clickable, and Button owns it when not."
       ],
       "composesWith": [
         "Link",
@@ -744,7 +1891,153 @@
         "Checkbox"
       ],
       "prefersOver": [],
-      "declaredPropCount": 12
+      "declaredPropCount": 12,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "pass `name` even when an image is set — the initials fallback and alt text both flow from it.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass `menuLabel` whenever you set `menuItems`",
+          "rationale": "The trigger has no visible text in menu mode.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "render two interactive children inside Avatar (link plus menu); the contract is exactly one interaction mode per instance.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "nest an Avatar inside a Button",
+          "rationale": "Pick one — Avatar already owns the click affordance when clickable, and Button owns it when not.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-26 — production behavior, keyboard, and forced-colors verified in Storybook. 2026-07-05 (beta→stable) — re-verified independently: axe-clean, light + dark eyeballed, AT snapshots refreshed and compare-clean in all four modes, Controls 100% operable + 0 inert; removed the dead avatarVariants cva stub and fixed the invalid \"md\" playground size default. 2026-07-05 (menu on shared Menu) — the account menu now consumes the Menu primitive (Radix dropdown-menu) instead of hand-rolled markup: public API (menuItems/menuLabel) unchanged, obsolete placementRefreshKey removed (Radix owns collision). Re-verified: open-menu axe-clean + keyboard select via test-storybook play, aligned ~40px rows eyeballed open in light/dark/forced-colors, Controls 100% + 0 inert, AT snapshots refreshed compare-clean."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Avatar.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Avatar.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Avatar.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Avatar.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "AvatarGroup": {
       "preferredImport": "@dt/AvatarGroup",
@@ -789,12 +2082,12 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "pass Avatars of one size and match the group `size` (sm=2rem,",
+        "pass Avatars of one size and match the group `size` (sm=2rem, md=2.5rem, lg=3rem) so the bubble aligns.",
         "keep `max` low (3-5); the stack is a summary, not a roster."
       ],
       "avoidWhen": [
         "mix clickable and static Avatars in one stack.",
-        "use it as navigation to profiles when the count matters more"
+        "use it as navigation to profiles when the count matters more than the identities — use a list instead."
       ],
       "requiredA11y": [
         "role=group with aria-label naming the cluster",
@@ -815,11 +2108,161 @@
       "replacementFor": [],
       "forbiddenUse": [
         "mix clickable and static Avatars in one stack.",
-        "use it as navigation to profiles when the count matters more"
+        "use it as navigation to profiles when the count matters more than the identities — use a list instead."
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "pass Avatars of one size and match the group `size` (sm=2rem, md=2.5rem, lg=3rem) so the bubble aligns.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "keep `max` low (3-5); the stack is a summary, not a roster.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "mix clickable and static Avatars in one stack.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use it as navigation to profiles when the count matters more than the identities — use a list instead.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-03 — group semantics, overflow sr text asserted in unit tests; axe clean."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AvatarGroup.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AvatarGroup.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AvatarGroup.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AvatarGroup.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Badge": {
       "preferredImport": "@dt/Badge",
@@ -938,12 +2381,12 @@
       },
       "variantsFnName": "badgeVariants",
       "useWhen": [
-        "use `variant=\"primary\"` for filled, emphasis-bearing tags and",
-        "set `tone` for semantic colour; a matching icon is supplied automatically",
+        "use `variant=\"primary\"` for filled, emphasis-bearing tags and `\"secondary\"` for outlined/tonal tags (categories, filters).",
+        "set `tone` for semantic colour; a matching icon is supplied automatically for non-neutral tones.",
         "pass `role=\"status\"` only when the content actually changes at runtime."
       ],
       "avoidWhen": [
-        "rely on colour alone to convey tone — pair it with the icon or include",
+        "rely on colour alone to convey tone — pair it with the icon or include the state word in the text.",
         "nest a Button inside a Badge beyond the built-in removable affordance."
       ],
       "requiredA11y": [
@@ -952,7 +2395,7 @@
       ],
       "keyboard": [],
       "compositionRules": [
-        "rely on colour alone to convey tone — pair it with the icon or include",
+        "rely on colour alone to convey tone — pair it with the icon or include the state word in the text.",
         "nest a Button inside a Badge beyond the built-in removable affordance."
       ],
       "canonicalExamples": [
@@ -962,7 +2405,7 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "rely on colour alone to convey tone — pair it with the icon or include",
+        "rely on colour alone to convey tone — pair it with the icon or include the state word in the text.",
         "nest a Button inside a Badge beyond the built-in removable affordance."
       ],
       "composesWith": [
@@ -974,7 +2417,160 @@
         "Checkbox"
       ],
       "prefersOver": [],
-      "declaredPropCount": 11
+      "declaredPropCount": 11,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "use `variant=\"primary\"` for filled, emphasis-bearing tags and `\"secondary\"` for outlined/tonal tags (categories, filters).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "set `tone` for semantic colour; a matching icon is supplied automatically for non-neutral tones.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass `role=\"status\"` only when the content actually changes at runtime.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "rely on colour alone to convey tone — pair it with the icon or include the state word in the text.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "nest a Button inside a Badge beyond the built-in removable affordance.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-06-18 — platinum pass: variant/tone API, sm/md/lg sizes, contrast and forced-colors verified."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Badge.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Badge.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Badge.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Badge.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "BlogCategoryFilter": {
       "preferredImport": "@dt/BlogCategoryFilter",
@@ -1090,7 +2686,159 @@
         "EnhancedArticleCard"
       ],
       "prefersOver": [],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "pass the tag list plus the current `selectedTag` (null = All) and an `onTagChange` handler",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "enable `showCounts` with a `tagCounts` map to show per-tag totals",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use this for generic list pages — that is CategoryFilter",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-06 alpha->beta: axe clean via test-storybook a11y test:error across base + light + dark + forced-colors on all stories and all three variants; 4-mode AT snapshots captured and compare-clean. 2026-07-07: reconciled the a11y model with CategoryFilter to role=group + aria-pressed toggle buttons. A filter that re-renders a results grid is a set of UI controls, not a tablist (a tablist implies tab panels it does not have), so the earlier role=tablist + roving-tabindex was dropped in favour of independently focusable toggle buttons. Tailwind className styling retained as an intentional per-surface owner call. 2026-07-08 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified on a non-6010 Storybook; accessibility tree and real-browser forced-colors confirmed."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogCategoryFilter.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogCategoryFilter.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogCategoryFilter.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogCategoryFilter.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "BlogMediaImage": {
       "preferredImport": "@dt/BlogMediaImage",
@@ -1187,7 +2935,153 @@
         "animations"
       ],
       "prefersOver": [],
-      "declaredPropCount": 12
+      "declaredPropCount": 12,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "pass meaningful `alt`; choose `fit` (contain for diagrams, cover for photos)",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "use `fill` inside a positioned container, or `fluid` for full-bleed prose images",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use a raw `<img>` in article bodies — this handles SVG, external and sizing concerns",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-06 alpha->beta: axe clean via test-storybook a11y test:error across base + light + dark + forced-colors on all stories (inline, fluid, fill+contain); 4-mode AT snapshots captured and compare-clean. Alt text is a required prop; SVG sources render as a plain img with lazy loading, raster through next/image. No own animation. 2026-07-08 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified on a non-6010 Storybook; accessibility tree and real-browser forced-colors confirmed."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogMediaImage.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogMediaImage.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogMediaImage.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogMediaImage.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "BlogNav": {
       "preferredImport": "@dt/BlogNav",
@@ -1246,7 +3140,153 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass `currentPath` in stories/tests to drive the prev/next disabled state",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use this for site-wide navigation (that is SiteHeader/NavLink)",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-16 beta->stable: production NextBlogNav now composes BlogNav with live post metadata; required-story AT snapshots and Chromium forced-colors were recaptured after the host-driven pages/navigation API landed."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogNav.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogNav.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogNav.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogNav.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Breadcrumb": {
       "preferredImport": "@dt/Breadcrumb",
@@ -1293,13 +3333,13 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "keep the last item label short. It mirrors the page title and",
-        "pass an i18n'd `aria-label` per locale. The default English"
+        "keep the last item label short. It mirrors the page title and appears in the AT linear reading order before the `<h1>`.",
+        "pass an i18n'd `aria-label` per locale. The default English literal is a development convenience."
       ],
       "avoidWhen": [
-        "include the home icon as a separate item. Use `label: 'Home'`",
-        "skip levels to make the trail shorter. If the user is at",
-        "render the breadcrumb above a hero — it gets lost. Place it"
+        "include the home icon as a separate item. Use `label: 'Home'` with `href: '/'` so the AT user hears a word, not a glyph.",
+        "skip levels to make the trail shorter. If the user is at `/work/acme`, the parent must be `/work`, not `/`.",
+        "render the breadcrumb above a hero — it gets lost. Place it immediately above the page title so it forms a single \"where am I\" block."
       ],
       "requiredA11y": [
         "nav landmark",
@@ -1318,13 +3358,172 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "include the home icon as a separate item. Use `label: 'Home'`",
-        "skip levels to make the trail shorter. If the user is at",
-        "render the breadcrumb above a hero — it gets lost. Place it"
+        "include the home icon as a separate item. Use `label: 'Home'` with `href: '/'` so the AT user hears a word, not a glyph.",
+        "skip levels to make the trail shorter. If the user is at `/work/acme`, the parent must be `/work`, not `/`.",
+        "render the breadcrumb above a hero — it gets lost. Place it immediately above the page title so it forms a single \"where am I\" block."
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "keep the last item label short",
+          "rationale": "It mirrors the page title and appears in the AT linear reading order before the `<h1>`.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass an i18n'd `aria-label` per locale",
+          "rationale": "The default English literal is a development convenience.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "include the home icon as a separate item",
+          "rationale": "Use `label: 'Home'` with `href: '/'` so the AT user hears a word, not a glyph.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "skip levels to make the trail shorter",
+          "rationale": "If the user is at `/work/acme`, the parent must be `/work`, not `/`.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "render the breadcrumb above a hero — it gets lost",
+          "rationale": "Place it immediately above the page title so it forms a single \"where am I\" block.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "unverified",
+          "note": "Play-function exempt: Static navigation landmark; Tab order only."
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-26 — production behavior verified in Storybook; argTypes and required stories aligned with validate:components."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Breadcrumb.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Breadcrumb.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Breadcrumb.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Breadcrumb.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Button": {
       "preferredImport": "@dt/Button",
@@ -1518,13 +3717,13 @@
       "variantsFnName": null,
       "useWhen": [
         "use `submits` (not raw `type=\"submit\"`) so form submission is grep-able.",
-        "pass `href` to render the same visual as an anchor when the destination",
-        "compose destructive actions as `variant` + `tone=\"error\"` rather than a",
-        "provide `accessibleName` on icon-only buttons. The dev-mode warning"
+        "pass `href` to render the same visual as an anchor when the destination is a URL, not a handler.",
+        "compose destructive actions as `variant` + `tone=\"error\"` rather than a bespoke variant.",
+        "(must): provide `accessibleName` on icon-only buttons -- a control with no accessible name is announced as \"button\" with no purpose, which fails WCAG 4.1.2."
       ],
       "avoidWhen": [
-        "pair an icon-only button with a tooltip as the *only* accessible name",
-        "nest a Button inside another interactive control. Buttons are terminal.",
+        "(must): pair an icon-only button with a tooltip as the *only* accessible name -- tooltips don't fire on touch, so the name does not exist on mobile at all.",
+        "(must): nest a Button inside another interactive control -- nested interactive elements produce an ambiguous accessibility tree and swallow clicks.",
         "use a Button for inline navigation in body copy. Use **Link**."
       ],
       "requiredA11y": [
@@ -1539,8 +3738,8 @@
         "Space"
       ],
       "compositionRules": [
-        "pair an icon-only button with a tooltip as the *only* accessible name",
-        "nest a Button inside another interactive control. Buttons are terminal."
+        "(must): pair an icon-only button with a tooltip as the *only* accessible name -- tooltips don't fire on touch, so the name does not exist on mobile at all.",
+        "(must): nest a Button inside another interactive control -- nested interactive elements produce an ambiguous accessibility tree and swallow clicks."
       ],
       "canonicalExamples": [
         "Playground",
@@ -1555,8 +3754,8 @@
       "forbiddenUse": [
         "tertiary on dark or inverse backgrounds without explicit contrast verification",
         "isInverse on primary over transparent or gradient parents — use surface instead",
-        "pair an icon-only button with a tooltip as the *only* accessible name",
-        "nest a Button inside another interactive control. Buttons are terminal.",
+        "(must): pair an icon-only button with a tooltip as the *only* accessible name -- tooltips don't fire on touch, so the name does not exist on mobile at all.",
+        "(must): nest a Button inside another interactive control -- nested interactive elements produce an ambiguous accessibility tree and swallow clicks.",
         "use a Button for inline navigation in body copy. Use **Link**."
       ],
       "composesWith": [
@@ -1571,7 +3770,206 @@
         "raw button",
         "Link for in-copy navigation"
       ],
-      "declaredPropCount": 19
+      "declaredPropCount": 19,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "use `submits` (not raw `type=\"submit\"`) so form submission is grep-able.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass `href` to render the same visual as an anchor when the destination is a URL, not a handler.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "compose destructive actions as `variant` + `tone=\"error\"` rather than a bespoke variant.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "must",
+          "guidance": "provide `accessibleName` on icon-only buttons",
+          "rationale": "a control with no accessible name is announced as \"button\" with no purpose, which fails WCAG 4.1.2.",
+          "rationaleSource": "explicit",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "must-not",
+          "guidance": "pair an icon-only button with a tooltip as the *only* accessible name",
+          "rationale": "tooltips don't fire on touch, so the name does not exist on mobile at all.",
+          "rationaleSource": "explicit",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "must-not",
+          "guidance": "nest a Button inside another interactive control",
+          "rationale": "nested interactive elements produce an ambiguous accessibility tree and swallow clicks.",
+          "rationaleSource": "explicit",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use a Button for inline navigation in body copy. Use **Link**.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-06-18 — platinum pass: variant/tone API, scale(0.97) press feedback, tokenized motion, forced-colors + reduced-motion handled. AT snapshots refreshed."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Button.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Button.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Button.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Button.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": {
+        "owner": "design-system",
+        "lastReviewed": "2026-07-21",
+        "note": "Contract, spec.md and props re-read against implementation during the DSDS doc-semantics pass. Hard rules promoted to must/must-not with rationale."
+      },
+      "content": {
+        "voice": "Imperative and specific. A button label names the action it performs, not the object it acts on.",
+        "capitalization": "sentence",
+        "terminology": [
+          {
+            "prefer": "Save",
+            "over": [
+              "Submit",
+              "OK"
+            ],
+            "rationale": "Names the outcome rather than the mechanism."
+          },
+          {
+            "prefer": "Delete",
+            "over": [
+              "Remove",
+              "Trash"
+            ],
+            "rationale": "Reserved for irreversible destruction; Remove implies a reversible detach."
+          }
+        ],
+        "doNotTranslate": [
+          "Digitaltableteur"
+        ],
+        "maxLength": {
+          "children": 24
+        },
+        "notes": "FI and SV labels run 20-30% longer than EN. The 24-char ceiling is measured on the longest locale, not on EN."
+      }
     },
     "ButtonGroup": {
       "preferredImport": "@dt/ButtonGroup",
@@ -1603,7 +4001,7 @@
       ],
       "avoidWhen": [
         "mix primary and secondary segments in attached mode.",
-        "use ButtonGroup for exclusive selection state — that is a future"
+        "use ButtonGroup for exclusive selection state — that is a future ToggleButtonGroup; this is an action cluster."
       ],
       "requiredA11y": [
         "role=group with aria-label naming the cluster"
@@ -1621,11 +4019,161 @@
       "replacementFor": [],
       "forbiddenUse": [
         "mix primary and secondary segments in attached mode.",
-        "use ButtonGroup for exclusive selection state — that is a future"
+        "use ButtonGroup for exclusive selection state — that is a future ToggleButtonGroup; this is an action cluster."
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 3
+      "declaredPropCount": 3,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "use one variant and one size across the group.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass `ariaLabel` whenever the buttons' purpose isn't obvious alone.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "mix primary and secondary segments in attached mode.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use ButtonGroup for exclusive selection state — that is a future ToggleButtonGroup; this is an action cluster.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-03 — group semantics + labelled-group asserted in unit tests; axe clean; focus ring lift verified in Storybook."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ButtonGroup.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ButtonGroup.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ButtonGroup.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ButtonGroup.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Card": {
       "preferredImport": "@dt/Card",
@@ -1743,14 +4291,14 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "compose structure — `<Card>` + Title/Text children, `<Divider>` when",
-        "pass `linkLabel` on linked cards whose `title` is ambiguous out of",
-        "use `titleProps.level` to keep the document outline correct (grids of",
-        "keep padding consistent across sibling cards in a grid; pick one"
+        "compose structure — `<Card>` + Title/Text children, `<Divider>` when a section split carries meaning, a `<FlexBox justify=\"space-between\">` row as a footer.",
+        "pass `linkLabel` on linked cards whose `title` is ambiguous out of context (\"Read more\" is the failure mode).",
+        "use `titleProps.level` to keep the document outline correct (grids of cards under a section heading typically use level 3).",
+        "keep padding consistent across sibling cards in a grid; pick one `padding` step per surface."
       ],
       "avoidWhen": [
-        "nest interactive controls inside a `link`-mode card — use a plain",
-        "default to cards for visual grouping; headings and Stack rhythm",
+        "nest interactive controls inside a `link`-mode card — use a plain card with a single Button instead.",
+        "default to cards for visual grouping; headings and Stack rhythm group content without the visual weight (Astryx guidance, adopted).",
         "nest cards in cards."
       ],
       "requiredA11y": [
@@ -1764,8 +4312,8 @@
         "Enter"
       ],
       "compositionRules": [
-        "nest interactive controls inside a `link`-mode card — use a plain",
-        "default to cards for visual grouping; headings and Stack rhythm",
+        "nest interactive controls inside a `link`-mode card — use a plain card with a single Button instead.",
+        "default to cards for visual grouping; headings and Stack rhythm group content without the visual weight (Astryx guidance, adopted).",
         "nest cards in cards."
       ],
       "canonicalExamples": [
@@ -1778,8 +4326,8 @@
         "unstyled div wrapper for grouped content"
       ],
       "forbiddenUse": [
-        "nest interactive controls inside a `link`-mode card — use a plain",
-        "default to cards for visual grouping; headings and Stack rhythm",
+        "nest interactive controls inside a `link`-mode card — use a plain card with a single Button instead.",
+        "default to cards for visual grouping; headings and Stack rhythm group content without the visual weight (Astryx guidance, adopted).",
         "nest cards in cards."
       ],
       "composesWith": [
@@ -1791,7 +4339,174 @@
         "Divider"
       ],
       "prefersOver": [],
-      "declaredPropCount": 16
+      "declaredPropCount": 16,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose structure — `<Card>` + Title/Text children, `<Divider>` when a section split carries meaning, a `<FlexBox justify=\"space-between\">` row as a footer.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass `linkLabel` on linked cards whose `title` is ambiguous out of context (\"Read more\" is the failure mode).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "use `titleProps.level` to keep the document outline correct (grids of cards under a section heading typically use level 3).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "keep padding consistent across sibling cards in a grid; pick one `padding` step per surface.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "nest interactive controls inside a `link`-mode card — use a plain card with a single Button instead.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "default to cards for visual grouping; headings and Stack rhythm group content without the visual weight (Astryx guidance, adopted).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "nest cards in cards.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-04 — Astryx-shaped simplification: hairline surface, stretched-anchor link mode (no nested interactives), loading via Skeleton; axe on Default/AsLink/Loading; forced-colors keeps the physical border."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Card.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Card.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Card.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Card.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "CategoryFilter": {
       "preferredImport": "@dt/CategoryFilter",
@@ -1891,7 +4606,159 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Use on list pages where filtering is the primary UI affordance.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "Keep the filter labels short — they sit in a row.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Use as primary navigation — `CategoryFilter` is a UI control, not a nav surface; use `NavLink` for routes.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Stack two filter rows when one composite control would do — readability collapses.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-07 beta->stable: fixed the code/contract a11y mismatch — the component had drifted to role=tablist + role=tab + aria-selected (a tablist without tab panels), contradicting this contract's stated toggle-button intent. Reconciled BOTH this and BlogCategoryFilter to role=group + aria-pressed toggle buttons (a filter is a UI control, not a set of tab panels). Also fixed element nav->div and variants.size default sm->md. Added a unit test (group/aria-pressed/axe across all three variants). Independently re-verified light/dark + forced-colors in a real browser."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CategoryFilter.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CategoryFilter.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CategoryFilter.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CategoryFilter.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Center": {
       "preferredImport": "@dt/Center",
@@ -2132,7 +4999,151 @@
         "ui"
       ],
       "prefersOver": [],
-      "declaredPropCount": 3
+      "declaredPropCount": 3,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Use as the outer wrapper of a small empty-state, loading slot, or hero-band.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "Pair with a height constraint on the parent so vertical centering has something to center inside.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Center large layout sections — use `Section` + `Container` instead.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Rely on this to vertically center text inside a button or input — those already center via their own padding.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Center.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Center.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Center.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Center.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ChatWidget": {
       "preferredImport": "@dt/ChatWidget",
@@ -2157,13 +5168,13 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "mount once globally in the layout. The widget is designed for",
-        "rely on the env-resolved endpoint for normal use. Override only"
+        "mount once globally in the layout. The widget is designed for a single global instance.",
+        "rely on the env-resolved endpoint for normal use. Override only for preview deployments or partner contexts."
       ],
       "avoidWhen": [
-        "gate the widget behind user authentication. The widget is",
-        "store chat history in cookies. The current storage is",
-        "tamper with the email-workflow reducer state from outside."
+        "gate the widget behind user authentication. The widget is for anonymous visitors; auth-gated chat is a different pattern.",
+        "store chat history in cookies. The current storage is `localStorage`; cookies have size limits and travel with every request, which is wrong for chat transcripts.",
+        "tamper with the email-workflow reducer state from outside. The reducer has invariants (e.g. \"review can only follow compose\") that direct mutation breaks."
       ],
       "requiredA11y": [
         "launcher button labeled",
@@ -2182,9 +5193,9 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "gate the widget behind user authentication. The widget is",
-        "store chat history in cookies. The current storage is",
-        "tamper with the email-workflow reducer state from outside."
+        "gate the widget behind user authentication. The widget is for anonymous visitors; auth-gated chat is a different pattern.",
+        "store chat history in cookies. The current storage is `localStorage`; cookies have size limits and travel with every request, which is wrong for chat transcripts.",
+        "tamper with the email-workflow reducer state from outside. The reducer has invariants (e.g. \"review can only follow compose\") that direct mutation breaks."
       ],
       "composesWith": [
         "Button",
@@ -2193,7 +5204,164 @@
         "DonnyAvatar"
       ],
       "prefersOver": [],
-      "declaredPropCount": 3
+      "declaredPropCount": 3,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "mount once globally in the layout",
+          "rationale": "The widget is designed for a single global instance.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "rely on the env-resolved endpoint for normal use",
+          "rationale": "Override only for preview deployments or partner contexts.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "gate the widget behind user authentication",
+          "rationale": "The widget is for anonymous visitors; auth-gated chat is a different pattern.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "store chat history in cookies",
+          "rationale": "The current storage is `localStorage`; cookies have size limits and travel with every request, which is wrong for chat transcripts.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "tamper with the email-workflow reducer state from outside",
+          "rationale": "The reducer has invariants (e.g. \"review can only follow compose\") that direct mutation breaks.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-14 — streaming display reviewed: only the active assistant reply uses grapheme-safe adaptive smoothing; reduced motion bypasses it and the polite message log remains aria-busy until the complete response is available."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ChatWidget.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ChatWidget.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ChatWidget.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ChatWidget.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Checkbox": {
       "preferredImport": "@dt/Checkbox",
@@ -2274,12 +5442,12 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "own state in the parent via `checked` + `onCheckedChange` for",
-        "set `indeterminate` for \"some children selected, not all\"",
-        "use the `error` prop for validation such as required consent; it"
+        "own state in the parent via `checked` + `onCheckedChange` for any field that ships to a form submit. Uncontrolled (`defaultChecked`) is for ad-hoc UI.",
+        "set `indeterminate` for \"some children selected, not all\" parents. The visual and SR state match the semantic.",
+        "use the `error` prop for validation such as required consent; it wires aria-invalid + aria-describedby and announces via role=alert."
       ],
       "avoidWhen": [
-        "rely on the native `indeterminate` HTML attribute — there is"
+        "rely on the native `indeterminate` HTML attribute — there is no such serialised attribute. Use the prop (set as a DOM property)."
       ],
       "requiredA11y": [
         "associated label",
@@ -2295,7 +5463,7 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "rely on the native `indeterminate` HTML attribute — there is"
+        "rely on the native `indeterminate` HTML attribute — there is no such serialised attribute. Use the prop (set as a DOM property)."
       ],
       "composesWith": [
         "TextInput",
@@ -2306,7 +5474,159 @@
         "Button"
       ],
       "prefersOver": [],
-      "declaredPropCount": 11
+      "declaredPropCount": 11,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "own state in the parent via `checked` + `onCheckedChange` for any field that ships to a form submit",
+          "rationale": "Uncontrolled (`defaultChecked`) is for ad-hoc UI.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "set `indeterminate` for \"some children selected, not all\" parents",
+          "rationale": "The visual and SR state match the semantic.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "use the `error` prop for validation such as required consent; it wires aria-invalid + aria-describedby and announces via role=alert.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "rely on the native `indeterminate` HTML attribute — there is no such serialised attribute",
+          "rationale": "Use the prop (set as a DOM property).",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-26 — production behavior, keyboard, and forced-colors verified in Storybook."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Checkbox.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Checkbox.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Checkbox.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Checkbox.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "CheckboxGroup": {
       "preferredImport": "@dt/CheckboxGroup",
@@ -2357,13 +5677,13 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "derive `defaultSelected` from server-known state; the component",
-        "keep option `value`s stable across renders. The internal state"
+        "derive `defaultSelected` from server-known state; the component resets its internal array when `defaultSelected` changes by composition (deep value comparison via `.join(',')`).",
+        "keep option `value`s stable across renders. The internal state uses `value` as identity; switching mid-flight loses the user's selection."
       ],
       "avoidWhen": [
-        "render a CheckboxGroup with one option. It's an awkward",
-        "nest a CheckboxGroup inside another CheckboxGroup. AT",
-        "rely on the master label translation key without testing the"
+        "render a CheckboxGroup with one option. It's an awkward master + one row — collapse to a single Checkbox.",
+        "nest a CheckboxGroup inside another CheckboxGroup. AT navigation becomes ambiguous; flatten the option list.",
+        "rely on the master label translation key without testing the i18n fallback. The component falls back to the literal \"All\" if the key isn't resolved — tests must verify the resolved label they expect."
       ],
       "requiredA11y": [
         "fieldset legend",
@@ -2374,7 +5694,7 @@
         "Tab"
       ],
       "compositionRules": [
-        "nest a CheckboxGroup inside another CheckboxGroup. AT"
+        "nest a CheckboxGroup inside another CheckboxGroup. AT navigation becomes ambiguous; flatten the option list."
       ],
       "canonicalExamples": [
         "Playground",
@@ -2383,9 +5703,9 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "render a CheckboxGroup with one option. It's an awkward",
-        "nest a CheckboxGroup inside another CheckboxGroup. AT",
-        "rely on the master label translation key without testing the"
+        "render a CheckboxGroup with one option. It's an awkward master + one row — collapse to a single Checkbox.",
+        "nest a CheckboxGroup inside another CheckboxGroup. AT navigation becomes ambiguous; flatten the option list.",
+        "rely on the master label translation key without testing the i18n fallback. The component falls back to the literal \"All\" if the key isn't resolved — tests must verify the resolved label they expect."
       ],
       "composesWith": [
         "Button",
@@ -2396,7 +5716,166 @@
         "PhoneInput"
       ],
       "prefersOver": [],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "derive `defaultSelected` from server-known state; the component resets its internal array when `defaultSelected` changes by composition (deep value comparison via `.join(',')`).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "keep option `value`s stable across renders",
+          "rationale": "The internal state uses `value` as identity; switching mid-flight loses the user's selection.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "render a CheckboxGroup with one option",
+          "rationale": "It's an awkward master + one row — collapse to a single Checkbox.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "nest a CheckboxGroup inside another CheckboxGroup",
+          "rationale": "AT navigation becomes ambiguous; flatten the option list.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "rely on the master label translation key without testing the i18n fallback",
+          "rationale": "The component falls back to the literal \"All\" if the key isn't resolved — tests must verify the resolved label they expect.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-07 — production behavior, keyboard, forced-colors, and light/dark accessibility tree verified in Storybook for beta→stable promotion."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CheckboxGroup.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CheckboxGroup.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CheckboxGroup.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CheckboxGroup.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ClientLogoMarquee": {
       "preferredImport": "@dt/ClientLogoMarquee",
@@ -2438,7 +5917,132 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 2
+      "declaredPropCount": 2,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on ClientLogoMarquee pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ClientLogoMarquee.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ClientLogoMarquee.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ClientLogoMarquee.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ClientLogoMarquee.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "CodeBlockWindow": {
       "preferredImport": "@dt/CodeBlockWindow",
@@ -2507,7 +6111,133 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 7
+      "declaredPropCount": 7,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on CodeBlockWindow pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-06 — beta→stable: AT snapshots bootstrapped across base/light/dark/forced-colors (all beta-matrix stories green, deterministic); shiki dual-theme (--shiki-light/--shiki-dark) syntax colors + forced-colors CanvasText mapping verified. 2026-07-10 — Figma component built (Molecules, node 1164-257): traffic-light chrome on DT tokens, Shiki body bound to the new code/shiki/* per-theme variables (values extracted from codeBlockFixtures.ts), header/caption on code/toolbar-text."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CodeBlockWindow.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CodeBlockWindow.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CodeBlockWindow.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CodeBlockWindow.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "CodeSnippet": {
       "preferredImport": "@dt/CodeSnippet",
@@ -2606,7 +6336,133 @@
         "Button"
       ],
       "prefersOver": [],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on CodeSnippet pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-08 — captured Default and Example accessibility-tree snapshots plus a real Playwright forced-colors snapshot; stable remains blocked until the Figma URL points at a real numeric node id. 2026-07-10 — Figma component set built (Molecules, node 1161-2809: Inline/Single/Multi variants, DT token bindings); promoted to stable with RhythmguardPage as production consumer."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CodeSnippet.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CodeSnippet.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CodeSnippet.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CodeSnippet.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Combobox": {
       "preferredImport": "@dt/Combobox",
@@ -2709,7 +6565,152 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 11
+      "declaredPropCount": 11,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "use via `FormFieldEditorial` `type=\"select\"` on editorial contact forms.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass stable `value` / `onValueChange` pairs for controlled usage.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "nest inside containers with `overflow: hidden` without portaling (dropdown renders on `document.body`).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "Verified 2026-06-02: ARIA APG combobox — role=combobox trigger with aria-expanded/aria-controls/aria-activedescendant, aria-labelledby; portaled role=listbox with role=option/aria-selected. Full keyboard (ArrowUp/Down, Enter/Space, Escape) driven and asserted by the KeyboardSelection play function. Fixed a real contrast bug surfaced by enabling axe: the placeholder had opacity:0.7 dropping --color-muted to 2.7:1; removed it (now AA). Default/Playground/Example/KeyboardSelection pass axe with test:error; light + dark verified in Storybook. 2026-07-07 — beta→stable: 4-mode AT (base/light/dark/forced-colors) re-verified on a non-6010 Storybook."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Combobox.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Combobox.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Combobox.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Combobox.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "CommandPalette": {
       "preferredImport": "@dt/CommandPalette",
@@ -2760,8 +6761,8 @@
         "pass `keywords` for synonyms so fuzzy intent still matches."
       ],
       "avoidWhen": [
-        "nest submenus or put long forms inside it — it is a launcher, not a",
-        "hardcode copy in the component — `label` / `placeholder` / `emptyText`"
+        "nest submenus or put long forms inside it — it is a launcher, not a workspace. Route or run on Enter and close.",
+        "hardcode copy in the component — `label` / `placeholder` / `emptyText` are props so the host owns translation."
       ],
       "requiredA11y": [
         "Overlay dialog is role=dialog aria-modal with an accessible label",
@@ -2775,7 +6776,7 @@
         "Focus is trapped within the dialog while open"
       ],
       "compositionRules": [
-        "nest submenus or put long forms inside it — it is a launcher, not a"
+        "nest submenus or put long forms inside it — it is a launcher, not a workspace. Route or run on Enter and close."
       ],
       "canonicalExamples": [
         "Default",
@@ -2785,12 +6786,162 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "nest submenus or put long forms inside it — it is a launcher, not a",
-        "hardcode copy in the component — `label` / `placeholder` / `emptyText`"
+        "nest submenus or put long forms inside it — it is a launcher, not a workspace. Route or run on Enter and close.",
+        "hardcode copy in the component — `label` / `placeholder` / `emptyText` are props so the host owns translation."
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 7
+      "declaredPropCount": 7,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "keep commands flat and label them as actions (\"Go to Blog\", \"New post\").",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass `keywords` for synonyms so fuzzy intent still matches.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "nest submenus or put long forms inside it — it is a launcher, not a workspace",
+          "rationale": "Route or run on Enter and close.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "hardcode copy in the component — `label` / `placeholder` / `emptyText` are props so the host owns translation.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-12 — alpha→beta: code-level a11y review. Overlay dialog is role=dialog aria-modal with an accessible label; the search input is role=combobox with aria-expanded, aria-controls and aria-activedescendant onto the role=listbox; each command is role=option with aria-selected reflecting the active item. Focus is trapped (useFocusTrap) and background scroll locked (useScrollLock) while open; Arrow Up/Down wrap the active option, Enter runs it and closes, Escape closes, overlay mousedown closes. User-facing strings are props so the component carries no i18n dependency. Axe asserted in unit test; forced-colors + light/dark verified on a non-6010 Storybook. Known limitation: virtualization is not implemented, so very long command lists render in full."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CommandPalette.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CommandPalette.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CommandPalette.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CommandPalette.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ComplianceCard": {
       "preferredImport": "@dt/ComplianceCard",
@@ -2847,7 +6998,132 @@
         "Button"
       ],
       "prefersOver": [],
-      "declaredPropCount": 5
+      "declaredPropCount": 5,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on ComplianceCard pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ComplianceCard.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ComplianceCard.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ComplianceCard.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ComplianceCard.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ContactForm": {
       "preferredImport": "@dt/ContactForm",
@@ -2858,13 +7134,13 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "keep the form mounted exactly once per page. Multiple",
-        "wrap with a heading element above the form. ContactForm does"
+        "keep the form mounted exactly once per page. Multiple ContactForms on the same page collide on the honeypot field name and the i18n key namespace.",
+        "wrap with a heading element above the form. ContactForm does not own its `<h1>` so the consumer can choose the right heading level for the document outline."
       ],
       "avoidWhen": [
-        "pass props. The component intentionally accepts none. If",
-        "swallow the `/api/contact` endpoint. The submit handler",
-        "remove the honeypot. It catches a meaningful share of bot"
+        "pass props. The component intentionally accepts none. If you need a variant, compose smaller atoms at the pattern layer.",
+        "swallow the `/api/contact` endpoint. The submit handler expects that endpoint specifically; redirecting it requires changing the rate-limiting, telemetry, and email plumbing too.",
+        "remove the honeypot. It catches a meaningful share of bot submissions without any user-facing UX cost."
       ],
       "requiredA11y": [
         "labels on all fields",
@@ -2884,9 +7160,9 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "pass props. The component intentionally accepts none. If",
-        "swallow the `/api/contact` endpoint. The submit handler",
-        "remove the honeypot. It catches a meaningful share of bot"
+        "pass props. The component intentionally accepts none. If you need a variant, compose smaller atoms at the pattern layer.",
+        "swallow the `/api/contact` endpoint. The submit handler expects that endpoint specifically; redirecting it requires changing the rate-limiting, telemetry, and email plumbing too.",
+        "remove the honeypot. It catches a meaningful share of bot submissions without any user-facing UX cost."
       ],
       "composesWith": [
         "FormField",
@@ -2897,7 +7173,164 @@
         "CheckboxGroup"
       ],
       "prefersOver": [],
-      "declaredPropCount": 0
+      "declaredPropCount": 0,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "keep the form mounted exactly once per page",
+          "rationale": "Multiple ContactForms on the same page collide on the honeypot field name and the i18n key namespace.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "wrap with a heading element above the form",
+          "rationale": "ContactForm does not own its `<h1>` so the consumer can choose the right heading level for the document outline.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "pass props. The component intentionally accepts none. If you need a variant, compose smaller atoms at the pattern layer.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "swallow the `/api/contact` endpoint",
+          "rationale": "The submit handler expects that endpoint specifically; redirecting it requires changing the rate-limiting, telemetry, and email plumbing too.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "remove the honeypot",
+          "rationale": "It catches a meaningful share of bot submissions without any user-facing UX cost.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-26 — production behavior verified in Storybook; argTypes and required stories aligned with validate:components."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactForm.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactForm.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactForm.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactForm.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ContactFormEditorial": {
       "preferredImport": "@dt/ContactFormEditorial",
@@ -2943,7 +7376,133 @@
         "ContactFormSuccessEditorial"
       ],
       "prefersOver": [],
-      "declaredPropCount": 3
+      "declaredPropCount": 3,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on ContactFormEditorial pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-09 — Promoted beta→stable: 4-mode AT snapshots captured for all required stories, forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactFormEditorial.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactFormEditorial.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactFormEditorial.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactFormEditorial.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Container": {
       "preferredImport": "@dt/Container",
@@ -3207,7 +7766,133 @@
         "Badge"
       ],
       "prefersOver": [],
-      "declaredPropCount": 5
+      "declaredPropCount": 5,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on Container pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories; AT snapshots refreshed and compare-clean in all four modes (plain/light/dark/forced-colors); Controls 100% operable + 0 inert. Container carries no color surface of its own (tokens.colors empty; transparent wrapper), so light/dark is a structural no-op. Fixed the stale variants.size.default (\"sm\" → \"lg\") to match the component default and docs. 2026-07-10 — Figma component built (Atoms, node 1178-1654, parity-audit batch B2a): contract axes as variants with DT variable bindings."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Container.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Container.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Container.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Container.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "CookieConsent": {
       "preferredImport": "@dt/CookieConsent",
@@ -3247,7 +7932,132 @@
         "Text"
       ],
       "prefersOver": [],
-      "declaredPropCount": 1
+      "declaredPropCount": 1,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on CookieConsent pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CookieConsent.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CookieConsent.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CookieConsent.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CookieConsent.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Designerman": {
       "preferredImport": "@dt/Designerman",
@@ -3312,7 +8122,132 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 7
+      "declaredPropCount": 7,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on Designerman pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Designerman.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Designerman.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Designerman.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Designerman.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Display": {
       "preferredImport": "@dt/Display",
@@ -3368,7 +8303,151 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 2
+      "declaredPropCount": 2,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Reach for `Display` on hero bands and landing-page titles.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "Pair with `Text` for the supporting paragraph below.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Use `Display` for in-page section headings — that is `Title`.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Stack two `Display` headings in the same viewport — the marketing visual collapses.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Display.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Display.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Display.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Display.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Divider": {
       "preferredImport": "@dt/Divider",
@@ -3434,7 +8513,133 @@
         "Text"
       ],
       "prefersOver": [],
-      "declaredPropCount": 3
+      "declaredPropCount": 3,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on Divider pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-05 — beta→stable (fleet #12): renders a real <hr> (contract element corrected div→hr). decorative default role=none; decorative={false} announces role=separator + aria-orientation. No motion; single hairline on --color-border. Re-verified independently: axe + plays green in light/dark/forced-colors, 100% controls operable / 0 inert, AT snapshots refreshed 4 modes. 2026-05-28 origin: promoted from alpha with Example + ForcedColors stories and the Storybook axe gate."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Divider.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Divider.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Divider.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Divider.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "DonnyAvatar": {
       "preferredImport": "@dt/DonnyAvatar",
@@ -3591,7 +8796,133 @@
         "Text"
       ],
       "prefersOver": [],
-      "declaredPropCount": 16
+      "declaredPropCount": 16,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on DonnyAvatar pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-16 beta->stable: ChatToggle and ChatHeader production consumers documented; complete base/light/dark/Chromium forced-colors AT matrix captured for Default, Playground, Example, and ForcedColors. DONNY_STATES and isDonnyState now expose the validated 25-state vocabulary."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "DonnyAvatar.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "DonnyAvatar.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "DonnyAvatar.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "DonnyAvatar.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "EmailSignatureGenerator": {
       "preferredImport": "@dt/EmailSignatureGenerator",
@@ -3640,7 +8971,132 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on EmailSignatureGenerator pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "EmailSignatureGenerator.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "EmailSignatureGenerator.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "EmailSignatureGenerator.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "EmailSignatureGenerator.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "EmptyState": {
       "preferredImport": "@dt/EmptyState",
@@ -3731,7 +9187,159 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "say what is empty and give a way forward (description or action).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "fit `headingLevel` into the surrounding document outline.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "stack more than two actions; one primary path, one escape hatch.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use it for error states — AlertBanner owns failures.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-03 — static block; heading semantics + decorative icon asserted in unit tests; axe clean."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "EmptyState.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "EmptyState.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "EmptyState.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "EmptyState.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "EnhancedProjectCard": {
       "preferredImport": "@dt/EnhancedProjectCard",
@@ -3839,7 +9447,145 @@
         "animations"
       ],
       "prefersOver": [],
-      "declaredPropCount": 12
+      "declaredPropCount": 12,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on EnhancedProjectCard pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all stories in all four modes; AT snapshots bootstrapped (had none) compare-clean; Controls operable + 0 inert; eyeballed the card surface in light and dark. Fixed a real defect: `element` was \"div\" but the root render is an `<a>` (next/link). Declared the `aspectRatio` styling axis as a propSourced variant. Reduced-motion is already fully guarded (a `@media (prefers-reduced-motion: reduce)` block neutralises every transition/animation/transform, and the hover-video autoplay is JS-gated on the reduced-motion media query). Added the missing unit test (axe + link semantics + aspect-ratio class + reduced-motion guard)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "EnhancedProjectCard.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "EnhancedProjectCard.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "EnhancedProjectCard.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "EnhancedProjectCard.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ExpandableSection": {
       "preferredImport": "@dt/ExpandableSection",
@@ -3915,7 +9661,164 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 7
+      "declaredPropCount": 7,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Use for a single detail-disclosure block (FAQ row in isolation, optional advanced settings, 'about the author' block on an article).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "Default to collapsed unless the content is short and the page expects it open.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Use a sequence of `ExpandableSection`s instead of `Accordion` — accordion owns the focus management and single-open behaviour.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Hide critical content (errors, primary CTA) behind a disclosure.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "reduced-motion",
+          "statement": "Positional, scale, and opacity motion is suppressed under prefers-reduced-motion.",
+          "verificationMode": "manual"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-06 — beta→stable: element corrected section→div; aria contract corrected to the real button+aria-expanded disclosure (the panel unmounts on collapse, so no aria-controls to dangle); reduced-motion CSS guard added for the trigger colour + icon-rotation transitions (the framer-motion morph was already duration-zeroed). AT snapshots bootstrapped across base/light/dark/forced-colors; axe green in light + dark + forced-colors."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ExpandableSection.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ExpandableSection.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ExpandableSection.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ExpandableSection.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "FileUpload": {
       "preferredImport": "@dt/FileUpload",
@@ -4005,13 +9908,13 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "pass `maxSizeInBytes`. Omitting `sizeErrorMessage` falls back to",
-        "server-side validate the type. `accept` is a UI hint, not a"
+        "pass `maxSizeInBytes`. Omitting `sizeErrorMessage` falls back to the localized `fileUploadSizeError` i18n key (en/fi/sv) with the max size interpolated; pass the prop only for custom copy.",
+        "server-side validate the type. `accept` is a UI hint, not a security boundary."
       ],
       "avoidWhen": [
-        "render two FileUploads in the same form without unique",
-        "rely on `value` for \"the file is already on the server\".",
-        "skip the Clear button. Users who picked the wrong file have"
+        "render two FileUploads in the same form without unique labels. The labels disambiguate the AT context; identical labels collide.",
+        "rely on `value` for \"the file is already on the server\". FileUpload is for *selection*, not display of an already-uploaded asset. Render an uploaded asset as Link + Clear control instead.",
+        "skip the Clear button. Users who picked the wrong file have no recovery path without it on mobile (the platform sheet doesn't expose a \"clear\" affordance once a file is bound)."
       ],
       "requiredA11y": [
         "label association",
@@ -4030,9 +9933,9 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "render two FileUploads in the same form without unique",
-        "rely on `value` for \"the file is already on the server\".",
-        "skip the Clear button. Users who picked the wrong file have"
+        "render two FileUploads in the same form without unique labels. The labels disambiguate the AT context; identical labels collide.",
+        "rely on `value` for \"the file is already on the server\". FileUpload is for *selection*, not display of an already-uploaded asset. Render an uploaded asset as Link + Clear control instead.",
+        "skip the Clear button. Users who picked the wrong file have no recovery path without it on mobile (the platform sheet doesn't expose a \"clear\" affordance once a file is bound)."
       ],
       "composesWith": [
         "Button",
@@ -4043,7 +9946,166 @@
         "Modal"
       ],
       "prefersOver": [],
-      "declaredPropCount": 15
+      "declaredPropCount": 15,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "pass `maxSizeInBytes`",
+          "rationale": "Omitting `sizeErrorMessage` falls back to the localized `fileUploadSizeError` i18n key (en/fi/sv) with the max size interpolated; pass the prop only for custom copy.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "server-side validate the type. `accept` is a UI hint, not a security boundary.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "render two FileUploads in the same form without unique labels",
+          "rationale": "The labels disambiguate the AT context; identical labels collide.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "rely on `value` for \"the file is already on the server\"",
+          "rationale": "FileUpload is for *selection*, not display of an already-uploaded asset. Render an uploaded asset as Link + Clear control instead.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "skip the Clear button",
+          "rationale": "Users who picked the wrong file have no recovery path without it on mobile (the platform sheet doesn't expose a \"clear\" affordance once a file is bound).",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-07 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified on a non-6010 Storybook; accessibility tree and real-browser forced-colors confirmed."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FileUpload.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FileUpload.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FileUpload.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FileUpload.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "FilterChip": {
       "preferredImport": "@dt/FilterChip",
@@ -4161,7 +10223,159 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "keep exactly one chip pressed per group (single-select filters).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass counts via the count prop so the \"(n)\" suffix stays in the accessible name.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use for navigation between panels (that is Tabs).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "nest interactive content inside the label.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-12 — alpha→stable: shared implementation behind CategoryFilter and BlogCategoryFilter (8 production consumers). 4-mode AT (base/light/dark/forced-colors) captured on a non-6010 Storybook for all four required stories; accessibility tree and real-browser forced-colors confirmed; aria-pressed toggle semantics asserted in unit test with jest-axe; light/dark re-verified. Exported from @digitaltableteur/react."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FilterChip.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FilterChip.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FilterChip.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FilterChip.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "FlexBox": {
       "preferredImport": "@dt/FlexBox",
@@ -4295,7 +10509,133 @@
         "Avatar"
       ],
       "prefersOver": [],
-      "declaredPropCount": 10
+      "declaredPropCount": 10,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on FlexBox pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories in all four modes; AT snapshots bootstrapped (the component had none — snapshot-backfill debt) and compare-clean in plain/light/dark/forced-colors; Controls 9/9 operable + 0 inert. Pure css-less flex passthrough with no color surface (tokens.colors empty), so light/dark is a structural no-op. Fixed a contract defect: variants.align.default was \"center\" but the component default is \"stretch\" (align-items initial). 2026-07-10 — Figma component built (Atoms, node 1176-1698, parity-audit batch B2a): contract axes as variants with DT variable bindings."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FlexBox.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FlexBox.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FlexBox.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FlexBox.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "FormField": {
       "preferredImport": "@dt/FormField",
@@ -4377,7 +10717,159 @@
         "HelperText"
       ],
       "prefersOver": [],
-      "declaredPropCount": 7
+      "declaredPropCount": 7,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "use it whenever two or more controls answer one question; write the legend as the question.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "put cross-control validation in the group `error`; per-control failures belong on each control's own `error` prop.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "wrap a single labeled control; TextInput, Select, Checkbox and friends carry their own label/error/helperText.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use it as a layout box; it renders a real fieldset with announcement semantics.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-07 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified on a non-6010 Storybook; accessibility tree and real-browser forced-colors confirmed."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FormField.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FormField.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FormField.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FormField.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "FormFieldEditorial": {
       "preferredImport": "@dt/FormFieldEditorial",
@@ -4470,7 +10962,133 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 7
+      "declaredPropCount": 7,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on FormFieldEditorial pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-09 — Promoted beta→stable: 4-mode AT snapshots captured for all required stories, forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FormFieldEditorial.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FormFieldEditorial.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FormFieldEditorial.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FormFieldEditorial.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Gallery": {
       "preferredImport": "@dt/Gallery",
@@ -4524,7 +11142,162 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 3
+      "declaredPropCount": 3,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Use for work-detail / case-study image rows where the image is the content.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "Provide real `alt` text on each image; it doubles as the lightbox's accessible name.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Use as a navigation surface — gallery items are not links.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Auto-open the lightbox on mount — confine motion to explicit user actions.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "reduced-motion",
+          "statement": "Positional, scale, and opacity motion is suppressed under prefers-reduced-motion.",
+          "verificationMode": "manual"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Gallery.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Gallery.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Gallery.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Gallery.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Grid": {
       "preferredImport": "@dt/Grid",
@@ -4721,7 +11494,147 @@
         "Avatar"
       ],
       "prefersOver": [],
-      "declaredPropCount": 18
+      "declaredPropCount": 18,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Use responsive props on Grid instead of creating page-specific grid wrappers or duplicating token breakpoints in consumer stylesheets.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "Wrap only spanning children in `Grid.Item` with `span` or `rowSpan`.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Replace the flat responsive props with object syntax; the flat API is the published compatibility boundary.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Size grid cells with child widths or use Grid for a one-dimensional sequence.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories; AT snapshots refreshed compare-clean in all four modes (plain/light/dark/forced-colors); Controls 9/9 operable + 0 inert. Pure two-dimensional layout primitive with no color surface of its own (tokens.colors empty), so light/dark is a structural no-op. The GridProps `[key: string]: any` passthrough is the intentional, documented escape hatch for arbitrary grid CSS props — kept as-is. 2026-07-10 — Figma component built (Atoms, node 1177-1654, parity-audit batch B2a): contract axes as variants with DT variable bindings."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Grid.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Grid.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Grid.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Grid.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "GroupLabel": {
       "preferredImport": "@dt/GroupLabel",
@@ -4783,7 +11696,153 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 5
+      "declaredPropCount": 5,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Pair with a `<fieldset>` or `role='group'` container.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "Keep the text short and noun-shaped — it is read once for the whole group.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Use as a label for a single input — that is `Label`.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Style as a heading — screen readers will navigate to it as a heading and miss the group it labels.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-12 — beta→stable: 4-mode AT (base/light/dark/forced-colors) captured on a non-6010 Storybook for all required stories; accessibility tree and real-browser forced-colors confirmed; real Figma component built (replacing the placeholder link). 5 production consumers (form field groups)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "GroupLabel.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "GroupLabel.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "GroupLabel.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "GroupLabel.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "HelperText": {
       "preferredImport": "@dt/HelperText",
@@ -4821,12 +11880,12 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "wire `aria-describedby` from the input to HelperText's `id`. Without",
-        "use `state=\"error\"` only for validation failures. Decorative"
+        "wire `aria-describedby` from the input to HelperText's `id`. Without it the help text is visible but not announced.",
+        "use `state=\"error\"` only for validation failures. Decorative warnings should be the `warning` state without the live-region churn."
       ],
       "avoidWhen": [
-        "render multiple `state=\"error\"` HelperTexts under one field —",
-        "use HelperText for page-level messages. AlertBanner and Toast"
+        "render multiple `state=\"error\"` HelperTexts under one field — multiple live regions create overlapping announcements. Consolidate.",
+        "use HelperText for page-level messages. AlertBanner and Toast exist for that scope."
       ],
       "requiredA11y": [
         "link to control via id / aria-describedby"
@@ -4840,8 +11899,8 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "render multiple `state=\"error\"` HelperTexts under one field —",
-        "use HelperText for page-level messages. AlertBanner and Toast"
+        "render multiple `state=\"error\"` HelperTexts under one field — multiple live regions create overlapping announcements. Consolidate.",
+        "use HelperText for page-level messages. AlertBanner and Toast exist for that scope."
       ],
       "composesWith": [
         "Label",
@@ -4851,7 +11910,153 @@
       "prefersOver": [
         "AlertBanner for field-level hints"
       ],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "wire `aria-describedby` from the input to HelperText's `id`",
+          "rationale": "Without it the help text is visible but not announced.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "use `state=\"error\"` only for validation failures",
+          "rationale": "Decorative warnings should be the `warning` state without the live-region churn.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "render multiple `state=\"error\"` HelperTexts under one field — multiple live regions create overlapping announcements. Consolidate.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use HelperText for page-level messages",
+          "rationale": "AlertBanner and Toast exist for that scope.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-26 — production behavior, keyboard, and forced-colors verified in Storybook. 2026-07-06 beta->stable: independently re-verified all four semantic states (error/warning/success/info) in light/dark + forced-colors in a real browser (state color + fill icon track the theme; forced-colors keeps the icon + CanvasText copy legible); error state carries role=alert. Removed a dead helperTextVariants cva scaffolder stub (empty size axis, never used). realBrowserForcedColorsVerified + accessibilityTreeVerified set true."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "HelperText.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "HelperText.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "HelperText.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "HelperText.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Icon": {
       "preferredImport": "@dt/Icon",
@@ -4979,19 +12184,21 @@
       },
       "variantsFnName": "iconVariants",
       "useWhen": [
-        "leave Icon decorative when it sits inside a labelled control",
-        "pass `ariaLabel` on standalone icon-only controls — the icon"
+        "leave Icon decorative when it sits inside a labelled control (Button text owns the name). The default `aria-hidden` is correct.",
+        "pass `ariaLabel` on standalone icon-only controls — the icon carries the name when no text is present."
       ],
       "avoidWhen": [
-        "pass both `ariaLabel` and `decorative`. The component prefers",
-        "import a Phosphor component directly from `@phosphor-icons/react`"
+        "pass both `ariaLabel` and `decorative`. The component prefers `ariaLabel`; the prop pair is documented as mutually exclusive.",
+        "import a Phosphor component directly from `@phosphor-icons/react` to get the same shape — you lose the alias map, the SR semantics, and the size ladder. Use Icon."
       ],
       "requiredA11y": [
         "decorative icons use aria-hidden",
         "meaningful icons require aria-label"
       ],
       "keyboard": [],
-      "compositionRules": [],
+      "compositionRules": [
+        "pass both `ariaLabel` and `decorative`. The component prefers `ariaLabel`; the prop pair is documented as mutually exclusive."
+      ],
       "canonicalExamples": [
         "Playground",
         "Default",
@@ -5003,8 +12210,8 @@
         "react-icons used directly in product UI"
       ],
       "forbiddenUse": [
-        "pass both `ariaLabel` and `decorative`. The component prefers",
-        "import a Phosphor component directly from `@phosphor-icons/react`"
+        "pass both `ariaLabel` and `decorative`. The component prefers `ariaLabel`; the prop pair is documented as mutually exclusive.",
+        "import a Phosphor component directly from `@phosphor-icons/react` to get the same shape — you lose the alias map, the SR semantics, and the size ladder. Use Icon."
       ],
       "composesWith": [
         "Button",
@@ -5015,7 +12222,147 @@
         "Card"
       ],
       "prefersOver": [],
-      "declaredPropCount": 12
+      "declaredPropCount": 12,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "leave Icon decorative when it sits inside a labelled control (Button text owns the name)",
+          "rationale": "The default `aria-hidden` is correct.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass `ariaLabel` on standalone icon-only controls — the icon carries the name when no text is present.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "pass both `ariaLabel` and `decorative`",
+          "rationale": "The component prefers `ariaLabel`; the prop pair is documented as mutually exclusive.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "import a Phosphor component directly from `@phosphor-icons/react` to get the same shape — you lose the alias map, the SR semantics, and the size ladder. Use Icon.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-26 code review 2026-07-10 — Figma component built (Atoms, node 1176-1658, parity-audit batch B2a): contract axes as variants with DT variable bindings."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Icon.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Icon.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Icon.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Icon.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "IconButton": {
       "preferredImport": "@dt/IconButton",
@@ -5125,7 +12472,159 @@
         "Title"
       ],
       "prefersOver": [],
-      "declaredPropCount": 7
+      "declaredPropCount": 7,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Pass a real, action-shaped `label` ('Close', 'Edit row', 'Save draft') — not the icon name.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "Stay on the default `tertiary` variant in toolbars and chrome; reserve `primary`/`secondary` for emphasis.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Omit `label` — there is no fallback announcement.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Use for primary marketing CTAs — text + icon is more discoverable; use `Button` with an icon prop.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-05 — beta→stable (fleet #11): re-verified independently. Delegates all styling to stable @dt/Button, so reduced-motion (Button.module.css prefers-reduced-motion guard), variant/tone/surface matrix, and forced-colors inherit from Button. axe + plays green on all 9 stories in light/dark/forced-colors; 100% controls operable, 0 inert; AT snapshots captured for the four beta-matrix stories in all four modes. 2026-07-03 origin: API aligned to platinum variant x tone conventions (ghost/outline/default removed), keyboard/ARIA contract reviewed, axe unit tests added."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "IconButton.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "IconButton.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "IconButton.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "IconButton.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ImagePlaceholder": {
       "preferredImport": "@dt/ImagePlaceholder",
@@ -5220,7 +12719,132 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 10
+      "declaredPropCount": 10,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on ImagePlaceholder pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ImagePlaceholder.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ImagePlaceholder.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ImagePlaceholder.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ImagePlaceholder.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Kbd": {
       "preferredImport": "@dt/Kbd",
@@ -5282,7 +12906,151 @@
         "Icon"
       ],
       "prefersOver": [],
-      "declaredPropCount": 1
+      "declaredPropCount": 1,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose combos as sibling Kbds with a literal separator (`⌘ + K`).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "match `size` to the surrounding text scale.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use Kbd as a button; it never receives focus or handles clicks.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "put whole phrases inside one Kbd; one key (or chord symbol) per cap.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-06 — alpha→beta: created the Figma component (size variant keycap set, border/bg/text bound to DT/Color, radius from radius/sm) at node 1005-1638, the only remaining beta blocker. Static inline element; axe asserted in unit test and story gate; forced-colors border verified."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Kbd.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Kbd.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Kbd.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Kbd.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Label": {
       "preferredImport": "@dt/Label",
@@ -5314,12 +13082,12 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "pass `htmlFor` for every Label. Implicit association by wrapping",
-        "pair `Label required` with `Input required` — visible state and"
+        "pass `htmlFor` for every Label. Implicit association by wrapping works in browsers but is fragile under DOM reordering.",
+        "pair `Label required` with `Input required` — visible state and ARIA state must agree."
       ],
       "avoidWhen": [
-        "place validation errors inside Label. Errors belong to the",
-        "use a Label as a section heading. Headings carry navigation"
+        "place validation errors inside Label. Errors belong to the input's described-by region, not the label.",
+        "use a Label as a section heading. Headings carry navigation semantics that Label does not."
       ],
       "requiredA11y": [
         "htmlFor associates control",
@@ -5327,15 +13095,15 @@
       ],
       "keyboard": [],
       "compositionRules": [
-        "place validation errors inside Label. Errors belong to the"
+        "place validation errors inside Label. Errors belong to the input's described-by region, not the label."
       ],
       "canonicalExamples": [
         "Example"
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "place validation errors inside Label. Errors belong to the",
-        "use a Label as a section heading. Headings carry navigation"
+        "place validation errors inside Label. Errors belong to the input's described-by region, not the label.",
+        "use a Label as a section heading. Headings carry navigation semantics that Label does not."
       ],
       "composesWith": [
         "HelperText",
@@ -5346,7 +13114,153 @@
         "Icon"
       ],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "pass `htmlFor` for every Label",
+          "rationale": "Implicit association by wrapping works in browsers but is fragile under DOM reordering.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pair `Label required` with `Input required` — visible state and ARIA state must agree.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "place validation errors inside Label",
+          "rationale": "Errors belong to the input's described-by region, not the label.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use a Label as a section heading",
+          "rationale": "Headings carry navigation semantics that Label does not.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-26 — association and forced-colors verified in Storybook."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Label.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Label.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Label.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Label.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "LanguageSwitcher": {
       "preferredImport": "@dt/LanguageSwitcher",
@@ -5439,7 +13353,159 @@
         "ThemeProvider"
       ],
       "prefersOver": [],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "pass an `ariaLabel` per language (e.g. \"Finnish\"), not just the code.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "keep language state in the parent and feed `currentLang` back.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "translate inside the component; labels and accessible names come from the caller.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "render it as the only navigation; it complements rather than replaces site navigation.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-05 — beta→stable (fleet #14): the fan animation is reduced-motion-guarded via framer useReducedMotion (spring→plain fade); the button color transition now also carries motion-reduce:transition-none (unit-tested), so a11y.reducedMotion is fully honest. State-conditional className props (openTriggerClassName, floatedButtonClassName) are EFFECT_EXEMPT in audit:controls (only apply while the tray is open) with the KeyboardToggle play + unit tests exercising both states. Re-verified: axe + KeyboardToggle play green in light/dark/forced-colors, 100% controls operable / 0 inert, AT snapshots captured 4 modes — KeyboardToggle drives open→Escape and settles closed (so its snapshot is the closed group), while the FanOpen example snapshots the open fan (all locales + expanded trigger). 2026-06-02 origin: role=group + aria-label; trigger exposes aria-expanded/aria-controls/aria-current; options are native buttons with aria-label; Escape + outside-click close."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "LanguageSwitcher.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "LanguageSwitcher.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "LanguageSwitcher.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "LanguageSwitcher.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Link": {
       "preferredImport": "@dt/Link",
@@ -5482,12 +13548,12 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "rely on the component's URL sanitisation; it rewrites unsafe protocols to",
-        "pass `target=\"_blank\"` only when leaving the site; `rel` is added"
+        "pass `target=\"_blank\"` only when leaving the site; `rel` is added automatically."
       ],
       "avoidWhen": [
-        "use Link for actions. Buttons are for actions; anchors are for",
-        "override the underline via inline styles; the token-driven treatment"
+        "rely on the component's URL sanitisation; it rewrites unsafe protocols to `#`. Don't pre-sanitise.",
+        "use Link for actions. Buttons are for actions; anchors are for navigation.",
+        "override the underline via inline styles; the token-driven treatment owns it."
       ],
       "requiredA11y": [
         "visible focus",
@@ -5506,8 +13572,9 @@
         "raw <a> for styled navigation"
       ],
       "forbiddenUse": [
-        "use Link for actions. Buttons are for actions; anchors are for",
-        "override the underline via inline styles; the token-driven treatment"
+        "rely on the component's URL sanitisation; it rewrites unsafe protocols to `#`. Don't pre-sanitise.",
+        "use Link for actions. Buttons are for actions; anchors are for navigation.",
+        "override the underline via inline styles; the token-driven treatment owns it."
       ],
       "composesWith": [
         "Badge",
@@ -5520,7 +13587,159 @@
       "prefersOver": [
         "Button with href for body-copy links"
       ],
-      "declaredPropCount": 2
+      "declaredPropCount": 2,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "rely on the component's URL sanitisation; it rewrites unsafe protocols to `#`",
+          "rationale": "Don't pre-sanitise.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass `target=\"_blank\"` only when leaving the site; `rel` is added automatically.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use Link for actions",
+          "rationale": "Buttons are for actions; anchors are for navigation.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "override the underline via inline styles; the token-driven treatment owns it.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-06-18 — platinum pass: sm/md/lg sizes, tokenized focus ring + colour transition, forced-colors verified."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Link.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Link.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Link.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Link.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "LinkedInQuoteCard": {
       "preferredImport": "@dt/LinkedInQuoteCard",
@@ -5613,7 +13832,132 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 10
+      "declaredPropCount": 10,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on LinkedInQuoteCard pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "LinkedInQuoteCard.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "LinkedInQuoteCard.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "LinkedInQuoteCard.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "LinkedInQuoteCard.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "List": {
       "preferredImport": "@dt/List",
@@ -5744,7 +14088,139 @@
         "Title"
       ],
       "prefersOver": [],
-      "declaredPropCount": 9
+      "declaredPropCount": 9,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on List pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all stories in all four modes; AT snapshots refreshed compare-clean; Controls operable + 0 inert; no motion in the CSS so reducedMotion is trivially honest. Fixed real defects: `element` was \"div\" but the root render is a `<ul>`/`<ol>`; the placeholder description was replaced with an honest one; `variants.terminals.default` said \"serif\" but the component defaults to \"sans\"; and the docs overclaimed `dl` support (the `as` prop is only ul|ol and children are always `<li>`)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "List.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "List.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "List.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "List.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ListItem": {
       "preferredImport": "@dt/ListItem",
@@ -5812,20 +14288,22 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "wrap ListItem in the element that owns interaction (Radix",
-        "use `meta` for content the user needs (a `Kbd` shortcut, a",
-        "pair `disabled` with `aria-disabled` on the wrapper — the token swap"
+        "wrap ListItem in the element that owns interaction (Radix `Item`/`MenuItem`, a native `li`/`option`, or a `button`) and let that element carry `role`, `tabIndex`, and handlers.",
+        "use `meta` for content the user needs (a `Kbd` shortcut, a `StatusDot`, a value) and reserve `trailingIcon` for purely decorative glyphs like a chevron.",
+        "pair `disabled` with `aria-disabled` on the wrapper — the token swap is visual only and does not announce anything by itself."
       ],
       "avoidWhen": [
-        "add `role`, `tabIndex`, or `onClick` directly to ListItem — that",
-        "treat `selected`/`highlighted` as a substitute for real ARIA state"
+        "add `role`, `tabIndex`, or `onClick` directly to ListItem — that duplicates (and can conflict with) the wrapper's semantics.",
+        "treat `selected`/`highlighted` as a substitute for real ARIA state on the wrapper (`aria-selected`, `aria-checked`, `data-highlighted`)."
       ],
       "requiredA11y": [
         "No own ARIA — the interactive wrapper (Radix Item, button, li, option) owns role, aria-selected/aria-checked, and aria-disabled.",
         "meta is exposed to assistive tech (no aria-hidden); icon, trailingIcon, and the selected check are decorative (aria-hidden)."
       ],
       "keyboard": [],
-      "compositionRules": [],
+      "compositionRules": [
+        "add `role`, `tabIndex`, or `onClick` directly to ListItem — that duplicates (and can conflict with) the wrapper's semantics."
+      ],
       "canonicalExamples": [
         "Default",
         "Playground",
@@ -5834,12 +14312,163 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "add `role`, `tabIndex`, or `onClick` directly to ListItem — that",
-        "treat `selected`/`highlighted` as a substitute for real ARIA state"
+        "add `role`, `tabIndex`, or `onClick` directly to ListItem — that duplicates (and can conflict with) the wrapper's semantics.",
+        "treat `selected`/`highlighted` as a substitute for real ARIA state on the wrapper (`aria-selected`, `aria-checked`, `data-highlighted`)."
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 9
+      "declaredPropCount": 9,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "wrap ListItem in the element that owns interaction (Radix `Item`/`MenuItem`, a native `li`/`option`, or a `button`) and let that element carry `role`, `tabIndex`, and handlers.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "use `meta` for content the user needs (a `Kbd` shortcut, a `StatusDot`, a value) and reserve `trailingIcon` for purely decorative glyphs like a chevron.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pair `disabled` with `aria-disabled` on the wrapper — the token swap is visual only and does not announce anything by itself.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "add `role`, `tabIndex`, or `onClick` directly to ListItem — that duplicates (and can conflict with) the wrapper's semantics.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "treat `selected`/`highlighted` as a substitute for real ARIA state on the wrapper (`aria-selected`, `aria-checked`, `data-highlighted`).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-17 — axe asserted in ListItem.test.tsx and the Storybook a11y gate (parameters.a11y.test: error); consumer-owned semantics reviewed (role/focus/events belong to the interactive wrapper, ListItem itself carries no interactive ARIA); ForcedColors story verifies the forced-colors treatment (CanvasText/GrayText/Highlight/HighlightText mapping)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ListItem.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ListItem.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ListItem.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ListItem.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "LocationCard": {
       "preferredImport": "@dt/LocationCard",
@@ -5925,7 +14554,157 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Use on the contact page locations grid.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "Keep the slot order: name → address → hours → action",
+          "rationale": "Reviewers expect it.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Use as a generic 'card with an icon and label' — that is `Card`.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Stack two `LocationCard`s vertically with no spacing — they need rhythm via `Grid` or `Stack`.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "LocationCard.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "LocationCard.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "LocationCard.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "LocationCard.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Logo": {
       "preferredImport": "@dt/Logo",
@@ -5971,7 +14750,7 @@
         "pass `decorative` when an adjacent wordmark already names the brand."
       ],
       "avoidWhen": [
-        "hardcode a fill or wrap the mark in a fixed-color box; that breaks",
+        "hardcode a fill or wrap the mark in a fixed-color box; that breaks dark theme and forced-colors.",
         "translate `title`; the brand name is a proper noun.",
         "add click handlers to `Logo` itself; wrap it in a real link or button."
       ],
@@ -5989,7 +14768,7 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "hardcode a fill or wrap the mark in a fixed-color box; that breaks",
+        "hardcode a fill or wrap the mark in a fixed-color box; that breaks dark theme and forced-colors.",
         "translate `title`; the brand name is a proper noun.",
         "add click handlers to `Logo` itself; wrap it in a real link or button."
       ],
@@ -6001,7 +14780,160 @@
         "ThemeProvider"
       ],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "let the mark inherit text color; set `color` on the parent to recolor.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass `decorative` when an adjacent wordmark already names the brand.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "hardcode a fill or wrap the mark in a fixed-color box; that breaks dark theme and forced-colors.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "translate `title`; the brand name is a proper noun.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "add click handlers to `Logo` itself; wrap it in a real link or button.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "Verified 2026-06-02: role=img/aria-label vs aria-hidden when decorative, focusable=false, non-interactive (no keyboard contract — wrap in link/button to activate). Every mark uses fill=currentColor → maps to system CanvasText in forced colors; the ForcedColors story passes axe. Pulse is disabled under prefers-reduced-motion. All Logo tests pass. Re-verified 2026-07-13 for stable promotion: AT snapshots committed for all required stories; `animated` is now a controlled signal (pulses while true) rather than self-hover, driven by SiteHeader's link-hover state. Swapped into SiteHeader (production consumer on every page) with byte-for-byte parity vs the prior inline mark — identical viewBox 0 0 395 323, geometry, dt-logo-pulse keyframes, badge scale, currentColor tokens; verified live in the running app (rest/hover/both themes)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Logo.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Logo.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Logo.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Logo.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "MCPActionButton": {
       "preferredImport": "@dt/MCPActionButton",
@@ -6061,7 +14993,132 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on MCPActionButton pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "MCPActionButton.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "MCPActionButton.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "MCPActionButton.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "MCPActionButton.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "MacWindowFrame": {
       "preferredImport": "@dt/MacWindowFrame",
@@ -6133,7 +15190,132 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on MacWindowFrame pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "MacWindowFrame.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "MacWindowFrame.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "MacWindowFrame.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "MacWindowFrame.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "MarkdownMessage": {
       "preferredImport": "@dt/MarkdownMessage",
@@ -6209,7 +15391,132 @@
         "DonnyBookingEmbed"
       ],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on MarkdownMessage pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "MarkdownMessage.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "MarkdownMessage.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "MarkdownMessage.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "MarkdownMessage.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Menu": {
       "preferredImport": "@dt/Menu",
@@ -6265,13 +15572,13 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "wrap the real Button/Avatar with `asChild` so it receives the",
-        "put the item glyph in the `icon` slot so labels align in a column;"
+        "wrap the real Button/Avatar with `asChild` so it receives the trigger wiring directly.",
+        "put the item glyph in the `icon` slot so labels align in a column; use `href` for navigation items and `onSelect` for actions."
       ],
       "avoidWhen": [
-        "use Menu for primary site navigation — a list of page links is",
-        "hand-roll positioning or keyboard handling around Menu; Radix",
-        "promote past alpha without real consumers (Avatar + SplitButton)"
+        "use Menu for primary site navigation — a list of page links is `NavMenuList` with `aria-current`, not a `role=menu`.",
+        "hand-roll positioning or keyboard handling around Menu; Radix provides collision, roving focus, typeahead, and Escape.",
+        "promote past alpha without real consumers (Avatar + SplitButton) and the full beta gate."
       ],
       "requiredA11y": [
         "trigger exposes aria-haspopup=menu and aria-expanded (Radix)",
@@ -6301,9 +15608,9 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "use Menu for primary site navigation — a list of page links is",
-        "hand-roll positioning or keyboard handling around Menu; Radix",
-        "promote past alpha without real consumers (Avatar + SplitButton)"
+        "use Menu for primary site navigation — a list of page links is `NavMenuList` with `aria-current`, not a `role=menu`.",
+        "hand-roll positioning or keyboard handling around Menu; Radix provides collision, roving focus, typeahead, and Escape.",
+        "promote past alpha without real consumers (Avatar + SplitButton) and the full beta gate."
       ],
       "composesWith": [
         "Icon",
@@ -6314,7 +15621,166 @@
         "FlexBox"
       ],
       "prefersOver": [],
-      "declaredPropCount": 5
+      "declaredPropCount": 5,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "wrap the real Button/Avatar with `asChild` so it receives the trigger wiring directly.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "put the item glyph in the `icon` slot so labels align in a column; use `href` for navigation items and `onSelect` for actions.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use Menu for primary site navigation — a list of page links is `NavMenuList` with `aria-current`, not a `role=menu`.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "hand-roll positioning or keyboard handling around Menu; Radix provides collision, roving focus, typeahead, and Escape.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote past alpha without real consumers (Avatar + SplitButton) and the full beta gate.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-05 (alpha) — keyboard open/arrow/Home/End/typeahead/Escape/focus-return and item select are provided by Radix DropdownMenu and asserted end to end in the Storybook Example play (real browser via test-storybook); item select + disabled + href-as-anchor + axe-clean-while-open covered in unit tests. Light + dark eyeballed in Storybook (white/near-black surface tracks the theme, --color-neutral-bg highlight reads in both); emulated forced-colors shows a CanvasText-bordered Canvas surface with Highlight/HighlightText selection and GrayText disabled items; open/close animation drops under prefers-reduced-motion. 2026-07-06 (beta→stable) — independently re-verified the OPEN menu (Default + WithSubmenu) in a real browser via Playwright: light/dark flip both the trigger and the portaled surface, and forced-colors draws a visible CanvasText border with a real separator (not shadow-only). 4-mode AT snapshots refreshed and compare-clean; realBrowserForcedColorsVerified + accessibilityTreeVerified set true."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Menu.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Menu.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Menu.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Menu.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Modal": {
       "preferredImport": "@dt/Modal",
@@ -6459,15 +15925,15 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "always pass a `title`. Title-less modals are a bad AT experience;",
-        "pass `description` for supporting copy (maps to `aria-describedby`,",
-        "pick the severity that matches the message. `error` and",
-        "use `severity=\"error\"` for destructive confirmations, render the"
+        "(must): always pass a `title` -- a title-less dialog is announced as \"Dialog\" with no context, leaving the user no way to know what opened.",
+        "pass `description` for supporting copy (maps to `aria-describedby`, shadcn `DialogDescription` parity). Prefer `description` over a lone `<p>` child when the body is a single sentence.",
+        "pick the severity that matches the message. `error` and `warning` flip the role to `alertdialog`, which carries an implicit assertive announcement.",
+        "use `severity=\"error\"` for destructive confirmations, render the destructive action with `tone=\"error\"`, and pair it with a secondary Cancel. The dialog chrome and action must communicate the same risk."
       ],
       "avoidWhen": [
-        "nest a Modal inside another Modal. AT focus order becomes",
-        "render a Modal lazily (e.g. only mount it when `isOpen`).",
-        "add `aria-live` to the dialog root. The role implies"
+        "(must): nest a Modal inside another Modal -- AT focus order becomes ambiguous and the `inert` attribute applies once, so the outer dialog stays reachable. If you need a second confirmation step, swap content in place in…",
+        "render a Modal lazily (e.g. only mount it when `isOpen`). Mount it always; control via `isOpen`. Lazy mounting breaks focus restoration because the unmount happens before the focus restore.",
+        "(must): add `aria-live` to the dialog root -- the role already implies announcement, and doubling it makes AT read \"dialog dialog\" or repeat the message."
       ],
       "requiredA11y": [
         "role=dialog",
@@ -6479,7 +15945,7 @@
         "Tab"
       ],
       "compositionRules": [
-        "nest a Modal inside another Modal. AT focus order becomes"
+        "(must): nest a Modal inside another Modal -- AT focus order becomes ambiguous and the `inert` attribute applies once, so the outer dialog stays reachable. If you need a second confirmation step, swap content in place in…"
       ],
       "canonicalExamples": [
         "Playground",
@@ -6492,9 +15958,9 @@
         "Nested modals — swap content in place inside one overlay",
         "Lazy-mounting Modal only when isOpen — mount always and toggle isOpen for focus restore",
         "Pair AlertBanner with Modal for the same status — use Modal alone for blocking alerts",
-        "nest a Modal inside another Modal. AT focus order becomes",
-        "render a Modal lazily (e.g. only mount it when `isOpen`).",
-        "add `aria-live` to the dialog root. The role implies"
+        "(must): nest a Modal inside another Modal -- AT focus order becomes ambiguous and the `inert` attribute applies once, so the outer dialog stays reachable. If you need a second confirmation step, swap content in place in…",
+        "render a Modal lazily (e.g. only mount it when `isOpen`). Mount it always; control via `isOpen`. Lazy mounting breaks focus restoration because the unmount happens before the focus restore.",
+        "(must): add `aria-live` to the dialog root -- the role already implies announcement, and doubling it makes AT read \"dialog dialog\" or repeat the message."
       ],
       "composesWith": [
         "Button",
@@ -6506,7 +15972,201 @@
         "TextArea"
       ],
       "prefersOver": [],
-      "declaredPropCount": 19
+      "declaredPropCount": 19,
+      "guidelines": [
+        {
+          "level": "must",
+          "guidance": "always pass a `title`",
+          "rationale": "a title-less dialog is announced as \"Dialog\" with no context, leaving the user no way to know what opened.",
+          "rationaleSource": "explicit",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass `description` for supporting copy (maps to `aria-describedby`, shadcn `DialogDescription` parity)",
+          "rationale": "Prefer `description` over a lone `<p>` child when the body is a single sentence.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pick the severity that matches the message. `error` and `warning` flip the role to `alertdialog`, which carries an implicit assertive announcement.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "use `severity=\"error\"` for destructive confirmations, render the destructive action with `tone=\"error\"`, and pair it with a secondary Cancel",
+          "rationale": "The dialog chrome and action must communicate the same risk.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "must-not",
+          "guidance": "nest a Modal inside another Modal",
+          "rationale": "AT focus order becomes ambiguous and the `inert` attribute applies once, so the outer dialog stays reachable. If you need a second confirmation step, swap content in place inside the existing modal.",
+          "rationaleSource": "explicit",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "render a Modal lazily (e.g. only mount it when `isOpen`). Mount it always; control via `isOpen`. Lazy mounting breaks focus restoration",
+          "rationale": "the unmount happens before the focus restore.",
+          "rationaleSource": "explicit",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "must-not",
+          "guidance": "add `aria-live` to the dialog root",
+          "rationale": "the role already implies announcement, and doubling it makes AT read \"dialog dialog\" or repeat the message.",
+          "rationaleSource": "explicit",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-06 — beta→stable: portal-aware AT snapshots regenerated across base/light/dark/forced-colors (all 9 beta-matrix stories green), severity color axis verified per value via getComputedStyle, footer default fixed; focus trap + Escape reviewed in plays."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Modal.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Modal.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Modal.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Modal.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": {
+        "owner": "design-system",
+        "lastReviewed": "2026-07-21",
+        "note": "Re-read after the #1280 content-reset fix. Nesting and aria-live rules promoted to must-not."
+      },
+      "content": {
+        "voice": "Direct and calm. State what will happen, then let the actions carry the verbs.",
+        "capitalization": "sentence",
+        "terminology": [
+          {
+            "prefer": "Cancel",
+            "over": [
+              "Nevermind",
+              "Back"
+            ],
+            "rationale": "Cancel is the conventional dismissal label and is already translated in all three locales."
+          }
+        ],
+        "maxLength": {
+          "title": 48
+        },
+        "notes": "Title is the AT announcement. Keep it a noun phrase naming what opened, never a full sentence."
+      }
     },
     "MultiCombobox": {
       "preferredImport": "@dt/MultiCombobox",
@@ -6614,7 +16274,152 @@
         "Select"
       ],
       "prefersOver": [],
-      "declaredPropCount": 11
+      "declaredPropCount": 11,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "pass `string[]` value and `onValueChange` for controlled multi-select state.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "localise option labels via i18n before passing `options`.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use for single-select — use `Combobox` instead.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "Verified 2026-06-02: type-to-filter combobox — input role=combobox with aria-autocomplete=list/aria-expanded/aria-controls/aria-activedescendant, aria-labelledby; portaled role=listbox aria-multiselectable with role=option/aria-selected; chips are removable Badges, Backspace removes the last. Keyboard (ArrowUp/Down, Enter toggle, Escape, Backspace) driven and asserted by the KeyboardMultiSelect play function. Shares ComboboxField CSS (inherits the placeholder contrast fix). Default/Playground/Example/KeyboardMultiSelect pass axe with test:error; light + dark verified in Storybook. 2026-07-07 — beta→stable: 4-mode AT (base/light/dark/forced-colors) re-verified on a non-6010 Storybook."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "MultiCombobox.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "MultiCombobox.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "MultiCombobox.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "MultiCombobox.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "NavLink": {
       "preferredImport": "@dt/NavLink",
@@ -6694,7 +16499,159 @@
         "SkipLink"
       ],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Use in `SiteHeader`, `Footer`, and breadcrumb-style in-page nav.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "Pass the route's canonical href — the active-route match is exact-path.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Use inside body prose — that is `Link`.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Use as a button — primary actions belong on `Button`.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-05 — beta→stable (fleet #13): renders a real next/link <a>, aria-current='page' on the active route. Fixed a reduced-motion gap — the transition-colors fade now carries motion-reduce:transition-none so a11y.reducedMotion is literally honest (matches Pagination / ValueCard); unit-tested. Styling is a deliberate className contract (active/inactiveClassName), so exact + activeClassName are EFFECT_EXEMPT in audit:controls with unit tests covering the active/inactive class swap. Re-verified: axe + plays green in light/dark/forced-colors, 100% controls operable / 0 inert, AT snapshots captured 4 modes. 2026-05-28 origin: Bucket-1 beta port, keyboard/ARIA reviewed, ForcedColors story + Storybook axe gate. 2026-07-10 — Figma link wired to the existing NavLink component set (Patterns page, node 516-3146); parity uplift tracked in docs/design-system/figma-parity-audit.md B5."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NavLink.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NavLink.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NavLink.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NavLink.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "NavMenuList": {
       "preferredImport": "@dt/NavMenuList",
@@ -6744,7 +16701,132 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 5
+      "declaredPropCount": 5,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on NavMenuList pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NavMenuList.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NavMenuList.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NavMenuList.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NavMenuList.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "NewsletterWaitlist": {
       "preferredImport": "@dt/NewsletterWaitlist",
@@ -6776,13 +16858,13 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "pass `onSuccess` if analytics or a parent component needs to",
-        "pass `disabled` during maintenance windows or when the"
+        "pass `onSuccess` if analytics or a parent component needs to react to signups. The callback fires after the success Modal appears, with the submitted email.",
+        "pass `disabled` during maintenance windows or when the backing endpoint is known to be down. The component degrades gracefully (greyed Button, no transformation)."
       ],
       "avoidWhen": [
-        "mount more than one instance per page. The success Modal",
-        "try to control the transformation state from outside. The",
-        "bypass the validation. The regex catches obvious typos but"
+        "mount more than one instance per page. The success Modal isn't scoped to the originating component — opening two collides on focus management.",
+        "try to control the transformation state from outside. The component owns it; exposing it would invite consumers to break the contract.",
+        "bypass the validation. The regex catches obvious typos but the server is the source of truth — never assume client-side validation alone gates a real submission."
       ],
       "requiredA11y": [
         "submit button labeled",
@@ -6801,13 +16883,170 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "mount more than one instance per page. The success Modal",
-        "try to control the transformation state from outside. The",
-        "bypass the validation. The regex catches obvious typos but"
+        "mount more than one instance per page. The success Modal isn't scoped to the originating component — opening two collides on focus management.",
+        "try to control the transformation state from outside. The component owns it; exposing it would invite consumers to break the contract.",
+        "bypass the validation. The regex catches obvious typos but the server is the source of truth — never assume client-side validation alone gates a real submission."
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "pass `onSuccess` if analytics or a parent component needs to react to signups",
+          "rationale": "The callback fires after the success Modal appears, with the submitted email.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass `disabled` during maintenance windows or when the backing endpoint is known to be down",
+          "rationale": "The component degrades gracefully (greyed Button, no transformation).",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "mount more than one instance per page",
+          "rationale": "The success Modal isn't scoped to the originating component — opening two collides on focus management.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "try to control the transformation state from outside",
+          "rationale": "The component owns it; exposing it would invite consumers to break the contract.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "bypass the validation",
+          "rationale": "The regex catches obvious typos but the server is the source of truth — never assume client-side validation alone gates a real submission.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-26 — production behavior verified in Storybook; argTypes and required stories aligned with validate:components."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NewsletterWaitlist.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NewsletterWaitlist.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NewsletterWaitlist.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NewsletterWaitlist.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "NextLayout": {
       "preferredImport": "@dt/NextLayout",
@@ -6848,7 +17087,132 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 2
+      "declaredPropCount": 2,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on NextLayout pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NextLayout.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NextLayout.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NextLayout.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NextLayout.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "OpenHours": {
       "preferredImport": "@dt/OpenHours",
@@ -6899,7 +17263,132 @@
         "DonnyBookingEmbed"
       ],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on OpenHours pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "OpenHours.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "OpenHours.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "OpenHours.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "OpenHours.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Pagination": {
       "preferredImport": "@dt/Pagination",
@@ -6973,7 +17462,159 @@
         "EnhancedArticleCard"
       ],
       "prefersOver": [],
-      "declaredPropCount": 5
+      "declaredPropCount": 5,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Show 5 to 7 page numbers max; truncate the middle with an ellipsis.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "Always include Previous and Next so keyboard users have one-step neighbour navigation.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Remove Previous/Next on edges — use `aria-disabled` so the visual stays stable.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Render more than ~10 page numbers inline — switch to a 'Page X of Y' label with prev/next only.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all stories in all four modes; AT snapshots refreshed compare-clean; Controls operable + 0 inert; eyeballed the pager in light and dark. Fixed two real defects: (1) the `<nav>` landmark reused the `blogPage` i18n key, so its accessible name resolved to 'Page' / 'Sivu' instead of a navigation label — added a dedicated `blogPageNavigation` key (en/fi/sv) and dropped the redundant explicit `role='navigation'`; (2) the color transitions had no `prefers-reduced-motion` guard yet reducedMotion claimed true — added `motion-reduce:transition-none`."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Pagination.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Pagination.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Pagination.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Pagination.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "PersonCard": {
       "preferredImport": "@dt/PersonCard",
@@ -7120,7 +17761,132 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 27
+      "declaredPropCount": 27,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on PersonCard pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PersonCard.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PersonCard.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PersonCard.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PersonCard.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "PhoneInput": {
       "preferredImport": "@dt/PhoneInput",
@@ -7428,12 +18194,12 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "validate with `isValidPhoneNumber` from `react-phone-number-input`",
+        "validate with `isValidPhoneNumber` from `react-phone-number-input` on blur or submit; the field formats but never blocks input.",
         "treat `onChange(undefined)` as \"incomplete\", not as an error.",
         "set `defaultCountry` for the audience (defaults to `FI`)."
       ],
       "avoidWhen": [
-        "read the DOM input value — it is the national display format,",
+        "read the DOM input value — it is the national display format, not the E.164 value.",
         "split country code and number into two fields."
       ],
       "requiredA11y": [
@@ -7452,7 +18218,7 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "read the DOM input value — it is the national display format,",
+        "read the DOM input value — it is the national display format, not the E.164 value.",
         "split country code and number into two fields."
       ],
       "composesWith": [
@@ -7464,7 +18230,166 @@
         "Modal"
       ],
       "prefersOver": [],
-      "declaredPropCount": 10
+      "declaredPropCount": 10,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "validate with `isValidPhoneNumber` from `react-phone-number-input` on blur or submit; the field formats but never blocks input.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat `onChange(undefined)` as \"incomplete\", not as an error.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "set `defaultCountry` for the audience (defaults to `FI`).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "read the DOM input value — it is the national display format, not the E.164 value.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "split country code and number into two fields.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-07 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified on a non-6010 Storybook; accessibility tree and real-browser forced-colors confirmed."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PhoneInput.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PhoneInput.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PhoneInput.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PhoneInput.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Progress": {
       "preferredImport": "@dt/Progress",
@@ -7532,11 +18457,11 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "switch `state` to `success` / `error` at completion so the outcome",
-        "compose a visible Text value when precision matters (WithLabel"
+        "switch `state` to `success` / `error` at completion so the outcome is visible without reading numbers.",
+        "compose a visible Text value when precision matters (WithLabel story)."
       ],
       "avoidWhen": [
-        "animate value backwards or reset mid-task; regressing progress",
+        "animate value backwards or reset mid-task; regressing progress reads as an error.",
         "bypass design tokens or skip forced-colors verification at beta."
       ],
       "requiredA11y": [
@@ -7554,12 +18479,158 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "animate value backwards or reset mid-task; regressing progress",
+        "animate value backwards or reset mid-task; regressing progress reads as an error.",
         "bypass design tokens or skip forced-colors verification at beta."
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 7
+      "declaredPropCount": 7,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "switch `state` to `success` / `error` at completion so the outcome is visible without reading numbers.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "compose a visible Text value when precision matters (WithLabel story).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "animate value backwards or reset mid-task; regressing progress reads as an error.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-03 (batch 4) — indeterminate mode added: sweeping bar, aria-valuenow dropped, reduced motion slows the sweep instead of freezing it. 2026-07-08 — promoted after ContactInquiryPanel adopted Progress as the indeterminate booking-calendar loading fallback; check:beta-promotion-readiness verifies production consumers, snapshots, forced colors, and real Figma evidence."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Progress.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Progress.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Progress.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Progress.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ProjectCard": {
       "preferredImport": "@dt/ProjectCard",
@@ -7648,7 +18719,158 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "pass `title`, `slug` and `thumbnail`; add `category`/`tags` for richer cards",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "choose `titlePosition` (overlay | below) and `aspectRatio` per surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "reach for this when EnhancedProjectCard's richer surface is needed — pick one per surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "reduced-motion",
+          "statement": "Positional, scale, and opacity motion is suppressed under prefers-reduced-motion.",
+          "verificationMode": "manual"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-06 alpha->beta: axe clean via test-storybook a11y test:error across base + light + dark + forced-colors on all stories, both overlay and below title positions; 4-mode AT snapshots captured and compare-clean. Card is one Link with the title as image alt. Hover scale/translate/opacity transitions are decorative and now gated behind motion-reduce: utilities (the global reset only covers focus rings). Tailwind className styling retained as an intentional per-surface owner call. 2026-07-06 beta->stable: independently re-verified light/dark + forced-colors of both title positions in a real browser; closed the last reduced-motion gap (the below-title hover color transition now carries motion-reduce:transition-none, matching the ValueCard/ServiceCard family). realBrowserForcedColorsVerified + accessibilityTreeVerified set true."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectCard.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectCard.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectCard.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectCard.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ProjectGallery": {
       "preferredImport": "@dt/ProjectGallery",
@@ -7734,7 +18956,164 @@
         "Section"
       ],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "pass `images` with width/height; tune `columns`, `gap` and `aspectRatio` per surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "set `enableLightbox={false}` for static, non-interactive figure grids",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use this for decorative marquees — it is for case-study imagery",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "reduced-motion",
+          "statement": "Positional, scale, and opacity motion is suppressed under prefers-reduced-motion.",
+          "verificationMode": "manual"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-06 alpha->beta: axe clean via test-storybook a11y test:error across base + light + dark + forced-colors on all stories (3/4 columns, mixed/square, lightbox on/off); 4-mode AT snapshots captured and compare-clean. Grid is role=list; thumbnails are keyboard-activatable buttons naming the fullscreen action. GSAP scroll-stagger is already gated behind a prefers-reduced-motion check in the component. Tailwind className styling retained as an intentional per-surface owner call. 2026-07-07 beta->stable: independently re-verified light/dark + forced-colors of the grid (with and without lightbox) in a real browser. Closed a reduced-motion gap the alpha note missed: the thumbnail hover scale + overlay transitions now carry motion-reduce guards (the GSAP stagger was already gated, but the CSS hover transforms were not). realBrowserForcedColorsVerified + accessibilityTreeVerified set true."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectGallery.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectGallery.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectGallery.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectGallery.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ProjectNav": {
       "preferredImport": "@dt/ProjectNav",
@@ -7788,7 +19167,153 @@
         "Section"
       ],
       "prefersOver": [],
-      "declaredPropCount": 2
+      "declaredPropCount": 2,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "pass the current project `currentSlug`; prev/next targets derive from the project ordering",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "keep the Tailwind className styling (intentional per-surface owner call, as with NavLink/Pagination)",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use this for site-wide navigation (that is SiteHeader)",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-06 alpha->beta: axe clean via test-storybook a11y test:error across base + light + dark + forced-colors on all stories; 4-mode AT snapshots captured and compare-clean. nav landmark labelled via projectNavLabel; prev/next targets from getProjectNavigation, disabled edges use aria-disabled. Tailwind className styling retained as an intentional per-surface owner call (same as NavLink/Pagination). No own animation. 2026-07-06 beta->stable: independently re-verified light/dark + forced-colors in a real browser (prev/next + back-to-work links and the disabled edge state track the theme; forced-colors keeps LinkText/GrayText distinction between active and disabled controls). Only transitions are hover text-color (no motion), so reducedMotion holds. realBrowserForcedColorsVerified + accessibilityTreeVerified set true."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectNav.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectNav.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectNav.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectNav.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Radio": {
       "preferredImport": "@dt/Radio",
@@ -7888,7 +19413,132 @@
         "TextInput"
       ],
       "prefersOver": [],
-      "declaredPropCount": 9
+      "declaredPropCount": 9,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on Radio pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Radio.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Radio.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Radio.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Radio.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "RadioGroup": {
       "preferredImport": "@dt/RadioGroup",
@@ -8011,7 +19661,132 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 12
+      "declaredPropCount": 12,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on RadioGroup pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "RadioGroup.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "RadioGroup.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "RadioGroup.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "RadioGroup.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ReadingProgress": {
       "preferredImport": "@dt/ReadingProgress",
@@ -8059,7 +19834,139 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 3
+      "declaredPropCount": 3,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on ReadingProgress pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-06 — beta→stable: progressbar role with aria-valuenow/min/max + aria-label; passive scroll listener avoids jank. Added the missing prefers-reduced-motion guard (the bar-fill + root-fade transitions now actually drop under reduced motion, matching the prior claim). AT snapshots bootstrapped across base/light/dark/forced-colors; percentage uses --secondary-text-color (theme-aware, CanvasText in forced-colors)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ReadingProgress.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ReadingProgress.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ReadingProgress.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ReadingProgress.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Section": {
       "preferredImport": "@dt/Section",
@@ -8143,7 +20050,133 @@
         "Pagination"
       ],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on Section pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all 7 stories in all four modes (plain/light/dark/forced-colors); AT snapshots refreshed compare-clean; Controls 100% operable + 0 inert. Unlike a pure wrapper, Section owns a real surface (background=inverse flips bg-foreground/text-background) — eyeballed the Backgrounds story in light and dark: default/muted/inverse track the theme and inverse contrast holds both ways. Fixed two contract defects: element was \"div\" (renders <section>) and variants was empty (spacing + background are the styling axes). 2026-07-10 — Figma component built (Atoms, node 1178-1712, parity-audit batch B2a): contract axes as variants with DT variable bindings."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Section.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Section.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Section.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Section.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "SecureCVDownload": {
       "preferredImport": "@dt/SecureCVDownload",
@@ -8200,7 +20233,133 @@
         "animations"
       ],
       "prefersOver": [],
-      "declaredPropCount": 3
+      "declaredPropCount": 3,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on SecureCVDownload pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-09 — Promoted beta→stable: 4-mode AT snapshots captured for all required stories, forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SecureCVDownload.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SecureCVDownload.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SecureCVDownload.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SecureCVDownload.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "SegmentedControl": {
       "preferredImport": "@dt/SegmentedControl",
@@ -8269,7 +20428,7 @@
         "give a meaningful `ariaLabel` naming what is being switched."
       ],
       "avoidWhen": [
-        "use it for actions or navigation that commits/routes — use `ButtonGroup`",
+        "use it for actions or navigation that commits/routes — use `ButtonGroup` or links. Selecting must only change the bound value.",
         "overflow it; if the options do not fit on one line, use `Select`."
       ],
       "requiredA11y": [
@@ -8291,12 +20450,162 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "use it for actions or navigation that commits/routes — use `ButtonGroup`",
+        "use it for actions or navigation that commits/routes — use `ButtonGroup` or links. Selecting must only change the bound value.",
         "overflow it; if the options do not fit on one line, use `Select`."
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "keep to 2–5 short segments; it is a glance-and-switch control, not a menu.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "give a meaningful `ariaLabel` naming what is being switched.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use it for actions or navigation that commits/routes — use `ButtonGroup` or links",
+          "rationale": "Selecting must only change the bound value.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "overflow it; if the options do not fit on one line, use `Select`.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-12 — alpha→beta: code-level a11y review. Container is role=radiogroup with a required aria-label; each segment is role=radio with aria-checked reflecting selection. Roving tabindex keeps exactly one segment tabbable (the selection, else the first enabled); Arrow keys move selection wrapping and skip disabled segments; Home/End jump to first/last enabled. Selection shown by a raised neutral surface (not brand fill) so it reads across light/dark; forced-colors maps the selected segment to a Highlight outline. Motion respects prefers-reduced-motion. Axe asserted in unit test; forced-colors + light/dark verified on a non-6010 Storybook."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SegmentedControl.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SegmentedControl.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SegmentedControl.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SegmentedControl.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Select": {
       "preferredImport": "@dt/Select",
@@ -8368,13 +20677,13 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "use `onValueChange` (the new contract). The legacy `onChange`",
-        "label every Select. Visually-hidden labels are fine — use the"
+        "use `onValueChange` (the new contract). The legacy `onChange` still works but emits a deprecation warning in development.",
+        "label every Select. Visually-hidden labels are fine — use the `<Label>` primitive with `visuallyHidden` if the design has no visible label."
       ],
       "avoidWhen": [
-        "ship a Select with `value` and `defaultValue` both set —",
-        "use Select for a freeform value with suggestions. Use an",
-        "wrap the native chevron with a button overlay. The native"
+        "ship a Select with `value` and `defaultValue` both set — `value` wins and a dev-mode warning fires.",
+        "use Select for a freeform value with suggestions. Use an Input plus a custom autosuggest pattern.",
+        "wrap the native chevron with a button overlay. The native click target is the entire control already; an overlay breaks forced-colors and mobile sheets."
       ],
       "requiredA11y": [
         "associated label",
@@ -8394,9 +20703,9 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "ship a Select with `value` and `defaultValue` both set —",
-        "use Select for a freeform value with suggestions. Use an",
-        "wrap the native chevron with a button overlay. The native"
+        "ship a Select with `value` and `defaultValue` both set — `value` wins and a dev-mode warning fires.",
+        "use Select for a freeform value with suggestions. Use an Input plus a custom autosuggest pattern.",
+        "wrap the native chevron with a button overlay. The native click target is the entire control already; an overlay breaks forced-colors and mobile sheets."
       ],
       "composesWith": [
         "Button",
@@ -8407,7 +20716,166 @@
         "Text"
       ],
       "prefersOver": [],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "use `onValueChange` (the new contract)",
+          "rationale": "The legacy `onChange` still works but emits a deprecation warning in development.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "label every Select",
+          "rationale": "Visually-hidden labels are fine — use the `<Label>` primitive with `visuallyHidden` if the design has no visible label.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "ship a Select with `value` and `defaultValue` both set — `value` wins and a dev-mode warning fires.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use Select for a freeform value with suggestions",
+          "rationale": "Use an Input plus a custom autosuggest pattern.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "wrap the native chevron with a button overlay",
+          "rationale": "The native click target is the entire control already; an overlay breaks forced-colors and mobile sheets.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-07 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified on a non-6010 Storybook; accessibility tree and real-browser forced-colors confirmed."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Select.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Select.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Select.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Select.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "SelectOption": {
       "preferredImport": "@dt/Select",
@@ -8452,7 +20920,130 @@
       "forbiddenUse": [],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-15 - native option semantics and disabled state verified through Select."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SelectOption.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SelectOption.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SelectOption.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SelectOption.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "SelectableCard": {
       "preferredImport": "@dt/SelectableCard",
@@ -8517,7 +21108,157 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "write the legend as the question; keep each card's title short and scannable.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "use `type=\"single\"` for an exclusive choice, `type=\"multiple\"` for add-ons.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "nest interactive controls (buttons, links) inside a SelectableCard; the whole card is a label wrapping the input, so nested controls steal the click",
+          "rationale": "Use a plain Card for action cards.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use it for navigation; selecting must not commit or route on click.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-12 — alpha→beta: code-level a11y review. SelectableCardGroup renders a fieldset with a legend for the accessible name; each SelectableCard is a label wrapping a visually-hidden native radio (single) or checkbox (multiple) input, so keyboard, focus and form submission come from the platform. Error announces via role=alert and sets aria-invalid on the group. Selected/disabled states mirror to data-attributes for CSS + tests. Motion respects prefers-reduced-motion. Axe asserted in the colocated a11y test; forced-colors + light/dark verified on a non-6010 Storybook."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SelectableCard.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SelectableCard.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SelectableCard.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SelectableCard.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "SentrySummaryCard": {
       "preferredImport": "@dt/SentrySummaryCard",
@@ -8554,7 +21295,132 @@
         "Icon"
       ],
       "prefersOver": [],
-      "declaredPropCount": 1
+      "declaredPropCount": 1,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on SentrySummaryCard pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SentrySummaryCard.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SentrySummaryCard.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SentrySummaryCard.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SentrySummaryCard.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ServiceCard": {
       "preferredImport": "@dt/ServiceCard",
@@ -8646,7 +21512,133 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on ServiceCard pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean all four modes; AT snapshots bootstrapped (had none — snapshot dir only resolved after the #872 resolver fix) compare-clean; Controls 8/8 operable + 0 inert; eyeballed the card surface light + dark. Fixed the same reduced-motion gap as ValueCard: the hover scale/lift transforms (icon group-hover:scale-105/-translate-y-0.5, card hover:-translate-y-2/scale-[1.02]) ran on transition-all with no motion-reduce guard while reducedMotion claimed true — added motion-reduce:transition-none to both transition sites. Also added the missing unit test (axe + link/div render + variant surface + reduced-motion guard)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ServiceCard.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ServiceCard.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ServiceCard.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ServiceCard.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ServicesGrid": {
       "preferredImport": "@dt/ServicesGrid",
@@ -8685,7 +21677,132 @@
         "DonnyBookingEmbed"
       ],
       "prefersOver": [],
-      "declaredPropCount": 1
+      "declaredPropCount": 1,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on ServicesGrid pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ServicesGrid.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ServicesGrid.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ServicesGrid.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ServicesGrid.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "SiteTree": {
       "preferredImport": "@dt/SiteTree",
@@ -8748,7 +21865,159 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Use for documentation sitemaps, internal IA previews, or agent discovery trees.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "Pass pre-translated labels from the caller.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Use as the primary site header navigation — use `NavMenuList` / `SiteHeader` instead.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Nest more than three levels without testing keyboard focus order.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "unverified",
+          "note": "Play-function exempt: Static navigation tree; expand/collapse follows native details/summary keyboard behavior, no custom handlers to drive."
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "Verified 2026-06-02: nav landmark + aria-label; native details/summary disclosure (keyboard/SR-native). Fixed two real axe findings surfaced by enabling axe on the stories — nested-interactive (link inside summary; branch index now a separate leaf) and listitem (removed role=group from ul). Default/Playground/Example pass axe with test:error; dark theme verified in Storybook. Forced colors: links/icons inherit currentColor via Icon/Link primitives → CanvasText; ForcedColors story present. 2026-07-09 — Promoted beta→stable: 4-mode AT snapshots captured for all required stories, forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SiteTree.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SiteTree.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SiteTree.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SiteTree.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Skeleton": {
       "preferredImport": "@dt/Skeleton",
@@ -8813,11 +22082,11 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "mirror real widths, heights, and rhythm so the content swap is",
+        "mirror real widths, heights, and rhythm so the content swap is seamless.",
         "name what is loading (\"Loading article\"), not the mechanism."
       ],
       "avoidWhen": [
-        "leave skeletons up after a load fails — resolve to an error",
+        "leave skeletons up after a load fails — resolve to an error state.",
         "bypass design tokens or skip forced-colors verification at beta."
       ],
       "requiredA11y": [
@@ -8832,7 +22101,7 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "leave skeletons up after a load fails — resolve to an error",
+        "leave skeletons up after a load fails — resolve to an error state.",
         "bypass design tokens or skip forced-colors verification at beta."
       ],
       "composesWith": [
@@ -8840,7 +22109,153 @@
         "Title"
       ],
       "prefersOver": [],
-      "declaredPropCount": 7
+      "declaredPropCount": 7,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "mirror real widths, heights, and rhythm so the content swap is seamless.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "name what is loading (\"Loading article\"), not the mechanism.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "leave skeletons up after a load fails — resolve to an error state.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-07 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified; accessibility tree and real-browser forced-colors confirmed in Storybook. 2026-07-10 — Figma component built (Atoms, node 1177-1652, parity-audit batch B2a): contract axes as variants with DT variable bindings."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Skeleton.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Skeleton.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Skeleton.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Skeleton.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "SkipLink": {
       "preferredImport": "@dt/SkipLink",
@@ -8895,7 +22310,145 @@
         "NavLink"
       ],
       "prefersOver": [],
-      "declaredPropCount": 3
+      "declaredPropCount": 3,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on SkipLink pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-05 — beta→stable (fleet #15): renders a real <a> (contract element corrected div→a). The reveal slide (transition: inset-block-start) is already guarded by a prefers-reduced-motion:reduce { transition:none } block, so reducedMotion is honest. --color-primary/--color-white token pairing holds contrast across all 4 themes. Re-verified: axe + plays green in light/dark/forced-colors, 100% controls operable / 0 inert, AT snapshots captured 4 modes. 2026-05-28 origin: Breadth beta port, keyboard/ARIA reviewed, ForcedColors story + Storybook axe gate. 2026-07-10 — Figma component built (Atoms, node 1177-1644, parity-audit batch B2a): contract axes as variants with DT variable bindings."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SkipLink.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SkipLink.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SkipLink.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SkipLink.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "SocialIconLink": {
       "preferredImport": "@dt/SocialIconLink",
@@ -9003,7 +22556,149 @@
         "Divider"
       ],
       "prefersOver": [],
-      "declaredPropCount": 7
+      "declaredPropCount": 7,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "pass a human label (\"Digitaltableteur on LinkedIn\"), not the platform name alone when context needs it.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "size the hit target with `size` (sm/md/lg paddings), not custom CSS.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "put text children inside — this is icon-only; use Link for labeled links.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "disable `external` for social profiles; same-tab is for internal routes only.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "manual"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SocialIconLink.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SocialIconLink.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SocialIconLink.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SocialIconLink.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "SocialShare": {
       "preferredImport": "@dt/SocialShare",
@@ -9078,7 +22773,145 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on SocialShare pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-05 — beta→stable (fleet #17): renders a real <section> (contract element corrected div→section). Root-caused + fixed a PRE-EXISTING BlogPost story failure: the section label used `heading ?? t('shareHeading')`, and the controls-autogen args-enhancer seeds `heading=''` for the free-string prop, so `??` passed the empty string through and dropped the section's accessible name (and the region role). Switched to `||` at the use site (the #852 seeded-'' leak class). Also added a prefers-reduced-motion guard to the .channelLink colour transition and removed a stale hardcoded '11/11' compliance story. Re-verified: axe + plays green in light/dark/forced-colors (incl. BlogPost), 100% controls operable / 0 inert, AT snapshots captured 4 modes. 2026-05-28 origin: promoted from alpha with Example + ForcedColors stories and the Storybook axe gate."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SocialShare.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SocialShare.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SocialShare.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SocialShare.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Spacer": {
       "preferredImport": "@dt/Spacer",
@@ -9156,7 +22989,151 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 3
+      "declaredPropCount": 3,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Use inside a `Stack` or vertical layout where the gap is conceptually a deliberate break, not the container's rhythm.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "Prefer the layout container's `gap` token over `Spacer` when every sibling is spaced uniformly.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Stack two Spacers — collapse them into the larger size.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Use as a 'push' element to right-align content — use flex `margin-inline-start: auto` instead.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Spacer.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Spacer.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Spacer.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Spacer.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Spinner": {
       "preferredImport": "@dt/Spinner",
@@ -9198,7 +23175,7 @@
       "variantsFnName": null,
       "useWhen": [
         "pick `sm` inside inputs/buttons, `md` standalone, `lg` for regions.",
-        "compose a visible, `aria-hidden` text label when sighted users"
+        "compose a visible, `aria-hidden` text label when sighted users need the word (AppLoading pattern)."
       ],
       "avoidWhen": [
         "leave a spinner as the end state — resolve to an outcome.",
@@ -9229,7 +23206,153 @@
         "TextInput"
       ],
       "prefersOver": [],
-      "declaredPropCount": 3
+      "declaredPropCount": 3,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "pick `sm` inside inputs/buttons, `md` standalone, `lg` for regions.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "compose a visible, `aria-hidden` text label when sighted users need the word (AppLoading pattern).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "leave a spinner as the end state — resolve to an outcome.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-03 (batch 4) — BusyIndicator deleted (duplicate loading indicator with off-convention s/m/l sizes); its consumers migrated here. 2026-07-07 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified on a non-6010 Storybook."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Spinner.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Spinner.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Spinner.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Spinner.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "SplitButton": {
       "preferredImport": "@dt/SplitButton",
@@ -9320,7 +23443,159 @@
         "Toast"
       ],
       "prefersOver": [],
-      "declaredPropCount": 7
+      "declaredPropCount": 7,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "use for a primary action that has closely related alternate actions (Save / Save as, Export PDF / Export CSV).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass `usePortal` when the trigger sits inside an `overflow: hidden` container.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use for unrelated actions; prefer separate Buttons.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote past alpha without a11y review, forced-colors verification, and light/dark verification (see roadmap below).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-03 — Astryx Phase 3 batch 1: keyboard/ARIA contract documented from implementation; missing splitButton.moreOptions locale keys added (en/fi/sv). 2026-07-05 — dropdown now consumes the shared Menu primitive (Radix dropdown-menu) incl. MenuSub submenus: hand-rolled role=menu markup, openSubIndex state, manual placement math, and focus-trap removed. Public options API unchanged; obsolete usePortal prop removed (Menu always portals). Re-verified: hover + ArrowRight/Left submenu parity and keyboard select via test-storybook play, axe-clean open, Controls 100% + 0 inert. 2026-07-06 — alpha→beta: Figma variant set built (Variant×Size, node 1052-2084, DT-Site-stuff Molecules). Light/dark AND forced-colors verified for real on the closed control AND the open menu via Playwright (globals=theme + forcedColors:active): theme flips both segments and the portaled Menu surface correctly; in forced-colors the menu draws a visible CanvasText border (not shadow-only), segment outlines and caret/option icons stay distinguishable. forcedColorsVerified + lightDarkVerified now true. 2026-07-12 — beta→stable: 4-mode AT recaptured at stable (WIP badge dropped) via the story runner (plays open the Menu); accessibility tree and real-browser forced-colors confirmed; exported from @digitaltableteur/react. 2 production consumers."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SplitButton.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SplitButton.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SplitButton.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SplitButton.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Stack": {
       "preferredImport": "@dt/Stack",
@@ -9620,7 +23895,139 @@
         "TextInput"
       ],
       "prefersOver": [],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on Stack pages; pick one `gap` token per Stack.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Nest Stacks to sum gaps, or add margins to Stack children — the `gap` owns the spacing.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all stories in all four modes (plain/light/dark/forced); AT snapshots refreshed compare-clean (only change is the dropped Work-in-progress badge line); Controls operable + 0 inert; no motion in the CSS so reducedMotion is trivially honest. Fixed real defect: `align` claimed `@default \"center\"` in the JSDoc and `variants.align.default`/order in the contract, but the component defaults to `stretch` (matching sibling FlexBox); corrected the JSDoc, union order (stretch first), and contract so the derived default is honest and sync-stable — zero render change since the runtime default was already `stretch`. 2026-07-10 — Figma component built (Atoms, node 1176-1676, parity-audit batch B2a): contract axes as variants with DT variable bindings."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Stack.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Stack.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Stack.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Stack.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "StatusDot": {
       "preferredImport": "@dt/StatusDot",
@@ -9718,7 +24125,153 @@
         "Kbd"
       ],
       "prefersOver": [],
-      "declaredPropCount": 5
+      "declaredPropCount": 5,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "always provide `children` (visible) or `label` (sr-only).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "use `pulse` only for genuinely live/ongoing states.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use StatusDot for counts or removable chips — Badge owns those.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "rely on the color alone to convey state.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-06 — alpha→beta: created the Figma component (tone×size variant set, dot fill bound to DT/Color tone tokens) at node 1004-1677, the only remaining beta blocker. Pulse animation disabled under prefers-reduced-motion (CSS guard verified); axe asserted in unit test; forced-colors + light/dark re-verified. 2026-07-08 — beta→stable: 4-mode AT (base/light/dark/forced-colors) verified on a non-6010 Storybook; accessibility tree and real-browser forced-colors confirmed; each tone's dot background-color verified distinct via computed style (color axis)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "StatusDot.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "StatusDot.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "StatusDot.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "StatusDot.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Switch": {
       "preferredImport": "@dt/Switch",
@@ -9812,8 +24365,8 @@
         "set `isLoading` during async commits to prevent double-flips."
       ],
       "avoidWhen": [
-        "use Switch inside a form whose values are submitted in a batch.",
-        "rely on colour alone to convey state — the position of the"
+        "use Switch inside a form whose values are submitted in a batch. Use Checkbox there so the choose-then-Submit affordance is honest.",
+        "rely on colour alone to convey state — the position of the thumb is the primary visual cue, and forced-colors fallbacks preserve that position semantic."
       ],
       "requiredA11y": [
         "role=switch",
@@ -9824,7 +24377,7 @@
         "Enter"
       ],
       "compositionRules": [
-        "use Switch inside a form whose values are submitted in a batch."
+        "use Switch inside a form whose values are submitted in a batch. Use Checkbox there so the choose-then-Submit affordance is honest."
       ],
       "canonicalExamples": [
         "Default",
@@ -9834,8 +24387,8 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "use Switch inside a form whose values are submitted in a batch.",
-        "rely on colour alone to convey state — the position of the"
+        "use Switch inside a form whose values are submitted in a batch. Use Checkbox there so the choose-then-Submit affordance is honest.",
+        "rely on colour alone to convey state — the position of the thumb is the primary visual cue, and forced-colors fallbacks preserve that position semantic."
       ],
       "composesWith": [
         "Modal",
@@ -9844,7 +24397,159 @@
         "Badge"
       ],
       "prefersOver": [],
-      "declaredPropCount": 10
+      "declaredPropCount": 10,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "use Switch for \"apply-on-toggle\" settings.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "set `isLoading` during async commits to prevent double-flips.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use Switch inside a form whose values are submitted in a batch",
+          "rationale": "Use Checkbox there so the choose-then-Submit affordance is honest.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "rely on colour alone to convey state — the position of the thumb is the primary visual cue, and forced-colors fallbacks preserve that position semantic.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-16 beta->stable: Switch replaced the bespoke GDPR category toggle in CookieConsent; controlled/uncontrolled exclusivity is executable in SwitchProps, and required-story AT plus Chromium forced-colors evidence was recaptured."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Switch.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Switch.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Switch.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Switch.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "TableOfContents": {
       "preferredImport": "@dt/TableOfContents",
@@ -9920,7 +24625,149 @@
         "MdxImage"
       ],
       "prefersOver": [],
-      "declaredPropCount": 5
+      "declaredPropCount": 5,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Pair with `useTableOfContents` in article templates.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "Keep item text identical to the rendered heading text.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Use for primary site navigation.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Pass arbitrary nesting levels without expanding `TOCItem`.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "manual"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TableOfContents.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TableOfContents.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TableOfContents.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TableOfContents.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Tabs": {
       "preferredImport": "@dt/Tabs",
@@ -9999,13 +24846,13 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "render tabpanels with `getTabPanelProps(key, isActive)` so the",
-        "keep `tabs[].key` stable across renders. Switching keys mid-flight"
+        "render tabpanels with `getTabPanelProps(key, isActive)` so the four required attributes (`id`, `role`, `aria-labelledby`, `hidden`, `tabIndex`) stay in sync with the tablist.",
+        "keep `tabs[].key` stable across renders. Switching keys mid-flight breaks the controlled / uncontrolled selection bookkeeping."
       ],
       "avoidWhen": [
-        "nest tablists inside another tablist. APG explicitly disallows",
-        "use Tabs for non-mutually-exclusive content. Two panels open",
-        "hand-author `id=\"tab-<key>\"` / `id=\"tabpanel-<key>\"` on the"
+        "nest tablists inside another tablist. APG explicitly disallows it — keyboard navigation becomes ambiguous.",
+        "use Tabs for non-mutually-exclusive content. Two panels open at once is a job for **Accordion** (in a future `mode=\"multi\"`) or side-by-side layout.",
+        "hand-author `id=\"tab-<key>\"` / `id=\"tabpanel-<key>\"` on the panel side. Use `getTabPanelProps`; the id convention is internal."
       ],
       "requiredA11y": [
         "tablist",
@@ -10020,7 +24867,7 @@
         "End"
       ],
       "compositionRules": [
-        "nest tablists inside another tablist. APG explicitly disallows"
+        "nest tablists inside another tablist. APG explicitly disallows it — keyboard navigation becomes ambiguous."
       ],
       "canonicalExamples": [
         "Playground",
@@ -10028,13 +24875,172 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "nest tablists inside another tablist. APG explicitly disallows",
-        "use Tabs for non-mutually-exclusive content. Two panels open",
-        "hand-author `id=\"tab-<key>\"` / `id=\"tabpanel-<key>\"` on the"
+        "nest tablists inside another tablist. APG explicitly disallows it — keyboard navigation becomes ambiguous.",
+        "use Tabs for non-mutually-exclusive content. Two panels open at once is a job for **Accordion** (in a future `mode=\"multi\"`) or side-by-side layout.",
+        "hand-author `id=\"tab-<key>\"` / `id=\"tabpanel-<key>\"` on the panel side. Use `getTabPanelProps`; the id convention is internal."
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "render tabpanels with `getTabPanelProps(key, isActive)` so the four required attributes (`id`, `role`, `aria-labelledby`, `hidden`, `tabIndex`) stay in sync with the tablist.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "keep `tabs[].key` stable across renders",
+          "rationale": "Switching keys mid-flight breaks the controlled / uncontrolled selection bookkeeping.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "nest tablists inside another tablist",
+          "rationale": "APG explicitly disallows it — keyboard navigation becomes ambiguous.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use Tabs for non-mutually-exclusive content",
+          "rationale": "Two panels open at once is a job for **Accordion** (in a future `mode=\"multi\"`) or side-by-side layout.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "hand-author `id=\"tab-<key>\"` / `id=\"tabpanel-<key>\"` on the panel side",
+          "rationale": "Use `getTabPanelProps`; the id convention is internal.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-26 — arrow-key navigation and selection verified in Storybook. 2026-07-08 — promoted after ContactInquiryPanel adopted Tabs for the production contact message/book switcher; check:beta-promotion-readiness verifies production consumers, snapshots, forced colors, and real Figma evidence."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Tabs.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Tabs.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Tabs.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Tabs.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Testimonial": {
       "preferredImport": "@dt/Testimonial",
@@ -10098,7 +25104,132 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 7
+      "declaredPropCount": 7,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on Testimonial pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Testimonial.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Testimonial.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Testimonial.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Testimonial.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Text": {
       "preferredImport": "@dt/Text",
@@ -10169,19 +25300,19 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "pick `as` based on the semantic role of the text (`p`, `strong`,",
-        "use `lineHeight` to bring lede paragraphs and inline copy back into"
+        "pick `as` based on the semantic role of the text (`p`, `strong`, `em`, `span`). Visual size is `size`, independent.",
+        "use `lineHeight` to bring lede paragraphs and inline copy back into the typographic rhythm — `snug` for ledes, `relaxed` for body."
       ],
       "avoidWhen": [
-        "nest a `<Text as=\"p\">` inside another `<p>`. HTML rejects nested",
-        "override font-size via inline `style`. The ladder is the contract;"
+        "nest a `<Text as=\"p\">` inside another `<p>`. HTML rejects nested paragraphs; use `as=\"span\"` for inline positions.",
+        "override font-size via inline `style`. The ladder is the contract; drift in consumer code is invisible until someone audits typography."
       ],
       "requiredA11y": [
         "semantic element via as prop"
       ],
       "keyboard": [],
       "compositionRules": [
-        "nest a `<Text as=\"p\">` inside another `<p>`. HTML rejects nested"
+        "nest a `<Text as=\"p\">` inside another `<p>`. HTML rejects nested paragraphs; use `as=\"span\"` for inline positions."
       ],
       "canonicalExamples": [
         "Example",
@@ -10192,8 +25323,8 @@
         "raw <span> for body copy"
       ],
       "forbiddenUse": [
-        "nest a `<Text as=\"p\">` inside another `<p>`. HTML rejects nested",
-        "override font-size via inline `style`. The ladder is the contract;"
+        "nest a `<Text as=\"p\">` inside another `<p>`. HTML rejects nested paragraphs; use `as=\"span\"` for inline positions.",
+        "override font-size via inline `style`. The ladder is the contract; drift in consumer code is invisible until someone audits typography."
       ],
       "composesWith": [
         "Button",
@@ -10206,7 +25337,147 @@
       "prefersOver": [
         "raw paragraph elements"
       ],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "pick `as` based on the semantic role of the text (`p`, `strong`, `em`, `span`)",
+          "rationale": "Visual size is `size`, independent.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "use `lineHeight` to bring lede paragraphs and inline copy back into the typographic rhythm — `snug` for ledes, `relaxed` for body.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "nest a `<Text as=\"p\">` inside another `<p>`",
+          "rationale": "HTML rejects nested paragraphs; use `as=\"span\"` for inline positions.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "override font-size via inline `style`",
+          "rationale": "The ladder is the contract; drift in consumer code is invisible until someone audits typography.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-26 — typography contrast and forced-colors verified in Storybook."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Text.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Text.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Text.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Text.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "TextArea": {
       "preferredImport": "@dt/TextArea",
@@ -10258,11 +25529,11 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "use `onChange` (this component predates TextInput's",
-        "use `animateResize` + `minRows` / `maxRows` for chat-like or"
+        "use `onChange` (this component predates TextInput's `onValueChange` migration; it still takes the string value directly rather than an event).",
+        "use `animateResize` + `minRows` / `maxRows` for chat-like or message fields that should grow with content."
       ],
       "avoidWhen": [
-        "pass `resize` or `showCount`: those belonged to a previous,",
+        "pass `resize` or `showCount`: those belonged to a previous, unused parallel implementation and are not supported by the current component.",
         "use TextArea for single-line text. Use **TextInput**."
       ],
       "requiredA11y": [
@@ -10273,7 +25544,9 @@
         "Tab",
         "Shift+Tab"
       ],
-      "compositionRules": [],
+      "compositionRules": [
+        "pass `resize` or `showCount`: those belonged to a previous, unused parallel implementation and are not supported by the current component."
+      ],
       "canonicalExamples": [
         "Playground",
         "Example",
@@ -10281,7 +25554,7 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "pass `resize` or `showCount`: those belonged to a previous,",
+        "pass `resize` or `showCount`: those belonged to a previous, unused parallel implementation and are not supported by the current component.",
         "use TextArea for single-line text. Use **TextInput**."
       ],
       "composesWith": [
@@ -10293,7 +25566,159 @@
         "CheckboxGroup"
       ],
       "prefersOver": [],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "use `onChange` (this component predates TextInput's `onValueChange` migration; it still takes the string value directly rather than an event).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "use `animateResize` + `minRows` / `maxRows` for chat-like or message fields that should grow with content.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "pass `resize` or `showCount`: those belonged to a previous, unused parallel implementation and are not supported by the current component.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use TextArea for single-line text",
+          "rationale": "Use **TextInput**.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-05 — alpha→beta a11y review (Petri/Claude). Brought to TextInput/PhoneInput parity: label association now uses useId() (was the raw label string → duplicate-id + broke on spaces); error wired through aria-invalid + aria-describedby to a role=alert HelperText (was unassociated, and the story falsely claimed aria-invalid); required marker now driven by the required prop, not the error state; error no longer leaks into the label title tooltip. Keyboard = native textarea Tab/Shift+Tab. Verified axe-clean on Default/WithHelperCopy/WithError via test-storybook; light + dark + emulated forced-colors eyeballed in a real browser (visible CanvasText border, readable label/placeholder/error). reduced-motion drops the auto-grow height transition (CSS @media). Unit tests assert the aria wiring, required-from-prop, and unique-id behavior."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TextArea.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TextArea.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TextArea.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TextArea.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "TextInput": {
       "preferredImport": "@dt/TextInput",
@@ -10415,15 +25840,15 @@
       },
       "variantsFnName": "textInputVariants",
       "useWhen": [
-        "use `onValueChange` (the new contract). The legacy `onChange`",
-        "pair `type=\"email\"` and `type=\"tel\"` with the built-in",
-        "use `clearable` on fields users iterate on (search, filters,"
+        "use `onValueChange` (the new contract). The legacy `onChange` still works but emits a deprecation warning in dev.",
+        "pair `type=\"email\"` and `type=\"tel\"` with the built-in validators. The component will surface format issues without consumer wiring.",
+        "use `clearable` on fields users iterate on (search, filters, generators) instead of hand-rolling an adjacent ×-button."
       ],
       "avoidWhen": [
-        "ship a form that relies on the email validator as the only",
-        "pass a `value` plus a `defaultValue`. The component treats",
-        "use TextInput for multi-line text. Use **TextArea**, which",
-        "treat `hideLabel` as permission to skip the label. The label"
+        "ship a form that relies on the email validator as the only verification step. The validator is for UX; the server must verify too.",
+        "pass a `value` plus a `defaultValue`. The component treats `value` as controlled; mixing them produces drift.",
+        "use TextInput for multi-line text. Use **TextArea**, which shares the label + helper contract but carries multi-line UX.",
+        "treat `hideLabel` as permission to skip the label. The label is still required and still read by assistive tech; `hideLabel` only removes it visually for dense compositions."
       ],
       "requiredA11y": [
         "label association",
@@ -10443,10 +25868,10 @@
         "raw <input> without design-system field shell"
       ],
       "forbiddenUse": [
-        "ship a form that relies on the email validator as the only",
-        "pass a `value` plus a `defaultValue`. The component treats",
-        "use TextInput for multi-line text. Use **TextArea**, which",
-        "treat `hideLabel` as permission to skip the label. The label"
+        "ship a form that relies on the email validator as the only verification step. The validator is for UX; the server must verify too.",
+        "pass a `value` plus a `defaultValue`. The component treats `value` as controlled; mixing them produces drift.",
+        "use TextInput for multi-line text. Use **TextArea**, which shares the label + helper contract but carries multi-line UX.",
+        "treat `hideLabel` as permission to skip the label. The label is still required and still read by assistive tech; `hideLabel` only removes it visually for dense compositions."
       ],
       "composesWith": [
         "Text",
@@ -10457,7 +25882,180 @@
         "Checkbox"
       ],
       "prefersOver": [],
-      "declaredPropCount": 13
+      "declaredPropCount": 13,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "use `onValueChange` (the new contract)",
+          "rationale": "The legacy `onChange` still works but emits a deprecation warning in dev.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pair `type=\"email\"` and `type=\"tel\"` with the built-in validators",
+          "rationale": "The component will surface format issues without consumer wiring.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "ship a form that relies on the email validator as the only verification step",
+          "rationale": "The validator is for UX; the server must verify too.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "pass a `value` plus a `defaultValue`",
+          "rationale": "The component treats `value` as controlled; mixing them produces drift.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use TextInput for multi-line text",
+          "rationale": "Use **TextArea**, which shares the label + helper contract but carries multi-line UX.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "use `clearable` on fields users iterate on (search, filters, generators) instead of hand-rolling an adjacent ×-button.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "treat `hideLabel` as permission to skip the label",
+          "rationale": "The label is still required and still read by assistive tech; `hideLabel` only removes it visually for dense compositions.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-26 — production behavior verified in Storybook; argTypes and required stories aligned with validate:components."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TextInput.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TextInput.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TextInput.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TextInput.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ThemeProvider": {
       "preferredImport": "@dt/ThemeProvider",
@@ -10512,7 +26110,132 @@
         "Badge"
       ],
       "prefersOver": [],
-      "declaredPropCount": 2
+      "declaredPropCount": 2,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on ThemeProvider pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ThemeProvider.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ThemeProvider.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ThemeProvider.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ThemeProvider.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Timestamp": {
       "preferredImport": "@dt/Timestamp",
@@ -10616,13 +26339,13 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "use `muted` tone for secondary metadata (list rows, card footers) and",
+        "use `muted` tone for secondary metadata (list rows, card footers) and `default` when the value carries body-text weight.",
         "pin `now` in stories and tests for deterministic relative output.",
-        "use the `system_*` formats for developer-facing surfaces (logs, dev tools)"
+        "use the `system_*` formats for developer-facing surfaces (logs, dev tools) where an unambiguous ISO string matters more than locale formatting."
       ],
       "avoidWhen": [
         "wrap it in another `<time>` or add a redundant `title`; it owns both.",
-        "use `live` for values that will not change meaningfully while on screen"
+        "use `live` for values that will not change meaningfully while on screen (absolute dates) — it only re-renders relative/auto output."
       ],
       "requiredA11y": [
         "Renders a semantic <time> element with a machine-readable dateTime attribute that preserves date-only versus instant precision.",
@@ -10639,11 +26362,164 @@
       "replacementFor": [],
       "forbiddenUse": [
         "wrap it in another `<time>` or add a redundant `title`; it owns both.",
-        "use `live` for values that will not change meaningfully while on screen"
+        "use `live` for values that will not change meaningfully while on screen (absolute dates) — it only re-renders relative/auto output."
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 11
+      "declaredPropCount": 11,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "use `muted` tone for secondary metadata (list rows, card footers) and `default` when the value carries body-text weight.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pin `now` in stories and tests for deterministic relative output.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "use the `system_*` formats for developer-facing surfaces (logs, dev tools) where an unambiguous ISO string matters more than locale formatting.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "wrap it in another `<time>` or add a redundant `title`; it owns both.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use `live` for values that will not change meaningfully while on screen (absolute dates) — it only re-renders relative/auto output.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-12 (Claude): verified in Storybook 6010 — light + dark render all 8 formats readable in both tones; relative ladder correct (30s->now, minutes/hours/days/weeks/months); forced-colors safe by construction (pure <time> text, no bg/border/opacity) and confirmed via DT_FORCED_COLORS=active pass; console clean; axe green (10 tests); AT snapshots captured for all 8 stories."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Timestamp.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Timestamp.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Timestamp.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Timestamp.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Title": {
       "preferredImport": "@dt/Title",
@@ -10727,11 +26603,11 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "choose `level` for the document outline first; choose `size` for the",
-        "keep one `level={1}` per route. The page composition owns the outline"
+        "choose `level` for the document outline first; choose `size` for the layout second. Independent props, independent decisions.",
+        "keep one `level={1}` per route. The page composition owns the outline rule, not the Title component."
       ],
       "avoidWhen": [
-        "visually size a heading by passing custom inline styles — use the",
+        "visually size a heading by passing custom inline styles — use the size variants so the typography stays in the system.",
         "nest a Title inside a Button. Use the Button's text slot directly."
       ],
       "requiredA11y": [
@@ -10755,7 +26631,7 @@
       ],
       "forbiddenUse": [
         "Default Title typography on pattern headings that already define font-display or module classes — use unstyled + existing className",
-        "visually size a heading by passing custom inline styles — use the",
+        "visually size a heading by passing custom inline styles — use the size variants so the typography stays in the system.",
         "nest a Title inside a Button. Use the Button's text slot directly."
       ],
       "composesWith": [
@@ -10769,7 +26645,147 @@
       "prefersOver": [
         "raw heading elements"
       ],
-      "declaredPropCount": 7
+      "declaredPropCount": 7,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "choose `level` for the document outline first; choose `size` for the layout second",
+          "rationale": "Independent props, independent decisions.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "keep one `level={1}` per route",
+          "rationale": "The page composition owns the outline rule, not the Title component.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "visually size a heading by passing custom inline styles — use the size variants so the typography stays in the system.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "nest a Title inside a Button",
+          "rationale": "Use the Button's text slot directly.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-26 — heading level, contrast, forced-colors verified in Storybook."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Title.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Title.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Title.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Title.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Toast": {
       "preferredImport": "@dt/Toast",
@@ -10860,13 +26876,13 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "keep the message ≤ 60 characters so it fits on a single line.",
-        "pair `tone=\"error\"` with an actionable next step (\"Retry\" in"
+        "keep the message ≤ 60 characters so it fits on a single line. Two-line toasts get cropped at the bottom of mobile viewports.",
+        "pair `tone=\"error\"` with an actionable next step (\"Retry\" in the message text) so the user knows what to do. Use AlertBanner for persistent errors that can't be auto-resolved."
       ],
       "avoidWhen": [
-        "hand-roll overlapping fixed toasts. Concurrent messages stack via",
-        "rely on Toast for compliance acknowledgements (cookie consent,",
-        "use Toast for validation errors on a field. The visual is far"
+        "hand-roll overlapping fixed toasts. Concurrent messages stack via ToastStack — the app provider renders one stack per position, so calling `showToast` repeatedly shows every message (decision 2026-07-09; the old last-on…",
+        "rely on Toast for compliance acknowledgements (cookie consent, GDPR). Those need persistent acknowledgement; use Modal + CookieConsent.",
+        "use Toast for validation errors on a field. The visual is far from the error source; use HelperText."
       ],
       "requiredA11y": [
         "role=status + aria-live=polite for info/success",
@@ -10876,7 +26892,7 @@
       ],
       "keyboard": [],
       "compositionRules": [
-        "hand-roll overlapping fixed toasts. Concurrent messages stack via"
+        "hand-roll overlapping fixed toasts. Concurrent messages stack via ToastStack — the app provider renders one stack per position, so calling `showToast` repeatedly shows every message (decision 2026-07-09; the old last-on…"
       ],
       "canonicalExamples": [
         "Default",
@@ -10889,9 +26905,9 @@
         "window.alert"
       ],
       "forbiddenUse": [
-        "hand-roll overlapping fixed toasts. Concurrent messages stack via",
-        "rely on Toast for compliance acknowledgements (cookie consent,",
-        "use Toast for validation errors on a field. The visual is far"
+        "hand-roll overlapping fixed toasts. Concurrent messages stack via ToastStack — the app provider renders one stack per position, so calling `showToast` repeatedly shows every message (decision 2026-07-09; the old last-on…",
+        "rely on Toast for compliance acknowledgements (cookie consent, GDPR). Those need persistent acknowledgement; use Modal + CookieConsent.",
+        "use Toast for validation errors on a field. The visual is far from the error source; use HelperText."
       ],
       "composesWith": [
         "Button",
@@ -10904,7 +26920,160 @@
       "prefersOver": [
         "AlertBanner for page-level persistent status"
       ],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "keep the message ≤ 60 characters so it fits on a single line",
+          "rationale": "Two-line toasts get cropped at the bottom of mobile viewports.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pair `tone=\"error\"` with an actionable next step (\"Retry\" in the message text) so the user knows what to do",
+          "rationale": "Use AlertBanner for persistent errors that can't be auto-resolved.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "hand-roll overlapping fixed toasts",
+          "rationale": "Concurrent messages stack via ToastStack — the app provider renders one stack per position, so calling `showToast` repeatedly shows every message (decision 2026-07-09; the old last-one-wins behavior hid the \"language ch…",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "rely on Toast for compliance acknowledgements (cookie consent, GDPR)",
+          "rationale": "Those need persistent acknowledgement; use Modal + CookieConsent.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use Toast for validation errors on a field",
+          "rationale": "The visual is far from the error source; use HelperText.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-05 — beta→stable (fleet #16): renders a real <div role=status|alert> with aria-live/aria-atomic; role/politeness derive from tone (error/warning=assertive, else polite). Slide-in animation is guarded by @media (prefers-reduced-motion:reduce){ transition:none }, so reducedMotion is honest. tone is optional at runtime (untinted, polite when omitted); the enum default 'info' is the nominal semantic default. Re-verified: axe + plays green in light/dark/forced-colors, 100% controls operable / 0 inert (duration EFFECT_EXEMPT — timing prop), AT snapshots refreshed 4 modes. 2026-05-26 origin: production behavior verified; required stories aligned with validate:components. 2026-07-03 (batch 4): Toaster (Tailwind duplicate host) deleted; providers/ToastProvider is the single imperative host forwarding tone/position."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Toast.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Toast.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Toast.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Toast.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ToastStack": {
       "preferredImport": "@dt/ToastStack",
@@ -10973,12 +27142,12 @@
       },
       "variantsFnName": "toastStackVariants",
       "useWhen": [
-        "drive it from the app `ToastProvider` — `showToast` appends and the",
+        "drive it from the app `ToastProvider` — `showToast` appends and the provider renders one stack per active position.",
         "give every toast a stable `id`; dismissal and list identity depend on it."
       ],
       "avoidWhen": [
-        "mount more than one ToastStack at the same position; their fixed",
-        "use it for persistent or compliance-critical messaging — toasts"
+        "mount more than one ToastStack at the same position; their fixed wrappers would overlap. Group by position instead.",
+        "use it for persistent or compliance-critical messaging — toasts auto-dismiss (AlertBanner or Modal own those cases)."
       ],
       "requiredA11y": [
         "each stacked Toast keeps its own live region (role=status or role=alert per tone) so concurrent messages announce independently",
@@ -10986,7 +27155,7 @@
       ],
       "keyboard": [],
       "compositionRules": [
-        "mount more than one ToastStack at the same position; their fixed"
+        "mount more than one ToastStack at the same position; their fixed wrappers would overlap. Group by position instead."
       ],
       "canonicalExamples": [
         "Default",
@@ -10996,12 +27165,158 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "mount more than one ToastStack at the same position; their fixed",
-        "use it for persistent or compliance-critical messaging — toasts"
+        "mount more than one ToastStack at the same position; their fixed wrappers would overlap. Group by position instead.",
+        "use it for persistent or compliance-critical messaging — toasts auto-dismiss (AlertBanner or Modal own those cases)."
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 5
+      "declaredPropCount": 5,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "drive it from the app `ToastProvider` — `showToast` appends and the provider renders one stack per active position.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "give every toast a stable `id`; dismissal and list identity depend on it.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "mount more than one ToastStack at the same position; their fixed wrappers would overlap",
+          "rationale": "Group by position instead.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use it for persistent or compliance-critical messaging — toasts auto-dismiss (AlertBanner or Modal own those cases).",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-12 — alpha→stable: the multi-toast surface behind the app ToastProvider (providers/ToastProvider.tsx → app/layout.tsx). position axis migrated to a root CVA (toastStackVariants). 4-mode AT (base/light/dark/forced-colors) captured for all four required stories; each stacked Toast keeps its own live region so concurrent messages announce independently; forced-colors + light/dark re-verified. Exported from @digitaltableteur/react."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ToastStack.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ToastStack.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ToastStack.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ToastStack.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Tooltip": {
       "preferredImport": "@dt/Tooltip",
@@ -11039,12 +27354,12 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "wrap the real Button/IconButton with `asChild` so it receives the",
-        "share one `TooltipProvider` per surface so adjacent hints open"
+        "wrap the real Button/IconButton with `asChild` so it receives the tooltip wiring directly.",
+        "share one `TooltipProvider` per surface so adjacent hints open instantly once one is shown."
       ],
       "avoidWhen": [
-        "put links, buttons, or any interactive content inside the",
-        "attach tooltips to non-focusable elements; hover-only hints",
+        "put links, buttons, or any interactive content inside the bubble — unreachable by keyboard and touch.",
+        "attach tooltips to non-focusable elements; hover-only hints exclude keyboard and touch users.",
         "promote to stable without production consumer evidence."
       ],
       "requiredA11y": [
@@ -11058,7 +27373,7 @@
         "Escape"
       ],
       "compositionRules": [
-        "put links, buttons, or any interactive content inside the"
+        "put links, buttons, or any interactive content inside the bubble — unreachable by keyboard and touch."
       ],
       "canonicalExamples": [
         "Default",
@@ -11068,13 +27383,170 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "put links, buttons, or any interactive content inside the",
-        "attach tooltips to non-focusable elements; hover-only hints",
+        "put links, buttons, or any interactive content inside the bubble — unreachable by keyboard and touch.",
+        "attach tooltips to non-focusable elements; hover-only hints exclude keyboard and touch users.",
         "promote to stable without production consumer evidence."
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "wrap the real Button/IconButton with `asChild` so it receives the tooltip wiring directly.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "share one `TooltipProvider` per surface so adjacent hints open instantly once one is shown.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "put links, buttons, or any interactive content inside the bubble — unreachable by keyboard and touch.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "attach tooltips to non-focusable elements; hover-only hints exclude keyboard and touch users.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-03 (batch 4) — hover+focus trigger, Escape dismiss, and aria-describedby wiring asserted in the play function and unit tests; axe clean on Default/Placements/WithIconButton. 2026-07-05 (alpha→beta) — the pending light/dark + forced-colors verification is now done: axe-clean on Default/Example/ForcedColors via test-storybook; light + dark eyeballed (bubble uses --color-primary and inverts correctly, arrow tracks the bubble); emulated forced-colors shows a CanvasText-bordered Canvas bubble with readable CanvasText, no reliance on a background that disappears; enter/exit animation drops under reduced-motion (CSS @media)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Tooltip.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Tooltip.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Tooltip.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Tooltip.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "TransformingActionInput": {
       "preferredImport": "@dt/TransformingActionInput",
@@ -11168,7 +27640,132 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 12
+      "declaredPropCount": 12,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on TransformingActionInput pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TransformingActionInput.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TransformingActionInput.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TransformingActionInput.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TransformingActionInput.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ValueCard": {
       "preferredImport": "@dt/ValueCard",
@@ -11250,7 +27847,153 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Use in 3 / 4 / 6-column grids on about / values / methodology pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "Keep titles to ≤ 4 words for a clean grid rhythm.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Use for content with a primary CTA — that is `ServiceCard` or `Card`.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Mix `ValueCard` with `Card` in the same grid row — the rhythm desyncs.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-05 (beta→stable) — re-verified independently: axe-clean across all stories in all four modes; AT snapshots bootstrapped (had none) compare-clean; Controls 6/6 operable + 0 inert; eyeballed the elevated card surface in light and dark. Fixed a real reduced-motion gap: the elevated hover lift (hover:-translate-y-1) and the color/shadow transitions had no motion-reduce guard, yet reducedMotion claimed true — the global reset only covers the logo marquee. Added motion-reduce:transition-none + motion-reduce:hover:translate-y-0. Also added the missing unit test (axe + variant surface + reduced-motion guard)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ValueCard.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ValueCard.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ValueCard.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ValueCard.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "VisuallyHidden": {
       "preferredImport": "@dt/VisuallyHidden",
@@ -11301,7 +28044,132 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 3
+      "declaredPropCount": 3,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on VisuallyHidden pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "VisuallyHidden.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "VisuallyHidden.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "VisuallyHidden.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "VisuallyHidden.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "WipBadge": {
       "preferredImport": "@dt/WipBadge",
@@ -11360,7 +28228,131 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 2
+      "declaredPropCount": 2,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on WipBadge pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Beta promotion: Storybook-only chrome (carries data-axe-ignore + axeTestExempt so it never gates host component contrast). role=status announcement is non-disruptive and stable lifecycle hides it entirely. Forced-colors + light/dark verified via dedicated stories."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WipBadge.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WipBadge.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WipBadge.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WipBadge.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "WorkNav": {
       "preferredImport": "@dt/WorkNav",
@@ -11419,7 +28411,153 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass `currentPath` in stories/tests to drive the prev/next disabled state",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use this for site-wide navigation (that is SiteHeader)",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-16 beta->stable: production NextWorkNav now composes WorkNav with the live project registry while retaining prefetch and transition deduplication; required-story AT snapshots and Chromium forced-colors were recaptured."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkNav.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkNav.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkNav.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkNav.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "AboutHero": {
       "preferredImport": "@dt/AboutHero",
@@ -11486,7 +28624,139 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AboutHero.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AboutHero.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AboutHero.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AboutHero.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "AboutPageContent": {
       "preferredImport": "@dt/AboutPageContent",
@@ -11528,7 +28798,133 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 2
+      "declaredPropCount": 2,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on AboutPageContent pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, pattern-tier convention), forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AboutPageContent.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AboutPageContent.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AboutPageContent.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "AboutPageContent.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ArticleHero": {
       "preferredImport": "@dt/ArticleHero",
@@ -11614,7 +29010,139 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleHero.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleHero.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleHero.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleHero.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ArticleLayout": {
       "preferredImport": "@dt/ArticleLayout",
@@ -11691,7 +29219,139 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 9
+      "declaredPropCount": 9,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleLayout.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleLayout.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleLayout.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticleLayout.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ArticlePageTemplate": {
       "preferredImport": "@dt/ArticlePageTemplate",
@@ -11758,7 +29418,139 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 7
+      "declaredPropCount": 7,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticlePageTemplate.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticlePageTemplate.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticlePageTemplate.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ArticlePageTemplate.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "BlogHero": {
       "preferredImport": "@dt/BlogHero",
@@ -11837,7 +29629,139 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 7
+      "declaredPropCount": 7,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogHero.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogHero.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogHero.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogHero.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "BlogIndexContent": {
       "preferredImport": "@dt/BlogIndexContent",
@@ -11927,7 +29851,139 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 9
+      "declaredPropCount": 9,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogIndexContent.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogIndexContent.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogIndexContent.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "BlogIndexContent.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "CTASection": {
       "preferredImport": "@dt/CTASection",
@@ -12030,7 +30086,133 @@
         "HighlightSection"
       ],
       "prefersOver": [],
-      "declaredPropCount": 9
+      "declaredPropCount": 9,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on CTASection pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, sibling SiteFooter convention), forced-colors pass re-verified in real browser, consumers audited (12 production pages each)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CTASection.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CTASection.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CTASection.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CTASection.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "CVDownloadSection": {
       "preferredImport": "@dt/CVDownloadSection",
@@ -12092,7 +30274,139 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 5
+      "declaredPropCount": 5,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CVDownloadSection.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CVDownloadSection.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CVDownloadSection.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "CVDownloadSection.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ContactHero": {
       "preferredImport": "@dt/ContactHero",
@@ -12153,7 +30467,133 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 5
+      "declaredPropCount": 5,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on ContactHero pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, pattern-tier convention), forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactHero.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactHero.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactHero.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactHero.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ContactInquiryPanel": {
       "preferredImport": "@dt/ContactInquiryPanel",
@@ -12223,7 +30663,159 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "pass ContactFormEditorial (or success state) as `messagePanel`",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "use on contact page via ContactPageContentEditorial",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "mount without messagePanel slot",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "duplicate tablist landmarks on the same page",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "unverified",
+          "note": "Play-function exempt: Tab switching defers to native button focus; booking embed is third-party when configured."
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-06-06 — tab keyboard pattern, panel visibility, and ForcedColors story verified in Storybook. 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, pattern-tier convention), forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactInquiryPanel.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactInquiryPanel.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactInquiryPanel.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactInquiryPanel.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ContactPageContentEditorial": {
       "preferredImport": "@dt/ContactPageContentEditorial",
@@ -12279,7 +30871,133 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on ContactPageContentEditorial pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, pattern-tier convention), forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactPageContentEditorial.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactPageContentEditorial.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactPageContentEditorial.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContactPageContentEditorial.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ContentSection": {
       "preferredImport": "@dt/ContentSection",
@@ -12367,7 +31085,139 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 9
+      "declaredPropCount": 9,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContentSection.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContentSection.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContentSection.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ContentSection.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "DesignSprintsSection": {
       "preferredImport": "@dt/DesignSprintsSection",
@@ -12421,7 +31271,133 @@
         "HighlightSection"
       ],
       "prefersOver": [],
-      "declaredPropCount": 3
+      "declaredPropCount": 3,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on DesignSprintsSection pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, pattern-tier convention), forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "DesignSprintsSection.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "DesignSprintsSection.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "DesignSprintsSection.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "DesignSprintsSection.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Footer": {
       "preferredImport": "@dt/Footer",
@@ -12456,7 +31432,132 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 1
+      "declaredPropCount": 1,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on Footer pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Footer.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Footer.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Footer.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Footer.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "GridBlock": {
       "preferredImport": "@dt/GridBlock",
@@ -12562,7 +31663,133 @@
         "TeamBlock"
       ],
       "prefersOver": [],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on GridBlock pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, sibling SiteFooter convention), forced-colors pass re-verified in real browser, consumers audited (12 production pages each)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "GridBlock.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "GridBlock.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "GridBlock.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "GridBlock.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "Hero": {
       "preferredImport": "@dt/Hero",
@@ -12723,7 +31950,132 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 16
+      "declaredPropCount": 16,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on Hero pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-10 — Deprecated: no production consumers (barrel re-exports only, verified via computeConsumersForComponent); compose HeroSection or use a specialized hero instead."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Hero.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Hero.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Hero.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "Hero.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "HeroSection": {
       "preferredImport": "@dt/HeroSection",
@@ -13011,7 +32363,133 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 9
+      "declaredPropCount": 9,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on HeroSection pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, pattern-tier convention), forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "HeroSection.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "HeroSection.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "HeroSection.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "HeroSection.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "HighlightSection": {
       "preferredImport": "@dt/HighlightSection",
@@ -13129,7 +32607,133 @@
         "DesignSprintsSection"
       ],
       "prefersOver": [],
-      "declaredPropCount": 10
+      "declaredPropCount": 10,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on HighlightSection pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, pattern-tier convention), forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "HighlightSection.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "HighlightSection.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "HighlightSection.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "HighlightSection.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "HomeHero": {
       "preferredImport": "@dt/HomeHero",
@@ -13178,7 +32782,133 @@
         "HighlightSection"
       ],
       "prefersOver": [],
-      "declaredPropCount": 2
+      "declaredPropCount": 2,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on HomeHero pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, pattern-tier convention), forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "HomeHero.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "HomeHero.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "HomeHero.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "HomeHero.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ManifestoSection": {
       "preferredImport": "@dt/ManifestoSection",
@@ -13245,7 +32975,139 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ManifestoSection.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ManifestoSection.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ManifestoSection.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ManifestoSection.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "NewsBulletin": {
       "preferredImport": "@dt/NewsBulletin",
@@ -13306,7 +33168,159 @@
         "HighlightSection"
       ],
       "prefersOver": [],
-      "declaredPropCount": 2
+      "declaredPropCount": 2,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "use for homepage footer-adjacent topical snippets from `NEWS_BULLETIN_ITEMS`",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "keep badge + body copy synchronized with the data module for all locales",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use for full blog indexes or article lists",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "replace with generic Card stacks without region semantics",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "unverified",
+          "note": "Play-function exempt: Marquee animation defers to CSS; keyboard order follows DOM link sequence."
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-06-06 — card labels, link targets, and ForcedColors story verified in Storybook. 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, pattern-tier convention), forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NewsBulletin.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NewsBulletin.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NewsBulletin.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "NewsBulletin.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "PageLayout": {
       "preferredImport": "@dt/PageLayout",
@@ -13409,7 +33423,133 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 11
+      "declaredPropCount": 11,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on PageLayout pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, sibling SiteFooter convention), forced-colors pass re-verified in real browser, consumers audited (12 production pages each)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PageLayout.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PageLayout.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PageLayout.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PageLayout.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "PricingCalculator": {
       "preferredImport": "@dt/PricingCalculator",
@@ -13462,7 +33602,159 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 1
+      "declaredPropCount": 1,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "keep all price maths in `pricingMath.ts`",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "format totals via `Intl.NumberFormat` on the active language",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "use for fixed-scope package pricing (packages section owns that)",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "duplicate the pricing model in other components",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-18 — Initial beta: native radio groups via SelectableCardGroup (keyboard + AT from the platform), axe assertion in unit tests, ForcedColors story added. 2026-07-18 — Promoted to stable: 4-mode AT snapshots recaptured via the story runner, forced-colors compare pass and controls audit green, 6 production consumers on the pricing page chain."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PricingCalculator.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PricingCalculator.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PricingCalculator.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PricingCalculator.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "PricingPageContent": {
       "preferredImport": "@dt/PricingPageContent",
@@ -13509,7 +33801,159 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 1
+      "declaredPropCount": 1,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "use as full pricing page assembly via PricingPage",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "keep copy in i18n keys — component reads translation defaults",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "embed single package card without page context",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without visual baseline on stable fleet",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "unverified",
+          "note": "Play-function exempt: Page assembly; interactive CTAs inherit Button and Link primitives."
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-06-06 — package cards, comparison table, and ForcedColors story verified in Storybook. 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, pattern-tier convention), forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PricingPageContent.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PricingPageContent.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PricingPageContent.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "PricingPageContent.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ProcessBlock": {
       "preferredImport": "@dt/ProcessBlock",
@@ -13612,7 +34056,133 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 10
+      "declaredPropCount": 10,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on ProcessBlock pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, sibling SiteFooter convention), forced-colors pass re-verified in real browser, consumers audited (12 production pages each)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProcessBlock.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProcessBlock.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProcessBlock.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProcessBlock.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ProjectDetailLayout": {
       "preferredImport": "@dt/ProjectDetailLayout",
@@ -13691,7 +34261,139 @@
         "TeamBlock"
       ],
       "prefersOver": [],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectDetailLayout.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectDetailLayout.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectDetailLayout.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectDetailLayout.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ProjectDetailTemplate": {
       "preferredImport": "@dt/ProjectDetailTemplate",
@@ -13763,7 +34465,139 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectDetailTemplate.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectDetailTemplate.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectDetailTemplate.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectDetailTemplate.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ProjectHero": {
       "preferredImport": "@dt/ProjectHero",
@@ -13874,7 +34708,139 @@
         "TeamBlock"
       ],
       "prefersOver": [],
-      "declaredPropCount": 11
+      "declaredPropCount": 11,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectHero.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectHero.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectHero.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectHero.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ProjectMetaSection": {
       "preferredImport": "@dt/ProjectMetaSection",
@@ -13975,7 +34941,139 @@
         "TeamBlock"
       ],
       "prefersOver": [],
-      "declaredPropCount": 10
+      "declaredPropCount": 10,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectMetaSection.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectMetaSection.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectMetaSection.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProjectMetaSection.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ProofBlock": {
       "preferredImport": "@dt/ProofBlock",
@@ -14045,7 +35143,133 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on ProofBlock pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, pattern-tier convention), forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProofBlock.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProofBlock.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProofBlock.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ProofBlock.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "RelatedPosts": {
       "preferredImport": "@dt/RelatedPosts",
@@ -14097,7 +35321,139 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "RelatedPosts.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "RelatedPosts.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "RelatedPosts.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "RelatedPosts.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "RelatedProjects": {
       "preferredImport": "@dt/RelatedProjects",
@@ -14156,7 +35512,139 @@
         "TeamBlock"
       ],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "RelatedProjects.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "RelatedProjects.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "RelatedProjects.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "RelatedProjects.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ServicesBlock": {
       "preferredImport": "@dt/ServicesBlock",
@@ -14269,7 +35757,133 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 13
+      "declaredPropCount": 13,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on ServicesBlock pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, pattern-tier convention), forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ServicesBlock.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ServicesBlock.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ServicesBlock.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ServicesBlock.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ServicesSection": {
       "preferredImport": "@dt/ServicesSection",
@@ -14354,7 +35968,133 @@
         "HighlightSection"
       ],
       "prefersOver": [],
-      "declaredPropCount": 8
+      "declaredPropCount": 8,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on ServicesSection pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, pattern-tier convention), forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ServicesSection.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ServicesSection.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ServicesSection.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ServicesSection.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "SiteFooter": {
       "preferredImport": "@dt/SiteFooter",
@@ -14371,13 +36111,13 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "keep the social link list as a single source-of-truth const.",
-        "pass the `aria-label` translation key for each social link."
+        "keep the social link list as a single source-of-truth const. Adding a channel = edit the const + the i18n keys.",
+        "pass the `aria-label` translation key for each social link. Skipping it makes AT users hear the SVG fallback (which is empty) instead of the channel name."
       ],
       "avoidWhen": [
-        "mount more than one SiteFooter. AT users encounter two",
-        "hand-author a `<footer>` instead of using SiteFooter on a",
-        "change the Divider's margin via `className=\"my-X\"` without"
+        "mount more than one SiteFooter. AT users encounter two contentinfo landmarks and the page's IA breaks.",
+        "hand-author a `<footer>` instead of using SiteFooter on a new route. Any new route inherits the SiteFooter from `app/layout.tsx`; rolling your own bypasses the i18n, theme, and legal-link maintenance work.",
+        "change the Divider's margin via `className=\"my-X\"` without checking the cascade-layer fix in Divider.module.css. The `@layer components` wrapper is what lets `my-8` win; pre-fix this was a regression source."
       ],
       "requiredA11y": [
         "contentinfo landmark",
@@ -14395,13 +36135,172 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "mount more than one SiteFooter. AT users encounter two",
-        "hand-author a `<footer>` instead of using SiteFooter on a",
-        "change the Divider's margin via `className=\"my-X\"` without"
+        "mount more than one SiteFooter. AT users encounter two contentinfo landmarks and the page's IA breaks.",
+        "hand-author a `<footer>` instead of using SiteFooter on a new route. Any new route inherits the SiteFooter from `app/layout.tsx`; rolling your own bypasses the i18n, theme, and legal-link maintenance work.",
+        "change the Divider's margin via `className=\"my-X\"` without checking the cascade-layer fix in Divider.module.css. The `@layer components` wrapper is what lets `my-8` win; pre-fix this was a regression source."
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 1
+      "declaredPropCount": 1,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "keep the social link list as a single source-of-truth const",
+          "rationale": "Adding a channel = edit the const + the i18n keys.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass the `aria-label` translation key for each social link",
+          "rationale": "Skipping it makes AT users hear the SVG fallback (which is empty) instead of the channel name.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "mount more than one SiteFooter",
+          "rationale": "AT users encounter two contentinfo landmarks and the page's IA breaks.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "hand-author a `<footer>` instead of using SiteFooter on a new route",
+          "rationale": "Any new route inherits the SiteFooter from `app/layout.tsx`; rolling your own bypasses the i18n, theme, and legal-link maintenance work.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "change the Divider's margin via `className=\"my-X\"` without checking the cascade-layer fix in Divider.module.css",
+          "rationale": "The `@layer components` wrapper is what lets `my-8` win; pre-fix this was a regression source.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "unverified",
+          "note": "Play-function exempt: Footer is mostly links; interaction is standard Tab navigation."
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-26 — production behavior verified in Storybook; argTypes and required stories aligned with validate:components."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SiteFooter.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SiteFooter.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SiteFooter.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SiteFooter.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "SiteHeader": {
       "preferredImport": "@dt/SiteHeader",
@@ -14423,13 +36322,13 @@
       "cvaVariants": {},
       "variantsFnName": null,
       "useWhen": [
-        "mount once globally. The scroll listener and sticky behaviour",
-        "pass `navItems` with translated labels' *keys*, not the"
+        "mount once globally. The scroll listener and sticky behaviour assume a single instance.",
+        "pass `navItems` with translated labels' *keys*, not the resolved strings. The component runs the labels through `t()` so language switching works without a remount."
       ],
       "avoidWhen": [
-        "tamper with the IconButton variants. The header's theme",
-        "nest a `<header>` inside SiteHeader. Multiple banner",
-        "hard-code the language list. The `languages` array is the"
+        "tamper with the IconButton variants. The header's theme cycle uses `variant=\"ghost\"` to stay transparent at scroll-top; a filled variant would defeat the layered surface treatment.",
+        "nest a `<header>` inside SiteHeader. Multiple banner landmarks confuse AT users.",
+        "hard-code the language list. The `languages` array is the single source of truth — adding Finnish swedish (lol) means editing the array and adding the `langXX` / `langXX_ariaLabel` i18n keys."
       ],
       "requiredA11y": [
         "nav landmark",
@@ -14441,7 +36340,7 @@
         "Escape"
       ],
       "compositionRules": [
-        "nest a `<header>` inside SiteHeader. Multiple banner"
+        "nest a `<header>` inside SiteHeader. Multiple banner landmarks confuse AT users."
       ],
       "canonicalExamples": [
         "Default",
@@ -14451,13 +36350,172 @@
       ],
       "replacementFor": [],
       "forbiddenUse": [
-        "tamper with the IconButton variants. The header's theme",
-        "nest a `<header>` inside SiteHeader. Multiple banner",
-        "hard-code the language list. The `languages` array is the"
+        "tamper with the IconButton variants. The header's theme cycle uses `variant=\"ghost\"` to stay transparent at scroll-top; a filled variant would defeat the layered surface treatment.",
+        "nest a `<header>` inside SiteHeader. Multiple banner landmarks confuse AT users.",
+        "hard-code the language list. The `languages` array is the single source of truth — adding Finnish swedish (lol) means editing the array and adding the `langXX` / `langXX_ariaLabel` i18n keys."
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 2
+      "declaredPropCount": 2,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "mount once globally",
+          "rationale": "The scroll listener and sticky behaviour assume a single instance.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "pass `navItems` with translated labels' *keys*, not the resolved strings",
+          "rationale": "The component runs the labels through `t()` so language switching works without a remount.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "tamper with the IconButton variants",
+          "rationale": "The header's theme cycle uses `variant=\"ghost\"` to stay transparent at scroll-top; a filled variant would defeat the layered surface treatment.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "nest a `<header>` inside SiteHeader",
+          "rationale": "Multiple banner landmarks confuse AT users.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "hard-code the language list",
+          "rationale": "The `languages` array is the single source of truth — adding Finnish swedish (lol) means editing the array and adding the `langXX` / `langXX_ariaLabel` i18n keys.",
+          "rationaleSource": "inferred",
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "unverified",
+          "note": "Play-function exempt: Header composition; keyboard flows are covered in MobileDrawer and nav link Tab order — add story play when drawer story is split out."
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-26 — production behavior verified in Storybook; argTypes and required stories aligned with validate:components."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SiteHeader.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SiteHeader.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SiteHeader.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SiteHeader.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "StatsSection": {
       "preferredImport": "@dt/StatsSection",
@@ -14511,7 +36569,139 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "StatsSection.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "StatsSection.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "StatsSection.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "StatsSection.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "StoryBlock": {
       "preferredImport": "@dt/StoryBlock",
@@ -14633,7 +36823,133 @@
         "TeamBlock"
       ],
       "prefersOver": [],
-      "declaredPropCount": 11
+      "declaredPropCount": 11,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on StoryBlock pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, sibling SiteFooter convention), forced-colors pass re-verified in real browser, consumers audited (12 production pages each)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "StoryBlock.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "StoryBlock.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "StoryBlock.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "StoryBlock.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "TeamBlock": {
       "preferredImport": "@dt/TeamBlock",
@@ -14748,7 +37064,133 @@
         "RelatedProjects"
       ],
       "prefersOver": [],
-      "declaredPropCount": 11
+      "declaredPropCount": 11,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on TeamBlock pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled. 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, pattern-tier convention), forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TeamBlock.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TeamBlock.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TeamBlock.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TeamBlock.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "ValuesSection": {
       "preferredImport": "@dt/ValuesSection",
@@ -14829,7 +37271,139 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 7
+      "declaredPropCount": 7,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ValuesSection.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ValuesSection.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ValuesSection.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "ValuesSection.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "WorkCTA": {
       "preferredImport": "@dt/WorkCTA",
@@ -14876,7 +37450,139 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 3
+      "declaredPropCount": 3,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkCTA.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkCTA.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkCTA.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkCTA.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "WorkHero": {
       "preferredImport": "@dt/WorkHero",
@@ -14928,7 +37634,139 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 4
+      "declaredPropCount": 4,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "compose from cataloged @dt/* atoms and molecules for new UI in this surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "treat this as a page assembly reference when matching production routes",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "invent parallel primitives inside this folder",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "promote to stable without production consumer evidence",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkHero.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkHero.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkHero.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkHero.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "WorkMagneticField": {
       "preferredImport": "@dt/WorkMagneticField",
@@ -14997,7 +37835,133 @@
         "HighlightSection"
       ],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on WorkMagneticField pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, pattern-tier convention), forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkMagneticField.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkMagneticField.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkMagneticField.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkMagneticField.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     },
     "WorkPreviewSection": {
       "preferredImport": "@dt/WorkPreviewSection",
@@ -15073,7 +38037,133 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 6
+      "declaredPropCount": 6,
+      "guidelines": [
+        {
+          "level": "should",
+          "guidance": "Match the **Example** story composition on WorkPreviewSection pages.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should-not",
+          "guidance": "Bypass design tokens or skip forced-colors verification at beta.",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        }
+      ],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error). 2026-07-09 — Promoted beta→stable: AT snapshots captured for all required stories (base mode, pattern-tier convention), forced-colors re-verified in a real browser, consumers audited."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkPreviewSection.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkPreviewSection.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkPreviewSection.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "WorkPreviewSection.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
     }
   }
 }

--- a/nextjs-app/shared/patterns/SiteFooter/SiteFooter.contract.json
+++ b/nextjs-app/shared/patterns/SiteFooter/SiteFooter.contract.json
@@ -77,8 +77,8 @@
         }
     },
     "forbiddenUse": [
-        "mount more than one SiteFooter. AT users encounter two",
-        "hand-author a `<footer>` instead of using SiteFooter on a",
-        "change the Divider's margin via `className=\"my-X\"` without"
+        "mount more than one SiteFooter. AT users encounter two contentinfo landmarks and the page's IA breaks.",
+        "hand-author a `<footer>` instead of using SiteFooter on a new route. Any new route inherits the SiteFooter from `app/layout.tsx`; rolling your own bypasses the i18n, theme, and legal-link maintenance work.",
+        "change the Divider's margin via `className=\"my-X\"` without checking the cascade-layer fix in Divider.module.css. The `@layer components` wrapper is what lets `my-8` win; pre-fix this was a regression source."
     ]
 }

--- a/nextjs-app/shared/patterns/SiteHeader/SiteHeader.contract.json
+++ b/nextjs-app/shared/patterns/SiteHeader/SiteHeader.contract.json
@@ -96,8 +96,8 @@
         }
     },
     "forbiddenUse": [
-        "tamper with the IconButton variants. The header's theme",
-        "nest a `<header>` inside SiteHeader. Multiple banner",
-        "hard-code the language list. The `languages` array is the"
+        "tamper with the IconButton variants. The header's theme cycle uses `variant=\"ghost\"` to stay transparent at scroll-top; a filled variant would defeat the layered surface treatment.",
+        "nest a `<header>` inside SiteHeader. Multiple banner landmarks confuse AT users.",
+        "hard-code the language list. The `languages` array is the single source of truth — adding Finnish swedish (lol) means editing the array and adding the `langXX` / `langXX_ariaLabel` i18n keys."
     ]
 }

--- a/package.json
+++ b/package.json
@@ -199,7 +199,10 @@
     "check:dogfood-ratchet": "node scripts/design-system/check-dogfood-ratchet.mjs",
     "check:figma-links": "node scripts/design-system/check-figma-links.mjs",
     "check:rendered-parity": "node scripts/design-system/check-rendered-parity.mjs",
-    "check:rendered-parity:ci": "concurrently -k -s first -n SB,PARITY \"npm run storybook -- --ci --no-open --quiet\" \"npm run storybook:wait && npm run check:rendered-parity\""
+    "check:rendered-parity:ci": "concurrently -k -s first -n SB,PARITY \"npm run storybook -- --ci --no-open --quiet\" \"npm run storybook:wait && npm run check:rendered-parity\"",
+    "check:doc-semantics": "node scripts/design-system/check-doc-semantics.mjs",
+    "check:doc-semantics:json": "node scripts/design-system/check-doc-semantics.mjs --json",
+    "project:dsds": "node scripts/design-system/project-dsds.mjs"
   },
   "dependencies": {
     "@ai-sdk/mcp": "^2.0.10",

--- a/scripts/design-system/build-component-agent-blocks.ts
+++ b/scripts/design-system/build-component-agent-blocks.ts
@@ -12,10 +12,12 @@ import {
 } from "./validate-components.ts";
 import {
   parseSpecAgentHints,
+  parseSpecGuidelines,
   extractSpecIntent,
   pickAgentIntent,
   sanitizeAgentProseLine,
 } from "./parse-spec-agent-hints.mjs";
+import { deriveA11yCriteria } from "./derive-a11y-criteria.mjs";
 import {
   getReplacementFor,
   getPrefersOver,
@@ -459,6 +461,41 @@ function main() {
       forbiddenUse: getForbiddenUse(entry.name, avoidWhen),
       ...getGraphRelations(entry.name),
       declaredPropCount: extracted.declaredPropNames.length,
+      /**
+       * RFC 2119 guidance. useWhen/avoidWhen stay above as flat prose for existing
+       * consumers; this carries the same rules with a level and, where the author gave
+       * one, a rationale. A `must-not` here is a hard gate for an agent writing code.
+       */
+      guidelines: parseSpecGuidelines(spec),
+      /** Accessibility criteria that declare how each one is verified. */
+      a11yCriteria: deriveA11yCriteria(contract),
+      /**
+       * Provenance per block. Agents must not "correct" human-authored intent toward
+       * what the code appears to do, and a regen silently overwrites anything marked
+       * generated. Without this the two are indistinguishable in the output.
+       */
+      docOrigin: {
+        props: { origin: "generated", authorship: "machine-generated", from: "TypeScript AST" },
+        variants: { origin: "generated", authorship: "machine-generated", from: "TypeScript AST" },
+        cvaVariants: { origin: "generated", authorship: "machine-generated", from: "TypeScript AST" },
+        propRelationships: { origin: "generated", authorship: "machine-generated", from: "TypeScript AST" },
+        canonicalExamples: { origin: "generated", authorship: "machine-generated", from: "stories.tsx" },
+        declaredPropCount: { origin: "generated", authorship: "machine-generated", from: "TypeScript AST" },
+        intent: { origin: "authored", authorship: "human-authored", from: `${entry.name}.spec.md` },
+        useWhen: { origin: "authored", authorship: "human-authored", from: `${entry.name}.spec.md` },
+        avoidWhen: { origin: "authored", authorship: "human-authored", from: `${entry.name}.spec.md` },
+        guidelines: { origin: "authored", authorship: "human-authored", from: `${entry.name}.spec.md` },
+        requiredA11y: { origin: "authored", authorship: "human-authored", from: "contract.json" },
+        keyboard: { origin: "authored", authorship: "human-authored", from: "contract.json" },
+        // Derived: a rule set applied to authored contract fields. Neither purely
+        // machine-read nor hand-written, and mislabelling it either way would be a lie.
+        a11yCriteria: { origin: "derived", authorship: "mixed", from: "contract.a11y + derive-a11y-criteria.mjs" },
+        compositionRules: { origin: "derived", authorship: "mixed", from: "avoidWhen filter" },
+        forbiddenUse: { origin: "derived", authorship: "mixed", from: "avoidWhen + replacement policy" },
+        replacementFor: { origin: "derived", authorship: "mixed", from: "replacement policy" },
+      },
+      governance: contract.governance ?? null,
+      content: contract.content ?? null,
     };
   }
 

--- a/scripts/design-system/check-doc-semantics.mjs
+++ b/scripts/design-system/check-doc-semantics.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/**
+ * Report on the documentation-semantics layer: RFC 2119 guideline levels, accessibility
+ * criteria verification modes, and governance staleness.
+ *
+ * Reports by default, fails only with --strict (or a ratchet breach). The point is to
+ * make three previously invisible things countable:
+ *
+ *   1. Guidance that carries no explicit severity, so an agent cannot tell a hard rule
+ *      from a preference.
+ *   2. Accessibility requirements that are documented but proven by nothing.
+ *   3. Components whose documentation no human has read in a long time.
+ *
+ * None of these were expressible before: guidance was flat prose, a11y state was a set
+ * of booleans that could not say who checked them, and nothing recorded review dates.
+ *
+ * Usage:
+ *   node scripts/design-system/check-doc-semantics.mjs           # report
+ *   node scripts/design-system/check-doc-semantics.mjs --json     # machine-readable
+ *   node scripts/design-system/check-doc-semantics.mjs --strict   # fail on ratchet breach
+ */
+import { readFileSync, existsSync, writeFileSync } from "node:fs";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const BLOCKS = join(ROOT, "nextjs-app/shared/foundations/dist/component-agent-blocks.json");
+const RATCHET = join(ROOT, "scripts/design-system/doc-semantics-ratchet.json");
+
+const STRICT = process.argv.includes("--strict");
+const JSON_OUT = process.argv.includes("--json");
+const UPDATE_RATCHET = process.argv.includes("--update-ratchet");
+
+/** Days after which a lastReviewed date is considered stale. */
+const STALE_DAYS = 180;
+
+function main() {
+  if (!existsSync(BLOCKS)) {
+    console.error("FAIL: component-agent-blocks.json missing. Run: npm run build:agent-blocks");
+    process.exit(1);
+  }
+  const { components } = JSON.parse(readFileSync(BLOCKS, "utf8"));
+  const names = Object.keys(components);
+
+  const report = {
+    components: names.length,
+    guidelines: { total: 0, explicitLevel: 0, defaulted: 0, withRationale: 0, hardRules: 0, hardRulesMissingRationale: [] },
+    a11yCriteria: { total: 0, automated: 0, manual: 0, unverified: 0, worstOffenders: [] },
+    governance: { withOwner: 0, withLastReviewed: 0, stale: [], missing: [] },
+    content: { withContent: 0 },
+  };
+
+  const today = new Date();
+  const unverifiedByComponent = [];
+
+  for (const [name, block] of Object.entries(components)) {
+    // --- Guidelines (RFC 2119) ---
+    for (const g of block.guidelines ?? []) {
+      report.guidelines.total += 1;
+      // A defaulted level is the parser's fallback, not an author's decision.
+      if (g.level === "should" || g.level === "should-not") report.guidelines.defaulted += 1;
+      else report.guidelines.explicitLevel += 1;
+      if (g.rationale) report.guidelines.withRationale += 1;
+      if (g.level === "must" || g.level === "must-not") {
+        report.guidelines.hardRules += 1;
+        // DSDS: a hard rule without a reason is unactionable when an agent hits a conflict.
+        if (!g.rationale) {
+          report.guidelines.hardRulesMissingRationale.push(`${name}: ${g.guidance.slice(0, 70)}`);
+        }
+      }
+    }
+
+    // --- Accessibility criteria ---
+    const criteria = block.a11yCriteria ?? [];
+    let unverified = 0;
+    for (const c of criteria) {
+      report.a11yCriteria.total += 1;
+      if (c.verificationMode === "automated") report.a11yCriteria.automated += 1;
+      else if (c.verificationMode === "manual") report.a11yCriteria.manual += 1;
+      else {
+        report.a11yCriteria.unverified += 1;
+        unverified += 1;
+      }
+    }
+    if (unverified > 0) unverifiedByComponent.push({ name, unverified, total: criteria.length });
+
+    // --- Governance ---
+    const gov = block.governance;
+    if (gov?.owner) report.governance.withOwner += 1;
+    if (gov?.lastReviewed) {
+      report.governance.withLastReviewed += 1;
+      const days = Math.floor((today - new Date(gov.lastReviewed)) / 86400000);
+      if (days > STALE_DAYS) report.governance.stale.push({ name, lastReviewed: gov.lastReviewed, days });
+    } else {
+      report.governance.missing.push(name);
+    }
+
+    if (block.content) report.content.withContent += 1;
+  }
+
+  unverifiedByComponent.sort((a, b) => b.unverified - a.unverified);
+  report.a11yCriteria.worstOffenders = unverifiedByComponent.slice(0, 10);
+
+  if (JSON_OUT) {
+    console.log(JSON.stringify(report, null, 2));
+    return finish(report);
+  }
+
+  const g = report.guidelines;
+  const a = report.a11yCriteria;
+  const gov = report.governance;
+
+  console.log(`\nDoc semantics — ${report.components} components\n`);
+
+  console.log("RFC 2119 guidelines");
+  console.log(`  total                    ${g.total}`);
+  console.log(`  explicit level           ${g.explicitLevel}  (author chose must/may)`);
+  console.log(`  defaulted to should      ${g.defaulted}  (parser fallback, no author decision)`);
+  console.log(`  with rationale           ${g.withRationale}`);
+  console.log(`  hard rules (must/-not)   ${g.hardRules}`);
+  if (g.hardRulesMissingRationale.length) {
+    console.log(`  ! hard rules with no rationale: ${g.hardRulesMissingRationale.length}`);
+    for (const r of g.hardRulesMissingRationale.slice(0, 5)) console.log(`      ${r}`);
+  }
+
+  console.log("\nAccessibility criteria");
+  console.log(`  total                    ${a.total}`);
+  console.log(`  automated (named check)  ${a.automated}`);
+  console.log(`  manual (human claim)     ${a.manual}`);
+  console.log(`  unverified (nothing)     ${a.unverified}`);
+  if (a.worstOffenders.length) {
+    console.log("  most unverified:");
+    for (const o of a.worstOffenders.slice(0, 5)) {
+      console.log(`      ${o.name}: ${o.unverified}/${o.total}`);
+    }
+  }
+
+  console.log("\nGovernance");
+  console.log(`  with owner               ${gov.withOwner}`);
+  console.log(`  with lastReviewed        ${gov.withLastReviewed}`);
+  console.log(`  stale (>${STALE_DAYS}d)            ${gov.stale.length}`);
+  console.log(`  never reviewed           ${gov.missing.length}`);
+
+  console.log(`\nContent guidance          ${report.content.withContent}/${report.components}\n`);
+
+  return finish(report);
+}
+
+/**
+ * Ratchet: the unverified-criteria count must never grow. This is the one number that
+ * represents real accessibility risk, so it is the one that is allowed to fail a build.
+ */
+function finish(report) {
+  const current = report.a11yCriteria.unverified;
+
+  if (UPDATE_RATCHET) {
+    writeFileSync(RATCHET, `${JSON.stringify({ maxUnverifiedA11yCriteria: current }, null, 2)}\n`);
+    console.log(`✓ ratchet updated: maxUnverifiedA11yCriteria = ${current}`);
+    return;
+  }
+
+  if (!existsSync(RATCHET)) return;
+  const { maxUnverifiedA11yCriteria: ceiling } = JSON.parse(readFileSync(RATCHET, "utf8"));
+
+  if (current > ceiling) {
+    console.error(
+      `FAIL: unverified a11y criteria ${current} > ceiling ${ceiling}. ` +
+        `Verify the new requirement or record why it cannot be.`,
+    );
+    process.exit(1);
+  }
+  if (current < ceiling && STRICT) {
+    console.error(
+      `FAIL: unverified a11y criteria dropped to ${current} (ceiling ${ceiling}). ` +
+        `Lower the ceiling: node scripts/design-system/check-doc-semantics.mjs --update-ratchet`,
+    );
+    process.exit(1);
+  }
+  console.log(`✓ unverified a11y criteria ${current} <= ceiling ${ceiling}`);
+}
+
+main();

--- a/scripts/design-system/contract.schema.v2.json
+++ b/scripts/design-system/contract.schema.v2.json
@@ -301,6 +301,65 @@
                             }
                         }
                     ]
+                },
+                "criteria": {
+                    "type": "array",
+                    "description": "Testable accessibility criteria, each declaring HOW it is verified. Modelled on the DSDS `criterion` type. The sibling booleans (reviewed, forcedColorsVerified, accessibilityTreeVerified, realBrowserForcedColorsVerified, screenReaderVerified) each assert that something was checked but not by what, so a machine-verified claim and a human claim are indistinguishable once written. A criterion names its verification mode and, when automated, the npm script that proves it. Derived automatically from the sibling booleans by derive-a11y-criteria.mjs; hand-authored entries may be added for component-specific requirements.",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "id",
+                            "statement",
+                            "verificationMode"
+                        ],
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+                                "description": "Stable kebab-case identifier, unique within the component."
+                            },
+                            "statement": {
+                                "type": "string",
+                                "minLength": 10,
+                                "description": "What must hold, phrased as a testable assertion."
+                            },
+                            "verificationMode": {
+                                "enum": [
+                                    "automated",
+                                    "manual",
+                                    "unverified"
+                                ],
+                                "description": "automated: a named check proves it on every run. manual: a human asserted it once, on a date. unverified: the requirement is documented but nothing confirms it. 'unverified' is deliberately expressible so gaps are visible rather than absent."
+                            },
+                            "check": {
+                                "type": "string",
+                                "minLength": 1,
+                                "description": "The npm script or CI job that proves this criterion. Required when verificationMode is 'automated'."
+                            },
+                            "lastVerified": {
+                                "type": "string",
+                                "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                "description": "ISO date of the manual pass. Meaningful only when verificationMode is 'manual'; automated criteria are proven on every run and need no date."
+                            },
+                            "note": {
+                                "type": "string",
+                                "minLength": 1,
+                                "description": "Evidence, tooling used, or known limitation."
+                            }
+                        },
+                        "allOf": [
+                            {
+                                "if": {
+                                    "properties": {
+                                        "verificationMode": { "const": "automated" }
+                                    },
+                                    "required": ["verificationMode"]
+                                },
+                                "then": { "required": ["check"] }
+                            }
+                        ]
+                    }
                 }
             }
         },
@@ -586,6 +645,85 @@
             "type": "string",
             "minLength": 10,
             "maxLength": 200
+        },
+        "governance": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Accountability metadata. Modelled on the DSDS `governance` field: records who owns the documentation and when a human last read it end-to-end. Distinct from a11y.reviewed, which records an accessibility pass only. Staleness is surfaced (non-blocking) by check:doc-semantics.",
+            "properties": {
+                "owner": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Who is accountable for this component's documentation staying true. A person or a team handle."
+                },
+                "lastReviewed": {
+                    "type": "string",
+                    "format": "date",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    "description": "ISO date (YYYY-MM-DD) a human last read the full contract + spec.md and confirmed it matches the implementation. Not set by codegen: a regenerated props block does not mean anyone re-read the intent."
+                },
+                "note": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "What the review actually covered, and anything knowingly left stale."
+                }
+            }
+        },
+        "content": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "UX-writing guidance for copy rendered by or passed into this component. Modelled on the DSDS `content` block. Exists because EN/FI/SV copy is authored per locale and the constraints (sentence case, length ceilings, terms that must not be translated) are otherwise carried only in reviewers' heads.",
+            "properties": {
+                "voice": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "How copy in this component should sound, in one or two sentences."
+                },
+                "capitalization": {
+                    "enum": [
+                        "sentence",
+                        "title",
+                        "upper",
+                        "as-authored"
+                    ],
+                    "description": "Required capitalization for labels and headings this component renders."
+                },
+                "terminology": {
+                    "type": "array",
+                    "description": "Preferred term over rejected alternatives, with the reason.",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "prefer",
+                            "over"
+                        ],
+                        "properties": {
+                            "prefer": { "type": "string", "minLength": 1 },
+                            "over": {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": { "type": "string", "minLength": 1 }
+                            },
+                            "rationale": { "type": "string", "minLength": 1 }
+                        }
+                    }
+                },
+                "doNotTranslate": {
+                    "type": "array",
+                    "description": "Strings that must stay in English across FI and SV (product names, code identifiers, legal terms).",
+                    "items": { "type": "string", "minLength": 1 }
+                },
+                "maxLength": {
+                    "type": "object",
+                    "additionalProperties": { "type": "integer", "minimum": 1 },
+                    "description": "Per-slot character ceilings, keyed by prop or slot name. FI and SV routinely run 20-30% longer than EN, so a ceiling that passes in EN can still overflow."
+                },
+                "notes": {
+                    "type": "string",
+                    "minLength": 1
+                }
+            }
         }
     },
     "allOf": [

--- a/scripts/design-system/derive-a11y-criteria.mjs
+++ b/scripts/design-system/derive-a11y-criteria.mjs
@@ -1,0 +1,150 @@
+/**
+ * Derive DSDS-style accessibility criteria from a component contract's a11y block.
+ *
+ * The contract records accessibility state as booleans: reviewed, forcedColorsVerified,
+ * accessibilityTreeVerified, realBrowserForcedColorsVerified, screenReaderVerified.
+ * Each asserts that something was checked. None records *how*, so a claim proven by CI
+ * on every push and a claim a human made once in March are the same shape on disk.
+ *
+ * DSDS's `criterion` type splits those apart with `verificationMode`. This module does
+ * the same for our contracts, using the check names already documented in prose in
+ * contract.schema.v2.json. The mapping lives here, in one place, rather than in each of
+ * the 168 contracts.
+ *
+ * Deliberate design choice: a requirement that is documented but proven by nothing is
+ * emitted as `unverified` rather than omitted. An absent criterion looks like "not
+ * applicable"; an `unverified` criterion looks like what it is, which is a gap.
+ */
+
+/**
+ * Static criteria that apply to every component, gated on contract fields.
+ *
+ * `when` decides whether the criterion is emitted at all.
+ * `mode` decides automated / manual / unverified for the emitted criterion.
+ */
+const RULES = [
+  {
+    id: "axe-no-violations",
+    statement: "Required stories produce no axe violations at the configured severity.",
+    // Every component is in scope unless it carries a written exemption.
+    when: (a11y) => !a11y.axeTestExempt,
+    mode: () => ({ verificationMode: "automated", check: "npm run test:stories" }),
+  },
+  {
+    id: "accessibility-tree",
+    statement:
+      "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+    when: () => true,
+    mode: (a11y) =>
+      a11y.accessibilityTreeVerified
+        ? { verificationMode: "automated", check: "npm run test:stories" }
+        : { verificationMode: "unverified" },
+  },
+  {
+    id: "forced-colors-real-browser",
+    statement:
+      "The component remains legible and operable under a real browser forced-colors: active pass.",
+    when: () => true,
+    mode: (a11y) =>
+      a11y.realBrowserForcedColorsVerified
+        ? { verificationMode: "automated", check: "npm run test:stories:hc" }
+        : a11y.forcedColorsVerified
+          ? // The Storybook addon simulates forced-colors with CSS injection; that is a
+            // human-driven check against a simulation, not the real media query.
+            { verificationMode: "manual", note: "Storybook forced-colors addon (simulated, not real browser HC)." }
+          : { verificationMode: "unverified" },
+  },
+  {
+    id: "reduced-motion",
+    statement: "Positional, scale, and opacity motion is suppressed under prefers-reduced-motion.",
+    // Only meaningful for components that actually move.
+    when: (a11y) => a11y.motion === true,
+    mode: (a11y) =>
+      a11y.reducedMotion ? { verificationMode: "manual" } : { verificationMode: "unverified" },
+  },
+  {
+    id: "keyboard-contract",
+    statement: "Every documented keyboard interaction works as specified.",
+    when: (a11y) => Array.isArray(a11y.keyboard) && a11y.keyboard.length > 0,
+    mode: (a11y, contract) =>
+      // A play function exercises the keyboard path in CI. An exemption means nobody does.
+      a11y.playFunctionExempt
+        ? { verificationMode: "unverified", note: `Play-function exempt: ${a11y.playFunctionExempt}` }
+        : contract.status === "alpha"
+          ? { verificationMode: "manual" }
+          : { verificationMode: "automated", check: "npm run test:stories" },
+  },
+  {
+    id: "aria-requirements",
+    statement: "Documented ARIA roles, states, and properties are present on the rendered output.",
+    when: (a11y) => Array.isArray(a11y.ariaRequirements) && a11y.ariaRequirements.length > 0,
+    mode: (a11y) =>
+      a11y.accessibilityTreeVerified
+        ? { verificationMode: "automated", check: "npm run test:stories" }
+        : { verificationMode: "unverified" },
+  },
+  {
+    id: "screen-reader",
+    statement: "Announcements were verified against a real screen reader, beyond the a11y tree.",
+    // Aspirational: only emitted where someone actually claims it.
+    when: (a11y) => a11y.screenReaderVerified === true,
+    mode: (a11y) => ({
+      verificationMode: "manual",
+      note: a11y.screenReaderNote || undefined,
+    }),
+  },
+  {
+    id: "live-region",
+    statement: "Dynamic content is announced with the documented live-region politeness.",
+    when: (a11y) => a11y.announces != null,
+    mode: (a11y) =>
+      a11y.accessibilityTreeVerified
+        ? { verificationMode: "automated", check: "npm run test:stories" }
+        : { verificationMode: "unverified" },
+  },
+  {
+    id: "human-a11y-review",
+    statement: "A human completed an end-to-end accessibility review of this component.",
+    when: (a11y) => a11y.reviewed === true,
+    mode: (a11y) => ({ verificationMode: "manual", note: a11y.reviewedNote || undefined }),
+  },
+];
+
+/**
+ * @param {Record<string, any>} contract A parsed component contract (v2).
+ * @returns {Array<{id: string, statement: string, verificationMode: string, check?: string, note?: string}>}
+ */
+export function deriveA11yCriteria(contract) {
+  const a11y = contract?.a11y ?? {};
+  const derived = [];
+
+  for (const rule of RULES) {
+    if (!rule.when(a11y, contract)) continue;
+    const resolved = rule.mode(a11y, contract) ?? { verificationMode: "unverified" };
+    const criterion = {
+      id: rule.id,
+      statement: rule.statement,
+      verificationMode: resolved.verificationMode,
+    };
+    if (resolved.check) criterion.check = resolved.check;
+    if (resolved.note) criterion.note = resolved.note;
+    derived.push(criterion);
+  }
+
+  // Hand-authored criteria in the contract win over a derived one with the same id.
+  const authored = Array.isArray(a11y.criteria) ? a11y.criteria : [];
+  const authoredIds = new Set(authored.map((c) => c.id));
+  return [...authored, ...derived.filter((c) => !authoredIds.has(c.id))];
+}
+
+/**
+ * Roll criteria up into counts, for gates and reporting.
+ * @param {ReturnType<typeof deriveA11yCriteria>} criteria
+ */
+export function summarizeCriteria(criteria) {
+  const summary = { total: criteria.length, automated: 0, manual: 0, unverified: 0 };
+  for (const c of criteria) {
+    if (c.verificationMode in summary) summary[c.verificationMode] += 1;
+  }
+  return summary;
+}

--- a/scripts/design-system/doc-semantics-ratchet.json
+++ b/scripts/design-system/doc-semantics-ratchet.json
@@ -1,0 +1,3 @@
+{
+  "maxUnverifiedA11yCriteria": 115
+}

--- a/scripts/design-system/parse-spec-agent-hints.mjs
+++ b/scripts/design-system/parse-spec-agent-hints.mjs
@@ -25,6 +25,37 @@ export function sanitizeAgentProseLine(line) {
  * @param {string | null | undefined} specText
  * @returns {{ useWhen: string[], avoidWhen: string[] }}
  */
+/**
+ * Join wrapped bullet continuations into one logical line.
+ *
+ * spec.md bullets wrap at the prose margin:
+ *
+ *   - Do: compose destructive actions as `variant` + `tone="error"` rather than a
+ *     bespoke variant.
+ *
+ * Reading line-by-line truncates that to "...rather than a", which is what shipped to
+ * agents before this function existed. A continuation is any non-empty line that does
+ * not itself start a new bullet or heading.
+ *
+ * @param {string} sectionText
+ * @returns {string[]} One entry per logical bullet.
+ */
+export function unwrapBullets(sectionText) {
+  const out = [];
+  for (const raw of sectionText.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (line.startsWith("#")) continue;
+    if (/^[-*•]\s/.test(line)) {
+      out.push(line);
+    } else if (out.length) {
+      // Continuation of the bullet above.
+      out[out.length - 1] = `${out[out.length - 1]} ${line}`;
+    }
+  }
+  return out;
+}
+
 export function parseSpecAgentHints(specText) {
   const useWhen = [];
   const avoidWhen = [];
@@ -33,8 +64,7 @@ export function parseSpecAgentHints(specText) {
   const section = specText.match(/## Do \/ don't([\s\S]*?)(?=^## |\Z)/m);
   if (!section) return { useWhen, avoidWhen };
 
-  for (const line of section[1].split("\n")) {
-    const trimmed = line.trim();
+  for (const trimmed of unwrapBullets(section[1])) {
     let raw = null;
     if (trimmed.startsWith("- Do:")) {
       raw = trimmed.slice(5).trim();
@@ -59,6 +89,139 @@ export function parseSpecAgentHints(specText) {
     useWhen: [...new Set(useWhen)].slice(0, 6),
     avoidWhen: [...new Set(avoidWhen)].slice(0, 6),
   };
+}
+
+/** RFC 2119 levels, ordered strongest-first. */
+export const GUIDELINE_LEVELS = ["must", "must-not", "should", "should-not", "may"];
+
+/** Levels a "Do:" line may carry; a "Don't:" line takes the negative forms. */
+const POSITIVE_LEVELS = new Set(["must", "should", "may"]);
+const NEGATIVE_LEVELS = new Set(["must-not", "should-not"]);
+
+/**
+ * Split a guidance line into its rule and its reason.
+ *
+ * Authors write the reason after an em-dash-free separator (" because ", " so that ",
+ * or " -- "). A rule without a reason is still valid; DSDS only requires rationale on
+ * `must`/`must-not`, and check:doc-semantics reports the gap rather than failing.
+ *
+ * @param {string} text
+ * @returns {{ guidance: string, rationale: string | null }}
+ */
+function splitRationale(text) {
+  // 1. An explicit marker clause, when the author wrote one.
+  const marked = text.match(/^(.*?)(?:\s+--\s+|\s+because\s+|\s+so that\s+)(.+)$/i);
+  if (marked) {
+    const guidance = marked[1].trim().replace(/[,;:]$/, "");
+    const rationale = marked[2].trim();
+    if (guidance.length >= MIN_LINE_LEN && rationale.length >= MIN_LINE_LEN) {
+      return { guidance, rationale, rationaleSource: "explicit" };
+    }
+  }
+
+  // 2. Fallback: this corpus overwhelmingly states the rule in sentence one and the
+  //    reason in the sentences after it ("Buttons are terminal.", "AT focus order
+  //    becomes ambiguous."). Treat the tail as rationale when the split is clean.
+  //    Guarded against abbreviations and code spans so "e.g." or "`type=\"submit\"`."
+  //    does not split a sentence in half.
+  const sentence = text.match(/^(.*?[a-z0-9)`*_\]"']\.)\s+([A-Z].*)$/s);
+  if (sentence) {
+    const guidance = sentence[1].trim().replace(/\.$/, "");
+    const rationale = sentence[2].trim();
+    const endsInAbbrev = /\b(e\.g|i\.e|etc|vs|cf|no)\.$/i.test(sentence[1].trim());
+    const balancedTicks = (guidance.match(/`/g) ?? []).length % 2 === 0;
+    if (
+      !endsInAbbrev &&
+      balancedTicks &&
+      guidance.length >= MIN_LINE_LEN &&
+      rationale.length >= MIN_LINE_LEN
+    ) {
+      // Inferred, not asserted. Sampling puts precision around 80%: the tail sentence is
+      // usually the reason, but sometimes it is the remedy ("Use Checkbox there"). Marked
+      // so a consumer can weight it, and so the gate can count explicit rationale apart
+      // from guessed rationale.
+      return { guidance, rationale, rationaleSource: "inferred" };
+    }
+  }
+
+  return { guidance: text.trim(), rationale: null, rationaleSource: null };
+}
+
+/**
+ * Parse the spec.md "Do / don't" section into RFC 2119 guidelines.
+ *
+ * Accepted forms, all backward compatible with the flat `- Do:` / `- Don't:` lines
+ * that predate this parser:
+ *
+ *   - Do: use X for Y                      -> level "should"     (default)
+ *   - Don't: nest X inside Y               -> level "should-not"  (default)
+ *   - Do (must): label every input         -> level "must"        (explicit)
+ *   - Don't (must): nest interactive nodes -> level "must-not"    (explicit, negated)
+ *   - Don't (must): nest X because AT announces it twice
+ *                                          -> rationale captured
+ *
+ * An explicit level on a "Don't" line is negated automatically, so an author writes
+ * `(must)` and gets `must-not`. Writing `(must-not)` on a Don't line also works.
+ *
+ * @param {string | null | undefined} specText
+ * @returns {Array<{level: string, guidance: string, rationale: string | null, source: string}>}
+ */
+export function parseSpecGuidelines(specText) {
+  /** @type {Array<{level: string, guidance: string, rationale: string | null, source: string}>} */
+  const guidelines = [];
+  if (!specText) return guidelines;
+
+  const section = specText.match(/## Do \/ don't([\s\S]*?)(?=^## |\Z)/m);
+  if (!section) return guidelines;
+
+  for (const trimmed of unwrapBullets(section[1])) {
+    const m = trimmed.match(/^[-*•]\s+(Do|Don't)\s*(?:\(([a-z-]+)\))?\s*:?\s+(.*)$/i);
+    if (!m) continue;
+
+    const negative = m[1].toLowerCase() === "don't";
+    const declared = m[2]?.toLowerCase() ?? null;
+    // Split before sanitizing: sanitize truncates at 220 chars, which would swallow the
+    // rationale on a long bullet.
+    const { guidance: rawGuidance, rationale: rawRationale, rationaleSource } = splitRationale(
+      m[3].replace(/\s+/g, " ").trim(),
+    );
+    const clean = sanitizeAgentProseLine(rawGuidance);
+    if (!clean) continue;
+
+    let level;
+    if (!declared) {
+      level = negative ? "should-not" : "should";
+    } else if (negative) {
+      // `(must)` on a Don't line means must-not; `(must-not)` is already negative.
+      level = NEGATIVE_LEVELS.has(declared) ? declared : `${declared}-not`;
+    } else {
+      level = declared;
+    }
+    // An unrecognised level falls back to the default rather than emitting garbage.
+    if (!GUIDELINE_LEVELS.includes(level)) level = negative ? "should-not" : "should";
+    if (!negative && !POSITIVE_LEVELS.has(level)) level = "should";
+
+    guidelines.push({
+      level,
+      guidance: clean,
+      rationale: rawRationale ? sanitizeAgentProseLine(rawRationale) : null,
+      rationaleSource: rawRationale ? rationaleSource : null,
+      source: "spec.md#do-dont",
+    });
+  }
+
+  // Dedupe on guidance text, keeping the strongest level asserted for each rule.
+  /** @type {Map<string, {level: string, guidance: string, rationale: string | null, source: string}>} */
+  const byGuidance = new Map();
+  for (const g of guidelines) {
+    const prior = byGuidance.get(g.guidance);
+    if (!prior || GUIDELINE_LEVELS.indexOf(g.level) < GUIDELINE_LEVELS.indexOf(prior.level)) {
+      byGuidance.set(g.guidance, prior ? { ...g, rationale: g.rationale ?? prior.rationale } : g);
+    } else if (!prior.rationale && g.rationale) {
+      byGuidance.set(g.guidance, { ...prior, rationale: g.rationale });
+    }
+  }
+  return [...byGuidance.values()].slice(0, 12);
 }
 
 /**

--- a/scripts/design-system/project-dsds.mjs
+++ b/scripts/design-system/project-dsds.mjs
@@ -1,0 +1,383 @@
+#!/usr/bin/env node
+/**
+ * Project the design system into Design System Doc Spec (DSDS) documents.
+ *
+ * https://designsystemdocspec.org — a JSON schema for design-system documentation that
+ * sits above DTCG (token values) and Custom Elements Manifest (code APIs).
+ *
+ * This is a PROJECTION, not a migration. The contracts and spec.md files remain the
+ * source of truth. The projection exists to answer one question: what does our
+ * documentation carry that an external schema has no place to put, and vice versa?
+ * Everything that does not fit is recorded in the residue report rather than dropped,
+ * because the residue is the interesting output.
+ *
+ * Usage:
+ *   node scripts/design-system/project-dsds.mjs                 # write + report
+ *   node scripts/design-system/project-dsds.mjs --out <dir>
+ *   node scripts/design-system/project-dsds.mjs --report-only
+ */
+import { readFileSync, writeFileSync, mkdirSync, existsSync, globSync } from "node:fs";
+import { resolve, dirname, join, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const BLOCKS = join(ROOT, "nextjs-app/shared/foundations/dist/component-agent-blocks.json");
+const CATALOG = join(ROOT, "nextjs-app/shared/foundations/token-catalog.json");
+const DSDS_VERSION = "0.15.2";
+const SCHEMA_URL = `https://designsystemdocspec.org/v${DSDS_VERSION}/dsds.bundled.schema.json`;
+
+const argOut = process.argv.indexOf("--out");
+const OUT_DIR = argOut > -1 ? resolve(process.argv[argOut + 1]) : join(ROOT, "nextjs-app/shared/foundations/dist/dsds");
+const REPORT_ONLY = process.argv.includes("--report-only");
+
+/** Fields we carry that DSDS core has no home for. Recorded, then namespaced. */
+const RESIDUE = new Map();
+function residue(field, componentName, note) {
+  if (!RESIDUE.has(field)) RESIDUE.set(field, { field, count: 0, components: [], note });
+  const r = RESIDUE.get(field);
+  r.count += 1;
+  if (r.components.length < 5) r.components.push(componentName);
+}
+
+/** DSDS identifiers are kebab-case. */
+const kebab = (s) => s.replace(/([a-z0-9])([A-Z])/g, "$1-$2").replace(/[_\s]+/g, "-").toLowerCase();
+
+/** Map our status vocabulary onto the DSDS statusValue enum. */
+function mapStatus(status) {
+  switch (status) {
+    case "alpha": return "experimental";
+    case "beta": return "beta";
+    case "stable": return "stable";
+    case "deprecated": return "deprecated";
+    default: return "experimental";
+  }
+}
+
+/** props -> DSDS `api` block. */
+function apiBlock(block, name) {
+  const properties = Object.entries(block.props ?? {}).map(([id, p]) => {
+    const prop = {
+      identifier: id,
+      type: p.type === "union" && p.values ? p.values.map((v) => JSON.stringify(v)).join(" | ") : p.type,
+      required: p.optional === false,
+    };
+    // apiProperty requires a description. A prop documented only by its type has none,
+    // so the projection must invent one or drop the prop.
+    prop.description = p.description || `The ${id} prop.`;
+    if (!p.description) residue("api prop: no description", name, "DSDS apiProperty requires `description`. Props typed but undocumented cannot be represented without fabricating prose.");
+    if (p.defaultValue !== undefined) prop.defaultValue = String(p.defaultValue);
+    return prop;
+  });
+  if (!properties.length) return null;
+  return { kind: "api", properties };
+}
+
+/** guidelines -> DSDS `guidelines` block, levels map 1:1 onto RFC 2119. */
+function guidelinesBlock(block, name) {
+  const items = (block.guidelines ?? []).map((g) => {
+    // conformanceLevel is must|should|should-not|must-not. RFC 2119 also defines MAY,
+    // and DSDS deliberately omits it, so an optional allowance has no level to carry.
+    let level = g.level;
+    if (level === "may") {
+      level = "should";
+      residue("guideline level: may", name, "DSDS conformanceLevel omits 'may'. A genuinely optional allowance must be upgraded to 'should', which overstates it.");
+    }
+    const item = { level, guidance: g.guidance };
+    if (g.rationale) item.rationale = g.rationale;
+    return item;
+  });
+  const all = [...items, ...contentGuidelines(block)];
+  if (!all.length) return null;
+  return { kind: "guidelines", items: all };
+}
+
+/** useWhen -> DSDS `use-cases`. */
+function useCasesBlock(block, name) {
+  const items = [
+    ...(block.useWhen ?? []).map((u) => ({ description: u, stance: "recommended" })),
+    ...(block.avoidWhen ?? []).map((u) => ({ description: u, stance: "discouraged" })),
+  ];
+  if (!items.length) return null;
+  return { kind: "use-cases", items };
+}
+
+/** a11yCriteria -> DSDS `accessibility` block with criteria. */
+function accessibilityBlock(block, name) {
+  const unverifiedIds = [];
+  const criteria = (block.a11yCriteria ?? []).map((c) => {
+    const out = { identifier: c.id, statement: c.statement };
+    if (c.verificationMode === "automated") {
+      out.verification = "automated";
+      // criterionCheck identifies the RUNNER, not the command. Our evidence is an npm
+      // script; the scheme is the tool it dispatches to.
+      out.check = { scheme: "npm", identifier: c.check };
+    } else if (c.verificationMode === "manual") {
+      out.verification = "manual";
+      // DSDS forbids `check` on a manual criterion, so the note recording what a human
+      // actually ran cannot sit beside the claim.
+    } else {
+      // "unverified" has no member in verificationMode (automated|assisted|manual).
+      // Omitting the field means "automatability unknown", which is not the same claim
+      // as "we know nothing proves this". The gap survives only in an extension.
+      residue(
+        "a11y criterion: unverified",
+        name,
+        "verificationMode is automated|assisted|manual, and `criterion` is a closed object with NO $extensions (unlike its parent block, which gained one in 0.15.2). So the known-gap state cannot be recorded on the criterion at all, even in a vendor namespace. It has to be hoisted to the block, breaking the link to the specific criterion.",
+      );
+      unverifiedIds.push(c.id);
+    }
+    // `note` has no criterion field. techniques[] is the closest home, but it means
+    // "how to pass", not "what evidence exists", so the meaning shifts.
+    if (c.note) out.techniques = [c.note];
+    return out;
+  });
+  const requirements = block.requiredA11y ?? [];
+  const keyboard = block.keyboard ?? [];
+  if (!criteria.length && !requirements.length && !keyboard.length) return null;
+
+  const out = { kind: "accessibility" };
+  if (criteria.length) out.criteria = criteria;
+  // Hoisted from the criteria that could not carry it themselves.
+  if (unverifiedIds.length) out.$extensions = { "com.digitaltableteur": { unverifiedCriteria: unverifiedIds } };
+  if (requirements.length) {
+    out.ariaAttributes = requirements.map((r) => {
+      const m = r.match(/^(aria-[a-z-]+|role)\s*[:=]?\s*(.*)$/i);
+      return m && m[2] ? { attribute: m[1], description: m[2] } : { attribute: r, description: r };
+    });
+  }
+  if (keyboard.length) {
+    out.keyboardInteractions = keyboard.map((k) => {
+      const m = k.match(/^([^\s:]+)\s*[:]\s*(.+)$/);
+      return m ? { key: m[1], action: m[2] } : { key: k.split(/\s+/)[0], action: k };
+    });
+  }
+  return out;
+}
+
+/** content -> DSDS `content` block. */
+function contentBlock(block, name) {
+  const c = block.content;
+  if (!c) return null;
+  // DSDS splits what we merged: the `content` block is a label dictionary plus
+  // localization notes (facts), while voice and capitalization are RULES and belong in
+  // `guidelines` with category "content". Our single `content` field conflated both.
+  const out = { kind: "content" };
+  const labels = (c.terminology ?? []).map((t) => ({
+    term: t.prefer,
+    definition: t.rationale || `Preferred over ${t.over.join(", ")}.`,
+    alternatives: t.over,
+  }));
+  const localization = [];
+  if (c.maxLength) {
+    // `text-expansion` is a real concern member, so this has a home. What is lost is the
+    // TYPE: a per-slot integer ceiling becomes prose no gate can evaluate.
+    localization.push({
+      concern: "text-expansion",
+      description: `Character ceilings, measured on the longest locale: ${Object.entries(c.maxLength).map(([k, v]) => `${k} <= ${v}`).join(", ")}. ${c.notes ?? ""}`.trim(),
+    });
+    residue("content.maxLength: typed -> prose", name, "localizationEntry accepts the concern ('text-expansion') but its payload is richText. A per-slot integer ceiling degrades to a sentence, so no gate can evaluate it. The concern survives; the constraint does not.");
+  }
+  if (c.doNotTranslate?.length) {
+    localization.push({
+      concern: "do-not-translate",
+      description: `Keep untranslated across all locales: ${c.doNotTranslate.join(", ")}.`,
+    });
+  }
+  if (labels.length) out.labels = labels;
+  if (localization.length) out.localization = localization;
+  // anyOf requires at least one of labels/localization.
+  return labels.length || localization.length ? out : null;
+}
+
+/** voice + capitalization -> guidelines(category: content), per the DSDS rule/fact split. */
+function contentGuidelines(block) {
+  const c = block.content;
+  if (!c) return [];
+  const items = [];
+  if (c.voice) items.push({ level: "should", guidance: c.voice, category: "content" });
+  if (c.capitalization) items.push({ level: "must", guidance: `Use ${c.capitalization} case for labels and headings.`, category: "content" });
+  return items;
+}
+
+function projectComponent(name, block) {
+  const identifier = kebab(name);
+  const documentBlocks = [];
+  const agentDocumentBlocks = [];
+
+  const imports = block.preferredImport
+    ? { kind: "imports", items: [{ language: "tsx", package: block.preferredImport, code: `import { ${name} } from "${block.preferredImport}";` }] }
+    : null;
+  for (const b of [imports, apiBlock(block, name), guidelinesBlock(block, name), useCasesBlock(block, name), accessibilityBlock(block, name), contentBlock(block, name)]) {
+    if (b) documentBlocks.push(b);
+  }
+
+  // Agent-only rules: hard constraints and look-alike disambiguation.
+  const agentItems = [];
+  for (const f of block.forbiddenUse ?? []) agentItems.push({ level: "must-not", guidance: f });
+  for (const r of block.compositionRules ?? []) agentItems.push({ level: "must-not", guidance: r });
+  for (const p of block.prefersOver ?? []) agentItems.push({ level: "should", guidance: `Prefer ${name} over ${p}.` });
+  if (agentItems.length) agentDocumentBlocks.push({ kind: "guidelines", items: agentItems });
+
+  const relationships = [];
+  for (const c of block.composesWith ?? []) relationships.push({ relation: "composes", target: kebab(c) });
+  for (const r of block.replacementFor ?? []) relationships.push({ relation: "replaces", target: kebab(r) });
+
+  const metadata = { summary: (block.intent || "").slice(0, 300) };
+  if (block.governance) {
+    metadata.governance = {};
+    if (block.governance.owner) metadata.governance.owner = block.governance.owner;
+    if (block.governance.lastReviewed) metadata.governance.lastReviewed = block.governance.lastReviewed;
+  }
+  // docOrigin: DSDS keys this by block name. Ours is keyed by field, which is finer.
+  if (block.docOrigin) {
+    // docOriginValue: authored | generated | extracted | reconstructed.
+    // authorshipValue: human | ai-assisted | ai-generated | machine-assisted | machine-generated.
+    const ORIGIN = { generated: "generated", authored: "authored", derived: "generated" };
+    const AUTHORSHIP = { "machine-generated": "machine-generated", "human-authored": "human", mixed: "machine-assisted" };
+    metadata.docOrigin = { overall: "authored", authorship: "human", blocks: {} };
+    const mapping = { api: "props", guidelines: "guidelines", "use-cases": "useWhen", accessibility: "a11yCriteria" };
+    for (const [dsdsBlock, ourField] of Object.entries(mapping)) {
+      const o = block.docOrigin[ourField];
+      if (!o) continue;
+      if (o.origin === "derived") {
+        residue("docOrigin: derived", name, "docOriginValue is authored|generated|extracted|reconstructed. A block computed by a rule set FROM authored input is none of these: 'generated' implies read from source, and the distinction between 'a machine read this' and 'a machine inferred this from what a human wrote' is lost.");
+      }
+      metadata.docOrigin.blocks[dsdsBlock] = {
+        origin: ORIGIN[o.origin] ?? "authored",
+        authorship: AUTHORSHIP[o.authorship] ?? "human",
+      };
+    }
+  }
+
+  // Fields with no DSDS home.
+  const ext = {};
+  const noHome = [
+    ["requiredStories", "Story coverage requirements. DSDS links to Storybook but does not model which stories must exist."],
+    ["consumers", "Which app routes consume this component. No DSDS adoption/usage surface."],
+    ["tier", "Atomic-design tier. DSDS has category but no tier taxonomy."],
+    ["radixPrimitive", "Underlying headless primitive. No DSDS field for implementation substrate."],
+    ["lightDarkVerified", "Theme verification flag. DSDS themes are entities, not per-component verification state."],
+    ["declaredPropCount", "Prop-count metric used by our controls-coverage gate."],
+    ["cvaVariants", "CVA variant axes, distinct from prop-derived variants."],
+    ["subParts", "Named internal parts. DSDS anatomy models parts, but as prose items rather than addressable sub-component identifiers."],
+    ["tokens", "Which design tokens this component consumes. DSDS points components at tokens only through prose; there is no typed component-to-token edge."],
+  ];
+  for (const [field, note] of noHome) {
+    if (block[field] !== undefined && block[field] !== null) {
+      residue(field, name, note);
+      ext[field] = block[field];
+    }
+  }
+
+  const entity = { kind: "component", identifier, name, description: block.intent || name };
+  if (documentBlocks.length) entity.documentBlocks = documentBlocks;
+  if (agentDocumentBlocks.length) entity.agentDocumentBlocks = agentDocumentBlocks;
+  if (relationships.length) entity.relationships = relationships;
+  entity.metadata = metadata;
+  if (Object.keys(ext).length) entity.$extensions = { "com.digitaltableteur": ext };
+  return entity;
+}
+
+function main() {
+  if (!existsSync(BLOCKS)) {
+    console.error("FAIL: run `npm run build:agent-blocks` first.");
+    process.exit(1);
+  }
+  const { components } = JSON.parse(readFileSync(BLOCKS, "utf8"));
+
+  // Contracts carry status/governance/content that agent-blocks partly drop.
+  const contracts = new Map();
+  for (const f of globSync(join(ROOT, "nextjs-app/shared/**/*.contract.json"))) {
+    try {
+      const c = JSON.parse(readFileSync(f, "utf8"));
+      if (c.name) contracts.set(c.name, c);
+    } catch {}
+  }
+
+  const entities = [];
+  for (const [name, block] of Object.entries(components)) {
+    const contract = contracts.get(name) ?? {};
+    // Contract-only fields must take part in the residue count, otherwise the projection
+    // flatters itself by only measuring what the agent-block layer already carries.
+    const merged = {
+      ...block,
+      content: block.content ?? contract.content ?? null,
+      requiredStories: contract.requiredStories,
+      consumers: contract.consumers,
+      tier: contract.tier,
+      radixPrimitive: contract.radixPrimitive,
+      lightDarkVerified: contract.lightDarkVerified,
+      subParts: contract.subParts,
+      tokens: contract.tokens,
+    };
+    const entity = projectComponent(name, merged);
+    if (contract.status) {
+      const overall = mapStatus(contract.status);
+      // DSDS requires the object form for deprecated, with a notice saying what to use
+      // instead. Our contracts carry deprecatedReason, which satisfies it.
+      entity.metadata.status =
+        overall === "deprecated"
+          ? { overall, deprecationNotice: contract.deprecatedReason || "Deprecated; see the replacement component." }
+          : overall;
+    }
+    if (contract.figma) entity.metadata.links = [{ kind: "design", url: contract.figma }];
+    entities.push(entity);
+  }
+
+  const doc = {
+    $schema: SCHEMA_URL,
+    dsdsVersion: DSDS_VERSION,
+    systemInfo: { organization: "Digitaltableteur", name: "Digitaltableteur Design System", url: "https://digitaltableteur.com" },
+    entityGroups: [{ name: "Components", description: `Projected from ${entities.length} component contracts and agent blocks.`, entities }],
+  };
+
+  if (!REPORT_ONLY) {
+    mkdirSync(OUT_DIR, { recursive: true });
+    writeFileSync(join(OUT_DIR, "components.dsds.json"), `${JSON.stringify(doc, null, 2)}\n`);
+    const residueReport = [...RESIDUE.values()].sort((a, b) => b.count - a.count);
+    writeFileSync(join(OUT_DIR, "residue.json"), `${JSON.stringify({ generatedFrom: entities.length, residue: residueReport }, null, 2)}\n`);
+  }
+
+  console.log(`\nDSDS projection — ${entities.length} components -> ${DSDS_VERSION}\n`);
+  const counts = entities.reduce((acc, e) => {
+    for (const b of e.documentBlocks ?? []) acc[b.kind] = (acc[b.kind] ?? 0) + 1;
+    return acc;
+  }, {});
+  console.log("document blocks emitted:");
+  for (const [k, v] of Object.entries(counts).sort((a, b) => b[1] - a[1])) console.log(`  ${k.padEnd(16)} ${v}`);
+  console.log(`  agentDocumentBlocks  ${entities.filter((e) => e.agentDocumentBlocks).length}`);
+
+  // --- DSDS semantic conformance layer ---
+  // Schema validity is necessary but not sufficient. A conforming consumer "MUST treat
+  // unresolvable references as defects", so the projection checks the same things the
+  // spec's reference validator does.
+  const ids = new Set(entities.map((e) => e.identifier));
+  const dupes = entities.map((e) => e.identifier).filter((id, i, a) => a.indexOf(id) !== i);
+  const unresolved = new Map();
+  let edges = 0;
+  for (const e of entities) {
+    for (const r of e.relationships ?? []) {
+      edges += 1;
+      if (!ids.has(r.target)) unresolved.set(r.target, (unresolved.get(r.target) ?? 0) + 1);
+    }
+  }
+  const unresolvedCount = [...unresolved.values()].reduce((a, b) => a + b, 0);
+
+  console.log("\nsemantic conformance:");
+  console.log(`  identifiers unique       ${dupes.length === 0 ? `yes (${ids.size})` : `NO (${dupes.length} dupes)`}`);
+  console.log(`  relationship edges       ${edges}`);
+  console.log(`  unresolved targets       ${unresolvedCount} across ${unresolved.size} distinct`);
+  if (unresolved.size) {
+    for (const [t, n] of [...unresolved.entries()].sort((a, b) => b[1] - a[1]).slice(0, 8)) {
+      console.log(`      ${t} (${n})`);
+    }
+  }
+
+  console.log("\nresidue (carried in $extensions or lost):");
+  for (const r of [...RESIDUE.values()].sort((a, b) => b.count - a.count)) {
+    console.log(`  ${String(r.count).padStart(4)}  ${r.field}`);
+  }
+  if (!REPORT_ONLY) console.log(`\nwritten: ${OUT_DIR}\n`);
+}
+
+main();


### PR DESCRIPTION
Steals five ideas from the [Design System Doc Spec](https://designsystemdocspec.org) into our own contract schema, without adopting the format itself.

## What landed

| # | Steal | Implementation |
|---|-------|----------------|
| 1 | RFC 2119 levels + rationale | `- Don't (must): X -- because Y` in spec.md. Unmarked lines default to should/should-not, so all 166 spec files keep working. |
| 2 | `docOrigin` provenance | Per-field origin/authorship, so an agent can tell generated props from human-authored intent. |
| 3 | a11y `verificationMode` | 783 criteria derived from the eight a11y booleans: 473 automated (each naming the npm script that proves it), 195 manual, 115 unverified. |
| 4 | `governance.lastReviewed` | Doc-rot detection. |
| 5 | `content` block | UX writing, EN/FI/SV terminology + length ceilings. |

## Bug found on the way

spec.md bullets wrap across lines; the parser read them line-by-line and truncated guidance mid-clause. Agents were receiving:

```
compose destructive actions as `variant` + `tone="error"` rather than a
```

Eleven contracts had the truncated text baked into their stored `forbiddenUse`, so the corruption had already propagated from parser into committed data. Fixed, and contracts re-synced.

## New gates

- `check:doc-semantics` reports level coverage, criteria verification mix, and governance staleness. Ratchets on one number: **115 accessibility requirements currently proven by nothing**. Can go down, not up.
- `project:dsds` projects all 165 components into DSDS 0.15.2. Output validates against the spec's bundled schema (165/165 entities).

## Follow-up

The projection's semantic layer found **58 of 440 relationship edges point at nothing** (targets like `raw-<button>`, `@/components/ui/button`). Separate PR.

## Local gate

typecheck 0, lint 0, 2705 tests pass, build 0, check:contract-props 0, check:consumers 0, validate:agent-docs 0.

Pre-existing failures verified identical on `main` before starting: 3 contract-schema (NextLayoutShell, SelectableCardGroup, SelectOption), 5 prose-check drafts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer component documentation, including writing guidance, terminology, localization limits, ownership, and review information.
  * Added accessibility criteria with verification expectations for supported components.
  * Added tooling to validate documentation semantics and project component documentation into a standardized format.

* **Bug Fixes**
  * Fixed truncated Do/Don’t guidance so complete accessibility recommendations are preserved.

* **Documentation**
  * Clarified accessibility requirements for buttons, modals, headers, and footers.
  * Expanded guidance on prohibited usage patterns and accessibility considerations.

* **Updates**
  * Added the `xs` Badge size option and standardized size-value ordering across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->