### PR TITLE
feat(about): show web-components version alongside react and tokens

### DIFF
--- a/nextjs-app/shared/data/designSystemPackageVersions.ts
+++ b/nextjs-app/shared/data/designSystemPackageVersions.ts
@@ -1,9 +1,11 @@
 import reactPackage from "../../../node_modules/@digitaltableteur/react/package.json";
+import webComponentsPackage from "../../../node_modules/@digitaltableteur/web-components/package.json";
 import tokensPackage from "../../../node_modules/@digitaltableteur/tokens/package.json";
 import tokensCssPackage from "../../../node_modules/@digitaltableteur/tokens-css/package.json";
 
 export const DESIGN_SYSTEM_PACKAGE_VERSIONS = {
   react: reactPackage.version,
+  "web-components": webComponentsPackage.version,
   tokens: tokensPackage.version,
   "tokens-css": tokensCssPackage.version,
 } as const;

--- a/nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.test.tsx
+++ b/nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.test.tsx
@@ -49,6 +49,9 @@ describe("AboutPageContent", () => {
       screen.getByLabelText(/@digitaltableteur\/react \d/),
     ).toBeInTheDocument();
     expect(
+      screen.getByLabelText(/@digitaltableteur\/web-components \d/),
+    ).toBeInTheDocument();
+    expect(
       screen.getByLabelText(/@digitaltableteur\/tokens \d/),
     ).toBeInTheDocument();
     expect(

--- a/nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx
+++ b/nextjs-app/shared/patterns/AboutPageContent/AboutPageContent.tsx
@@ -16,6 +16,7 @@ import {
   SiReact,
   SiStorybook,
   SiTypescript,
+  SiWebcomponentsdotorg,
 } from "react-icons/si";
 
 import { DESIGN_SYSTEM_PACKAGE_VERSIONS } from "@/nextjs-app/shared/data/designSystemPackageVersions";
@@ -28,6 +29,7 @@ import styles from "./AboutPageContent.module.css";
 
 const TECH_STACK = [
   { label: "React 19", Icon: SiReact },
+  { label: "Web Components", Icon: SiWebcomponentsdotorg },
   { label: "TypeScript", Icon: SiTypescript },
   { label: "Next.js 16", Icon: SiNextdotjs },
   { label: "Storybook 10", Icon: SiStorybook },
@@ -39,6 +41,11 @@ const DESIGN_SYSTEM_PACKAGES = [
     name: "@digitaltableteur/react",
     shortName: "react",
     version: DESIGN_SYSTEM_PACKAGE_VERSIONS.react,
+  },
+  {
+    name: "@digitaltableteur/web-components",
+    shortName: "web-components",
+    version: DESIGN_SYSTEM_PACKAGE_VERSIONS["web-components"],
   },
   {
     name: "@digitaltableteur/tokens",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@digitaltableteur/react": "^0.1.17",
         "@digitaltableteur/tokens": "^0.1.2",
         "@digitaltableteur/tokens-css": "^0.1.3",
+        "@digitaltableteur/web-components": "^0.8.0",
         "@emailjs/browser": "^4.4.1",
         "@eslint/eslintrc": "^3.3.6",
         "@eslint/js": "^10.0.1",
@@ -3430,6 +3431,32 @@
       "resolved": "https://registry.npmjs.org/@digitaltableteur/tokens-css/-/tokens-css-0.1.3.tgz",
       "integrity": "sha512-GSp4k2s7yrLgOBZg7L7/DK38KOzxADrwLMtpR0Cvw7BstCVr8kDtEwlLLAwM3cGBYcH74cknrM3kQPfbLaW5oQ==",
       "license": "UNLICENSED"
+    },
+    "node_modules/@digitaltableteur/web-components": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@digitaltableteur/web-components/-/web-components-0.8.0.tgz",
+      "integrity": "sha512-k1vO0eS1tNeqlpCs3s0uAjL7x66tT49KkMuoRAVIlCk0mjRnDvErnW463ulChxzAhXa9cw1iENT/sZLZQ1hsDg==",
+      "license": "UNLICENSED",
+      "peerDependencies": {
+        "@digitaltableteur/react": "^0.1.16",
+        "@r2wc/react-to-web-component": "^2.1.1",
+        "react": ">=19.0.0",
+        "react-dom": ">=19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@digitaltableteur/react": {
+          "optional": true
+        },
+        "@r2wc/react-to-web-component": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
     "@digitaltableteur/react": "^0.1.17",
     "@digitaltableteur/tokens": "^0.1.2",
     "@digitaltableteur/tokens-css": "^0.1.3",
+    "@digitaltableteur/web-components": "^0.8.0",
     "@emailjs/browser": "^4.4.1",
     "@eslint/eslintrc": "^3.3.6",
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## What

The About page versioning strip listed `react`, `tokens` and `tokens-css` but omitted `@digitaltableteur/web-components`, so the published custom-elements package was invisible to visitors.

Row is now **react → web-components → tokens → tokens-css**, and the tech-stack logo strip gains a Web Components mark (`SiWebcomponentsdotorg`, present in the pinned react-icons 5.5.0).

## Dynamic, not hardcoded

The version is read from the installed `node_modules/@digitaltableteur/web-components/package.json`, the same mechanism as the other three, so it tracks the registry and moves on `npm update`/Dependabot.

This required adding the package as a dependency (`^0.8.0`). The site does **not** import web-components at runtime. The alternative, reading the in-repo `packages/web-components/package.json`, was rejected because it would let the About page advertise a version that is not published yet.

No files under `packages/web-components/` were touched.

## Verification (local gate, CI not consulted)

- `typecheck` — pass
- `lint` — 0 errors (2 pre-existing warnings in ToastStack.stories.tsx)
- `npm test` — 333 files / 2711 tests pass, incl. a new assertion for the web-components entry
- `build` — pass

Browser-verified against the running dev server: hit-testing at viewport centre returns the package list rendering `react 0.1.17 / web-components 0.8.0 / tokens 0.1.2 / tokens-css 0.1.3`. Screenshot capture in the browser pane returned blank frames for this page, so no visual is attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Web Components to the technical stack displayed on the About page.
  * Added the Web Components package and its version to the listed design-system packages.
  * Added runtime support for the Web Components package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->