### PR TITLE
fix(ds): gate a11y claims from contracts, and align the two AT-capture paths

### DIFF
--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-21T12:27:27.995Z",
+  "generatedAt": "2026-07-21T13:05:23.064Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -21837,6 +21837,246 @@
           "origin": "authored",
           "authorship": "human-authored",
           "from": "SelectableCard.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
+    },
+    "SelectableCardGroup": {
+      "preferredImport": "@dt/SelectableCard",
+      "intent": "Selection owner for a set of SelectableCard options, with native fieldset semantics, controlled or uncontrolled state, and single or multiple selection.",
+      "props": {
+        "type": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "single",
+            "multiple"
+          ],
+          "description": "Selection model — single is an exclusive set (radio), multiple toggles independently (checkbox)."
+        },
+        "legend": {
+          "optional": false,
+          "type": "string",
+          "description": "Group label rendered as the fieldset legend (required for an accessible name)."
+        },
+        "name": {
+          "optional": true,
+          "type": "string",
+          "description": "Native radio group name shared by the set (single); auto-generated when omitted."
+        },
+        "value": {
+          "optional": true,
+          "type": "string | string[]",
+          "description": "Controlled selection: `string` for single, `string[]` for multiple. `\"\"` / `[]` treated as absent (uncontrolled)."
+        },
+        "defaultValue": {
+          "optional": true,
+          "type": "string | string[]",
+          "description": "Initial selection when uncontrolled."
+        },
+        "onValueChange": {
+          "optional": true,
+          "type": "(value: string | string[]) => void",
+          "description": "Fired with the next selection — a `string` for single, a `string[]` for multiple."
+        },
+        "orientation": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "horizontal",
+            "vertical"
+          ],
+          "description": "Stack direction."
+        },
+        "disabled": {
+          "optional": true,
+          "type": "boolean",
+          "description": "Disables the whole set; per-card disabled still keeps individual choices visible."
+        },
+        "error": {
+          "optional": true,
+          "type": "string",
+          "description": "Error message; announces via role=alert and sets aria-invalid."
+        },
+        "helperText": {
+          "optional": true,
+          "type": "string",
+          "description": "Helper copy below the group; suppressed while error is set."
+        },
+        "className": {
+          "optional": true,
+          "type": "string",
+          "description": "Merged onto the fieldset."
+        },
+        "children": {
+          "optional": false,
+          "type": "React.ReactNode",
+          "description": "SelectableCard children."
+        }
+      },
+      "propRelationships": [],
+      "variants": {
+        "type": {
+          "values": [
+            "single",
+            "multiple"
+          ],
+          "default": "single"
+        },
+        "orientation": {
+          "values": [
+            "horizontal",
+            "vertical"
+          ],
+          "default": "horizontal"
+        }
+      },
+      "cvaVariants": {},
+      "variantsFnName": null,
+      "useWhen": [],
+      "avoidWhen": [],
+      "requiredA11y": [
+        "The fieldset has a visible legend",
+        "Helper and error messages are referenced by aria-describedby",
+        "An error sets aria-invalid and is announced through HelperText"
+      ],
+      "keyboard": [
+        "Tab moves focus into the option set",
+        "Arrow keys move between native radios in a single-select set",
+        "Space selects or toggles the focused option"
+      ],
+      "compositionRules": [],
+      "canonicalExamples": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+      ],
+      "replacementFor": [],
+      "forbiddenUse": [],
+      "composesWith": [],
+      "prefersOver": [],
+      "declaredPropCount": 12,
+      "guidelines": [],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+        },
+        {
+          "id": "keyboard-contract",
+          "statement": "Every documented keyboard interaction works as specified.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "automated",
+          "check": "npm run test:stories"
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-16: reviewed the fieldset/legend structure, native radio and checkbox keyboard behavior, disabled propagation, helper/error relationships, and forced-colors story while adding independent React and web-component documentation."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST (SelectableCard.tsx)"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST (SelectableCard.tsx)"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST (SelectableCard.tsx)"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST (SelectableCard.tsx)"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST (SelectableCard.tsx)"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SelectableCardGroup.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SelectableCardGroup.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SelectableCardGroup.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "SelectableCardGroup.spec.md"
         },
         "requiredA11y": {
           "origin": "authored",

--- a/scripts/design-system/build-component-agent-blocks.ts
+++ b/scripts/design-system/build-component-agent-blocks.ts
@@ -381,7 +381,36 @@ function main() {
     importName: string;
     contractPath: string;
     specPath: string;
+    sourcePath: string;
   }> = [];
+
+  /**
+   * Where this component's implementation actually lives.
+   *
+   * Usually `<Name>.tsx`. But a component may be exported from a sibling that carries
+   * the family (`SelectableCardGroup` lives in `SelectableCard.tsx`), and requiring
+   * `<Name>.tsx` dropped it from the output entirely. That was not a cosmetic gap: every
+   * consumer falls back to `@dt/${name}` when a block is missing, so agents were being
+   * handed `@dt/SelectableCardGroup`, a path that does not resolve. Emitting the block
+   * gives them `@dt/SelectableCard`, which does.
+   *
+   * Prop extraction is already name-keyed (`extractPropSchemasFromFile(sf, name)`,
+   * `<Name>Props`), so a sibling source needs no special handling downstream.
+   */
+  function resolveSourcePath(dir: string, name: string): string | null {
+    const own = join(dir, `${name}.tsx`);
+    if (existsSync(own)) return own;
+    const exportRe = new RegExp(`export\\s+(?:const|function|class)\\s+${name}\\b`);
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith(".tsx")) continue;
+      if (file.endsWith(".stories.tsx") || file.endsWith(".test.tsx")) continue;
+      if (exportRe.test(readFileSync(join(dir, file), "utf8"))) return join(dir, file);
+    }
+    // No implementation at all (a stories-only surface such as NextLayoutShell). It is
+    // not importable, so it does not belong in a file about what agents can import.
+    // check:doc-semantics reads contracts directly and still gates its a11y claims.
+    return null;
+  }
 
   // Walk nested directories: grouping folders like `components/animations/<Name>`
   // sit one level deeper than the rest, and a flat readdir silently skipped them,
