### PR TITLE
chore(design-sync): sync @digitaltableteur/react to Claude Design (83 components)

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,34 @@
+# design-sync NOTES — @digitaltableteur/react → Claude Design
+
+## Re-sync setup (do every sync)
+- **[GENERAL] Reference storybook base-path fix (CRITICAL).** `.storybook/main.ts` sets `config.base = "/storybook/"` for production builds (line ~364) and `<base href="/storybook/">` (line ~118). `storybook build` runs in production, so `.design-sync/sb-reference` references assets at absolute `/storybook/assets/...`. The compare harness serves the reference at ROOT → assets 404 → every story is `sb-error` ("no storybook root content") and NOTHING can be graded. FIX: after each `storybook build`, create a self-symlink so `/storybook/*` resolves:
+  `ln -sfn . .design-sync/sb-reference/storybook`
+  (sb-reference is gitignored + rebuilt each sync, so recreate the symlink every time.)
+- **Package types entry.** `@digitaltableteur/react` declares types only via `exports["."].types`, not a top-level `types` field. The converter's d.ts reader needs the top-level field, so `packages/react/package.json` now has `"types": "./dist/index.d.ts"` (added — committed). Without it: 0 exported symbols → 0 components.
+- **[GENERAL] Global CSS layer (Tailwind utilities + .wavyUnderline) — CRITICAL.** The package build compiles .module.css only; it NEVER emits Tailwind utilities or the app global helpers (.wavyUnderline wave-draw). Components using cn()/Tailwind (Center, Stack, Section, Spacer, AspectRatio, NavLink, Pagination) render UNSTYLED without them. FIX: ship the storybook compiled CSS (a superset: 967 module classes + Tailwind layer + globals + tokens) via cfg.cssEntry. cssEntry is pkgDir-bounded, so stage it each sync AFTER the storybook build:
+  `cp .design-sync/sb-reference/assets/iframe-*.css packages/react/_ds-sync-globals.css`  (cfg.cssEntry="_ds-sync-globals.css"). This also fixes the TextInput error-fill CSS-order bug (bundle cascade then matches storybook).
+- **Build the react package first:** `cd packages/react && npm run build` (compiles nextjs-app/shared/components via vite aliases). Entry: `packages/react/dist/index.js`.
+
+## Tokens / styling
+- Tokens ship via `cfg.tokensPkg: "@digitaltableteur/tokens-css"`. BUT the node_modules copy is the published **0.1.4**, which PREDATES the radius/shadow token sweep (missing --radius-circle, --shadow-*). The freshly-built local `packages/tokens-css/dist` has them. FIX every sync: after `build:tokens`, refresh the installed copy:
+  `cp -r packages/tokens-css/dist/* node_modules/@digitaltableteur/tokens-css/dist/`
+  (tokensGlob is a glob WITHIN the pkg dir, not arbitrary source paths — can't point it at nextjs-app source.)
+- Light tokens are `:root`-scoped; dark under `.themeDark`. Base previews need no theme provider for light.
+
+## Provider (decorators)
+- `.storybook/preview.tsx` decorators (ThemeProvider + I18next + Animation + CookieConsent) do NOT bundle: the preview imports `app/tailwind.css` (`@import "tailwindcss"`), which esbuild can't resolve → "! preview decorator bundle failed". TBD whether cfg.provider is needed (discover in solo phase: i18n/theme-sensitive components).
+
+## Re-sync risks
+- `--font-size-body-m` / `--line-height-m` referenced but defined nowhere (runtime or dead ref) — accepted, not shipped.
+
+## Grading guidance (subagents — read before grading)
+- **i18n demo labels → `close` (accepted).** Many stories wrap the demo label in a react-i18next `t()` helper (e.g. `<Label tKey="buttonPrimary">`). The preview shows the RAW KEY (e.g. "buttonPrimary", "storyTextDefault") while storybook shows the resolved English ("Primary"). A dual react-i18next instance prevents the provider from connecting; OWNER DECISION: accept these as `close` with a note "i18n demo label only; component render identical". Do NOT try to fix the .tsx for this — it's global, not per-component. Grade the actual RENDER (shape/color/size/typography); if that's faithful and the ONLY diff is the i18n label text, it's `close`.
+- **Overlay/portal components** (Modal, Toast, ToastStack, Tooltip, Menu, CommandPalette, CookieConsent, SplitButton, LanguageSwitcher, SegmentedControl if it portals): the storybook capture shows only the trigger — the overlay portals to document.body, OUTSIDE the captured #storybook-root. The PREVIEW captures the full overlay. Judge the overlay render on its own (per §4 rubric: "preview that renders more than the gated reference is not close"); grade `match` if the overlay renders faithfully, and REPORT the component for `cardMode: "single"` in your learnings (orchestrator applies it — you may NOT edit config).
+- **[GRID_OVERFLOW] wide components** need `cardMode: "column"` — report in learnings, orchestrator applies (presentation-only, doesn't affect your grade).
+- Styling baseline is VERIFIED GOOD (tokens/radius/shadows/fonts correct via Button/Avatar/Text/Modal solo). If a WHOLE component is unstyled/wrong-color, that's a NEW global issue — STOP and report `[GENERAL]`, don't work around it per-component.
+
+## Wave 2-3 findings (folded)
+- **[GENERAL] CSS-module hash desync (CRITICAL, root cause of the whole re-grade).** Shipping storybook's compiled CSS via cfg.cssEntry REPLACED the package style.css whose module hashes match the JS → pure-CSS-Module components (Badge, StatusDot, Toast, Spinner, code windows, SelectableCard, MacWindowFrame…) rendered unstyled. FIX: cfg.cssEntry must ship BOTH — build `_ds-sync-globals.css` = storybook iframe CSS + package dist/style.css (package LAST so its JS-matching classes win): `cat .design-sync/sb-reference/assets/iframe-*.css packages/react/dist/style.css > packages/react/_ds-sync-globals.css`. Verify `_badge_<hash>` from _ds_bundle.js is present in _ds_bundle.css after build.
+- **[GENERAL] Absolute public-asset paths (author photos).** Stories use `imageUrl="/images/authors/petri-lahdelma.jpg"`; the compare reference (and preview) have no host → broken image, and AuthorBio's storybook reference HANGS forever on it (deadlocked a 19-component compare for 5.5h). FIX: stage the images where both serve from — `cp public/images/authors/* .design-sync/sb-reference/images/authors/` AND `cp public/images/authors/* ds-bundle/images/authors/` (re-copy into ds-bundle after every rebuild; sb-reference persists). ALWAYS run compares with a hang guard / small chunks — one bad component can deadlock a whole serial run.
+- Native web-component duplicate stories (`web-components/*`) render blank in BOTH reference and preview (custom elements undefined in the React static build) — faithful emptiness, graded close/match. Bundle ships React, not native.
+- ValueCard/CategoryFilter/FilterChip/Gallery/NavMenuList native variants: same blank-both-sides pattern.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,186 @@
+{
+  "projectId": "476ee254-9446-4ba7-8d50-65721fe6b2f9",
+  "shape": "storybook",
+  "storybookConfigDir": ".storybook",
+  "pkg": "@digitaltableteur/react",
+  "storybookStatic": ".design-sync/sb-reference",
+  "buildCmd": "cd packages/react && npm run build",
+  "entry": "packages/react/dist/index.js",
+  "tokensPkg": "@digitaltableteur/tokens-css",
+  "provider": {
+    "component": "DsI18nProvider",
+    "props": {
+      "i18n": {
+        "$ref": "dsI18n"
+      }
+    },
+    "inner": {
+      "component": "TranslationProvider"
+    }
+  },
+  "extraEntries": [
+    "../../.design-sync/ds-i18n-entry.tsx"
+  ],
+  "cssEntry": "_ds-sync-globals.css",
+  "overrides": {
+    "Modal": {
+      "cardMode": "single"
+    },
+    "Menu": {
+      "cardMode": "single"
+    },
+    "Toast": {
+      "cardMode": "single"
+    },
+    "ToastStack": {
+      "cardMode": "single"
+    },
+    "Tooltip": {
+      "cardMode": "single"
+    },
+    "CommandPalette": {
+      "cardMode": "single"
+    },
+    "CookieConsent": {
+      "cardMode": "single"
+    },
+    "Accordion": {
+      "cardMode": "column"
+    },
+    "AlertBanner": {
+      "cardMode": "column"
+    },
+    "AspectRatio": {
+      "cardMode": "column"
+    },
+    "Author": {
+      "cardMode": "column"
+    },
+    "AuthorBio": {
+      "cardMode": "column"
+    },
+    "AvatarGroup": {
+      "cardMode": "column"
+    },
+    "Breadcrumb": {
+      "cardMode": "column"
+    },
+    "Card": {
+      "cardMode": "column"
+    },
+    "Center": {
+      "cardMode": "column"
+    },
+    "Checkbox": {
+      "cardMode": "column"
+    },
+    "CheckboxGroup": {
+      "cardMode": "column"
+    },
+    "CodeBlockWindow": {
+      "cardMode": "column"
+    },
+    "Combobox": {
+      "cardMode": "column"
+    },
+    "Container": {
+      "cardMode": "column"
+    },
+    "Display": {
+      "cardMode": "column"
+    },
+    "Divider": {
+      "cardMode": "column"
+    },
+    "EmptyState": {
+      "cardMode": "column"
+    },
+    "ExpandableSection": {
+      "cardMode": "column"
+    },
+    "Gallery": {
+      "cardMode": "column"
+    },
+    "GroupLabel": {
+      "cardMode": "column"
+    },
+    "HelperText": {
+      "cardMode": "column"
+    },
+    "Icon": {
+      "cardMode": "column"
+    },
+    "Label": {
+      "cardMode": "column"
+    },
+    "List": {
+      "cardMode": "column"
+    },
+    "MacWindowFrame": {
+      "cardMode": "column"
+    },
+    "MultiCombobox": {
+      "cardMode": "column"
+    },
+    "NavMenuList": {
+      "cardMode": "column"
+    },
+    "PageLayout": {
+      "cardMode": "column"
+    },
+    "Pagination": {
+      "cardMode": "column"
+    },
+    "PhoneInput": {
+      "cardMode": "column"
+    },
+    "ProcessBlock": {
+      "cardMode": "column"
+    },
+    "Progress": {
+      "cardMode": "column"
+    },
+    "Radio": {
+      "cardMode": "column"
+    },
+    "Select": {
+      "cardMode": "column"
+    },
+    "SelectableCard": {
+      "cardMode": "column"
+    },
+    "Skeleton": {
+      "cardMode": "column",
+      "skip": [
+        "feedback-skeleton--card",
+        "feedback-skeleton--avatar"
+      ]
+    },
+    "SkipLink": {
+      "cardMode": "column"
+    },
+    "SplitButton": {
+      "cardMode": "column"
+    },
+    "Switch": {
+      "cardMode": "column"
+    },
+    "Tabs": {
+      "cardMode": "column"
+    },
+    "Text": {
+      "cardMode": "column"
+    },
+    "TextInput": {
+      "cardMode": "column"
+    },
+    "Timestamp": {
+      "cardMode": "column"
+    },
+    "Title": {
+      "cardMode": "column"
+    }
+  },
+  "readmeHeader": ".design-sync/conventions.md",
+  "extraFonts": ".design-sync/satoshi-fonts.css"
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,57 @@
+# Building with @digitaltableteur/react
+
+Import components from `@digitaltableteur/react` and render `window.DigitaltableteurReact.<Name>`. Every component ships its styles in the bound stylesheet — no per-component CSS import needed.
+
+## Setup / wrapping
+
+Most components render correctly with **no provider** — the design tokens live at `:root`, so the light theme is always active. Add providers only when you need their behavior:
+
+- `ThemeProvider` — wrap the app root to enable dark / high-contrast themes (it toggles the `.themeDark` / `.themeHCB` class that re-points the color tokens). Not needed for the default light theme.
+- `TranslationProvider` — only if you render components that call the translation hook; for normal use, pass literal strings as `children` and skip it.
+
+```jsx
+<ThemeProvider>
+  <YourApp />
+</ThemeProvider>
+```
+
+## Styling idiom — props first, tokens for glue
+
+This system is **not** a utility-class kit. Do not write Tailwind-style classes and do not invent class names — the component classes are scoped (hashed) and internal. Style in two ways only:
+
+1. **Component props carry the design language.** The recurring axes, consistent across controls:
+   - `variant`: `"primary" | "secondary" | "tertiary"` (visual weight)
+   - `tone`: `"neutral" | "error" | "warning" | "success" | "info"` (semantic color)
+   - `size`: `"sm" | "md" | "lg"`
+   - `surface`: `"default" | "onDark" | "onBrand"` (contrast-safe on tinted bands)
+   Reach for these before any custom CSS.
+
+2. **Design tokens (`var(--*)`) for your own layout glue.** Real names:
+   - Color: `--color-text`, `--color-muted`, `--color-primary`, `--color-border`, `--color-surface` (+ `--color-error/-warning/-success/-info`)
+   - Radius: `--radius-sm` (2) `--radius-md` (4) `--radius-lg` (8) `--radius-xl` (16) `--radius-full`
+   - Elevation: `--shadow-sm` `--shadow-md` `--shadow-lg` `--shadow-xl`
+   - Type: `--font-body`, `--font-size-text-xs/-s/-m`
+   - Spacing: `--space-internal-{2,6,8,12,16,24}`
+
+## Where the truth lives
+
+Read `styles.css` (and its `@import` closure) for the full token set before styling, and each component's `<Name>.prompt.md` (usage) and `<Name>.d.ts` (prop contract) before composing it.
+
+## Idiomatic example
+
+```jsx
+import { Card, Stack, Title, Text, Button } from "@digitaltableteur/react";
+
+<Card>
+  <Stack gap="md">
+    <Title size="lg">Project spine</Title>
+    <Text tone="muted">A governed, AI-native component library.</Text>
+    <div style={{ display: "flex", gap: "var(--space-internal-8)" }}>
+      <Button variant="primary">Get started</Button>
+      <Button variant="secondary">Docs</Button>
+    </div>
+  </Stack>
+</Card>
+```
+
+Library components for the controls; the DS tokens (`var(--space-internal-8)`) for your own layout — never hardcoded pixels or hex.

--- a/.design-sync/ds-i18n-entry.tsx
+++ b/.design-sync/ds-i18n-entry.tsx
@@ -1,0 +1,27 @@
+// design-sync preview i18n. Story files import `useTranslation` from
+// react-i18next directly (not the DS TranslationProvider), so previews need a
+// real, initialized i18next instance in context — this mirrors what
+// .storybook/preview.tsx does. Self-contained (fresh instance + en resources)
+// to avoid the app's init chain. Exposed on window.<Global> via cfg.extraEntries;
+// referenced by cfg.provider ({"$ref": "dsI18n"}).
+import i18next from "i18next";
+import { initReactI18next, I18nextProvider } from "react-i18next";
+import en from "../nextjs-app/shared/locales/en/translation.json";
+
+const dsI18n = i18next.createInstance();
+void dsI18n.use(initReactI18next).init({
+  lng: "en",
+  fallbackLng: "en",
+  ns: ["translation"],
+  defaultNS: "translation",
+  resources: { en: { translation: en as Record<string, unknown> } },
+  interpolation: { escapeValue: false },
+  // Synchronous init: with inline resources this flips isInitialized before
+  // the one-shot preview snapshot renders (default async init leaves t()
+  // returning raw keys on the first paint).
+  initImmediate: false,
+  react: { useSuspense: false },
+});
+
+export const DsI18nProvider = I18nextProvider;
+export { dsI18n };

--- a/.design-sync/satoshi-fonts.css
+++ b/.design-sync/satoshi-fonts.css
@@ -1,0 +1,14 @@
+@font-face {
+  font-family: "Satoshi";
+  src: url("../app/fonts/Satoshi-Variable.woff2") format("woff2");
+  font-weight: 300 900;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Satoshi";
+  src: url("../app/fonts/Satoshi-VariableItalic.woff2") format("woff2");
+  font-weight: 300 900;
+  font-style: italic;
+  font-display: swap;
+}

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,10 @@ public/visual-diff/report.json
 # Project-local npm userconfig (.npmrc redirects userconfig here) — may hold a
 # live read token for private @digitaltableteur installs; never track it.
 .npm-userconfig
+.design-sync/sb-reference/
+.design-sync/learnings/
+.design-sync/.cache/
+.design-sync/node_modules
+.ds-sync/
+ds-bundle/
+packages/react/_ds-sync-globals.css

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -89,9 +89,9 @@
   ],
   "peerDependencies": {
     "framer-motion": ">=12.0.0",
-    "react-markdown": ">=10.0.0",
     "react": ">=19.0.0",
-    "react-dom": ">=19.0.0"
+    "react-dom": ">=19.0.0",
+    "react-markdown": ">=10.0.0"
   },
   "dependencies": {
     "@phosphor-icons/react": "^2.1.10",
@@ -101,5 +101,6 @@
   },
   "scripts": {
     "build": "vite build --config vite.config.ts && node ../../scripts/design-system/build-react-package-css.mjs && tsc -p tsconfig.types.json && node ../../scripts/design-system/assemble-react-package-types.mjs"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }


### PR DESCRIPTION
## Sync @digitaltableteur/react to Claude Design

First-time high-fidelity import of the design system into the Claude Design project (`476ee254…`). From now on the Claude Design agent builds with the **actual** `@digitaltableteur/react` components — on-brand, mapping 1:1 to shippable code.

### What this PR commits (durable sync state only)
- `.design-sync/config.json` — the sync anchor: project pin, shape, provider/i18n/font glue, `cssEntry`, and 51 `cardMode` overrides
- `.design-sync/NOTES.md` — every global issue + its fix, so re-syncs replay them (fast + mostly deterministic)
- `.design-sync/conventions.md` — the conventions header inlined into the design agent's context (props idiom, real token names, wrap guidance)
- `.design-sync/{ds-i18n-entry.tsx, satoshi-fonts.css}` — react-i18next + Satoshi-font glue
- `packages/react/package.json` — adds a top-level `types` field (standard; `exports.types` alone made the converter discover **0** components)
- `.gitignore` — sync scratch dirs

No build artifacts (`dist` is byte-identical), no `_screenshots`, no verification cache.

### Result
**83 components** imported and verified against their Storybook render (`match`, or documented `close` for i18n demo labels / play-driven state / portal framing / native-web-component blanks). Closing driver receipt: `ok: true`, all stages green, `pendingGrade: []`, no `FONT_MISSING`.

### Global issues found + fixed during the sync (see NOTES.md)
types entry · storybook `/storybook/` base path · stale token package · react-i18next provider · missing Tailwind/globals layer · CSS-module hash desync · Satoshi brand-font (the `[FONT_MISSING]` trap) · author-image asset paths (also a reference-hang fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added design-sync configuration for Storybook previews, component overrides, fonts, styling, and internationalization.
  * Added initialized English translation support for design-sync previews.
  * Added Satoshi font support, including regular and italic styles.
  * Added TypeScript package metadata for improved editor and build support.

* **Documentation**
  * Added design-sync conventions and expanded setup, troubleshooting, and grading guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->