### PR TITLE
fix(a11y): resolve AT-snapshot dirs from Storybook's index, close beta unverified criteria

### DIFF
--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -214,60 +214,70 @@ const THEME = (process.env.DT_THEME ?? "").toLowerCase();
 const FORCED_COLORS = (process.env.DT_FORCED_COLORS ?? "").toLowerCase();
 const VIEWPORT = Number.parseInt(process.env.DT_VIEWPORT ?? "", 10);
 
-let storyPrefixToDir: Map<string, string> | null = null;
+let storyDirMap: Promise<Map<string, string>> | null = null;
 
 /**
- * Replicate Storybook's own id derivation (@storybook/csf `sanitize`). The
- * story id's kind segment is `sanitize(title)`: lowercase, every non-alphanumeric
- * run collapsed to a single "-", trimmed. It does NOT insert hyphens at camelCase
- * boundaries — so `Forms/TextArea` → `forms-textarea`, not `forms-text-area`.
- * The previous derivation split camelCase, so the prefix map never matched the
- * real story id for any camelCase-titled component and their snapshot dirs were
- * silently unresolved (dead snapshots, skipped enforcement).
+ * Map story id -> component directory, from Storybook's own index.
+ *
+ * This used to be derived by scraping `title:` out of every `*.stories.tsx`
+ * under a hard-coded root list, then re-implementing @storybook/csf's `sanitize`
+ * to turn that title back into a story-id prefix. Re-deriving what Storybook
+ * already knows was wrong in four independent ways, and every one of them failed
+ * *silently* — an unresolved dir means `captureAccessibilityTree` returns early,
+ * so the component simply had no snapshots and no enforcement, with no error:
+ *
+ *   1. `readdirSync(base)` was flat, so nested components (`components/
+ *      animations/FadeIn`) were never seen.
+ *   2. The root list omitted `templates/`, so `NextLayoutShell` was never seen —
+ *      even though tag-beta-matrix-stories.mjs *does* walk templates, so its
+ *      stories were tagged and run but never captured.
+ *   3. The contract was assumed to be `<DirName>.contract.json`, so a second
+ *      component sharing a directory (`SelectableCard/SelectableCardGroup`) was
+ *      never seen.
+ *   4. The "first `title:` containing a slash is the meta title" heuristic was
+ *      itself a fix for arg-title hijacking, and it was incomplete: NavMenuList
+ *      and SentrySummaryCard seed a checklist arg `title: "Design tokens for
+ *      spacing/colors"`, which contains a slash and wins the match, mapping the
+ *      directory under a prefix no story id can ever have.
+ *
+ * The index carries `importPath` per story, so the directory is a fact rather
+ * than an inference and all four classes disappear at once. The contract check
+ * is kept so scope is unchanged: `shared/stories/WebComponents/**` holds no
+ * contracts and stays excluded, exactly as it was under the old roots list.
  */
