### PR TITLE
fix(dev): flip tailwind-test to registry imports for published symbols

### DIFF
--- a/app/dev/tailwind-test/TailwindTest.tsx
+++ b/app/dev/tailwind-test/TailwindTest.tsx
@@ -34,23 +34,23 @@ import {
   TextReveal,
   Parallax,
 } from "@/nextjs-app/shared/components/animations";
-import { Container } from "@/nextjs-app/shared/components/Container";
-import { Stack } from "@/nextjs-app/shared/components/Stack";
-import { Center } from "@/nextjs-app/shared/components/Center";
-import { AspectRatio } from "@/nextjs-app/shared/components/AspectRatio";
 import {
+  AspectRatio,
+  Badge,
+  Center,
+  Checkbox,
+  Container,
   Divider,
-  IconButton,
-  Prose,
   FormField,
-} from "@/nextjs-app/shared/components/ui";
-import Badge from "@dt/Badge";
-import Checkbox from "@dt/Checkbox";
-import Link from "@dt/Link";
-import { useToast } from "@/nextjs-app/shared/lib/toast";
+  IconButton,
+  Link,
+  NavLink,
+  Stack,
+  useToast,
+} from "@digitaltableteur/react";
+import { Prose } from "@/nextjs-app/shared/components/ui";
 import { Lightbox } from "@/nextjs-app/shared/components/Lightbox";
 import { ArrowRight, Heart, Share, Star, Image as ImageIcon } from "@phosphor-icons/react";
-import { NavLink } from "@/nextjs-app/shared/patterns/navigation";
 
 /**
  * Temporary test component to verify Tailwind CSS + shadcn/ui integration.


### PR DESCRIPTION
Clears the 13 pre-existing check:package-registry-resolution failures (all in app/dev/tailwind-test/TailwindTest.tsx) that would block the react publish preflight. Published symbols now import from @digitaltableteur/react; Prose/Lightbox/animations stay local (not published). The local Logo import flips in the 0.1.18 consume PR.

Verification: resolution guard green (17 classified), typecheck, lint (0 errors), 2732/2732 tests, build — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated shared layout, UI, form, navigation, and notification components under a unified component library.
  * Preserved existing page behavior and visual functionality while simplifying component imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->