### PR TITLE
chore(release): prep publish round — react 0.1.18, wc 0.9.0, tokens 0.1.3, tokens-css 0.1.4

### DIFF
--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-22T15:19:49.730Z",
+  "generatedAt": "2026-07-22T15:51:05.967Z",
   "summary": {
     "componentCount": 166,
     "statusCounts": {
@@ -12,8 +12,8 @@
     "honestBetaDocDebt": 0,
     "catalogCompletenessPercent": 90.2,
     "codebaseComponentCount": 184,
-    "usageCoveragePercent": 94.6,
-    "componentsWithProductionUsage": 42,
+    "usageCoveragePercent": 93.4,
+    "componentsWithProductionUsage": 36,
     "notReadyForStablePromotion": false
   },
   "exportPolicy": {
@@ -78,20 +78,20 @@
   "usageCoverage": {
     "description": "Auto-detected import evidence from app/** and nextjs-app/**. Separate from contract.consumers[], which remains the stable-promotion gate for shipping-product proof.",
     "catalogedComponents": 166,
-    "withAnyUsage": 157,
-    "withProductionUsage": 42,
-    "uniqueImportedComponents": 157,
-    "totalEvidenceRows": 775,
-    "aliasImportFiles": 395,
-    "relativeImportFiles": 413,
+    "withAnyUsage": 155,
+    "withProductionUsage": 36,
+    "uniqueImportedComponents": 155,
+    "totalEvidenceRows": 768,
+    "aliasImportFiles": 392,
+    "relativeImportFiles": 409,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
   },
   "relationshipGraph": {
     "description": "Merged static composesWith policy + co-import evidence (see generate-relationship-graph.mjs).",
-    "generatedAt": "2026-07-21T09:57:27.970Z",
+    "generatedAt": "2026-07-22T15:51:02.980Z",
     "coImportMinFiles": 3,
-    "nodesWithComposesWith": 85,
+    "nodesWithComposesWith": 82,
     "regenerate": "npm run build:relationship-graph or npm run build:tokens",
     "path": "nextjs-app/shared/foundations/dist/relationship-graph.json"
   },
@@ -2404,18 +2404,11 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/AspectRatio",
-        "importCount": 1,
-        "productionImportCount": 1,
+        "importCount": 0,
+        "productionImportCount": 0,
         "patternImportCount": 0,
         "componentImportCount": 0,
-        "evidence": [
-          {
-            "path": "app/dev/tailwind-test/TailwindTest.tsx",
-            "importKind": "relative",
-            "importPath": "@/nextjs-app/shared/components/AspectRatio",
-            "context": "production"
-          }
-        ]
+        "evidence": []
       },
       "agent": {
         "preferredImport": "@dt/AspectRatio",
@@ -2473,14 +2466,7 @@
           "Use this as a generic flex/grid item — pick a layout primitive instead.",
           "Add padding or margin via className — children will overlap their own padding because the wrapper is `position: relative`."
         ],
-        "composesWith": [
-          "Badge",
-          "Checkbox",
-          "Link",
-          "TextInput",
-          "TextArea",
-          "Container"
-        ],
+        "composesWith": [],
         "prefersOver": [],
         "declaredPropCount": 3,
         "guidelines": [
@@ -4612,17 +4598,11 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Badge",
-        "importCount": 12,
-        "productionImportCount": 1,
+        "importCount": 11,
+        "productionImportCount": 0,
         "patternImportCount": 0,
         "componentImportCount": 4,
         "evidence": [
-          {
-            "path": "app/dev/tailwind-test/TailwindTest.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/Badge",
-            "context": "production"
-          },
           {
             "path": "nextjs-app/shared/components/CookieConsent/CookieConsent.tsx",
             "importKind": "alias",
@@ -4837,11 +4817,11 @@
         ],
         "composesWith": [
           "TextInput",
-          "Link",
           "Text",
-          "Icon",
           "Button",
-          "Checkbox"
+          "Icon",
+          "Grid",
+          "FlexBox"
         ],
         "prefersOver": [],
         "declaredPropCount": 11,
@@ -9471,18 +9451,11 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Center",
-        "importCount": 1,
-        "productionImportCount": 1,
+        "importCount": 0,
+        "productionImportCount": 0,
         "patternImportCount": 0,
         "componentImportCount": 0,
-        "evidence": [
-          {
-            "path": "app/dev/tailwind-test/TailwindTest.tsx",
-            "importKind": "relative",
-            "importPath": "@/nextjs-app/shared/components/Center",
-            "context": "production"
-          }
-        ]
+        "evidence": []
       },
       "agent": {
         "preferredImport": "@dt/Center",
@@ -9714,14 +9687,7 @@
           "Center large layout sections — use `Section` + `Container` instead.",
           "Rely on this to vertically center text inside a button or input — those already center via their own padding."
         ],
-        "composesWith": [
-          "Badge",
-          "Checkbox",
-          "Link",
-          "TextInput",
-          "TextArea",
-          "Container"
-        ],
+        "composesWith": [],
         "prefersOver": [],
         "declaredPropCount": 3,
         "guidelines": [
@@ -10426,17 +10392,11 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Checkbox",
-        "importCount": 8,
-        "productionImportCount": 1,
+        "importCount": 7,
+        "productionImportCount": 0,
         "patternImportCount": 0,
         "componentImportCount": 3,
         "evidence": [
-          {
-            "path": "app/dev/tailwind-test/TailwindTest.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/Checkbox",
-            "context": "production"
-          },
           {
             "path": "nextjs-app/shared/components/AskAI/AskAI.tsx",
             "importKind": "alias",
@@ -10585,11 +10545,11 @@
         ],
         "composesWith": [
           "TextInput",
-          "Link",
-          "Badge",
           "Label",
           "Text",
-          "Button"
+          "Button",
+          "Grid",
+          "ArticleCard"
         ],
         "prefersOver": [],
         "declaredPropCount": 11,
@@ -14602,8 +14562,8 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Container",
-        "importCount": 30,
-        "productionImportCount": 3,
+        "importCount": 29,
+        "productionImportCount": 2,
         "patternImportCount": 23,
         "componentImportCount": 3,
         "evidence": [
@@ -14615,12 +14575,6 @@
           },
           {
             "path": "app/blog/[slug]/ServerRelatedPosts.tsx",
-            "importKind": "relative",
-            "importPath": "@/nextjs-app/shared/components/Container",
-            "context": "production"
-          },
-          {
-            "path": "app/dev/tailwind-test/TailwindTest.tsx",
             "importKind": "relative",
             "importPath": "@/nextjs-app/shared/components/Container",
             "context": "production"
@@ -14675,6 +14629,12 @@
           },
           {
             "path": "nextjs-app/shared/patterns/DesignSprintsSection/DesignSprintsSection.tsx",
+            "importKind": "relative",
+            "importPath": "../../components/Container",
+            "context": "pattern"
+          },
+          {
+            "path": "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
             "importKind": "relative",
             "importPath": "../../components/Container",
             "context": "pattern"
@@ -14936,11 +14896,11 @@
         ],
         "composesWith": [
           "Section",
-          "Stack",
-          "Link",
           "ScrollIndicator",
-          "Badge",
-          "Checkbox"
+          "Stack",
+          "Title",
+          "EnhancedProjectCard",
+          "BlogCategoryFilter"
         ],
         "prefersOver": [],
         "declaredPropCount": 5,
@@ -25107,7 +25067,7 @@
           "Text",
           "Checkbox",
           "TextInput",
-          "Icon"
+          "Grid"
         ],
         "prefersOver": [],
         "declaredPropCount": 4,
@@ -25908,14 +25868,7 @@
           "put interactive controls in a caption. The caption is announced as part of the image's description, and controls inside it are unreachable in that reading order.",
           "rely on the counter as the only position cue. It is visual; the accessible name carries position for AT."
         ],
-        "composesWith": [
-          "Badge",
-          "Checkbox",
-          "Link",
-          "TextInput",
-          "TextArea",
-          "Container"
-        ],
+        "composesWith": [],
         "prefersOver": [],
         "declaredPropCount": 4,
         "guidelines": [
@@ -26329,17 +26282,11 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Link",
-        "importCount": 13,
-        "productionImportCount": 1,
+        "importCount": 12,
+        "productionImportCount": 0,
         "patternImportCount": 1,
         "componentImportCount": 10,
         "evidence": [
-          {
-            "path": "app/dev/tailwind-test/TailwindTest.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/Link",
-            "context": "production"
-          },
           {
             "path": "nextjs-app/shared/patterns/SiteFooter/SiteFooter.tsx",
             "importKind": "relative",
@@ -26405,6 +26352,12 @@
             "importKind": "alias",
             "importPath": "@dt/Link",
             "context": "component"
+          },
+          {
+            "path": "nextjs-app/shared/stories/KitchenSink.stories.tsx",
+            "importKind": "relative",
+            "importPath": "../components/Link/Link.stories",
+            "context": "story"
           }
         ]
       },
@@ -26478,12 +26431,12 @@
           "override the underline via inline styles; the token-driven treatment owns it."
         ],
         "composesWith": [
-          "Badge",
-          "Checkbox",
-          "TextInput",
           "Text",
           "Button",
-          "Title"
+          "Title",
+          "Avatar",
+          "Badge",
+          "Grid"
         ],
         "prefersOver": [
           "Button with href for body-copy links"
@@ -45141,17 +45094,11 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Stack",
-        "importCount": 3,
-        "productionImportCount": 1,
+        "importCount": 2,
+        "productionImportCount": 0,
         "patternImportCount": 2,
         "componentImportCount": 0,
         "evidence": [
-          {
-            "path": "app/dev/tailwind-test/TailwindTest.tsx",
-            "importKind": "relative",
-            "importPath": "@/nextjs-app/shared/components/Stack",
-            "context": "production"
-          },
           {
             "path": "nextjs-app/shared/patterns/HomeHero/HomeHero.tsx",
             "importKind": "relative",
@@ -45457,11 +45404,11 @@
         ],
         "composesWith": [
           "Container",
+          "HeroBackground",
+          "ScrollIndicator",
           "Link",
-          "Badge",
-          "Checkbox",
-          "TextInput",
-          "TextArea"
+          "SocialIconLink",
+          "Divider"
         ],
         "prefersOver": [],
         "declaredPropCount": 8,
@@ -48648,11 +48595,11 @@
         ],
         "composesWith": [
           "TextInput",
-          "Badge",
           "Button",
           "Text",
           "CheckboxGroup",
-          "Checkbox"
+          "Badge",
+          "Modal"
         ],
         "prefersOver": [],
         "declaredPropCount": 8,
@@ -49328,10 +49275,10 @@
         "composesWith": [
           "Text",
           "Button",
+          "CheckboxGroup",
           "Badge",
           "TextArea",
-          "Checkbox",
-          "CheckboxGroup"
+          "Title"
         ],
         "prefersOver": [],
         "declaredPropCount": 13,

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-22T15:19:49.445Z",
+  "generatedAt": "2026-07-22T15:51:05.652Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -1258,14 +1258,7 @@
         "Use this as a generic flex/grid item — pick a layout primitive instead.",
         "Add padding or margin via className — children will overlap their own padding because the wrapper is `position: relative`."
       ],
-      "composesWith": [
-        "Badge",
-        "Checkbox",
-        "Link",
-        "TextInput",
-        "TextArea",
-        "Container"
-      ],
+      "composesWith": [],
       "prefersOver": [],
       "declaredPropCount": 3,
       "guidelines": [
@@ -2449,11 +2442,11 @@
       ],
       "composesWith": [
         "TextInput",
-        "Link",
         "Text",
-        "Icon",
         "Button",
-        "Checkbox"
+        "Icon",
+        "Grid",
+        "FlexBox"
       ],
       "prefersOver": [],
       "declaredPropCount": 11,
@@ -5030,14 +5023,7 @@
         "Center large layout sections — use `Section` + `Container` instead.",
         "Rely on this to vertically center text inside a button or input — those already center via their own padding."
       ],