@@ -408,15 +437,16 @@ function main() {
         if (!file.endsWith(".contract.json")) continue;
         const name = file.slice(0, -".contract.json".length);
         const contractPath = join(dir, file);
-        const tsxPath = join(dir, `${name}.tsx`);
-        if (!existsSync(tsxPath)) continue;
-        tsxPaths.push(tsxPath);
+        const sourcePath = resolveSourcePath(dir, name);
+        if (!sourcePath) continue;
+        tsxPaths.push(sourcePath);
         meta.push({
           name,
           dir,
           importName,
           contractPath,
           specPath: join(dir, `${name}.spec.md`),
+          sourcePath,
         });
       }
     }
@@ -431,13 +461,13 @@ function main() {
   const blocks: Record<string, object> = {};
 
   for (const entry of meta) {
-    const tsxPath = join(entry.dir, `${entry.name}.tsx`);
+    const tsxPath = entry.sourcePath;
     const sf = project.getSourceFile(tsxPath);
     if (!sf) continue;
 
     const contract = JSON.parse(readFileSync(entry.contractPath, "utf8"));
     const spec = existsSync(entry.specPath) ? readFileSync(entry.specPath, "utf8") : null;
-    const extracted = extractComponentFromSourceFile(sf, tsxPath);
+    const extracted = extractComponentFromSourceFile(sf, tsxPath, entry.name);
     const props = extractPropSchemasFromFile(sf, entry.name);
     const propsName = `${entry.name}Props`;
     const propsDecl =
@@ -455,6 +485,12 @@ function main() {
       ariaRequirements?: string[];
       keyboard?: string[];
     };
+    // Name the file when props came from a sibling rather than `<Name>.tsx`, so the
+    // provenance does not imply a source file that does not exist.
+    const astFrom =
+      basename(tsxPath) === `${entry.name}.tsx`
+        ? "TypeScript AST"
+        : `TypeScript AST (${basename(tsxPath)})`;
 
     blocks[entry.name] = {
       preferredImport: `@dt/${entry.importName}`,
@@ -491,12 +527,12 @@ function main() {
        * generated. Without this the two are indistinguishable in the output.
        */
       docOrigin: {
-        props: { origin: "generated", authorship: "machine-generated", from: "TypeScript AST" },
-        variants: { origin: "generated", authorship: "machine-generated", from: "TypeScript AST" },
-        cvaVariants: { origin: "generated", authorship: "machine-generated", from: "TypeScript AST" },
-        propRelationships: { origin: "generated", authorship: "machine-generated", from: "TypeScript AST" },
+        props: { origin: "generated", authorship: "machine-generated", from: astFrom },
+        variants: { origin: "generated", authorship: "machine-generated", from: astFrom },
+        cvaVariants: { origin: "generated", authorship: "machine-generated", from: astFrom },
+        propRelationships: { origin: "generated", authorship: "machine-generated", from: astFrom },
         canonicalExamples: { origin: "generated", authorship: "machine-generated", from: "stories.tsx" },
-        declaredPropCount: { origin: "generated", authorship: "machine-generated", from: "TypeScript AST" },
+        declaredPropCount: { origin: "generated", authorship: "machine-generated", from: astFrom },
         intent: { origin: "authored", authorship: "human-authored", from: `${entry.name}.spec.md` },
         useWhen: { origin: "authored", authorship: "human-authored", from: `${entry.name}.spec.md` },
         avoidWhen: { origin: "authored", authorship: "human-authored", from: `${entry.name}.spec.md` },

--- a/scripts/design-system/capture-story-a11y-snapshots.mjs
+++ b/scripts/design-system/capture-story-a11y-snapshots.mjs
@@ -78,6 +78,39 @@ async function loadStoryDirMap() {
   return storyPrefixToDir;
 }
 
+/**
+ * Honour `parameters.atSnapshot.waitForSelector`, exactly as `.storybook/test-runner.ts`
+ * does in postVisit.
+ *
+ * Without this the two capture paths disagree: the test-runner waits for the declared
+ * late element, this script waited a flat 800ms, so capturing a component with a
+ * `React.lazy` chunk here could write a snapshot the test-runner then rejects. That is
+ * not hypothetical — it is what happened to NextLayoutShell, whose chat toggle is lazy.
+ *
+ * Parameters come from the running preview's story store rather than the story source,
+ * for the same reason the snapshot directory does: the store is the fact, parsing the
+ * source is a guess. `__getContext` is injected by the test-runner and does not exist
+ * here, so call the store directly the way that helper does.
+ *
+ * A missing selector is not fatal: capture proceeds and a genuinely absent element then
+ * surfaces as a visible snapshot mismatch instead of a silent skip.
+ */
+async function waitForAtSnapshotSelector(storyId) {
+  let selector = null;
+  try {
+    selector = await page.evaluate(async (id) => {
+      const store = globalThis.__STORYBOOK_PREVIEW__?.storyStore;
+      if (!store?.loadStory) return null;
+      const story = await store.loadStory({ storyId: id });
+      return story?.parameters?.atSnapshot?.waitForSelector ?? null;
+    }, storyId);
+  } catch {
+    return;
+  }
+  if (!selector) return;
+  await page.waitForSelector(selector, { state: "visible", timeout: 5_000 }).catch(() => {});
+}
+
 function snapshotVariantSuffix() {
   const parts = [];
   if (THEME) parts.push(THEME);
@@ -119,6 +152,7 @@ for (const storyId of storyIds) {
       : 120000,
   });
   await page.waitForTimeout(800);
+  await waitForAtSnapshotSelector(storyId);
 
   const dir = await componentSnapshotDir(storyId);
   mkdirSync(dir, { recursive: true });

--- a/scripts/design-system/check-doc-semantics.mjs
+++ b/scripts/design-system/check-doc-semantics.mjs
@@ -22,9 +22,10 @@
 import { readFileSync, existsSync, writeFileSync, globSync } from "node:fs";
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { parseSpecGuidelines } from "./parse-spec-agent-hints.mjs";
+import { deriveA11yCriteria } from "./derive-a11y-criteria.mjs";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
-const BLOCKS = join(ROOT, "nextjs-app/shared/foundations/dist/component-agent-blocks.json");
 const RATCHET = join(ROOT, "scripts/design-system/doc-semantics-ratchet.json");
 
 const STRICT = process.argv.includes("--strict");
@@ -34,29 +35,49 @@ const UPDATE_RATCHET = process.argv.includes("--update-ratchet");
 /** Days after which a lastReviewed date is considered stale. */
 const STALE_DAYS = 180;
 
-/** Contract status per component, so the gate can tell a claim from a known gap. */
-function contractStatus() {
-  const map = new Map();
+/**
+ * Every component contract, keyed by name.
+ *
+ * This used to iterate `component-agent-blocks.json`, which coupled two unrelated
+ * questions: "is this documented for agents" and "is this accessibility claim proven".
+ * A block is only emitted for a contract that has its own `<Name>.tsx`, because that is
+ * where props are extracted from — so a contract-only surface (NextLayoutShell) and a
+ * component exported from a sibling file (SelectableCardGroup) were invisible to this
+ * gate, and a beta component could carry an unproven a11y claim that nothing counted.
+ *
+ * The thing being gated is a property of the contract, so read contracts. Everything
+ * needed is available without the block: criteria are derived from `contract.a11y`,
+ * governance and content are copied verbatim from the contract, and guidelines are
+ * parsed from the sibling `.spec.md`.
+ */
+function loadContracts() {
+  const entries = [];
   for (const f of globSync(join(ROOT, "nextjs-app/shared/**/*.contract.json"))) {
     try {
-      const c = JSON.parse(readFileSync(f, "utf8"));
-      if (c.name) map.set(c.name, c.status ?? null);
+      const contract = JSON.parse(readFileSync(f, "utf8"));
+      if (!contract.name) continue;
+      const specPath = join(dirname(f), `${contract.name}.spec.md`);
+      entries.push({
+        name: contract.name,
+        status: contract.status ?? null,
+        contract,
+        spec: existsSync(specPath) ? readFileSync(specPath, "utf8") : null,
+      });
     } catch {}
   }
-  return map;
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  return entries;
 }
 
 function main() {
-  if (!existsSync(BLOCKS)) {
-    console.error("FAIL: component-agent-blocks.json missing. Run: npm run build:agent-blocks");
+  const contracts = loadContracts();
+  if (contracts.length === 0) {
+    console.error("FAIL: no component contracts found under nextjs-app/shared.");
     process.exit(1);
   }
-  const { components } = JSON.parse(readFileSync(BLOCKS, "utf8"));
-  const names = Object.keys(components);
-  const status = contractStatus();
 
   const report = {
-    components: names.length,
+    components: contracts.length,
     guidelines: { total: 0, explicitLevel: 0, defaulted: 0, withRationale: 0, hardRules: 0, hardRulesMissingRationale: [] },
     a11yCriteria: {
       total: 0,
@@ -79,9 +100,9 @@ function main() {
   const today = new Date();
   const unverifiedByComponent = [];
 
-  for (const [name, block] of Object.entries(components)) {
+  for (const { name, status, contract, spec } of contracts) {
     // --- Guidelines (RFC 2119) ---
-    for (const g of block.guidelines ?? []) {
+    for (const g of parseSpecGuidelines(spec)) {
       report.guidelines.total += 1;
       // A defaulted level is the parser's fallback, not an author's decision.
       if (g.level === "should" || g.level === "should-not") report.guidelines.defaulted += 1;
@@ -97,7 +118,7 @@ function main() {
     }
 
     // --- Accessibility criteria ---
-    const criteria = block.a11yCriteria ?? [];
+    const criteria = deriveA11yCriteria(contract);
     let unverified = 0;
     for (const c of criteria) {
       report.a11yCriteria.total += 1;
@@ -106,16 +127,15 @@ function main() {
       else {
         report.a11yCriteria.unverified += 1;
         unverified += 1;
-        const st = status.get(name);
-        if (st === "beta" || st === "stable") report.a11yCriteria.unverifiedOnReady += 1;
-        if (st === "stable") report.a11yCriteria.unverifiedOnStable += 1;
-        if (st === "alpha") report.a11yCriteria.unverifiedOnAlpha += 1;
+        if (status === "beta" || status === "stable") report.a11yCriteria.unverifiedOnReady += 1;
+        if (status === "stable") report.a11yCriteria.unverifiedOnStable += 1;
+        if (status === "alpha") report.a11yCriteria.unverifiedOnAlpha += 1;
       }
     }
     if (unverified > 0) unverifiedByComponent.push({ name, unverified, total: criteria.length });
 
     // --- Governance ---
-    const gov = block.governance;
+    const gov = contract.governance;
     if (gov?.owner) report.governance.withOwner += 1;
     if (gov?.lastReviewed) {
       report.governance.withLastReviewed += 1;
@@ -125,7 +145,7 @@ function main() {
       report.governance.missing.push(name);
     }
 
-    if (block.content) report.content.withContent += 1;
+    if (contract.content) report.content.withContent += 1;
   }
 
   unverifiedByComponent.sort((a, b) => b.unverified - a.unverified);

--- a/scripts/design-system/validate-components.ts
+++ b/scripts/design-system/validate-components.ts
@@ -104,10 +104,16 @@ function extractCvaConfig(call: CallExpression): VariantMap {
 export function extractComponentFromSourceFile(
     sf: SourceFile,
     tsxPath?: string,
+    /**
+     * Component to extract, when it is not the one the filename implies. A file may
+     * export more than one component (SelectableCard.tsx also exports
+     * SelectableCardGroup); without this the basename wins and the caller silently gets
+     * the sibling's CVA variants and declared-prop count under the wrong name.
+     */
+    componentNameOverride?: string,
 ): ExtractedComponent {
-    const componentName = tsxPath
-        ? basename(tsxPath, '.tsx')
-        : basename(sf.getFilePath(), '.tsx')
+    const componentName = componentNameOverride
+        ?? basename(tsxPath ?? sf.getFilePath(), '.tsx')
     return extractComponentInner(sf, componentName)
 }
 


### PR DESCRIPTION
Follow-up to #1292, closing the two open questions it deliberately left, plus a wrong-guidance bug found while closing them.

## 1. The gate was blind because it read the wrong artifact

`check:doc-semantics` iterated `component-agent-blocks.json`. That coupled two unrelated questions: *is this documented for agents* and *is this accessibility claim proven*. A block is only emitted for a contract that has its own `<Name>.tsx`, because that is where props are extracted from — so a contract-only surface (`NextLayoutShell`) and a component exported from a sibling file (`SelectableCardGroup`) were invisible, and a beta component could carry an unproven a11y claim that nothing counted.

The thing being gated is a property of the **contract**, so the gate now reads contracts. Nothing is lost:

| Field | Source |
|---|---|
| `a11yCriteria` | `deriveA11yCriteria(contract)` |
| `governance`, `content` | copied verbatim from the contract |
| `guidelines` | parsed from the sibling `.spec.md` |

It now sees **170** components (was 168) and no longer needs the generated artifact at all — verified by running it with `component-agent-blocks.json` deleted.

**Falsifiability:** setting `NextLayoutShell`'s flag false, a regression that was previously invisible, now fails: `FAIL: unverified a11y criteria on beta/stable 1 > ceiling 0`. `unverifiedOnReady` remains **0**.

This resolves the blindness *without* the design change #1292 flagged, so nothing non-importable is forced into agent-blocks.

## 2. The two AT-capture paths disagreed

`capture-story-a11y-snapshots.mjs` waited a flat 800ms and ignored `parameters.atSnapshot.waitForSelector`, which `.storybook/test-runner.ts` honours. So the script could write a snapshot the test-runner then rejected for any component with a `React.lazy` chunk — exactly what happened to `NextLayoutShell` in #1292.

It now reads the parameter from the running preview's story store, the same source the test-runner's `__getContext` uses. Re-capturing `NextLayoutShell` with the script produces output **byte-identical** to the test-runner's.

I checked the store API actually resolves under Storybook 10 rather than silently returning `null` — which would have made the fix a no-op and that byte-match a coincidence. It returns the selector for both lazy components and `null` for a non-lazy one.

## 3. Agents were being handed an import that does not resolve

Found while fixing the above. Because `SelectableCardGroup` was absent from agent-blocks, every consumer falls back to `@dt/${name}`, advertising **`@dt/SelectableCardGroup` — a path that does not exist**. Wrong guidance, not a cosmetic gap.

Source resolution now falls back to a sibling `.tsx` that exports the name, yielding the correct `@dt/SelectableCard`. Provenance stays honest: `docOrigin.props.from` reads `TypeScript AST (SelectableCard.tsx)`.

`NextLayoutShell` stays out deliberately — stories-only and genuinely not importable, so advertising an import for it would be the same bug.

That fix surfaced one more: `extractComponentFromSourceFile` derived the component name from the **file basename**, so a sibling-sourced component inherited its neighbour's CVA variants and declared-prop count under its own name. `SelectableCardGroup` reported `declaredPropCount: 4` (SelectableCard's) and now reports `12` (its own). Added an explicit override parameter rather than smuggling the name through a synthetic path; single caller.

## Verification

- Local gate: typecheck, lint, **2711 tests**, build — all green.
- `check:doc-semantics`, `check:relationship-graph`, `check:keyboard-delegation`, `check:contract-props`, `check:consumers`, `audit:snapshot-debt`, `validate:agent-docs` all pass.
- Agent-blocks diff is the new `SelectableCardGroup` block plus the timestamp: **no existing component's block changed**.
- No snapshot churn — the `NextLayoutShell` re-capture was byte-identical to what is already committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component metadata extraction for components implemented in non-standard or shared source files.
  * Accessibility snapshots now wait for story-specific content to appear, improving capture reliability.

* **Tests**
  * Documentation and accessibility checks now validate directly against component contracts and specifications.
  * Updated validation to correctly identify components when multiple components share a source file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->