### PR TITLE
fix(storybook): real previews for every component-gallery card + 3-col layout

### DIFF
--- a/.storybook/blocks/ComponentsGallery.module.css
+++ b/.storybook/blocks/ComponentsGallery.module.css
@@ -10,22 +10,35 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: var(--space-internal-16);
+}
+
+@media (width <= 900px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (width <= 600px) {
+  .grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 /* .gallery prefix outguns the docs container's `.sbdocs a` link styling,
    which otherwise paints its underline and link color into the cards. */
+
 .gallery .card {
   display: flex;
   flex-direction: column;
   border: 1px solid var(--color-border-light);
   border-radius: var(--radius-md, 8px);
-  overflow: hidden;
+  background: var(--main-body-background-color);
   text-decoration: none;
   color: var(--color-text);
-  background: var(--main-body-background-color);
   transition: border-color 120ms ease;
+  overflow: hidden;
 }
 
 .gallery .card:hover,
@@ -41,46 +54,123 @@
 
 .preview {
   display: grid;
-  place-items: center;
+  padding: var(--space-internal-12);
   block-size: 120px;
-  overflow: hidden;
-  pointer-events: none;
+  place-items: center;
+  border-block-end: 1px solid var(--color-border-light);
   background:
     radial-gradient(
       circle at 1px 1px,
       var(--color-border-light) 1px,
       transparent 0
     );
-  background-size: 16px 16px;
   background-color: var(--main-body-background-color);
-  border-block-end: 1px solid var(--color-border-light);
-  padding: var(--space-internal-12);
+  background-size: 16px 16px;
+  pointer-events: none;
+
+  /* `contain: layout` makes the preview a containing block for any
+     fixed/absolute descendant, so a component that mounts its own overlay
+     (e.g. CodeSnippet's copy toast) stays clipped inside the card instead of
+     floating over the whole docs viewport. */
+  contain: layout;
+  overflow: hidden;
 }
 
 .previewInner {
   display: grid;
-  place-items: center;
   max-inline-size: 100%;
+  place-items: center;
+}
+
+/* Full-bleed marks (a rule/bar/skeleton) have no intrinsic width; stretch them
+   so they read as the component instead of collapsing to nothing. */
+
+.fill {
+  inline-size: 100%;
+  justify-items: stretch;
+}
+
+/* SkipLink is absolutely positioned off-screen until focused; pull the real
+   component back into flow so the card shows its focused pill. */
+
+.skipLinkPreview a {
+  position: static;
+  inset: auto;
+}
+
+/* Representative Modal thumbnail — the live Modal portals full-screen. */
+
+.modalPreview {
+  display: flex;
+  padding: var(--space-internal-12);
+  inline-size: min(240px, 100%);
+  flex-direction: column;
+  gap: var(--space-internal-4);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md, 8px);
+  background: var(--main-body-background-color);
+  box-shadow: var(--shadow-lg, 0 10px 30px rgb(0 0 0 / 12%));
+  text-align: start;
+}
+
+.modalPreviewTitle {
+  margin: 0;
+}
+
+.modalPreviewActions {
+  display: flex;
+  margin-block-start: var(--space-internal-8);
+  justify-content: flex-end;
+  gap: var(--space-internal-8);
+}
+
+/* Representative Tooltip bubble — mirrors Tooltip.module.css tokens; the live
+   Tooltip renders its content through a Radix portal. */
+
+.tooltipPreview {
+  padding: var(--space-internal-8) var(--space-internal-12);
+  border-radius: var(--radius-md);
+  background-color: var(--color-primary);
+  box-shadow: var(--shadow-md);
+  font-size: var(--font-size-text-s);
+  line-height: var(--line-height-snug, 1.3);
+  text-align: center;
+  color: var(--main-body-background-color, var(--color-white));
+}
+
+/* A visible gap framed by two rules — the live Spacer is an invisible box. */
+
+.spacerPreview {
+  display: flex;
+  inline-size: 100%;
+  flex-direction: column;
+  align-items: center;
+}
+
+.spacerRule {
+  block-size: 1px;
+  inline-size: 100%;
+  background: var(--color-border-light);
 }
 
 .monogram {
   font-size: var(--font-size-text-l, 1.25rem);
   font-weight: 600;
-  color: var(--color-muted);
   letter-spacing: 0.04em;
+  color: var(--color-muted);
 }
 
 .meta {
   display: flex;
+  padding: var(--space-internal-12);
   flex-direction: column;
   gap: var(--space-internal-4);
-  padding: var(--space-internal-12);
 }
 
 .nameRow {
   display: flex;
-  align-items: center;
   justify-content: space-between;
+  align-items: center;
   gap: var(--space-internal-8);
 }
 
@@ -89,9 +179,9 @@
 }
 
 .dense {
-  color: var(--color-muted);
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  color: var(--color-muted);
   -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   overflow: hidden;
 }