-      "composesWith": [
-        "Badge",
-        "Checkbox",
-        "Link",
-        "TextInput",
-        "TextArea",
-        "Container"
-      ],
+      "composesWith": [],
       "prefersOver": [],
       "declaredPropCount": 3,
       "guidelines": [
@@ -5511,11 +5497,11 @@
       ],
       "composesWith": [
         "TextInput",
-        "Link",
-        "Badge",
         "Label",
         "Text",
-        "Button"
+        "Button",
+        "Grid",
+        "ArticleCard"
       ],
       "prefersOver": [],
       "declaredPropCount": 11,
@@ -7809,11 +7795,11 @@
       ],
       "composesWith": [
         "Section",
-        "Stack",
-        "Link",
         "ScrollIndicator",
-        "Badge",
-        "Checkbox"
+        "Stack",
+        "Title",
+        "EnhancedProjectCard",
+        "BlogCategoryFilter"
       ],
       "prefersOver": [],
       "declaredPropCount": 5,
@@ -13170,7 +13156,7 @@
         "Text",
         "Checkbox",
         "TextInput",
-        "Icon"
+        "Grid"
       ],
       "prefersOver": [],
       "declaredPropCount": 4,
@@ -13631,14 +13617,7 @@
         "put interactive controls in a caption. The caption is announced as part of the image's description, and controls inside it are unreachable in that reading order.",
         "rely on the counter as the only position cue. It is visual; the accessible name carries position for AT."
       ],