-function sanitizeStorybookTitle(title: string): string {
-  return title
-    .toLowerCase()
-    .replace(/[ ’–—―′¿'`~!@#$%^&*()_|+\-=?;:'",.<>{}[\]\\/]/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-+/, "")
-    .replace(/-+$/, "");
-}
-
-function loadStoryPrefixMap(): Map<string, string> {
-  if (storyPrefixToDir) return storyPrefixToDir;
-  storyPrefixToDir = new Map();
-  const roots = [
-    path.join(ROOT_DIR, "nextjs-app/shared/components"),
-    path.join(ROOT_DIR, "nextjs-app/shared/patterns"),
-  ];
-  const titleRe = /title:\s*["']([^"']+)["']/g;
-
-  for (const base of roots) {
-    if (!fs.existsSync(base)) continue;
-    for (const name of fs.readdirSync(base)) {
-      const dir = path.join(base, name);
-      const contractPath = path.join(dir, `${name}.contract.json`);
-      const storyPath = path.join(dir, `${name}.stories.tsx`);
-      if (!fs.existsSync(contractPath) || !fs.existsSync(storyPath)) continue;
-      const text = fs.readFileSync(storyPath, "utf8");
-      // The meta title is the story-path one ("Category/Name"). A component whose
-      // stories seed a `title:` ARG (e.g. ValueCard's defaultArgs.title "Clarity
-      // first") would otherwise hijack the first match and the snapshot dir would
-      // never resolve. Pick the first title: value shaped like a story path.
-      const metaTitle = [...text.matchAll(titleRe)]
-        .map((mt) => mt[1])
-        .find((t) => t.includes("/"));
-      if (!metaTitle) continue;
-      storyPrefixToDir.set(sanitizeStorybookTitle(metaTitle), dir);
+async function loadStoryDirMap(): Promise<Map<string, string>> {
+  if (storyDirMap) return storyDirMap;
+  storyDirMap = (async () => {
+    const target = process.env.TARGET_URL ?? "";
+    const res = await fetch(new URL("index.json", target).toString());
+    if (!res.ok) {
+      throw new Error(`Storybook index fetch failed: ${res.status} ${res.statusText}`);
     }
-  }
-  return storyPrefixToDir;
+    const index = (await res.json()) as {
+      entries?: Record<string, { importPath?: string }>;
+    };
+    const map = new Map<string, string>();
+    const dirHasContract = new Map<string, boolean>();
+
+    for (const [id, entry] of Object.entries(index.entries ?? {})) {
+      if (!entry.importPath) continue;
+      const dir = path.dirname(path.resolve(ROOT_DIR, entry.importPath));
+      let hasContract = dirHasContract.get(dir);
+      if (hasContract === undefined) {
+        hasContract =
+          fs.existsSync(dir) &&
+          fs.readdirSync(dir).some((f) => f.endsWith(".contract.json"));
+        dirHasContract.set(dir, hasContract);
+      }
+      if (hasContract) map.set(id, dir);
+    }
+    return map;
+  })();
+  return storyDirMap;
 }
 
-function componentSnapshotDir(storyId: string): string | null {
-  const prefix = storyId.split("--")[0];
-  const componentDir = loadStoryPrefixMap().get(prefix);
+async function componentSnapshotDir(storyId: string): Promise<string | null> {
+  const componentDir = (await loadStoryDirMap()).get(storyId);
   if (!componentDir) return null;
   return path.join(componentDir, "__a11y-snapshots__");
 }
@@ -308,7 +318,7 @@ async function captureAccessibilityTree(
   storyId: string,
   { betaMatrix = false }: { betaMatrix?: boolean } = {},
 ) {
-  const dir = componentSnapshotDir(storyId);
+  const dir = await componentSnapshotDir(storyId);
   if (!dir) return;
   fs.mkdirSync(dir, { recursive: true });
   const suffix = snapshotVariantSuffix();

--- a/nextjs-app/shared/components/Accordion/Accordion.contract.json
+++ b/nextjs-app/shared/components/Accordion/Accordion.contract.json
@@ -49,7 +49,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "reviewedNote": "2026-05-26 — production behavior verified in Storybook; argTypes and required stories aligned with validate:components.",
-        "forcedColorsVerified": true
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/ArticleCard/ArticleCard.contract.json
+++ b/nextjs-app/shared/components/ArticleCard/ArticleCard.contract.json
@@ -23,7 +23,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error).",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/AspectRatio/AspectRatio.contract.json
+++ b/nextjs-app/shared/components/AspectRatio/AspectRatio.contract.json
@@ -26,7 +26,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error).",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/Author/Author.contract.json
+++ b/nextjs-app/shared/components/Author/Author.contract.json
@@ -24,7 +24,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/AvatarGroup/AvatarGroup.contract.json
+++ b/nextjs-app/shared/components/AvatarGroup/AvatarGroup.contract.json
@@ -39,7 +39,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "reviewedNote": "2026-07-03 — group semantics, overflow sr text asserted in unit tests; axe clean.",
-        "forcedColorsVerified": true
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [

--- a/nextjs-app/shared/components/ButtonGroup/ButtonGroup.contract.json
+++ b/nextjs-app/shared/components/ButtonGroup/ButtonGroup.contract.json
@@ -28,7 +28,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "reviewedNote": "2026-07-03 — group semantics + labelled-group asserted in unit tests; axe clean; focus ring lift verified in Storybook.",
-        "forcedColorsVerified": true
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/Center/Center.contract.json
+++ b/nextjs-app/shared/components/Center/Center.contract.json
@@ -26,7 +26,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error).",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/ChatWidget/ChatWidget.contract.json
+++ b/nextjs-app/shared/components/ChatWidget/ChatWidget.contract.json
@@ -31,7 +31,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "reviewedNote": "2026-07-14 — streaming display reviewed: only the active assistant reply uses grapheme-safe adaptive smoothing; reduced motion bypasses it and the polite message log remains aria-busy until the complete response is available.",
-        "forcedColorsVerified": true
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-aiprocessingstate--default.dark.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-aiprocessingstate--default.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (alpha)
+- status "Thinking…"

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-aiprocessingstate--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-aiprocessingstate--default.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (alpha)
+- status "Thinking…"

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-aiprocessingstate--default.light.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-aiprocessingstate--default.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (alpha)
+- status "Thinking…"

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-aiprocessingstate--default.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-aiprocessingstate--default.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (alpha)
+- status "Thinking…"

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatcomposer--interactive.dark.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatcomposer--interactive.dark.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (alpha)
+- text: Ask Donny a question
+- textbox "Ask Donny a question":
+  - /placeholder: Ask about open hours, service, or approach…
+  - text: Hello, how can I help?
+- button "Send message": Send
+- paragraph: Press '⌘ + Enter' (Mac) or 'Ctrl + Enter' to send.

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatcomposer--interactive.forced-colors.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatcomposer--interactive.forced-colors.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (alpha)
+- text: Ask Donny a question
+- textbox "Ask Donny a question":
+  - /placeholder: Ask about open hours, service, or approach…
+  - text: Hello, how can I help?
+- button "Send message": Send
+- paragraph: Press '⌘ + Enter' (Mac) or 'Ctrl + Enter' to send.

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatcomposer--interactive.light.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatcomposer--interactive.light.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (alpha)
+- text: Ask Donny a question
+- textbox "Ask Donny a question":
+  - /placeholder: Ask about open hours, service, or approach…
+  - text: Hello, how can I help?
+- button "Send message": Send
+- paragraph: Press '⌘ + Enter' (Mac) or 'Ctrl + Enter' to send.

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatcomposer--interactive.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatcomposer--interactive.yaml
@@ -1,0 +1,7 @@
+- status: Work in progress (alpha)
+- text: Ask Donny a question
+- textbox "Ask Donny a question":
+  - /placeholder: Ask about open hours, service, or approach…
+  - text: Hello, how can I help?
+- button "Send message": Send
+- paragraph: Press '⌘ + Enter' (Mac) or 'Ctrl + Enter' to send.

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatheader--default.dark.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatheader--default.dark.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (alpha)
+- banner:
+  - img "Donny is idle":
+    - img
+  - paragraph:
+    - text: DT Donny
+    - status "Available now"
+  - heading "Chat with Donny" [level=2]
+  - button "Minimize chat":
+    - img "Minimize chat"

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatheader--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatheader--default.forced-colors.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (alpha)
+- banner:
+  - img "Donny is idle":
+    - img
+  - paragraph:
+    - text: DT Donny
+    - status "Available now"
+  - heading "Chat with Donny" [level=2]
+  - button "Minimize chat":
+    - img "Minimize chat"

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatheader--default.light.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatheader--default.light.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (alpha)
+- banner:
+  - img "Donny is idle":
+    - img
+  - paragraph:
+    - text: DT Donny
+    - status "Available now"
+  - heading "Chat with Donny" [level=2]
+  - button "Minimize chat":
+    - img "Minimize chat"

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatheader--default.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatheader--default.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (alpha)
+- banner:
+  - img "Donny is idle":
+    - img
+  - paragraph:
+    - text: DT Donny
+    - status "Available now"
+  - heading "Chat with Donny" [level=2]
+  - button "Minimize chat":
+    - img "Minimize chat"

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatmessagebubble--assistant-message.dark.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatmessagebubble--assistant-message.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (alpha)
+- paragraph: Hello! I'm Donny, your guide to Digitaltableteur. How can I help you today?

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatmessagebubble--assistant-message.forced-colors.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatmessagebubble--assistant-message.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (alpha)
+- paragraph: Hello! I'm Donny, your guide to Digitaltableteur. How can I help you today?

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatmessagebubble--assistant-message.light.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatmessagebubble--assistant-message.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (alpha)
+- paragraph: Hello! I'm Donny, your guide to Digitaltableteur. How can I help you today?

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatmessagebubble--assistant-message.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatmessagebubble--assistant-message.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (alpha)
+- paragraph: Hello! I'm Donny, your guide to Digitaltableteur. How can I help you today?

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatmessages--default.dark.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatmessages--default.dark.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (alpha)
+- log "Chat messages":
+  - paragraph: Hi! I'm Donny, the Digitaltableteur studio guide. Feel free to ask about our work or anything you notice on the site.
+  - paragraph: What services do you offer?
+  - paragraph: We blend strategic design, development, and content craft to ship end-to-end brand and digital experiences.
+  - text: Design Development Strategy AI Innovation

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatmessages--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatmessages--default.forced-colors.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (alpha)
+- log "Chat messages":
+  - paragraph: Hi! I'm Donny, the Digitaltableteur studio guide. Feel free to ask about our work or anything you notice on the site.
+  - paragraph: What services do you offer?
+  - paragraph: We blend strategic design, development, and content craft to ship end-to-end brand and digital experiences.
+  - text: Design Development Strategy AI Innovation

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatmessages--default.light.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatmessages--default.light.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (alpha)
+- log "Chat messages":
+  - paragraph: Hi! I'm Donny, the Digitaltableteur studio guide. Feel free to ask about our work or anything you notice on the site.
+  - paragraph: What services do you offer?
+  - paragraph: We blend strategic design, development, and content craft to ship end-to-end brand and digital experiences.
+  - text: Design Development Strategy AI Innovation

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatmessages--default.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chatmessages--default.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (alpha)
+- log "Chat messages":
+  - paragraph: Hi! I'm Donny, the Digitaltableteur studio guide. Feel free to ask about our work or anything you notice on the site.
+  - paragraph: What services do you offer?
+  - paragraph: We blend strategic design, development, and content craft to ship end-to-end brand and digital experiences.
+  - text: Design Development Strategy AI Innovation

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chattoggle--default.dark.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chattoggle--default.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (alpha)
+- button "Chat — Chat with Donny": Chat

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chattoggle--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chattoggle--default.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (alpha)
+- button "Chat — Chat with Donny": Chat

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chattoggle--default.light.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chattoggle--default.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (alpha)
+- button "Chat — Chat with Donny": Chat

--- a/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chattoggle--default.yaml
+++ b/nextjs-app/shared/components/ChatWidget/__a11y-snapshots__/site-chat-chattoggle--default.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (alpha)
+- button "Chat — Chat with Donny": Chat

--- a/nextjs-app/shared/components/ClientLogoMarquee/ClientLogoMarquee.contract.json
+++ b/nextjs-app/shared/components/ClientLogoMarquee/ClientLogoMarquee.contract.json
@@ -23,7 +23,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error).",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/CommandPalette/CommandPalette.contract.json
+++ b/nextjs-app/shared/components/CommandPalette/CommandPalette.contract.json
@@ -33,7 +33,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "reviewedNote": "2026-07-12 — alpha→beta: code-level a11y review. Overlay dialog is role=dialog aria-modal with an accessible label; the search input is role=combobox with aria-expanded, aria-controls and aria-activedescendant onto the role=listbox; each command is role=option with aria-selected reflecting the active item. Focus is trapped (useFocusTrap) and background scroll locked (useScrollLock) while open; Arrow Up/Down wrap the active option, Enter runs it and closes, Escape closes, overlay mousedown closes. User-facing strings are props so the component carries no i18n dependency. Axe asserted in unit test; forced-colors + light/dark verified on a non-6010 Storybook. Known limitation: virtualization is not implemented, so very long command lists render in full.",
-        "forcedColorsVerified": true
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [

--- a/nextjs-app/shared/components/ComplianceCard/ComplianceCard.contract.json
+++ b/nextjs-app/shared/components/ComplianceCard/ComplianceCard.contract.json
@@ -26,7 +26,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [

--- a/nextjs-app/shared/components/ContactForm/ContactForm.contract.json
+++ b/nextjs-app/shared/components/ContactForm/ContactForm.contract.json
@@ -31,7 +31,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "reviewedNote": "2026-05-26 — production behavior verified in Storybook; argTypes and required stories aligned with validate:components.",
-        "forcedColorsVerified": true
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/CookieConsent/CookieConsent.contract.json
+++ b/nextjs-app/shared/components/CookieConsent/CookieConsent.contract.json
@@ -23,7 +23,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error).",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/Designerman/Designerman.contract.json
+++ b/nextjs-app/shared/components/Designerman/Designerman.contract.json
@@ -24,7 +24,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/Display/Display.contract.json
+++ b/nextjs-app/shared/components/Display/Display.contract.json
@@ -26,7 +26,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error).",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [

--- a/nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.contract.json
+++ b/nextjs-app/shared/components/EmailSignatureGenerator/EmailSignatureGenerator.contract.json
@@ -24,7 +24,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [

--- a/nextjs-app/shared/components/Gallery/Gallery.contract.json
+++ b/nextjs-app/shared/components/Gallery/Gallery.contract.json
@@ -32,7 +32,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "motion": true,
-        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error).",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [

--- a/nextjs-app/shared/components/ImagePlaceholder/ImagePlaceholder.contract.json
+++ b/nextjs-app/shared/components/ImagePlaceholder/ImagePlaceholder.contract.json
@@ -35,7 +35,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/Kbd/Kbd.contract.json
+++ b/nextjs-app/shared/components/Kbd/Kbd.contract.json
@@ -36,7 +36,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "reviewedNote": "2026-07-06 — alpha→beta: created the Figma component (size variant keycap set, border/bg/text bound to DT/Color, radius from radius/sm) at node 1005-1638, the only remaining beta blocker. Static inline element; axe asserted in unit test and story gate; forced-colors border verified.",
-        "forcedColorsVerified": true
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [

--- a/nextjs-app/shared/components/LinkedInQuoteCard/LinkedInQuoteCard.contract.json
+++ b/nextjs-app/shared/components/LinkedInQuoteCard/LinkedInQuoteCard.contract.json
@@ -34,7 +34,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/ListItem/ListItem.contract.json
+++ b/nextjs-app/shared/components/ListItem/ListItem.contract.json
@@ -40,7 +40,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "reviewedNote": "2026-07-17 — axe asserted in ListItem.test.tsx and the Storybook a11y gate (parameters.a11y.test: error); consumer-owned semantics reviewed (role/focus/events belong to the interactive wrapper, ListItem itself carries no interactive ARIA); ForcedColors story verifies the forced-colors treatment (CanvasText/GrayText/Highlight/HighlightText mapping).",
-        "forcedColorsVerified": true
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [

--- a/nextjs-app/shared/components/LocationCard/LocationCard.contract.json
+++ b/nextjs-app/shared/components/LocationCard/LocationCard.contract.json
@@ -39,7 +39,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error).",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [

--- a/nextjs-app/shared/components/MCPActionButton/MCPActionButton.contract.json
+++ b/nextjs-app/shared/components/MCPActionButton/MCPActionButton.contract.json
@@ -24,7 +24,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.contract.json
+++ b/nextjs-app/shared/components/MacWindowFrame/MacWindowFrame.contract.json
@@ -33,7 +33,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.contract.json
+++ b/nextjs-app/shared/components/MarkdownMessage/MarkdownMessage.contract.json
@@ -33,7 +33,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/NavMenuList/NavMenuList.contract.json
+++ b/nextjs-app/shared/components/NavMenuList/NavMenuList.contract.json
@@ -24,7 +24,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--default.dark.yaml
+++ b/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--default.dark.yaml
@@ -1,0 +1,17 @@
+- status: Work in progress (beta)
+- list:
+  - listitem:
+    - link "Home":
+      - /url: /
+  - listitem:
+    - link "Work":
+      - /url: /work
+  - listitem:
+    - link "About":
+      - /url: /about
+  - listitem:
+    - link "Blog":
+      - /url: /blog
+  - listitem:
+    - link "Contact":
+      - /url: /contact

--- a/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--default.forced-colors.yaml
@@ -1,0 +1,17 @@
+- status: Work in progress (beta)
+- list:
+  - listitem:
+    - link "Home":
+      - /url: /
+  - listitem:
+    - link "Work":
+      - /url: /work
+  - listitem:
+    - link "About":
+      - /url: /about
+  - listitem:
+    - link "Blog":
+      - /url: /blog
+  - listitem:
+    - link "Contact":
+      - /url: /contact

--- a/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--default.light.yaml
+++ b/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--default.light.yaml
@@ -1,0 +1,17 @@
+- status: Work in progress (beta)
+- list:
+  - listitem:
+    - link "Home":
+      - /url: /
+  - listitem:
+    - link "Work":
+      - /url: /work
+  - listitem:
+    - link "About":
+      - /url: /about
+  - listitem:
+    - link "Blog":
+      - /url: /blog
+  - listitem:
+    - link "Contact":
+      - /url: /contact

--- a/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--default.yaml
+++ b/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--default.yaml
@@ -1,0 +1,17 @@
+- status: Work in progress (beta)
+- list:
+  - listitem:
+    - link "Home":
+      - /url: /
+  - listitem:
+    - link "Work":
+      - /url: /work
+  - listitem:
+    - link "About":
+      - /url: /about
+  - listitem:
+    - link "Blog":
+      - /url: /blog
+  - listitem:
+    - link "Contact":
+      - /url: /contact

--- a/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--example.dark.yaml
+++ b/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--example.dark.yaml
@@ -1,0 +1,17 @@
+- status: Work in progress (beta)
+- list:
+  - listitem:
+    - link "Home":
+      - /url: /
+  - listitem:
+    - link "Work":
+      - /url: /work
+  - listitem:
+    - link "About":
+      - /url: /about
+  - listitem:
+    - link "Blog":
+      - /url: /blog
+  - listitem:
+    - link "Contact":
+      - /url: /contact

--- a/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--example.forced-colors.yaml
@@ -1,0 +1,17 @@
+- status: Work in progress (beta)
+- list:
+  - listitem:
+    - link "Home":
+      - /url: /
+  - listitem:
+    - link "Work":
+      - /url: /work
+  - listitem:
+    - link "About":
+      - /url: /about
+  - listitem:
+    - link "Blog":
+      - /url: /blog
+  - listitem:
+    - link "Contact":
+      - /url: /contact

--- a/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--example.light.yaml
+++ b/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--example.light.yaml
@@ -1,0 +1,17 @@
+- status: Work in progress (beta)
+- list:
+  - listitem:
+    - link "Home":
+      - /url: /
+  - listitem:
+    - link "Work":
+      - /url: /work
+  - listitem:
+    - link "About":
+      - /url: /about
+  - listitem:
+    - link "Blog":
+      - /url: /blog
+  - listitem:
+    - link "Contact":
+      - /url: /contact

--- a/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--example.yaml
+++ b/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--example.yaml
@@ -1,0 +1,17 @@
+- status: Work in progress (beta)
+- list:
+  - listitem:
+    - link "Home":
+      - /url: /
+  - listitem:
+    - link "Work":
+      - /url: /work
+  - listitem:
+    - link "About":
+      - /url: /about
+  - listitem:
+    - link "Blog":
+      - /url: /blog
+  - listitem:
+    - link "Contact":
+      - /url: /contact

--- a/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--forced-colors.dark.yaml
@@ -1,0 +1,17 @@
+- status: Work in progress (beta)
+- list:
+  - listitem:
+    - link "Home":
+      - /url: /
+  - listitem:
+    - link "Work":
+      - /url: /work
+  - listitem:
+    - link "About":
+      - /url: /about
+  - listitem:
+    - link "Blog":
+      - /url: /blog
+  - listitem:
+    - link "Contact":
+      - /url: /contact

--- a/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--forced-colors.forced-colors.yaml
@@ -1,0 +1,17 @@
+- status: Work in progress (beta)
+- list:
+  - listitem:
+    - link "Home":
+      - /url: /
+  - listitem:
+    - link "Work":
+      - /url: /work
+  - listitem:
+    - link "About":
+      - /url: /about
+  - listitem:
+    - link "Blog":
+      - /url: /blog
+  - listitem:
+    - link "Contact":
+      - /url: /contact

--- a/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--forced-colors.light.yaml
@@ -1,0 +1,17 @@
+- status: Work in progress (beta)
+- list:
+  - listitem:
+    - link "Home":
+      - /url: /
+  - listitem:
+    - link "Work":
+      - /url: /work
+  - listitem:
+    - link "About":
+      - /url: /about
+  - listitem:
+    - link "Blog":
+      - /url: /blog
+  - listitem:
+    - link "Contact":
+      - /url: /contact

--- a/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--forced-colors.yaml
+++ b/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--forced-colors.yaml
@@ -1,0 +1,17 @@
+- status: Work in progress (beta)
+- list:
+  - listitem:
+    - link "Home":
+      - /url: /
+  - listitem:
+    - link "Work":
+      - /url: /work
+  - listitem:
+    - link "About":
+      - /url: /about
+  - listitem:
+    - link "Blog":
+      - /url: /blog
+  - listitem:
+    - link "Contact":
+      - /url: /contact

--- a/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--playground.dark.yaml
+++ b/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--playground.dark.yaml
@@ -1,0 +1,17 @@
+- status: Work in progress (beta)
+- list:
+  - listitem:
+    - link "Home":
+      - /url: /
+  - listitem:
+    - link "Work":
+      - /url: /work
+  - listitem:
+    - link "About":
+      - /url: /about
+  - listitem:
+    - link "Blog":
+      - /url: /blog
+  - listitem:
+    - link "Contact":
+      - /url: /contact

--- a/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--playground.forced-colors.yaml
@@ -1,0 +1,17 @@
+- status: Work in progress (beta)
+- list:
+  - listitem:
+    - link "Home":
+      - /url: /
+  - listitem:
+    - link "Work":
+      - /url: /work
+  - listitem:
+    - link "About":
+      - /url: /about
+  - listitem:
+    - link "Blog":
+      - /url: /blog
+  - listitem:
+    - link "Contact":
+      - /url: /contact

--- a/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--playground.light.yaml
+++ b/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--playground.light.yaml
@@ -1,0 +1,17 @@
+- status: Work in progress (beta)
+- list:
+  - listitem:
+    - link "Home":
+      - /url: /
+  - listitem:
+    - link "Work":
+      - /url: /work
+  - listitem:
+    - link "About":
+      - /url: /about
+  - listitem:
+    - link "Blog":
+      - /url: /blog
+  - listitem:
+    - link "Contact":
+      - /url: /contact

--- a/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--playground.yaml
+++ b/nextjs-app/shared/components/NavMenuList/__a11y-snapshots__/site-navmenulist--playground.yaml
@@ -1,0 +1,17 @@
+- status: Work in progress (beta)
+- list:
+  - listitem:
+    - link "Home":
+      - /url: /
+  - listitem:
+    - link "Work":
+      - /url: /work
+  - listitem:
+    - link "About":
+      - /url: /about
+  - listitem:
+    - link "Blog":
+      - /url: /blog
+  - listitem:
+    - link "Contact":
+      - /url: /contact

--- a/nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.contract.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/NewsletterWaitlist.contract.json
@@ -30,7 +30,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "reviewedNote": "2026-05-26 — production behavior verified in Storybook; argTypes and required stories aligned with validate:components.",
-        "forcedColorsVerified": true
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/NextLayout/NextLayout.contract.json
+++ b/nextjs-app/shared/components/NextLayout/NextLayout.contract.json
@@ -24,7 +24,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error).",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--default.dark.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--default.dark.yaml
@@ -40,10 +40,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--default.forced-colors.yaml
@@ -40,10 +40,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--default.light.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--default.light.yaml
@@ -40,10 +40,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--default.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--default.yaml
@@ -40,10 +40,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--example.dark.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--example.dark.yaml
@@ -40,10 +40,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--example.forced-colors.yaml
@@ -40,10 +40,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--example.light.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--example.light.yaml
@@ -40,10 +40,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--example.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--example.yaml
@@ -40,10 +40,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--forced-colors.dark.yaml
@@ -40,10 +40,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--forced-colors.forced-colors.yaml
@@ -40,10 +40,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--forced-colors.light.yaml
@@ -40,10 +40,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--forced-colors.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--forced-colors.yaml
@@ -40,10 +40,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--playground.dark.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--playground.dark.yaml
@@ -38,10 +38,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--playground.forced-colors.yaml
@@ -38,10 +38,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--playground.light.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--playground.light.yaml
@@ -38,10 +38,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--playground.yaml
+++ b/nextjs-app/shared/components/NextLayout/__a11y-snapshots__/templates-nextlayout--playground.yaml
@@ -38,10 +38,10 @@
     - /url: /work
   - link "About":
     - /url: /about
-  - link "Blog":
-    - /url: /blog
   - link "Pricing":
     - /url: /pricing
+  - link "Blog":
+    - /url: /blog
   - link "Contact":
     - /url: /contact
   - paragraph: Legal

--- a/nextjs-app/shared/components/OpenHours/OpenHours.contract.json
+++ b/nextjs-app/shared/components/OpenHours/OpenHours.contract.json
@@ -24,7 +24,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/PersonCard/PersonCard.contract.json
+++ b/nextjs-app/shared/components/PersonCard/PersonCard.contract.json
@@ -24,7 +24,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/Radio/Radio.contract.json
+++ b/nextjs-app/shared/components/Radio/Radio.contract.json
@@ -37,7 +37,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [

--- a/nextjs-app/shared/components/RadioGroup/RadioGroup.contract.json
+++ b/nextjs-app/shared/components/RadioGroup/RadioGroup.contract.json
@@ -46,7 +46,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [

--- a/nextjs-app/shared/components/SegmentedControl/SegmentedControl.contract.json
+++ b/nextjs-app/shared/components/SegmentedControl/SegmentedControl.contract.json
@@ -41,7 +41,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "reviewedNote": "2026-07-12 — alpha→beta: code-level a11y review. Container is role=radiogroup with a required aria-label; each segment is role=radio with aria-checked reflecting selection. Roving tabindex keeps exactly one segment tabbable (the selection, else the first enabled); Arrow keys move selection wrapping and skip disabled segments; Home/End jump to first/last enabled. Selection shown by a raised neutral surface (not brand fill) so it reads across light/dark; forced-colors maps the selected segment to a Highlight outline. Motion respects prefers-reduced-motion. Axe asserted in unit test; forced-colors + light/dark verified on a non-6010 Storybook.",
-        "forcedColorsVerified": true
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--default.dark.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--default.dark.yaml
@@ -1,0 +1,6 @@
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1"
+  - option "Option 2" [selected]
+  - option "Option 3"
+- img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--default.forced-colors.yaml
@@ -1,0 +1,6 @@
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1"
+  - option "Option 2" [selected]
+  - option "Option 3"
+- img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--default.light.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--default.light.yaml
@@ -1,0 +1,6 @@
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1"
+  - option "Option 2" [selected]
+  - option "Option 3"
+- img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--default.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--default.yaml
@@ -1,0 +1,6 @@
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1"
+  - option "Option 2" [selected]
+  - option "Option 3"
+- img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--example.dark.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--example.dark.yaml
@@ -1,0 +1,6 @@
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1" [selected]
+  - option "Option 2"
+  - option "Option 3"
+- img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--example.forced-colors.yaml
@@ -1,0 +1,6 @@
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1" [selected]
+  - option "Option 2"
+  - option "Option 3"
+- img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--example.light.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--example.light.yaml
@@ -1,0 +1,6 @@
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1" [selected]
+  - option "Option 2"
+  - option "Option 3"
+- img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--example.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--example.yaml
@@ -1,0 +1,6 @@
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1" [selected]
+  - option "Option 2"
+  - option "Option 3"
+- img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--forced-colors.dark.yaml
@@ -1,0 +1,6 @@
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1" [selected]
+  - option "Option 2"
+  - option "Option 3"
+- img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--forced-colors.forced-colors.yaml
@@ -1,0 +1,6 @@
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1" [selected]
+  - option "Option 2"
+  - option "Option 3"
+- img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--forced-colors.light.yaml
@@ -1,0 +1,6 @@
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1" [selected]
+  - option "Option 2"
+  - option "Option 3"
+- img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--forced-colors.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--forced-colors.yaml
@@ -1,0 +1,6 @@
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1" [selected]
+  - option "Option 2"
+  - option "Option 3"
+- img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--playground.dark.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--playground.dark.yaml
@@ -1,0 +1,6 @@
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1" [selected]
+  - option "Option 2"
+  - option "Option 3"
+- img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--playground.forced-colors.yaml
@@ -1,0 +1,6 @@
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1" [selected]
+  - option "Option 2"
+  - option "Option 3"
+- img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--playground.light.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--playground.light.yaml
@@ -1,0 +1,6 @@
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1" [selected]
+  - option "Option 2"
+  - option "Option 3"
+- img "Toggle options"

--- a/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--playground.yaml
+++ b/nextjs-app/shared/components/Select/__a11y-snapshots__/forms-selectoption--playground.yaml
@@ -1,0 +1,6 @@
+- text: Select an option
+- combobox "Select an option":
+  - option "Option 1" [selected]
+  - option "Option 2"
+  - option "Option 3"
+- img "Toggle options"

--- a/nextjs-app/shared/components/SelectableCard/SelectableCard.contract.json
+++ b/nextjs-app/shared/components/SelectableCard/SelectableCard.contract.json
@@ -32,7 +32,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "reviewedNote": "2026-07-12 — alpha→beta: code-level a11y review. SelectableCardGroup renders a fieldset with a legend for the accessible name; each SelectableCard is a label wrapping a visually-hidden native radio (single) or checkbox (multiple) input, so keyboard, focus and form submission come from the platform. Error announces via role=alert and sets aria-invalid on the group. Selected/disabled states mirror to data-attributes for CSS + tests. Motion respects prefers-reduced-motion. Axe asserted in the colocated a11y test; forced-colors + light/dark verified on a non-6010 Storybook.",
-        "forcedColorsVerified": true
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [

--- a/nextjs-app/shared/components/SelectableCard/SelectableCardGroup.contract.json
+++ b/nextjs-app/shared/components/SelectableCard/SelectableCardGroup.contract.json
@@ -12,13 +12,31 @@
   "radixPrimitive": null,
   "element": "fieldset",
   "variants": {
-    "type": ["single", "multiple"],
-    "orientation": ["vertical", "horizontal"]
+    "type": [
+      "single",
+      "multiple"
+    ],
+    "orientation": [
+      "vertical",
+      "horizontal"
+    ]
   },
-  "slots": ["children"],
+  "slots": [
+    "children"
+  ],
   "asChild": false,
-  "subParts": ["legend", "options", "helperText", "error"],
-  "requiredStories": ["Default", "Playground", "Example", "ForcedColors"],
+  "subParts": [
+    "legend",
+    "options",
+    "helperText",
+    "error"
+  ],
+  "requiredStories": [
+    "Default",
+    "Playground",
+    "Example",
+    "ForcedColors"
+  ],
   "a11y": {
     "keyboard": [
       "Tab moves focus into the option set",
@@ -33,10 +51,15 @@
     "reducedMotion": true,
     "reviewed": true,
     "reviewedNote": "2026-07-16: reviewed the fieldset/legend structure, native radio and checkbox keyboard behavior, disabled propagation, helper/error relationships, and forced-colors story while adding independent React and web-component documentation.",
-    "forcedColorsVerified": true
+    "forcedColorsVerified": true,
+    "accessibilityTreeVerified": true
   },
   "tokens": {
-    "colors": ["--color-primary", "--color-border", "--color-surface"],
+    "colors": [
+      "--color-primary",
+      "--color-border",
+      "--color-surface"
+    ],
     "spacing": [
       "--space-internal-8",
       "--space-internal-12",
@@ -48,7 +71,10 @@
     "type": {
       "optional": true,
       "type": "union",
-      "values": ["single", "multiple"],
+      "values": [
+        "single",
+        "multiple"
+      ],
       "description": "Selection model: one exclusive value or several independent values."
     },
     "legend": {
@@ -79,7 +105,10 @@
     "orientation": {
       "optional": true,
       "type": "union",
-      "values": ["vertical", "horizontal"],
+      "values": [
+        "vertical",
+        "horizontal"
+      ],
       "description": "Visual stack direction for the options."
     },
     "disabled": {
@@ -108,7 +137,10 @@
       "description": "SelectableCard options owned by this group."
     }
   },
-  "composesWith": ["SelectableCard", "HelperText"],
+  "composesWith": [
+    "SelectableCard",
+    "HelperText"
+  ],
   "forbiddenUse": [
     "mix SelectableCard with unrelated interactive children inside the group",
     "pass value without updating it from onValueChange; use defaultValue for uncontrolled state"

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--default.dark.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--default.dark.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter"
+  - text: Starter
+  - radio "Team" [checked]
+  - text: Team
+  - radio "Scale"
+  - text: Scale
+  - paragraph: You can change this later.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--default.forced-colors.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter"
+  - text: Starter
+  - radio "Team" [checked]
+  - text: Team
+  - radio "Scale"
+  - text: Scale
+  - paragraph: You can change this later.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--default.light.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--default.light.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter"
+  - text: Starter
+  - radio "Team" [checked]
+  - text: Team
+  - radio "Scale"
+  - text: Scale
+  - paragraph: You can change this later.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--default.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--default.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter"
+  - text: Starter
+  - radio "Team" [checked]
+  - text: Team
+  - radio "Scale"
+  - text: Scale
+  - paragraph: You can change this later.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--example.dark.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--example.dark.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter"
+  - text: Starter
+  - radio "Team" [checked]
+  - text: Team
+  - radio "Scale"
+  - text: Scale
+  - paragraph: You can change this later.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--example.forced-colors.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter"
+  - text: Starter
+  - radio "Team" [checked]
+  - text: Team
+  - radio "Scale"
+  - text: Scale
+  - paragraph: You can change this later.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--example.light.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--example.light.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter"
+  - text: Starter
+  - radio "Team" [checked]
+  - text: Team
+  - radio "Scale"
+  - text: Scale
+  - paragraph: You can change this later.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--example.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--example.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter"
+  - text: Starter
+  - radio "Team" [checked]
+  - text: Team
+  - radio "Scale"
+  - text: Scale
+  - paragraph: You can change this later.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--forced-colors.dark.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter"
+  - text: Starter
+  - radio "Team" [checked]
+  - text: Team
+  - radio "Scale"
+  - text: Scale
+  - paragraph: You can change this later.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--forced-colors.forced-colors.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter"
+  - text: Starter
+  - radio "Team" [checked]
+  - text: Team
+  - radio "Scale"
+  - text: Scale
+  - paragraph: You can change this later.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--forced-colors.light.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter"
+  - text: Starter
+  - radio "Team" [checked]
+  - text: Team
+  - radio "Scale"
+  - text: Scale
+  - paragraph: You can change this later.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--forced-colors.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--forced-colors.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter"
+  - text: Starter
+  - radio "Team" [checked]
+  - text: Team
+  - radio "Scale"
+  - text: Scale
+  - paragraph: You can change this later.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--playground.dark.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--playground.dark.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter"
+  - text: Starter
+  - radio "Team" [checked]
+  - text: Team
+  - radio "Scale"
+  - text: Scale
+  - paragraph: You can change this later.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--playground.forced-colors.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter"
+  - text: Starter
+  - radio "Team" [checked]
+  - text: Team
+  - radio "Scale"
+  - text: Scale
+  - paragraph: You can change this later.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--playground.light.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--playground.light.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter"
+  - text: Starter
+  - radio "Team" [checked]
+  - text: Team
+  - radio "Scale"
+  - text: Scale
+  - paragraph: You can change this later.

--- a/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--playground.yaml
+++ b/nextjs-app/shared/components/SelectableCard/__a11y-snapshots__/layout-selectablecardgroup--playground.yaml
@@ -1,0 +1,10 @@
+- status: Work in progress (beta)
+- group "Choose a plan":
+  - text: Choose a plan
+  - radio "Starter"
+  - text: Starter
+  - radio "Team" [checked]
+  - text: Team
+  - radio "Scale"
+  - text: Scale
+  - paragraph: You can change this later.

--- a/nextjs-app/shared/components/SentrySummaryCard/SentrySummaryCard.contract.json
+++ b/nextjs-app/shared/components/SentrySummaryCard/SentrySummaryCard.contract.json
@@ -24,7 +24,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--default.dark.yaml
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--default.dark.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "Sentry Issues" [level=3]
+- alert: Failed to load Sentry data

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--default.forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "Sentry Issues" [level=3]
+- alert: Failed to load Sentry data

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--default.light.yaml
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--default.light.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "Sentry Issues" [level=3]
+- alert: Failed to load Sentry data

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--default.yaml
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--default.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "Sentry Issues" [level=3]
+- alert: Failed to load Sentry data

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--example.dark.yaml
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--example.dark.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "Sentry Issues" [level=3]
+- alert: Failed to load Sentry data

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--example.forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "Sentry Issues" [level=3]
+- alert: Failed to load Sentry data

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--example.light.yaml
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--example.light.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "Sentry Issues" [level=3]
+- alert: Failed to load Sentry data

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--example.yaml
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--example.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "Sentry Issues" [level=3]
+- alert: Failed to load Sentry data

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--forced-colors.dark.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "Sentry Issues" [level=3]
+- alert: Failed to load Sentry data

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--forced-colors.forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "Sentry Issues" [level=3]
+- alert: Failed to load Sentry data

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--forced-colors.light.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "Sentry Issues" [level=3]
+- alert: Failed to load Sentry data

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--forced-colors.yaml
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "Sentry Issues" [level=3]
+- alert: Failed to load Sentry data

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--playground.dark.yaml
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--playground.dark.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "Sentry Issues" [level=3]
+- alert: Failed to load Sentry data

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--playground.forced-colors.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "Sentry Issues" [level=3]
+- alert: Failed to load Sentry data

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--playground.light.yaml
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--playground.light.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "Sentry Issues" [level=3]
+- alert: Failed to load Sentry data

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--playground.yaml
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-snapshots__/site-sentrysummarycard--playground.yaml
@@ -1,0 +1,3 @@
+- status: Work in progress (beta)
+- heading "Sentry Issues" [level=3]
+- alert: Failed to load Sentry data

--- a/nextjs-app/shared/components/ServicesGrid/ServicesGrid.contract.json
+++ b/nextjs-app/shared/components/ServicesGrid/ServicesGrid.contract.json
@@ -24,7 +24,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/Spacer/Spacer.contract.json
+++ b/nextjs-app/shared/components/Spacer/Spacer.contract.json
@@ -39,7 +39,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "reviewedNote": "2026-05-28 — Bucket-1 beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error).",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/Testimonial/Testimonial.contract.json
+++ b/nextjs-app/shared/components/Testimonial/Testimonial.contract.json
@@ -24,7 +24,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/ThemeProvider/ThemeProvider.contract.json
+++ b/nextjs-app/shared/components/ThemeProvider/ThemeProvider.contract.json
@@ -23,7 +23,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error).",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/Tooltip/Tooltip.contract.json
+++ b/nextjs-app/shared/components/Tooltip/Tooltip.contract.json
@@ -49,7 +49,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "reviewedNote": "2026-07-03 (batch 4) — hover+focus trigger, Escape dismiss, and aria-describedby wiring asserted in the play function and unit tests; axe clean on Default/Placements/WithIconButton. 2026-07-05 (alpha→beta) — the pending light/dark + forced-colors verification is now done: axe-clean on Default/Example/ForcedColors via test-storybook; light + dark eyeballed (bubble uses --color-primary and inverts correctly, arrow tracks the bubble); emulated forced-colors shows a CanvasText-bordered Canvas bubble with readable CanvasText, no reliance on a background that disappears; enter/exit animation drops under reduced-motion (CSS @media).",
-        "forcedColorsVerified": true
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.contract.json
+++ b/nextjs-app/shared/components/TransformingActionInput/TransformingActionInput.contract.json
@@ -24,7 +24,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/components/VisuallyHidden/VisuallyHidden.contract.json
+++ b/nextjs-app/shared/components/VisuallyHidden/VisuallyHidden.contract.json
@@ -24,7 +24,8 @@
         "reducedMotion": true,
         "reviewed": true,
         "forcedColorsVerified": true,
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [

--- a/nextjs-app/shared/components/WipBadge/WipBadge.contract.json
+++ b/nextjs-app/shared/components/WipBadge/WipBadge.contract.json
@@ -35,7 +35,8 @@
         "reviewed": true,
         "reviewedNote": "2026-05-28 — Beta promotion: Storybook-only chrome (carries data-axe-ignore + axeTestExempt so it never gates host component contrast). role=status announcement is non-disruptive and stable lifecycle hides it entirely. Forced-colors + light/dark verified via dedicated stories.",
         "forcedColorsVerified": true,
-        "axeTestExempt": "Storybook chrome only"
+        "axeTestExempt": "Storybook chrome only",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [

--- a/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--example.dark.yaml
+++ b/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--example.dark.yaml
@@ -1,2 +1,2 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - status: Work in progress (alpha)

--- a/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--example.forced-colors.yaml
@@ -1,2 +1,2 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - status: Work in progress (alpha)

--- a/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--example.light.yaml
+++ b/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--example.light.yaml
@@ -1,2 +1,2 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - status: Work in progress (alpha)

--- a/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--example.yaml
+++ b/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--example.yaml
@@ -1,2 +1,2 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - status: Work in progress (alpha)

--- a/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--forced-colors.dark.yaml
@@ -1,2 +1,2 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - status: Work in progress (beta)

--- a/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--forced-colors.forced-colors.yaml
@@ -1,2 +1,2 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - status: Work in progress (beta)

--- a/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--forced-colors.light.yaml
@@ -1,2 +1,2 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - status: Work in progress (beta)

--- a/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--forced-colors.yaml
+++ b/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--forced-colors.yaml
@@ -1,2 +1,2 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - status: Work in progress (beta)

--- a/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--playground.dark.yaml
+++ b/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--playground.dark.yaml
@@ -1,2 +1,2 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - status: Work in progress (beta)

--- a/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--playground.forced-colors.yaml
@@ -1,2 +1,2 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - status: Work in progress (beta)

--- a/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--playground.light.yaml
+++ b/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--playground.light.yaml
@@ -1,2 +1,2 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - status: Work in progress (beta)

--- a/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--playground.yaml
+++ b/nextjs-app/shared/components/WipBadge/__a11y-snapshots__/site-wipbadge--playground.yaml
@@ -1,2 +1,2 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - status: Work in progress (beta)

--- a/nextjs-app/shared/components/animations/FadeIn/FadeIn.contract.json
+++ b/nextjs-app/shared/components/animations/FadeIn/FadeIn.contract.json
@@ -24,7 +24,8 @@
     "reducedMotion": true,
     "reviewed": true,
     "forcedColorsVerified": true,
-    "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+    "reviewedNote": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error).",
+    "accessibilityTreeVerified": true
   },
   "tokens": {
     "colors": [],

--- a/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--default.dark.yaml
+++ b/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--default.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- paragraph: Fades in on scroll

--- a/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--default.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- paragraph: Fades in on scroll

--- a/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--default.light.yaml
+++ b/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--default.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- paragraph: Fades in on scroll

--- a/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--default.yaml
+++ b/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--default.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- paragraph: Fades in on scroll

--- a/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--example.dark.yaml
+++ b/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--example.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- paragraph: Production scroll reveal used across marketing sections.

--- a/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--example.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- paragraph: Production scroll reveal used across marketing sections.

--- a/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--example.light.yaml
+++ b/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--example.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- paragraph: Production scroll reveal used across marketing sections.

--- a/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--example.yaml
+++ b/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--example.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- paragraph: Production scroll reveal used across marketing sections.

--- a/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--forced-colors.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- paragraph: Fades in on scroll

--- a/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--forced-colors.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- paragraph: Fades in on scroll

--- a/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--forced-colors.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- paragraph: Fades in on scroll

--- a/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--forced-colors.yaml
+++ b/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- paragraph: Fades in on scroll

--- a/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--playground.dark.yaml
+++ b/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--playground.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- paragraph: Fades in on scroll

--- a/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--playground.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- paragraph: Fades in on scroll

--- a/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--playground.light.yaml
+++ b/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--playground.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- paragraph: Fades in on scroll

--- a/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--playground.yaml
+++ b/nextjs-app/shared/components/animations/FadeIn/__a11y-snapshots__/site-animations-fadein--playground.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- paragraph: Fades in on scroll

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-21T10:20:25.165Z",
+  "generatedAt": "2026-07-21T12:27:27.995Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -167,7 +167,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -184,7 +185,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -642,7 +644,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -1305,7 +1308,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -1316,7 +1320,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -1485,7 +1490,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -2153,7 +2159,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -2170,7 +2177,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -4063,7 +4071,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -4080,7 +4089,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -5039,7 +5049,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -5050,7 +5061,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -5251,7 +5263,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -5268,7 +5281,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -5943,7 +5957,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -6831,7 +6846,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -6848,7 +6864,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -7024,7 +7041,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -7220,7 +7238,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -7237,7 +7256,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -7958,7 +7978,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -8148,7 +8169,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -8343,7 +8365,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -8354,7 +8377,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -8997,7 +9021,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -11181,7 +11206,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -11203,7 +11229,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -12744,7 +12771,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -12945,7 +12973,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -12956,7 +12985,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -14129,7 +14159,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -14635,7 +14666,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -14646,7 +14678,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -14865,7 +14898,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -14882,7 +14916,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -15290,7 +15325,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -15487,7 +15523,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -15688,7 +15725,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -16998,7 +17036,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -17207,7 +17246,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -17224,7 +17264,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -17384,7 +17425,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -17560,7 +17602,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -18057,7 +18100,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -19709,7 +19753,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -19957,7 +20002,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -21058,7 +21104,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -21075,7 +21122,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -21711,7 +21759,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -21728,7 +21777,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -21884,7 +21934,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -22266,7 +22317,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -23593,7 +23645,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -23604,7 +23657,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -25694,7 +25748,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -26700,7 +26755,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -28000,7 +28056,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -28017,7 +28074,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -28230,7 +28288,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -28634,7 +28693,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -28812,7 +28872,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",
@@ -28823,7 +28884,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "human-a11y-review",
@@ -29087,6 +29149,362 @@
           "origin": "authored",
           "authorship": "human-authored",
           "from": "WorkNav.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
+    },
+    "FadeIn": {
+      "preferredImport": "@dt/FadeIn",
+      "intent": "Scroll-triggered fade-in animation wrapper (GSAP).",
+      "props": {
+        "children": {
+          "optional": false,
+          "type": "ReactNode"
+        },
+        "direction": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "none",
+            "left",
+            "right",
+            "up",
+            "down"
+          ]
+        },
+        "delay": {
+          "optional": true,
+          "type": "number"
+        },
+        "duration": {
+          "optional": true,
+          "type": "number"
+        },
+        "distance": {
+          "optional": true,
+          "type": "number"
+        },
+        "threshold": {
+          "optional": true,
+          "type": "string"
+        },
+        "className": {
+          "optional": true,
+          "type": "string"
+        },
+        "as": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "symbol",
+            "object",
+            "image",
+            "form",
+            "slot",
+            "style",
+            "title",
+            "button",
+            "search",
+            "article",
+            "dialog",
+            "figure",
+            "img",
+            "link",
+            "main",
+            "menu",
+            "menuitem",
+            "option",
+            "switch",
+            "table",
+            "text",
+            "time",
+            "div",
+            "section",
+            "aside",
+            "li",
+            "a",
+            "abbr",
+            "address",
+            "area",
+            "audio",
+            "b",
+            "base",
+            "bdi",
+            "bdo",
+            "big",
+            "blockquote",
+            "body",
+            "br",
+            "canvas",
+            "caption",
+            "center",
+            "cite",
+            "code",
+            "col",
+            "colgroup",
+            "data",
+            "datalist",
+            "dd",
+            "del",
+            "details",
+            "dfn",
+            "dl",
+            "dt",
+            "em",
+            "embed",
+            "fieldset",
+            "figcaption",
+            "footer",
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "h6",
+            "head",
+            "header",
+            "hgroup",
+            "hr",
+            "html",
+            "i",
+            "iframe",
+            "input",
+            "ins",
+            "kbd",
+            "keygen",
+            "label",
+            "legend",
+            "map",
+            "mark",
+            "meta",
+            "meter",
+            "nav",
+            "noindex",
+            "noscript",
+            "ol",
+            "optgroup",
+            "output",
+            "p",
+            "param",
+            "picture",
+            "pre",
+            "progress",
+            "q",
+            "rp",
+            "rt",
+            "ruby",
+            "s",
+            "samp",
+            "script",
+            "select",
+            "small",
+            "source",
+            "span",
+            "strong",
+            "sub",
+            "summary",
+            "sup",
+            "template",
+            "tbody",
+            "td",
+            "textarea",
+            "tfoot",
+            "th",
+            "thead",
+            "tr",
+            "track",
+            "u",
+            "ul",
+            "var",
+            "video",
+            "wbr",
+            "webview",
+            "svg",
+            "animate",
+            "animateMotion",
+            "animateTransform",
+            "circle",
+            "clipPath",
+            "defs",
+            "desc",
+            "ellipse",
+            "feBlend",
+            "feColorMatrix",
+            "feComponentTransfer",
+            "feComposite",
+            "feConvolveMatrix",
+            "feDiffuseLighting",
+            "feDisplacementMap",
+            "feDistantLight",
+            "feDropShadow",
+            "feFlood",
+            "feFuncA",
+            "feFuncB",
+            "feFuncG",
+            "feFuncR",
+            "feGaussianBlur",
+            "feImage",
+            "feMerge",
+            "feMergeNode",
+            "feMorphology",
+            "feOffset",
+            "fePointLight",
+            "feSpecularLighting",
+            "feSpotLight",
+            "feTile",
+            "feTurbulence",
+            "filter",
+            "foreignObject",
+            "g",
+            "line",
+            "linearGradient",
+            "marker",
+            "mask",
+            "metadata",
+            "mpath",
+            "path",
+            "pattern",
+            "polygon",
+            "polyline",
+            "radialGradient",
+            "rect",
+            "set",
+            "stop",
+            "textPath",
+            "tspan",
+            "use",
+            "view"
+          ]
+        }
+      },
+      "propRelationships": [],
+      "variants": {},
+      "cvaVariants": {},
+      "variantsFnName": null,
+      "useWhen": [],
+      "avoidWhen": [],
+      "requiredA11y": [],
+      "keyboard": [],
+      "compositionRules": [],
+      "canonicalExamples": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+      ],
+      "replacementFor": [],
+      "forbiddenUse": [],
+      "composesWith": [],
+      "prefersOver": [],
+      "declaredPropCount": 8,
+      "guidelines": [],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-05-28 — Breadth beta port: keyboard/ARIA contract reviewed, ForcedColors story added, Storybook axe gate (parameters.a11y.test: error)."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FadeIn.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FadeIn.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FadeIn.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "FadeIn.spec.md"
         },
         "requiredA11y": {
           "origin": "authored",
@@ -32023,7 +32441,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified"
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
         },
         {
           "id": "forced-colors-real-browser",

--- a/nextjs-app/shared/patterns/Footer/Footer.contract.json
+++ b/nextjs-app/shared/patterns/Footer/Footer.contract.json
@@ -34,7 +34,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.stories.tsx
+++ b/nextjs-app/shared/patterns/PricingCalculator/PricingCalculator.stories.tsx
@@ -66,6 +66,7 @@ export const Interactive: Story = {
 
 /** In-context composition: the section as it sits on the pricing page. */
 export const Example: Story = {
+  tags: ["beta-matrix"],
   render: () => (
     <div style={{ maxWidth: 1120, marginInline: "auto" }}>
       <PricingCalculator />

--- a/nextjs-app/shared/templates/NextLayoutShell/NextLayoutShell.contract.json
+++ b/nextjs-app/shared/templates/NextLayoutShell/NextLayoutShell.contract.json
@@ -24,7 +24,8 @@
         "reviewed": true,
         "forcedColorsVerified": true,
         "ariaRequirements": [],
-        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled."
+        "reviewedNote": "2026-05-28 — Promoted from alpha: Example + ForcedColors stories present; Storybook axe gate enabled.",
+        "accessibilityTreeVerified": true
     },
     "tokens": {
         "colors": [],

--- a/nextjs-app/shared/templates/NextLayoutShell/NextLayoutShell.stories.tsx
+++ b/nextjs-app/shared/templates/NextLayoutShell/NextLayoutShell.stories.tsx
@@ -16,6 +16,13 @@ const meta: Meta = {
     contractStatus: contract.status,
     a11y: { test: "error" },
     layout: "fullscreen",
+    // This shell renders <NextLayout>, so it inherits NextLayout's React.lazy
+    // chat toggle and the same capture race: cold page = no button, warmed page
+    // = button, so the AT snapshot flips with worker cache warmth. NextLayout
+    // already declares this wait; the shell needs it for the same reason. The
+    // race only surfaced once the snapshot-dir resolver started resolving
+    // templates/ at all — before that this component was never captured.
+    atSnapshot: { waitForSelector: "button[aria-label^=\"Chat\"]" },
     docs: {
       description: {
         component:

--- a/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--default.dark.yaml
+++ b/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--default.dark.yaml
@@ -1,0 +1,79 @@
+- status: Work in progress (beta)
+- link "Skip to main content":
+  - /url: "#main-content"
+- banner:
+  - link "Digitaltableteur":
+    - /url: /
+  - navigation "Main navigation":
+    - link "Home":
+      - /url: /
+    - link "Work":
+      - /url: /work
+    - link "About":
+      - /url: /about
+    - link "Pricing":
+      - /url: /pricing
+    - link "Blog":
+      - /url: /blog
+    - link "Contact":
+      - /url: /contact
+  - group "Language":
+    - button "EN — Switch to English. Show language options": EN
+    - text: Show language options
+  - button "Toggle dark mode"
+- main:
+  - heading "Page content" [level=1]
+  - paragraph: Same shell as app/layout.tsx — verify chrome and main landmark together.
+- contentinfo:
+  - paragraph: Visit
+  - link "Digitaltableteur":
+    - /url: /
+  - text: Hämeentie 8 C 00530 Helsinki
+  - link "mail@digitaltableteur.com":
+    - /url: mailto:mail@digitaltableteur.com
+  - paragraph: Billing details
+  - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
+  - paragraph: Explore
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Pricing":
+    - /url: /pricing
+  - link "Blog":
+    - /url: /blog
+  - link "Contact":
+    - /url: /contact
+  - paragraph: Legal
+  - link "Privacy Policy":
+    - /url: /privacy-policy
+  - link "Imprint":
+    - /url: /imprint
+  - link "AI Usage":
+    - /url: /ai-use
+  - link "Accessibility Statement":
+    - /url: /accessibility
+  - link "Sitemap":
+    - /url: /sitemap
+  - button "Cookie preferences"
+  - link "Instagram":
+    - /url: https://www.instagram.com/digitaltableteur/
+  - link "Facebook":
+    - /url: https://www.facebook.com/digitaltableteur
+  - link "LinkedIn":
+    - /url: https://www.linkedin.com/company/digitaltableteur/
+  - link "Medium":
+    - /url: https://medium.com/digitaltableteur
+  - link "X":
+    - /url: https://x.com/dtdoesdesign
+  - link "GitHub":
+    - /url: https://github.com/PetriLahdelma
+  - link "Substack":
+    - /url: https://substack.com/@petrilahdelma
+  - link "Dribbble":
+    - /url: https://dribbble.com/digitaltableteur
+  - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
+- status

--- a/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--default.forced-colors.yaml
+++ b/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--default.forced-colors.yaml
@@ -1,0 +1,79 @@
+- status: Work in progress (beta)
+- link "Skip to main content":
+  - /url: "#main-content"
+- banner:
+  - link "Digitaltableteur":
+    - /url: /
+  - navigation "Main navigation":
+    - link "Home":
+      - /url: /
+    - link "Work":
+      - /url: /work
+    - link "About":
+      - /url: /about
+    - link "Pricing":
+      - /url: /pricing
+    - link "Blog":
+      - /url: /blog
+    - link "Contact":
+      - /url: /contact
+  - group "Language":
+    - button "EN — Switch to English. Show language options": EN
+    - text: Show language options
+  - button "Toggle dark mode"
+- main:
+  - heading "Page content" [level=1]
+  - paragraph: Same shell as app/layout.tsx — verify chrome and main landmark together.
+- contentinfo:
+  - paragraph: Visit
+  - link "Digitaltableteur":
+    - /url: /
+  - text: Hämeentie 8 C 00530 Helsinki
+  - link "mail@digitaltableteur.com":
+    - /url: mailto:mail@digitaltableteur.com
+  - paragraph: Billing details
+  - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
+  - paragraph: Explore
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Pricing":
+    - /url: /pricing
+  - link "Blog":
+    - /url: /blog
+  - link "Contact":
+    - /url: /contact
+  - paragraph: Legal
+  - link "Privacy Policy":
+    - /url: /privacy-policy
+  - link "Imprint":
+    - /url: /imprint
+  - link "AI Usage":
+    - /url: /ai-use
+  - link "Accessibility Statement":
+    - /url: /accessibility
+  - link "Sitemap":
+    - /url: /sitemap
+  - button "Cookie preferences"
+  - link "Instagram":
+    - /url: https://www.instagram.com/digitaltableteur/
+  - link "Facebook":
+    - /url: https://www.facebook.com/digitaltableteur
+  - link "LinkedIn":
+    - /url: https://www.linkedin.com/company/digitaltableteur/
+  - link "Medium":
+    - /url: https://medium.com/digitaltableteur
+  - link "X":
+    - /url: https://x.com/dtdoesdesign
+  - link "GitHub":
+    - /url: https://github.com/PetriLahdelma
+  - link "Substack":
+    - /url: https://substack.com/@petrilahdelma
+  - link "Dribbble":
+    - /url: https://dribbble.com/digitaltableteur
+  - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
+- status

--- a/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--default.light.yaml
+++ b/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--default.light.yaml
@@ -1,0 +1,79 @@
+- status: Work in progress (beta)
+- link "Skip to main content":
+  - /url: "#main-content"
+- banner:
+  - link "Digitaltableteur":
+    - /url: /
+  - navigation "Main navigation":
+    - link "Home":
+      - /url: /
+    - link "Work":
+      - /url: /work
+    - link "About":
+      - /url: /about
+    - link "Pricing":
+      - /url: /pricing
+    - link "Blog":
+      - /url: /blog
+    - link "Contact":
+      - /url: /contact
+  - group "Language":
+    - button "EN — Switch to English. Show language options": EN
+    - text: Show language options
+  - button "Toggle dark mode"
+- main:
+  - heading "Page content" [level=1]
+  - paragraph: Same shell as app/layout.tsx — verify chrome and main landmark together.
+- contentinfo:
+  - paragraph: Visit
+  - link "Digitaltableteur":
+    - /url: /
+  - text: Hämeentie 8 C 00530 Helsinki
+  - link "mail@digitaltableteur.com":
+    - /url: mailto:mail@digitaltableteur.com
+  - paragraph: Billing details
+  - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
+  - paragraph: Explore
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Pricing":
+    - /url: /pricing
+  - link "Blog":
+    - /url: /blog
+  - link "Contact":
+    - /url: /contact
+  - paragraph: Legal
+  - link "Privacy Policy":
+    - /url: /privacy-policy
+  - link "Imprint":
+    - /url: /imprint
+  - link "AI Usage":
+    - /url: /ai-use
+  - link "Accessibility Statement":
+    - /url: /accessibility
+  - link "Sitemap":
+    - /url: /sitemap
+  - button "Cookie preferences"
+  - link "Instagram":
+    - /url: https://www.instagram.com/digitaltableteur/
+  - link "Facebook":
+    - /url: https://www.facebook.com/digitaltableteur
+  - link "LinkedIn":
+    - /url: https://www.linkedin.com/company/digitaltableteur/
+  - link "Medium":
+    - /url: https://medium.com/digitaltableteur
+  - link "X":
+    - /url: https://x.com/dtdoesdesign
+  - link "GitHub":
+    - /url: https://github.com/PetriLahdelma
+  - link "Substack":
+    - /url: https://substack.com/@petrilahdelma
+  - link "Dribbble":
+    - /url: https://dribbble.com/digitaltableteur
+  - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
+- status

--- a/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--default.yaml
+++ b/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--default.yaml
@@ -1,0 +1,79 @@
+- status: Work in progress (beta)
+- link "Skip to main content":
+  - /url: "#main-content"
+- banner:
+  - link "Digitaltableteur":
+    - /url: /
+  - navigation "Main navigation":
+    - link "Home":
+      - /url: /
+    - link "Work":
+      - /url: /work
+    - link "About":
+      - /url: /about
+    - link "Pricing":
+      - /url: /pricing
+    - link "Blog":
+      - /url: /blog
+    - link "Contact":
+      - /url: /contact
+  - group "Language":
+    - button "EN — Switch to English. Show language options": EN
+    - text: Show language options
+  - button "Toggle dark mode"
+- main:
+  - heading "Page content" [level=1]
+  - paragraph: Same shell as app/layout.tsx — verify chrome and main landmark together.
+- contentinfo:
+  - paragraph: Visit
+  - link "Digitaltableteur":
+    - /url: /
+  - text: Hämeentie 8 C 00530 Helsinki
+  - link "mail@digitaltableteur.com":
+    - /url: mailto:mail@digitaltableteur.com
+  - paragraph: Billing details
+  - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
+  - paragraph: Explore
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Pricing":
+    - /url: /pricing
+  - link "Blog":
+    - /url: /blog
+  - link "Contact":
+    - /url: /contact
+  - paragraph: Legal
+  - link "Privacy Policy":
+    - /url: /privacy-policy
+  - link "Imprint":
+    - /url: /imprint
+  - link "AI Usage":
+    - /url: /ai-use
+  - link "Accessibility Statement":
+    - /url: /accessibility
+  - link "Sitemap":
+    - /url: /sitemap
+  - button "Cookie preferences"
+  - link "Instagram":
+    - /url: https://www.instagram.com/digitaltableteur/
+  - link "Facebook":
+    - /url: https://www.facebook.com/digitaltableteur
+  - link "LinkedIn":
+    - /url: https://www.linkedin.com/company/digitaltableteur/
+  - link "Medium":
+    - /url: https://medium.com/digitaltableteur
+  - link "X":
+    - /url: https://x.com/dtdoesdesign
+  - link "GitHub":
+    - /url: https://github.com/PetriLahdelma
+  - link "Substack":
+    - /url: https://substack.com/@petrilahdelma
+  - link "Dribbble":
+    - /url: https://dribbble.com/digitaltableteur
+  - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
+- status

--- a/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--example.dark.yaml
+++ b/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--example.dark.yaml
@@ -1,0 +1,79 @@
+- status: Work in progress (beta)
+- link "Skip to main content":
+  - /url: "#main-content"
+- banner:
+  - link "Digitaltableteur":
+    - /url: /
+  - navigation "Main navigation":
+    - link "Home":
+      - /url: /
+    - link "Work":
+      - /url: /work
+    - link "About":
+      - /url: /about
+    - link "Pricing":
+      - /url: /pricing
+    - link "Blog":
+      - /url: /blog
+    - link "Contact":
+      - /url: /contact
+  - group "Language":
+    - button "EN — Switch to English. Show language options": EN
+    - text: Show language options
+  - button "Toggle dark mode"
+- main:
+  - heading "Page content" [level=1]
+  - paragraph: Same shell as app/layout.tsx — verify chrome and main landmark together.
+- contentinfo:
+  - paragraph: Visit
+  - link "Digitaltableteur":
+    - /url: /
+  - text: Hämeentie 8 C 00530 Helsinki
+  - link "mail@digitaltableteur.com":
+    - /url: mailto:mail@digitaltableteur.com
+  - paragraph: Billing details
+  - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
+  - paragraph: Explore
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Pricing":
+    - /url: /pricing
+  - link "Blog":
+    - /url: /blog
+  - link "Contact":
+    - /url: /contact
+  - paragraph: Legal
+  - link "Privacy Policy":
+    - /url: /privacy-policy
+  - link "Imprint":
+    - /url: /imprint
+  - link "AI Usage":
+    - /url: /ai-use
+  - link "Accessibility Statement":
+    - /url: /accessibility
+  - link "Sitemap":
+    - /url: /sitemap
+  - button "Cookie preferences"
+  - link "Instagram":
+    - /url: https://www.instagram.com/digitaltableteur/
+  - link "Facebook":
+    - /url: https://www.facebook.com/digitaltableteur
+  - link "LinkedIn":
+    - /url: https://www.linkedin.com/company/digitaltableteur/
+  - link "Medium":
+    - /url: https://medium.com/digitaltableteur
+  - link "X":
+    - /url: https://x.com/dtdoesdesign
+  - link "GitHub":
+    - /url: https://github.com/PetriLahdelma
+  - link "Substack":
+    - /url: https://substack.com/@petrilahdelma
+  - link "Dribbble":
+    - /url: https://dribbble.com/digitaltableteur
+  - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
+- status

--- a/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--example.forced-colors.yaml
+++ b/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--example.forced-colors.yaml
@@ -1,0 +1,79 @@
+- status: Work in progress (beta)
+- link "Skip to main content":
+  - /url: "#main-content"
+- banner:
+  - link "Digitaltableteur":
+    - /url: /
+  - navigation "Main navigation":
+    - link "Home":
+      - /url: /
+    - link "Work":
+      - /url: /work
+    - link "About":
+      - /url: /about
+    - link "Pricing":
+      - /url: /pricing
+    - link "Blog":
+      - /url: /blog
+    - link "Contact":
+      - /url: /contact
+  - group "Language":
+    - button "EN — Switch to English. Show language options": EN
+    - text: Show language options
+  - button "Toggle dark mode"
+- main:
+  - heading "Page content" [level=1]
+  - paragraph: Same shell as app/layout.tsx — verify chrome and main landmark together.
+- contentinfo:
+  - paragraph: Visit
+  - link "Digitaltableteur":
+    - /url: /
+  - text: Hämeentie 8 C 00530 Helsinki
+  - link "mail@digitaltableteur.com":
+    - /url: mailto:mail@digitaltableteur.com
+  - paragraph: Billing details
+  - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
+  - paragraph: Explore
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Pricing":
+    - /url: /pricing
+  - link "Blog":
+    - /url: /blog
+  - link "Contact":
+    - /url: /contact
+  - paragraph: Legal
+  - link "Privacy Policy":
+    - /url: /privacy-policy
+  - link "Imprint":
+    - /url: /imprint
+  - link "AI Usage":
+    - /url: /ai-use
+  - link "Accessibility Statement":
+    - /url: /accessibility
+  - link "Sitemap":
+    - /url: /sitemap
+  - button "Cookie preferences"
+  - link "Instagram":
+    - /url: https://www.instagram.com/digitaltableteur/
+  - link "Facebook":
+    - /url: https://www.facebook.com/digitaltableteur
+  - link "LinkedIn":
+    - /url: https://www.linkedin.com/company/digitaltableteur/
+  - link "Medium":
+    - /url: https://medium.com/digitaltableteur
+  - link "X":
+    - /url: https://x.com/dtdoesdesign
+  - link "GitHub":
+    - /url: https://github.com/PetriLahdelma
+  - link "Substack":
+    - /url: https://substack.com/@petrilahdelma
+  - link "Dribbble":
+    - /url: https://dribbble.com/digitaltableteur
+  - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
+- status

--- a/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--example.light.yaml
+++ b/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--example.light.yaml
@@ -1,0 +1,79 @@
+- status: Work in progress (beta)
+- link "Skip to main content":
+  - /url: "#main-content"
+- banner:
+  - link "Digitaltableteur":
+    - /url: /
+  - navigation "Main navigation":
+    - link "Home":
+      - /url: /
+    - link "Work":
+      - /url: /work
+    - link "About":
+      - /url: /about
+    - link "Pricing":
+      - /url: /pricing
+    - link "Blog":
+      - /url: /blog
+    - link "Contact":
+      - /url: /contact
+  - group "Language":
+    - button "EN — Switch to English. Show language options": EN
+    - text: Show language options
+  - button "Toggle dark mode"
+- main:
+  - heading "Page content" [level=1]
+  - paragraph: Same shell as app/layout.tsx — verify chrome and main landmark together.
+- contentinfo:
+  - paragraph: Visit
+  - link "Digitaltableteur":
+    - /url: /
+  - text: Hämeentie 8 C 00530 Helsinki
+  - link "mail@digitaltableteur.com":
+    - /url: mailto:mail@digitaltableteur.com
+  - paragraph: Billing details
+  - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
+  - paragraph: Explore
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Pricing":
+    - /url: /pricing
+  - link "Blog":
+    - /url: /blog
+  - link "Contact":
+    - /url: /contact
+  - paragraph: Legal
+  - link "Privacy Policy":
+    - /url: /privacy-policy
+  - link "Imprint":
+    - /url: /imprint
+  - link "AI Usage":
+    - /url: /ai-use
+  - link "Accessibility Statement":
+    - /url: /accessibility
+  - link "Sitemap":
+    - /url: /sitemap
+  - button "Cookie preferences"
+  - link "Instagram":
+    - /url: https://www.instagram.com/digitaltableteur/
+  - link "Facebook":
+    - /url: https://www.facebook.com/digitaltableteur
+  - link "LinkedIn":
+    - /url: https://www.linkedin.com/company/digitaltableteur/
+  - link "Medium":
+    - /url: https://medium.com/digitaltableteur
+  - link "X":
+    - /url: https://x.com/dtdoesdesign
+  - link "GitHub":
+    - /url: https://github.com/PetriLahdelma
+  - link "Substack":
+    - /url: https://substack.com/@petrilahdelma
+  - link "Dribbble":
+    - /url: https://dribbble.com/digitaltableteur
+  - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
+- status

--- a/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--example.yaml
+++ b/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--example.yaml
@@ -1,0 +1,79 @@
+- status: Work in progress (beta)
+- link "Skip to main content":
+  - /url: "#main-content"
+- banner:
+  - link "Digitaltableteur":
+    - /url: /
+  - navigation "Main navigation":
+    - link "Home":
+      - /url: /
+    - link "Work":
+      - /url: /work
+    - link "About":
+      - /url: /about
+    - link "Pricing":
+      - /url: /pricing
+    - link "Blog":
+      - /url: /blog
+    - link "Contact":
+      - /url: /contact
+  - group "Language":
+    - button "EN — Switch to English. Show language options": EN
+    - text: Show language options
+  - button "Toggle dark mode"
+- main:
+  - heading "Page content" [level=1]
+  - paragraph: Same shell as app/layout.tsx — verify chrome and main landmark together.
+- contentinfo:
+  - paragraph: Visit
+  - link "Digitaltableteur":
+    - /url: /
+  - text: Hämeentie 8 C 00530 Helsinki
+  - link "mail@digitaltableteur.com":
+    - /url: mailto:mail@digitaltableteur.com
+  - paragraph: Billing details
+  - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
+  - paragraph: Explore
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Pricing":
+    - /url: /pricing
+  - link "Blog":
+    - /url: /blog
+  - link "Contact":
+    - /url: /contact
+  - paragraph: Legal
+  - link "Privacy Policy":
+    - /url: /privacy-policy
+  - link "Imprint":
+    - /url: /imprint
+  - link "AI Usage":
+    - /url: /ai-use
+  - link "Accessibility Statement":
+    - /url: /accessibility
+  - link "Sitemap":
+    - /url: /sitemap
+  - button "Cookie preferences"
+  - link "Instagram":
+    - /url: https://www.instagram.com/digitaltableteur/
+  - link "Facebook":
+    - /url: https://www.facebook.com/digitaltableteur
+  - link "LinkedIn":
+    - /url: https://www.linkedin.com/company/digitaltableteur/
+  - link "Medium":
+    - /url: https://medium.com/digitaltableteur
+  - link "X":
+    - /url: https://x.com/dtdoesdesign
+  - link "GitHub":
+    - /url: https://github.com/PetriLahdelma
+  - link "Substack":
+    - /url: https://substack.com/@petrilahdelma
+  - link "Dribbble":
+    - /url: https://dribbble.com/digitaltableteur
+  - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
+- status

--- a/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--forced-colors.dark.yaml
+++ b/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--forced-colors.dark.yaml
@@ -1,0 +1,79 @@
+- status: Work in progress (beta)
+- link "Skip to main content":
+  - /url: "#main-content"
+- banner:
+  - link "Digitaltableteur":
+    - /url: /
+  - navigation "Main navigation":
+    - link "Home":
+      - /url: /
+    - link "Work":
+      - /url: /work
+    - link "About":
+      - /url: /about
+    - link "Pricing":
+      - /url: /pricing
+    - link "Blog":
+      - /url: /blog
+    - link "Contact":
+      - /url: /contact
+  - group "Language":
+    - button "EN — Switch to English. Show language options": EN
+    - text: Show language options
+  - button "Toggle dark mode"
+- main:
+  - heading "Page content" [level=1]
+  - paragraph: Same shell as app/layout.tsx — verify chrome and main landmark together.
+- contentinfo:
+  - paragraph: Visit
+  - link "Digitaltableteur":
+    - /url: /
+  - text: Hämeentie 8 C 00530 Helsinki
+  - link "mail@digitaltableteur.com":
+    - /url: mailto:mail@digitaltableteur.com
+  - paragraph: Billing details
+  - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
+  - paragraph: Explore
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Pricing":
+    - /url: /pricing
+  - link "Blog":
+    - /url: /blog
+  - link "Contact":
+    - /url: /contact
+  - paragraph: Legal
+  - link "Privacy Policy":
+    - /url: /privacy-policy
+  - link "Imprint":
+    - /url: /imprint
+  - link "AI Usage":
+    - /url: /ai-use
+  - link "Accessibility Statement":
+    - /url: /accessibility
+  - link "Sitemap":
+    - /url: /sitemap
+  - button "Cookie preferences"
+  - link "Instagram":
+    - /url: https://www.instagram.com/digitaltableteur/
+  - link "Facebook":
+    - /url: https://www.facebook.com/digitaltableteur
+  - link "LinkedIn":
+    - /url: https://www.linkedin.com/company/digitaltableteur/
+  - link "Medium":
+    - /url: https://medium.com/digitaltableteur
+  - link "X":
+    - /url: https://x.com/dtdoesdesign
+  - link "GitHub":
+    - /url: https://github.com/PetriLahdelma
+  - link "Substack":
+    - /url: https://substack.com/@petrilahdelma
+  - link "Dribbble":
+    - /url: https://dribbble.com/digitaltableteur
+  - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
+- status

--- a/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--forced-colors.forced-colors.yaml
@@ -1,0 +1,79 @@
+- status: Work in progress (beta)
+- link "Skip to main content":
+  - /url: "#main-content"
+- banner:
+  - link "Digitaltableteur":
+    - /url: /
+  - navigation "Main navigation":
+    - link "Home":
+      - /url: /
+    - link "Work":
+      - /url: /work
+    - link "About":
+      - /url: /about
+    - link "Pricing":
+      - /url: /pricing
+    - link "Blog":
+      - /url: /blog
+    - link "Contact":
+      - /url: /contact
+  - group "Language":
+    - button "EN — Switch to English. Show language options": EN
+    - text: Show language options
+  - button "Toggle dark mode"
+- main:
+  - heading "Page content" [level=1]
+  - paragraph: Same shell as app/layout.tsx — verify chrome and main landmark together.
+- contentinfo:
+  - paragraph: Visit
+  - link "Digitaltableteur":
+    - /url: /
+  - text: Hämeentie 8 C 00530 Helsinki
+  - link "mail@digitaltableteur.com":
+    - /url: mailto:mail@digitaltableteur.com
+  - paragraph: Billing details
+  - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
+  - paragraph: Explore
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Pricing":
+    - /url: /pricing
+  - link "Blog":
+    - /url: /blog
+  - link "Contact":
+    - /url: /contact
+  - paragraph: Legal
+  - link "Privacy Policy":
+    - /url: /privacy-policy
+  - link "Imprint":
+    - /url: /imprint
+  - link "AI Usage":
+    - /url: /ai-use
+  - link "Accessibility Statement":
+    - /url: /accessibility
+  - link "Sitemap":
+    - /url: /sitemap
+  - button "Cookie preferences"
+  - link "Instagram":
+    - /url: https://www.instagram.com/digitaltableteur/
+  - link "Facebook":
+    - /url: https://www.facebook.com/digitaltableteur
+  - link "LinkedIn":
+    - /url: https://www.linkedin.com/company/digitaltableteur/
+  - link "Medium":
+    - /url: https://medium.com/digitaltableteur
+  - link "X":
+    - /url: https://x.com/dtdoesdesign
+  - link "GitHub":
+    - /url: https://github.com/PetriLahdelma
+  - link "Substack":
+    - /url: https://substack.com/@petrilahdelma
+  - link "Dribbble":
+    - /url: https://dribbble.com/digitaltableteur
+  - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
+- status

--- a/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--forced-colors.light.yaml
+++ b/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--forced-colors.light.yaml
@@ -1,0 +1,79 @@
+- status: Work in progress (beta)
+- link "Skip to main content":
+  - /url: "#main-content"
+- banner:
+  - link "Digitaltableteur":
+    - /url: /
+  - navigation "Main navigation":
+    - link "Home":
+      - /url: /
+    - link "Work":
+      - /url: /work
+    - link "About":
+      - /url: /about
+    - link "Pricing":
+      - /url: /pricing
+    - link "Blog":
+      - /url: /blog
+    - link "Contact":
+      - /url: /contact
+  - group "Language":
+    - button "EN — Switch to English. Show language options": EN
+    - text: Show language options
+  - button "Toggle dark mode"
+- main:
+  - heading "Page content" [level=1]
+  - paragraph: Same shell as app/layout.tsx — verify chrome and main landmark together.
+- contentinfo:
+  - paragraph: Visit
+  - link "Digitaltableteur":
+    - /url: /
+  - text: Hämeentie 8 C 00530 Helsinki
+  - link "mail@digitaltableteur.com":
+    - /url: mailto:mail@digitaltableteur.com
+  - paragraph: Billing details
+  - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
+  - paragraph: Explore
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Pricing":
+    - /url: /pricing
+  - link "Blog":
+    - /url: /blog
+  - link "Contact":
+    - /url: /contact
+  - paragraph: Legal
+  - link "Privacy Policy":
+    - /url: /privacy-policy
+  - link "Imprint":
+    - /url: /imprint
+  - link "AI Usage":
+    - /url: /ai-use
+  - link "Accessibility Statement":
+    - /url: /accessibility
+  - link "Sitemap":
+    - /url: /sitemap
+  - button "Cookie preferences"
+  - link "Instagram":
+    - /url: https://www.instagram.com/digitaltableteur/
+  - link "Facebook":
+    - /url: https://www.facebook.com/digitaltableteur
+  - link "LinkedIn":
+    - /url: https://www.linkedin.com/company/digitaltableteur/
+  - link "Medium":
+    - /url: https://medium.com/digitaltableteur
+  - link "X":
+    - /url: https://x.com/dtdoesdesign
+  - link "GitHub":
+    - /url: https://github.com/PetriLahdelma
+  - link "Substack":
+    - /url: https://substack.com/@petrilahdelma
+  - link "Dribbble":
+    - /url: https://dribbble.com/digitaltableteur
+  - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
+- status

--- a/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--forced-colors.yaml
+++ b/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--forced-colors.yaml
@@ -1,0 +1,79 @@
+- status: Work in progress (beta)
+- link "Skip to main content":
+  - /url: "#main-content"
+- banner:
+  - link "Digitaltableteur":
+    - /url: /
+  - navigation "Main navigation":
+    - link "Home":
+      - /url: /
+    - link "Work":
+      - /url: /work
+    - link "About":
+      - /url: /about
+    - link "Pricing":
+      - /url: /pricing
+    - link "Blog":
+      - /url: /blog
+    - link "Contact":
+      - /url: /contact
+  - group "Language":
+    - button "EN — Switch to English. Show language options": EN
+    - text: Show language options
+  - button "Toggle dark mode"
+- main:
+  - heading "Page content" [level=1]
+  - paragraph: Same shell as app/layout.tsx — verify chrome and main landmark together.
+- contentinfo:
+  - paragraph: Visit
+  - link "Digitaltableteur":
+    - /url: /
+  - text: Hämeentie 8 C 00530 Helsinki
+  - link "mail@digitaltableteur.com":
+    - /url: mailto:mail@digitaltableteur.com
+  - paragraph: Billing details
+  - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
+  - paragraph: Explore
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Pricing":
+    - /url: /pricing
+  - link "Blog":
+    - /url: /blog
+  - link "Contact":
+    - /url: /contact
+  - paragraph: Legal
+  - link "Privacy Policy":
+    - /url: /privacy-policy
+  - link "Imprint":
+    - /url: /imprint
+  - link "AI Usage":
+    - /url: /ai-use
+  - link "Accessibility Statement":
+    - /url: /accessibility
+  - link "Sitemap":
+    - /url: /sitemap
+  - button "Cookie preferences"
+  - link "Instagram":
+    - /url: https://www.instagram.com/digitaltableteur/
+  - link "Facebook":
+    - /url: https://www.facebook.com/digitaltableteur
+  - link "LinkedIn":
+    - /url: https://www.linkedin.com/company/digitaltableteur/
+  - link "Medium":
+    - /url: https://medium.com/digitaltableteur
+  - link "X":
+    - /url: https://x.com/dtdoesdesign
+  - link "GitHub":
+    - /url: https://github.com/PetriLahdelma
+  - link "Substack":
+    - /url: https://substack.com/@petrilahdelma
+  - link "Dribbble":
+    - /url: https://dribbble.com/digitaltableteur
+  - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
+- status

--- a/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--playground.dark.yaml
+++ b/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--playground.dark.yaml
@@ -1,0 +1,79 @@
+- status: Work in progress (beta)
+- link "Skip to main content":
+  - /url: "#main-content"
+- banner:
+  - link "Digitaltableteur":
+    - /url: /
+  - navigation "Main navigation":
+    - link "Home":
+      - /url: /
+    - link "Work":
+      - /url: /work
+    - link "About":
+      - /url: /about
+    - link "Pricing":
+      - /url: /pricing
+    - link "Blog":
+      - /url: /blog
+    - link "Contact":
+      - /url: /contact
+  - group "Language":
+    - button "EN — Switch to English. Show language options": EN
+    - text: Show language options
+  - button "Toggle dark mode"
+- main:
+  - heading "Page content" [level=1]
+  - paragraph: Same shell as app/layout.tsx — verify chrome and main landmark together.
+- contentinfo:
+  - paragraph: Visit
+  - link "Digitaltableteur":
+    - /url: /
+  - text: Hämeentie 8 C 00530 Helsinki
+  - link "mail@digitaltableteur.com":
+    - /url: mailto:mail@digitaltableteur.com
+  - paragraph: Billing details
+  - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
+  - paragraph: Explore
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Pricing":
+    - /url: /pricing
+  - link "Blog":
+    - /url: /blog
+  - link "Contact":
+    - /url: /contact
+  - paragraph: Legal
+  - link "Privacy Policy":
+    - /url: /privacy-policy
+  - link "Imprint":
+    - /url: /imprint
+  - link "AI Usage":
+    - /url: /ai-use
+  - link "Accessibility Statement":
+    - /url: /accessibility
+  - link "Sitemap":
+    - /url: /sitemap
+  - button "Cookie preferences"
+  - link "Instagram":
+    - /url: https://www.instagram.com/digitaltableteur/
+  - link "Facebook":
+    - /url: https://www.facebook.com/digitaltableteur
+  - link "LinkedIn":
+    - /url: https://www.linkedin.com/company/digitaltableteur/
+  - link "Medium":
+    - /url: https://medium.com/digitaltableteur
+  - link "X":
+    - /url: https://x.com/dtdoesdesign
+  - link "GitHub":
+    - /url: https://github.com/PetriLahdelma
+  - link "Substack":
+    - /url: https://substack.com/@petrilahdelma
+  - link "Dribbble":
+    - /url: https://dribbble.com/digitaltableteur
+  - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
+- status

--- a/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--playground.forced-colors.yaml
+++ b/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--playground.forced-colors.yaml
@@ -1,0 +1,79 @@
+- status: Work in progress (beta)
+- link "Skip to main content":
+  - /url: "#main-content"
+- banner:
+  - link "Digitaltableteur":
+    - /url: /
+  - navigation "Main navigation":
+    - link "Home":
+      - /url: /
+    - link "Work":
+      - /url: /work
+    - link "About":
+      - /url: /about
+    - link "Pricing":
+      - /url: /pricing
+    - link "Blog":
+      - /url: /blog
+    - link "Contact":
+      - /url: /contact
+  - group "Language":
+    - button "EN — Switch to English. Show language options": EN
+    - text: Show language options
+  - button "Toggle dark mode"
+- main:
+  - heading "Page content" [level=1]
+  - paragraph: Same shell as app/layout.tsx — verify chrome and main landmark together.
+- contentinfo:
+  - paragraph: Visit
+  - link "Digitaltableteur":
+    - /url: /
+  - text: Hämeentie 8 C 00530 Helsinki
+  - link "mail@digitaltableteur.com":
+    - /url: mailto:mail@digitaltableteur.com
+  - paragraph: Billing details
+  - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
+  - paragraph: Explore
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Pricing":
+    - /url: /pricing
+  - link "Blog":
+    - /url: /blog
+  - link "Contact":
+    - /url: /contact
+  - paragraph: Legal
+  - link "Privacy Policy":
+    - /url: /privacy-policy
+  - link "Imprint":
+    - /url: /imprint
+  - link "AI Usage":
+    - /url: /ai-use
+  - link "Accessibility Statement":
+    - /url: /accessibility
+  - link "Sitemap":
+    - /url: /sitemap
+  - button "Cookie preferences"
+  - link "Instagram":
+    - /url: https://www.instagram.com/digitaltableteur/
+  - link "Facebook":
+    - /url: https://www.facebook.com/digitaltableteur
+  - link "LinkedIn":
+    - /url: https://www.linkedin.com/company/digitaltableteur/
+  - link "Medium":
+    - /url: https://medium.com/digitaltableteur
+  - link "X":
+    - /url: https://x.com/dtdoesdesign
+  - link "GitHub":
+    - /url: https://github.com/PetriLahdelma
+  - link "Substack":
+    - /url: https://substack.com/@petrilahdelma
+  - link "Dribbble":
+    - /url: https://dribbble.com/digitaltableteur
+  - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
+- status

--- a/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--playground.light.yaml
+++ b/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--playground.light.yaml
@@ -1,0 +1,79 @@
+- status: Work in progress (beta)
+- link "Skip to main content":
+  - /url: "#main-content"
+- banner:
+  - link "Digitaltableteur":
+    - /url: /
+  - navigation "Main navigation":
+    - link "Home":
+      - /url: /
+    - link "Work":
+      - /url: /work
+    - link "About":
+      - /url: /about
+    - link "Pricing":
+      - /url: /pricing
+    - link "Blog":
+      - /url: /blog
+    - link "Contact":
+      - /url: /contact
+  - group "Language":
+    - button "EN — Switch to English. Show language options": EN
+    - text: Show language options
+  - button "Toggle dark mode"
+- main:
+  - heading "Page content" [level=1]
+  - paragraph: Same shell as app/layout.tsx — verify chrome and main landmark together.
+- contentinfo:
+  - paragraph: Visit
+  - link "Digitaltableteur":
+    - /url: /
+  - text: Hämeentie 8 C 00530 Helsinki
+  - link "mail@digitaltableteur.com":
+    - /url: mailto:mail@digitaltableteur.com
+  - paragraph: Billing details
+  - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
+  - paragraph: Explore
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Pricing":
+    - /url: /pricing
+  - link "Blog":
+    - /url: /blog
+  - link "Contact":
+    - /url: /contact
+  - paragraph: Legal
+  - link "Privacy Policy":
+    - /url: /privacy-policy
+  - link "Imprint":
+    - /url: /imprint
+  - link "AI Usage":
+    - /url: /ai-use
+  - link "Accessibility Statement":
+    - /url: /accessibility
+  - link "Sitemap":
+    - /url: /sitemap
+  - button "Cookie preferences"
+  - link "Instagram":
+    - /url: https://www.instagram.com/digitaltableteur/
+  - link "Facebook":
+    - /url: https://www.facebook.com/digitaltableteur
+  - link "LinkedIn":
+    - /url: https://www.linkedin.com/company/digitaltableteur/
+  - link "Medium":
+    - /url: https://medium.com/digitaltableteur
+  - link "X":
+    - /url: https://x.com/dtdoesdesign
+  - link "GitHub":
+    - /url: https://github.com/PetriLahdelma
+  - link "Substack":
+    - /url: https://substack.com/@petrilahdelma
+  - link "Dribbble":
+    - /url: https://dribbble.com/digitaltableteur
+  - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
+- status

--- a/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--playground.yaml
+++ b/nextjs-app/shared/templates/NextLayoutShell/__a11y-snapshots__/templates-nextlayoutshell--playground.yaml
@@ -1,0 +1,79 @@
+- status: Work in progress (beta)
+- link "Skip to main content":
+  - /url: "#main-content"
+- banner:
+  - link "Digitaltableteur":
+    - /url: /
+  - navigation "Main navigation":
+    - link "Home":
+      - /url: /
+    - link "Work":
+      - /url: /work
+    - link "About":
+      - /url: /about
+    - link "Pricing":
+      - /url: /pricing
+    - link "Blog":
+      - /url: /blog
+    - link "Contact":
+      - /url: /contact
+  - group "Language":
+    - button "EN — Switch to English. Show language options": EN
+    - text: Show language options
+  - button "Toggle dark mode"
+- main:
+  - heading "Page content" [level=1]
+  - paragraph: Same shell as app/layout.tsx — verify chrome and main landmark together.
+- contentinfo:
+  - paragraph: Visit
+  - link "Digitaltableteur":
+    - /url: /
+  - text: Hämeentie 8 C 00530 Helsinki
+  - link "mail@digitaltableteur.com":
+    - /url: mailto:mail@digitaltableteur.com
+  - paragraph: Billing details
+  - text: E-invoice address 003722644552 Operator APIX Messaging Oy Operator ID 003723327487
+  - paragraph: Explore
+  - link "Home":
+    - /url: /
+  - link "Work":
+    - /url: /work
+  - link "About":
+    - /url: /about
+  - link "Pricing":
+    - /url: /pricing
+  - link "Blog":
+    - /url: /blog
+  - link "Contact":
+    - /url: /contact
+  - paragraph: Legal
+  - link "Privacy Policy":
+    - /url: /privacy-policy
+  - link "Imprint":
+    - /url: /imprint
+  - link "AI Usage":
+    - /url: /ai-use
+  - link "Accessibility Statement":
+    - /url: /accessibility
+  - link "Sitemap":
+    - /url: /sitemap
+  - button "Cookie preferences"
+  - link "Instagram":
+    - /url: https://www.instagram.com/digitaltableteur/
+  - link "Facebook":
+    - /url: https://www.facebook.com/digitaltableteur
+  - link "LinkedIn":
+    - /url: https://www.linkedin.com/company/digitaltableteur/
+  - link "Medium":
+    - /url: https://medium.com/digitaltableteur
+  - link "X":
+    - /url: https://x.com/dtdoesdesign
+  - link "GitHub":
+    - /url: https://github.com/PetriLahdelma
+  - link "Substack":
+    - /url: https://substack.com/@petrilahdelma
+  - link "Dribbble":
+    - /url: https://dribbble.com/digitaltableteur
+  - text: © 2026 Digitaltableteur. All rights reserved.
+- button "Chat — Chat with Donny": Chat
+- status

--- a/scripts/design-system/build-component-agent-blocks.ts
+++ b/scripts/design-system/build-component-agent-blocks.ts
@@ -4,7 +4,7 @@
  * Writes nextjs-app/shared/foundations/dist/component-agent-blocks.json
  */
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { join, resolve, dirname } from "node:path";
+import { join, resolve, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Project, SyntaxKind } from "ts-morph";
 import {
@@ -383,11 +383,27 @@ function main() {
     specPath: string;
   }> = [];
 
+  // Walk nested directories: grouping folders like `components/animations/<Name>`
+  // sit one level deeper than the rest, and a flat readdir silently skipped them,
+  // so those components had no agent block and were invisible to every gate that
+  // iterates this file (check:doc-semantics among them). Recursing adds exactly
+  // one component today (FadeIn) and keeps the layout free to nest later.
+  //
+  // A contract still needs its own `<Name>.tsx` to qualify: props are extracted
+  // from that source. Contracts without one (SelectableCardGroup, exported from
+  // SelectableCard.tsx; NextLayoutShell, stories-only) stay out by design, not by
+  // accident.
+  function* walkComponentDirs(dir: string): Generator<string> {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) yield* walkComponentDirs(join(dir, entry.name));
+    }
+    yield dir;
+  }
+
   for (const base of roots) {
-    for (const directory of readdirSync(base, { withFileTypes: true })) {
-      if (!directory.isDirectory()) continue;
-      const importName = directory.name;
-      const dir = join(base, importName);
+    for (const dir of walkComponentDirs(base)) {
+      if (dir === base) continue;
+      const importName = basename(dir);
       for (const file of readdirSync(dir)) {
         if (!file.endsWith(".contract.json")) continue;
         const name = file.slice(0, -".contract.json".length);

--- a/scripts/design-system/capture-story-a11y-snapshots.mjs
+++ b/scripts/design-system/capture-story-a11y-snapshots.mjs
@@ -5,7 +5,7 @@
  */
 import { chromium } from "@playwright/test";
 import { captureStoryAccessibilityTree } from "./a11y-snapshot-capture-lib.mjs";
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -41,43 +41,40 @@ function resolveNavigationWaitUntil(value) {
   return "load";
 }
 
-function loadStoryPrefixMap() {
+/**
+ * Map story id -> component directory, from Storybook's own index.
+ *
+ * Kept deliberately identical to the resolver in `.storybook/test-runner.ts`;
+ * see the long comment there for the four silent-failure classes that scraping
+ * `title:` out of story sources produced (nested dirs, the missing `templates/`
+ * root, a second component sharing a directory, and an arg `title:` containing
+ * a slash hijacking the meta title). `importPath` makes the directory a fact.
+ *
+ * A capture tool that resolves the wrong directory is worse than one that
+ * fails, so an unresolvable story id still throws at the call site below.
+ */
+async function loadStoryDirMap() {
   if (storyPrefixToDir) return storyPrefixToDir;
-  storyPrefixToDir = new Map();
-  const roots = [
-    join(ROOT, "nextjs-app/shared/components"),
-    join(ROOT, "nextjs-app/shared/patterns"),
-  ];
-  const titleRe = /title:\s*["']([^"']+)["']/g;
-
-  for (const base of roots) {
-    if (!existsSync(base)) continue;
-    for (const name of readdirSync(base)) {
-      const dir = join(base, name);
-      const contractPath = join(dir, `${name}.contract.json`);
-      const storyPath = join(dir, `${name}.stories.tsx`);
-      if (!existsSync(contractPath) || !existsSync(storyPath)) continue;
-      const text = readFileSync(storyPath, "utf8");
-      // The meta title is the story-path one ("Category/Name"). A component whose
-      // stories seed a `title:` ARG (e.g. ValueCard's defaultArgs.title "Clarity
-      // first") would otherwise hijack the first match and the snapshot dir would
-      // never resolve. Pick the first title: value shaped like a story path.
-      const metaTitle = [...text.matchAll(titleRe)]
-        .map((mt) => mt[1])
-        .find((t) => t.includes("/"));
-      if (!metaTitle) continue;
-      // Match Storybook's own @storybook/csf `sanitize`: lowercase, collapse
-      // every non-alphanumeric run to a single "-", trim. No camelCase splitting,
-      // so `Forms/TextArea` → `forms-textarea` (the real story-id prefix).
-      const prefix = metaTitle
-        .toLowerCase()
-        .replace(/[ ’–—―′¿'`~!@#$%^&*()_|+\-=?;:'",.<>{}[\]\\/]/g, "-")
-        .replace(/-+/g, "-")
-        .replace(/^-+/, "")
-        .replace(/-+$/, "");
-      storyPrefixToDir.set(prefix, dir);
-    }
+  const res = await fetch(new URL("index.json", STORYBOOK_URL).toString());
+  if (!res.ok) {
+    throw new Error(`Storybook index fetch failed: ${res.status} ${res.statusText}`);
   }
+  const index = await res.json();
+  const map = new Map();
+  const dirHasContract = new Map();
+
+  for (const [id, entry] of Object.entries(index.entries ?? {})) {
+    if (!entry.importPath) continue;
+    const dir = dirname(join(ROOT, entry.importPath));
+    let hasContract = dirHasContract.get(dir);
+    if (hasContract === undefined) {
+      hasContract =
+        existsSync(dir) && readdirSync(dir).some((f) => f.endsWith(".contract.json"));
+      dirHasContract.set(dir, hasContract);
+    }
+    if (hasContract) map.set(id, dir);
+  }
+  storyPrefixToDir = map;
   return storyPrefixToDir;
 }
 
@@ -88,10 +85,9 @@ function snapshotVariantSuffix() {
   return parts.length > 0 ? `.${parts.join(".")}` : "";
 }
 
-function componentSnapshotDir(storyId) {
-  const prefix = storyId.split("--")[0];
-  const componentDir = loadStoryPrefixMap().get(prefix);
-  if (!componentDir) throw new Error(`No component dir for story prefix ${prefix}`);
+async function componentSnapshotDir(storyId) {
+  const componentDir = (await loadStoryDirMap()).get(storyId);
+  if (!componentDir) throw new Error(`No component dir for story ${storyId}`);
   return join(componentDir, "__a11y-snapshots__");
 }
 
@@ -124,7 +120,7 @@ for (const storyId of storyIds) {
   });
   await page.waitForTimeout(800);
 
-  const dir = componentSnapshotDir(storyId);
+  const dir = await componentSnapshotDir(storyId);
   mkdirSync(dir, { recursive: true });
   const file = join(dir, `${storyId}${snapshotVariantSuffix()}.yaml`);
   const content = await captureStoryAccessibilityTree(page);

--- a/scripts/design-system/doc-semantics-ratchet.json
+++ b/scripts/design-system/doc-semantics-ratchet.json
@@ -1,3 +1,3 @@
 {
-  "maxUnverifiedA11yCriteriaOnReady": 63
+  "maxUnverifiedA11yCriteriaOnReady": 0
 }


### PR DESCRIPTION
## Summary

`unverifiedOnReady` **63 → 0**, ratchet re-cut 63 → 0.

The 63 were not 63 gaps needing verification runs. They were one boolean, `accessibilityTreeVerified`, across 47 components: 43 already had committed, CI-enforced snapshots and the flag was simply never set on the beta path, and 4 could not be captured at all because the harness could not resolve their directories. Zero were `forced-colors-real-browser`, so `test:stories:hc` was the wrong tool. The real count was 67; the gate could not see 4 of them.

## Root cause: the resolver re-derived what Storybook already knows

`componentSnapshotDir()` scraped `title:` out of `*.stories.tsx` under a hard-coded root list and re-implemented `@storybook/csf`'s `sanitize` to rebuild the story-id prefix. That failed four ways, and **every one failed silently** — an unresolved directory makes `captureAccessibilityTree` return early, so the component has no snapshots and no enforcement, with no error:

| # | Defect | Victim |
|---|--------|--------|
| 1 | flat `readdirSync` missed nested dirs | `FadeIn` (`components/animations/`) |
| 2 | root list omitted `templates/` | `NextLayoutShell` |
| 3 | assumed `<DirName>.contract.json` | `SelectableCardGroup` |
| 4 | "first `title:` with a slash" heuristic hijacked by a checklist arg `title: "Design tokens for spacing/colors"` | `NavMenuList`, `SentrySummaryCard` |

Defect 2 is the sharpest: `tag-beta-matrix-stories.mjs` *does* walk `templates/`, so those stories were tagged and executed on every run, then silently captured nothing.

Both the test-runner and `capture-story-a11y-snapshots.mjs` now read `entries[].importPath` from Storybook's index, so the directory is a fact rather than an inference. The "dir contains a contract" gate is kept, holding scope exactly as before (`shared/stories/WebComponents/**` has no contracts and stays excluded). `build-component-agent-blocks.ts` had the same flat-readdir bug and now recurses, adding `FadeIn`.

Fixing resolution made **12 components capturable for the first time** (98 new snapshot files): the four above plus `SelectableCardGroup`, `SelectOption` and six chat sub-components, none of which were on any debt list.

## Three defects the working enforcement then surfaced

- **WipBadge** (12 snapshots) — #1278 added `tags: ["beta"]` to sync sidebar dots with contract status, flipping the *decorator* badge `alpha` → `beta`. Stale since.
- **NextLayout** (16 snapshots) — #1281 reordered footer nav, moving Blog after Pricing. Stale since.
- **NextLayoutShell** — renders `<NextLayout>` and inherits its `React.lazy` chat toggle but declared no `atSnapshot.waitForSelector`, so its tree flipped with worker cache warmth. It failed a *random subset* of stories per mode, which is the signature of a race rather than a content change. **Fixed at the source, not by re-capturing**; verified with three consecutive green runs of the mode that had been failing.

Both stale drifts were predicted from their suspected commit *before* re-capturing, then confirmed by checking the diff contained only the predicted lines — which is also how unrelated drift would have been caught.

## Verification

- `DT_REQUIRE_A11Y_SNAPSHOTS=1` green across **plain, light, dark, forced-colors**: 572 passed per mode, **zero mismatches, zero missing**. The zero-missing result is what proves the schema's "every required story" clause; `audit:snapshot-debt` only counts components with *zero* snapshots and cannot prove it.
- Fault-injected the ratchet to confirm it still fails: `FAIL: unverified a11y criteria on beta/stable 2 > ceiling 0`.
- Local gate: typecheck, lint, **2711 tests**, build — all green.
- `check:doc-semantics`, `check:relationship-graph`, `check:keyboard-delegation`, `check:contract-props`, `audit:snapshot-debt`, `validate:agent-docs` all pass.

## Open questions for follow-up (deliberately not decided here)

1. Contracts with no own `<Name>.tsx` (`SelectableCardGroup`, `NextLayoutShell`) stay outside `component-agent-blocks.json` because props are extracted from that source, so the doc-semantics gate remains blind to them. Including them is a design change to what qualifies as an agent block.
2. `capture-story-a11y-snapshots.mjs` waits a flat 800ms and ignores `atSnapshot.waitForSelector`, which the test-runner honours. That divergence is exactly what made the NextLayoutShell captures disagree with the verify run. Contained today (only two components declare it), but a latent trap for the next lazy-loading component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