--- a/.storybook/blocks/ComponentsGallery.tsx
+++ b/.storybook/blocks/ComponentsGallery.tsx
@@ -4,6 +4,7 @@ import {
   DOC_TIER_1_CATEGORIES,
   // eslint-disable-next-line import/no-relative-packages -- repo-internal single source for doc tiers
 } from "../../scripts/design-system/doc-tiers.mjs";
+import Button from "@dt/Button";
 import Text from "@dt/Text";
 import Title from "@dt/Title";
 import { getContractByName, storyIdFromTitle } from "../lib/contracts";
@@ -12,6 +13,129 @@ import { StatusPill } from "./StatusPill";
 import styles from "./ComponentsGallery.module.css";
 
 type Registry = Record<string, React.ComponentType<Record<string, unknown>>>;
+
+/**
+ * Preview-only component registry.
+ *
+ * The public barrel (`components/index`) intentionally omits many Tier 1
+ * components — layout primitives, form parts, and portal/utility components
+ * that are consumed via their `@dt/<Name>` paths rather than re-exported. The
+ * gallery, however, needs EVERY Tier 1 component, so it resolves each card's
+ * component from its own folder barrel (`<Name>/index.ts`), taking the default
+ * export or the export named after the component. Globbing `index.ts` (rather
+ * than `*.tsx`) structurally excludes stories, tests, and test templates, none
+ * of which should ever be pulled into the docs bundle.
+ */
+const previewModules = import.meta.glob(
+  "../../nextjs-app/shared/components/*/index.ts",
+  { eager: true },
+);
+const previewRegistry: Registry = {};
+for (const [path, mod] of Object.entries(previewModules)) {
+  const match = path.match(/\/([^/]+)\/index\.ts$/);
+  if (!match) continue;
+  const name = match[1];
+  const record = mod as Record<string, unknown>;
+  const comp = record.default ?? record[name];
+  // Accept plain function components AND forwardRef/memo objects (which carry a
+  // `$$typeof` tag rather than being `typeof "function"`).
+  const isRenderable =
+    typeof comp === "function" ||
+    (typeof comp === "object" && comp !== null && "$$typeof" in comp);
+  if (isRenderable) {
+    previewRegistry[name] = comp as React.ComponentType<Record<string, unknown>>;
+  }
+}
+
+function resolveComponent(name: string) {
+  return (
+    (componentRegistry as unknown as Registry)[name] ?? previewRegistry[name]
+  );
+}
+
+/**
+ * Per-component preview tuning. A handful of components have no honest static
+ * render from their raw playground defaults:
+ *  - `props`   merge over the contract defaults (e.g. keep a toast in flow).
+ *  - `fill`    stretch full-bleed marks (a rule/bar) so they are visible.
+ *  - `wrapClassName` extra class on the preview wrapper (e.g. un-hide SkipLink).
+ *  - `render`  a fully representative preview, built from real DS primitives,
+ *              for portal/overlay components that cannot render inside a card.
+ */
+type PreviewSpec = {
+  props?: Record<string, unknown>;
+  fill?: boolean;
+  wrapClassName?: string;
+  render?: (
+    defaults: Record<string, unknown>,
+    Component: React.ComponentType<Record<string, unknown>> | undefined,
+  ) => React.ReactNode;
+};
+
+/** Mini dialog built from real DS primitives; the live Modal portals full-screen. */
+function ModalPreview(defaults: Record<string, unknown>) {
+  const title = (defaults.title as string) ?? "Confirm changes";
+  const description = defaults.description as string | undefined;
+  return (
+    <span className={styles.modalPreview}>
+      <Title as="span" size="xs" className={styles.modalPreviewTitle}>
+        {title}
+      </Title>
+      {description ? (
+        <Text as="span" size="xs" lineHeight="snug" className={styles.dense}>
+          {description}
+        </Text>
+      ) : null}
+      <span className={styles.modalPreviewActions}>
+        <Button variant="secondary" size="sm">
+          Cancel
+        </Button>
+        <Button variant="primary" size="sm">
+          Confirm
+        </Button>
+      </span>
+    </span>
+  );
+}
+
+/** Resting tooltip bubble; the live Tooltip renders its content through a portal. */
+function TooltipPreview(defaults: Record<string, unknown>) {
+  return (
+    <span className={styles.tooltipPreview}>
+      {(defaults.children as string) ?? "Helpful hint about this action."}
+    </span>
+  );
+}
+
+/** A visible gap framed by two rules; the live Spacer is an invisible box. */
+function SpacerPreview(
+  defaults: Record<string, unknown>,
+  Component: React.ComponentType<Record<string, unknown>> | undefined,
+) {
+  return (
+    <span className={styles.spacerPreview}>
+      <span className={styles.spacerRule} />
+      {Component ? <Component {...defaults} /> : null}
+      <span className={styles.spacerRule} />
+    </span>
+  );
+}
+
+const PREVIEW_SPECS: Record<string, PreviewSpec> = {
+  // Toast fixes itself to the viewport by default; `inline` keeps it in flow.
+  Toast: { props: { inline: true } },
+  // Full-bleed marks collapse to zero width when centered — let them stretch.
+  Divider: { fill: true },
+  Progress: { fill: true },
+  Skeleton: { fill: true },
+  // AspectRatio sizes from its container width; give it one to fill.
+  AspectRatio: { fill: true },
+  // SkipLink is off-screen until focused; the wrapper restores it in flow.
+  SkipLink: { wrapClassName: styles.skipLinkPreview },
+  Spacer: { render: SpacerPreview, fill: true },
+  Modal: { render: ModalPreview },
+  Tooltip: { render: TooltipPreview },
+};
 
 class PreviewBoundary extends React.Component<
   { children: React.ReactNode; fallback: React.ReactNode },