-      "composesWith": [
-        "Badge",
-        "Checkbox",
-        "Link",
-        "TextInput",
-        "TextArea",
-        "Container"
-      ],
+      "composesWith": [],
       "prefersOver": [],
       "declaredPropCount": 4,
       "guidelines": [
@@ -13908,12 +13887,12 @@
         "override the underline via inline styles; the token-driven treatment owns it."
       ],
       "composesWith": [
-        "Badge",
-        "Checkbox",
-        "TextInput",
         "Text",
         "Button",
-        "Title"
+        "Title",
+        "Avatar",
+        "Badge",
+        "Grid"
       ],
       "prefersOver": [
         "Button with href for body-copy links"
@@ -24798,11 +24777,11 @@
       ],
       "composesWith": [
         "Container",
+        "HeroBackground",
+        "ScrollIndicator",
         "Link",
-        "Badge",
-        "Checkbox",
-        "TextInput",
-        "TextArea"
+        "SocialIconLink",
+        "Divider"
       ],
       "prefersOver": [],
       "declaredPropCount": 8,
@@ -26470,11 +26449,11 @@
       ],
       "composesWith": [
         "TextInput",
-        "Badge",
         "Button",
         "Text",
         "CheckboxGroup",
-        "Checkbox"
+        "Badge",
+        "Modal"
       ],
       "prefersOver": [],
       "declaredPropCount": 8,
