### PR TITLE
fix(release): unblock publish — public-surface policy + react-markdown peer

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -23,10 +23,14 @@
   AvatarGroup) to `AvatarSize`; tokens resolve to real CSS lengths before
   reaching `--avatar-size` and the img `sizes` attribute. Raw CSS lengths
   remain accepted.
-- Fixes server-side imports of the content entrypoint: the bundled
-  react-markdown chain now pins the universal Node build of
-  `decode-named-character-reference` instead of its DOM build, which called
-  `document.createElement` at module scope and crashed Node/SSR consumers.
+- NEW PEER DEPENDENCY: `react-markdown` (>=10) is externalized as a
+  peerDependency alongside AuthorBio's markdown bio rendering — the same
+  treatment as `framer-motion`. Consumers must install it; in exchange the
+  content-family graph stays ~50 kB (gzip) leaner and markdown resolves
+  through the host's own (Node-correct) module resolution instead of a
+  bundled copy. The package vite config also pins
+  `decode-named-character-reference` to its universal Node build as a
+  tripwire should a markdown dependency ever be bundled again.
 - Runtime public API grows additively from 129 to 132 exports; the only
   pre-existing API change is the additive `AvatarSize` token union.
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -89,6 +89,7 @@
   ],
   "peerDependencies": {
     "framer-motion": ">=12.0.0",
+    "react-markdown": ">=10.0.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"
   },

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -44,6 +44,7 @@ const externalPackages = [
   "class-variance-authority",
   "clsx",
   "react-phone-number-input",
+  "react-markdown",
 ];
 
 function isExternal(id: string): boolean {

--- a/scripts/design-system/astryx-roadmap.state.json
+++ b/scripts/design-system/astryx-roadmap.state.json
@@ -225,8 +225,6 @@
       "ArticleContent",
       "ArticleProse",
       "ArticleShareSection",
-      "Author",
-      "AuthorBio",
       "AuthorSocial",
       "BlogCategoryFilter",
       "BlogMediaImage",

--- a/scripts/design-system/check-npm-consumer-install.mjs
+++ b/scripts/design-system/check-npm-consumer-install.mjs
@@ -145,6 +145,11 @@ const reactDomTypesVersion =
 const framerMotionVersion =
   rootPackage.dependencies?.["framer-motion"] ??
   rootPackage.devDependencies?.["framer-motion"];
+// react-markdown became a peer alongside AuthorBio (0.1.18); same explicit
+// install requirement as framer-motion.
+const reactMarkdownVersion =
+  rootPackage.dependencies?.["react-markdown"] ??
+  rootPackage.devDependencies?.["react-markdown"];
 
 if (
   !reactVersion ||
@@ -674,6 +679,7 @@ void tree;
       `react@${reactVersion}`,
       `react-dom@${reactDomVersion}`,
       `framer-motion@${framerMotionVersion}`,
+      `react-markdown@${reactMarkdownVersion}`,
       `typescript@${typescriptVersion}`,
       `@types/react@${reactTypesVersion}`,
       `@types/react-dom@${reactDomTypesVersion}`,

--- a/scripts/design-system/check-react-registry-install.mjs
+++ b/scripts/design-system/check-react-registry-install.mjs
@@ -126,6 +126,10 @@ const reactDomTypesVersion =
 // legacy-peer-deps so the scratch consumer must install it explicitly.
 const framerMotionVersion =
   rootPackage.dependencies?.["framer-motion"] ?? rootPackage.devDependencies?.["framer-motion"];
+// react-markdown became a peer alongside AuthorBio (0.1.18); same explicit
+// install requirement as framer-motion.
+const reactMarkdownVersion =
+  rootPackage.dependencies?.["react-markdown"] ?? rootPackage.devDependencies?.["react-markdown"];
 const forbiddenReactExports = roadmapState.reactPublicSurface?.forbiddenExports ?? [];
 
 if (
@@ -496,6 +500,7 @@ void tree;
       `react@${reactDependencyVersion}`,
       `react-dom@${reactDomDependencyVersion}`,
       `framer-motion@${framerMotionVersion}`,
+      `react-markdown@${reactMarkdownVersion}`,
       `typescript@${typescriptVersion}`,
       `@types/react@${reactTypesVersion}`,
       `@types/react-dom@${reactDomTypesVersion}`,


### PR DESCRIPTION
Fixes the two failures the tokens ds-publish run tripped in the every-publish react verify:

- forbiddenExports policy updated: Author + AuthorBio removed (owner-directed elevation made them public API); AuthorSocial/EnhancedAuthorCard remain forbidden
- react-markdown externalized as a peerDependency (>=10, framer-motion precedent): content-family graph 56.6% → 47.1% of root, under the 55% topology ceiling; both consumer smokes install the peer explicitly; CHANGELOG declares it

Verification: check:astryx-roadmap, check:react-package (132 exports, 1.54 MiB), topology, release-notes, tarballs green; full gate typecheck/lint/2732 tests/build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)