@@ -42,18 +166,33 @@ export function GalleryCard({ name, category }: { name: string; category: string
   const href = managerHref(
     `/docs/${storyIdFromTitle(`${category}/${name}`)}--docs`,
   );
+  const spec = PREVIEW_SPECS[name];
   const defaults = contract?.playground?.defaults;
-  const Component = (componentRegistry as unknown as Registry)[name];
-  const canPreview = Boolean(defaults && Component);
+  const Component = resolveComponent(name);
+
+  let previewNode: React.ReactNode = null;
+  if (spec?.render) {
+    previewNode = spec.render(defaults ?? {}, Component);
+  } else if (Component && defaults) {
+    const previewProps = { ...defaults, ...(spec?.props ?? {}) };
+    previewNode = <Component {...previewProps} />;
+  }
+  const canPreview = Boolean(previewNode);
+
+  const previewInnerClassName = [
+    styles.previewInner,
+    spec?.fill ? styles.fill : null,
+    spec?.wrapClassName,
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   return (
     <a className={styles.card} href={href} target="_top">
       <span className={styles.preview} aria-hidden="true">
         {canPreview ? (
           <PreviewBoundary fallback={<Monogram name={name} />}>
-            <span className={styles.previewInner}>
-              <Component {...(defaults as Record<string, unknown>)} />
-            </span>
+            <span className={previewInnerClassName}>{previewNode}</span>
           </PreviewBoundary>
         ) : (
           <Monogram name={name} />

--- a/nextjs-app/shared/foundations/components-gallery.mdx
+++ b/nextjs-app/shared/foundations/components-gallery.mdx
@@ -5,8 +5,9 @@ import { ComponentsGallery } from "../../../.storybook/blocks/ComponentsGallery"
 
 # Components
 
-Every Tier 1 component in the system, grouped the way the sidebar is. Cards
-with a live preview render the component from its contract's playground
-defaults; the rest are queued for the Phase 3 content sweep.
+Every Tier 1 component in the system, grouped the way the sidebar is. Each
+card renders a live preview from the component's contract playground defaults;
+portal and utility components (Modal, Tooltip, Toast, SkipLink, Spacer) show a
+representative preview instead.
 
 <ComponentsGallery />

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -1,6 +1,6 @@
 {
   "generatedBy": "npm run lint:css:update",
-  "warningCount": 2315,
+  "warningCount": 2301,
   "warnings": [
     {
       "file": ".storybook/blocks/A11ySection.module.css",
@@ -148,133 +148,7 @@
     },
     {
       "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 95,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"-webkit-box-orient\" to come before \"-webkit-line-clamp\" (order/properties-order)",
-      "id": ".storybook/blocks/ComponentsGallery.module.css::order/properties-order::Expected \"-webkit-box-orient\" to come before \"-webkit-line-clamp\" (order/properties-order)::1"
-    },
-    {
-      "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 55,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"background-color\" to come before \"background-size\" (order/properties-order)",
-      "id": ".storybook/blocks/ComponentsGallery.module.css::order/properties-order::Expected \"background-color\" to come before \"background-size\" (order/properties-order)::1"
-    },
-    {
-      "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 27,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"background\" to come before \"color\" (order/properties-order)",
-      "id": ".storybook/blocks/ComponentsGallery.module.css::order/properties-order::Expected \"background\" to come before \"color\" (order/properties-order)::1"
-    },
-    {
-      "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 48,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"background\" to come before \"pointer-events\" (order/properties-order)",
-      "id": ".storybook/blocks/ComponentsGallery.module.css::order/properties-order::Expected \"background\" to come before \"pointer-events\" (order/properties-order)::1"
-    },
-    {
-      "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 45,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"block-size\" to come before \"place-items\" (order/properties-order)",
-      "id": ".storybook/blocks/ComponentsGallery.module.css::order/properties-order::Expected \"block-size\" to come before \"place-items\" (order/properties-order)::1"
-    },
-    {
-      "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 56,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"border-block-end\" to come before \"background-color\" (order/properties-order)",
-      "id": ".storybook/blocks/ComponentsGallery.module.css::order/properties-order::Expected \"border-block-end\" to come before \"background-color\" (order/properties-order)::1"
-    },
-    {
-      "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 93,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"display\" to come before \"color\" (order/properties-order)",
-      "id": ".storybook/blocks/ComponentsGallery.module.css::order/properties-order::Expected \"display\" to come before \"color\" (order/properties-order)::1"
-    },
-    {
-      "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 83,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"justify-content\" to come before \"align-items\" (order/properties-order)",
-      "id": ".storybook/blocks/ComponentsGallery.module.css::order/properties-order::Expected \"justify-content\" to come before \"align-items\" (order/properties-order)::1"
-    },
-    {
-      "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 70,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"letter-spacing\" to come before \"color\" (order/properties-order)",
-      "id": ".storybook/blocks/ComponentsGallery.module.css::order/properties-order::Expected \"letter-spacing\" to come before \"color\" (order/properties-order)::1"
-    },
-    {
-      "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 63,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"max-inline-size\" to come before \"place-items\" (order/properties-order)",
-      "id": ".storybook/blocks/ComponentsGallery.module.css::order/properties-order::Expected \"max-inline-size\" to come before \"place-items\" (order/properties-order)::1"
-    },
-    {
-      "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 57,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"padding\" to come before \"border-block-end\" (order/properties-order)",
-      "id": ".storybook/blocks/ComponentsGallery.module.css::order/properties-order::Expected \"padding\" to come before \"border-block-end\" (order/properties-order)::1"
-    },
-    {
-      "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 77,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"padding\" to come before \"gap\" (order/properties-order)",
-      "id": ".storybook/blocks/ComponentsGallery.module.css::order/properties-order::Expected \"padding\" to come before \"gap\" (order/properties-order)::1"
-    },
-    {
-      "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 47,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"pointer-events\" to come before \"overflow\" (order/properties-order)",
-      "id": ".storybook/blocks/ComponentsGallery.module.css::order/properties-order::Expected \"pointer-events\" to come before \"overflow\" (order/properties-order)::1"
-    },
-    {
-      "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 25,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"text-decoration\" to come before \"overflow\" (order/properties-order)",
-      "id": ".storybook/blocks/ComponentsGallery.module.css::order/properties-order::Expected \"text-decoration\" to come before \"overflow\" (order/properties-order)::1"
-    },
-    {
-      "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 39,
+      "line": 52,
       "column": 19,
       "rule": "rhythmguard/prefer-token",
       "severity": "warning",
@@ -283,7 +157,7 @@
     },
     {
       "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 70,
+      "line": 153,
       "column": 19,
       "rule": "rhythmguard/use-scale",
       "severity": "warning",
@@ -292,7 +166,7 @@
     },
     {
       "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 67,
+      "line": 151,
       "column": 38,
       "rule": "rhythmguard/use-scale",
       "severity": "warning",
@@ -301,7 +175,7 @@
     },
     {
       "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 45,
+      "line": 58,
       "column": 15,
       "rule": "rhythmguard/use-scale",
       "severity": "warning",
@@ -310,12 +184,12 @@
     },
     {
       "file": ".storybook/blocks/ComponentsGallery.module.css",
-      "line": 19,
-      "column": 1,
-      "rule": "rule-empty-line-before",
+      "line": 145,
+      "column": 15,
+      "rule": "rhythmguard/use-scale",
       "severity": "warning",
-      "text": "Expected empty line before rule (rule-empty-line-before)",
-      "id": ".storybook/blocks/ComponentsGallery.module.css::rule-empty-line-before::Expected empty line before rule (rule-empty-line-before)::1"
+      "text": "Unexpected off-scale value \"1px\". Use scale values (nearest: 0px or 2px). (rhythmguard/use-scale)",
+      "id": ".storybook/blocks/ComponentsGallery.module.css::rhythmguard/use-scale::Unexpected off-scale value \"1px\". Use scale values (nearest: 0px or 2px). (rhythmguard/use-scale)::1"
     },
     {
       "file": ".storybook/blocks/DocHeader.module.css",


### PR DESCRIPTION
## Problem

The **Overview / Components** gallery (`/docs/overview-components--docs`) imported components only from the public barrel (`components/index`), which intentionally omits many Tier 1 components (layout primitives, form parts, portal/utility components). Result:

- **18 cards** fell back to a 2-letter monogram placeholder.
- Several that did resolve rendered **broken previews**: Modal blank, Toast escaped to a fixed viewport position, Divider/Progress/Skeleton collapsed to 0 width.
- **CodeSnippet's** embedded copy-toast (`position: fixed`) escaped its card and floated over the docs viewport at all times.
- Cards were also cramped (auto-fill packed 4-5 tiny cards per row).

## Fix

- **Resolve every component** from its own folder barrel (`<Name>/index.ts`) via glob — default *or* named export, `forwardRef`/`memo` aware. Globbing `index.ts` (not `*.tsx`) structurally excludes stories, tests, and a vitest-importing test template that otherwise crashed the docs bundle. This avoids touching the package's public API surface (no ripple into consumers/manifest gates).
- **Per-component preview specs** for cases that can't render live in a 120px card: `Toast` (inline, not fixed), `Divider`/`Progress`/`Skeleton`/`AspectRatio` (fill width), `SkipLink` (un-hidden focus pill), and representative previews for `Modal`, `Tooltip`, `Spacer` built from real DS primitives.
- **`contain: layout`** on `.preview` so any component's own fixed/portal overlay stays clipped inside its card instead of floating over the page.
- **Cap the grid at 3 columns** (2 on tablet, 1 on mobile) so cards read larger.
- Refresh the intro copy; refresh the scoped stylelint baseline.

## Result

All **56 cards render a real preview** — zero monograms, zero blank/collapsed cards, nothing floating. Verified in Storybook by measuring every card.

## Local verification (all exit 0)

- `typecheck` ✓
- `lint` ✓
- `test` — 333 files, **2732 tests** passed ✓
- `build` ✓
- `lint:css` ✓ and `audit:rhythm:check` ✓ (stylelint baseline change scoped entirely to this file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded the Components gallery with representative previews for modals, tooltips, spacers, and skip links.
  - Improved preview rendering for additional components and layouts.

- **Improvements**
  - Gallery cards now use responsive three-, two-, and one-column layouts.
  - Enhanced preview styling, spacing, and content containment.
  - Updated gallery documentation to clarify preview behavior and component grouping.

- **Maintenance**
  - Refreshed style validation baseline data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->