@@ -26787,10 +26766,10 @@
       "composesWith": [
         "Text",
         "Button",
+        "CheckboxGroup",
         "Badge",
         "TextArea",
-        "Checkbox",
-        "CheckboxGroup"
+        "Title"
       ],
       "prefersOver": [],
       "declaredPropCount": 13,

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.1.18 - 2026-07-22
+
+- Exposes the `Logo` content atom from the root and content-family
+  entrypoints: renders the built-in Digitaltableteur mark by default, or any
+  custom PNG/JPEG/SVG logo via the new `src` prop (letterboxed in the square
+  `size` box; `title` becomes the alt text, `decorative` maps to `alt=""` +
+  `aria-hidden`, empty `src` falls back to the mark). The lime-circle option
+  is named `background` (renamed from the never-published `badge` before this
+  first release of the export, so no consumer API breaks).
+- Exposes the `Author` byline from the root and identity-family entrypoints:
+  fully input-driven (name, avatar URL/path, optional profile link) with a new
+  `bylinePrefix` prop whose default localizes to "By" / "Kirjoittanut" / "Av",
+  matching the native `dt-author`. The avatar now carries the author's name as
+  its accessible name and falls back to initials when `imageUrl` is omitted
+  (now optional).
+- Exposes the `AuthorBio` biography card from the root and content-family
+  entrypoints: pass `name`, `imageUrl`, `role`, `bio` (markdown after the lead
+  paragraph), and `email` directly; the site-registry `slug` lookup remains as
+  a convenience and direct props override it per field.
+- Adds canonical token sizes `sm`/`md`/`lg`/`xl` (2/2.5/3/4rem, aligned with
+  AvatarGroup) to `AvatarSize`; tokens resolve to real CSS lengths before
+  reaching `--avatar-size` and the img `sizes` attribute. Raw CSS lengths
+  remain accepted.
+- Fixes server-side imports of the content entrypoint: the bundled
+  react-markdown chain now pins the universal Node build of
+  `decode-named-character-reference` instead of its DOM build, which called
+  `document.createElement` at module scope and crashed Node/SSR consumers.
+- Runtime public API grows additively from 129 to 132 exports; the only
+  pre-existing API change is the additive `AvatarSize` token union.
+
 ## 0.1.17 - 2026-07-16
 
 - Redesigns SelectableCard: the whole card is the control — the radio/checkbox

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/react",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": false,
   "description": "React components and host adapters for the Digitaltableteur design system.",
   "type": "module",

