### PR TITLE
chore(lint): add .stylelintignore for generated/scratch CSS

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,22 @@
+# Generated / build / scratch artifacts. These contain minified single-line CSS
+# that (a) is not source we author and (b) floods Stylelint's JSON output past
+# spawnSync's 1MB maxBuffer in check-stylelint-baseline.mjs, breaking the gate.
+# Stylelint uses this file, NOT .gitignore, so gitignored build dirs must be
+# listed here explicitly.
+
+node_modules/**
+**/node_modules/**
+.next/**
+dist/**
+**/dist/**
+coverage/**
+
+# Storybook + design-system build/sync output
+storybook-static/**
+.design-sync/**
+.ds-sync/**
+ds-bundle/**
+packages/react/_ds-sync-globals.css
+
+# Any minified stylesheet
+**/*.min.css


### PR DESCRIPTION
## Problem
The pre-commit gate (`lint:css` → `check-stylelint-baseline.mjs`) failed locally with `FAIL: could not parse Stylelint JSON output`. Root cause: no `.stylelintignore` existed, so Stylelint's `**/*.css` glob scanned untracked generated artifacts (minified single-line CSS under `storybook-static/`, `.design-sync/`, `.ds-sync/`, `ds-bundle/`, `packages/react/_ds-sync-globals.css`). Their combined JSON output exceeded `spawnSync`'s default 1MB `maxBuffer` → stdout truncated → `JSON.parse` throws.

These artifacts are gitignored, so they never reached CI/Vercel — this only blocked local commits (forcing `--no-verify`).

## Fix
Added `.stylelintignore` listing the generated/scratch dirs. Stylelint reads `.stylelintignore`, not `.gitignore`, so gitignored build dirs must be listed explicitly.

Result: `lint:css` passes with **zero baseline change** — the 2301-warning source baseline still matches exactly (the artifacts were never legitimately part of it). No `lint:css:update` regeneration needed.

Verified green: `check:contrast`, `lint:css` (all 3 sub-checks), `typecheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded generated files, build artifacts, dependency directories, Storybook output, design-system sync files, and minified CSS from Stylelint checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->