--- a/packages/react/public-api.manifest.json
+++ b/packages/react/public-api.manifest.json
@@ -1,6 +1,6 @@
 {
   "packageName": "@digitaltableteur/react",
-  "packageVersion": "0.1.17",
+  "packageVersion": "0.1.18",
   "packageExports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -73,6 +73,8 @@
     "AlertBanner",
     "AnimationRuntimeProvider",
     "AspectRatio",
+    "Author",
+    "AuthorBio",
     "Avatar",
     "AvatarGroup",
     "Badge",
@@ -123,6 +125,7 @@
     "List",
     "ListItem",
     "loadConsentState",
+    "Logo",
     "MacWindowFrame",
     "Menu",
     "MenuContent",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,6 +5,10 @@ export type {
   AccordionItem,
   AccordionProps,
 } from "../../../nextjs-app/shared/components/Accordion";
+export { default as Author } from "../../../nextjs-app/shared/components/Author/Author";
+export type { AuthorProps } from "../../../nextjs-app/shared/components/Author/Author";
+export { default as AuthorBio } from "../../../nextjs-app/shared/components/AuthorBio/AuthorBio";
+export type { AuthorBioProps } from "../../../nextjs-app/shared/components/AuthorBio/AuthorBio";
 export { default as Avatar } from "../../../nextjs-app/shared/components/Avatar/Avatar";
 export type {
   AvatarMenuItem,
@@ -179,6 +183,8 @@ export { default as List } from "../../../nextjs-app/shared/components/List/List
 export type { ListProps } from "../../../nextjs-app/shared/components/List/List";
 export { default as ListItem } from "../../../nextjs-app/shared/components/ListItem/ListItem";
 export type { ListItemProps } from "../../../nextjs-app/shared/components/ListItem/ListItem";
+export { Logo } from "../../../nextjs-app/shared/components/Logo/Logo";
+export type { LogoProps } from "../../../nextjs-app/shared/components/Logo/Logo";
 export { default as MacWindowFrame } from "../../../nextjs-app/shared/components/MacWindowFrame/MacWindowFrame";
 export type { MacWindowFrameProps } from "../../../nextjs-app/shared/components/MacWindowFrame";
 export {

--- a/packages/tokens-css/CHANGELOG.md
+++ b/packages/tokens-css/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.1.4 - 2026-07-22
+
+- Adds the seven high-contrast legibility custom properties
+  (`--code-toolbar-text`, `--color-info-bg`, `--color-info-text`,
+  `--color-placeholder-dark`, `--color-placeholder-dark-fg`,
+  `--color-primary-dark`, `--switch-handle-ring-color`) across the light,
+  dark, high-contrast black, and high-contrast white themes.
+- Keeps the CSS package synchronized with
+  `@digitaltableteur/tokens@0.1.3` and its 192-token catalog.
+- Verified by `check:token-packages`, `check:package-release-notes`, and
+  `check:npm-consumer-install`.
+
 ## 0.1.3 - 2026-07-15
 
 - Adds `--color-switch-track-off` to the light, dark, high-contrast black, and

--- a/packages/tokens-css/package.json
+++ b/packages/tokens-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/tokens-css",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": false,
   "description": "Theme-complete Digitaltableteur token CSS generated from production variables.css.",
   "type": "module",

--- a/packages/tokens/CHANGELOG.md
+++ b/packages/tokens/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.1.3 - 2026-07-22
+
+- Adds seven semantic tokens from the high-contrast legibility round:
+  `code.toolbar.text`, the `color.info.bg`/`color.info.text` pair,
+  `color.placeholder.dark` and `color.placeholder.dark.fg`,
+  `color.primary.dark`, and `switch.handle.ring.color` — phantom CSS
+  variables promoted to real per-theme tokens.
+- Increases the generated token catalog from 185 to 192 entries and updates
+  the ESM, DTCG, Tailwind, type, and manifest exports together.
+- Verified by `check:token-packages`, `check:package-release-notes`, and
+  `check:npm-consumer-install`.
+
 ## 0.1.2 - 2026-07-15
 
 - Adds the theme-aware `color.switch.track.off` semantic token introduced for

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/tokens",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": false,
   "description": "CSS-sourced Digitaltableteur design tokens generated from production variables.css.",
   "type": "module",

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.9.0 - 2026-07-22
+
+- BREAKING: renames the `dt-logo` `badge` attribute/property to `background`
+  (same lime-circle rendering; the name now says what it does). The shadow
+  part follows: `part="badge"` is now `part="background"`. Update any
+  `dt-logo[badge]` usage and `::part(badge)` selectors.
+- Adds the `src` attribute to `dt-logo`: renders any custom PNG/JPEG/SVG logo
+  as an `<img>` letterboxed in the square `size` box (`accessible-title`
+  becomes the alt text, `decorative` maps to `alt=""` + `aria-hidden`, empty
+  `src` falls back to the built-in Digitaltableteur mark). `animated` and
+  `background` remain built-in-mark-only.
+- Adds canonical token sizes `sm`/`md`/`lg`/`xl` (2/2.5/3/4rem) to
+  `dt-avatar`, matching the React Avatar and AvatarGroup scale; tokens resolve
+  to real CSS lengths before reaching `--avatar-size` and the img `sizes`
+  attribute. `dt-author` inherits the tokens through its `size` passthrough.
+  Raw CSS lengths remain accepted.
+
 ## 0.8.0 - 2026-07-16
 
 - Ports the SelectableCard redesign to `dt-selectable-card`: the indicator

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/web-components",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": false,
   "description": "Framework-neutral custom elements for the Digitaltableteur design system.",
   "type": "module",


### PR DESCRIPTION
Prep for the four-package publish round.

- react 0.1.18: Logo/Author/AuthorBio exports (now also on the ROOT barrel — family entries alone missed the root import path; 132 runtime exports), Avatar sm/md/lg/xl tokens, SSR fix for the content entry
- web-components 0.9.0: dt-logo src + badge→background rename (breaking, changelogged), dt-avatar token sizes
- tokens 0.1.3 / tokens-css 0.1.4: seven HC-legibility tokens (185→192) that never shipped — caught by the registry-token-install preflight tripwire
- Public API manifest trued to 0.1.18/132

Verification: check:token-packages, check:package-release-notes, check:package-tarballs, check:react-public-api all green; full gate typecheck/lint/2732 tests/build exit 0. React preflight intentionally re-runs after the token publishes (registry-token-install compares published tokens against the local 192-count catalog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)