### PR TITLE
chore(lint): ignore generated design-sync dirs in ESLint + Rhythmguard

### DIFF
--- a/.rhythmguardignore
+++ b/.rhythmguardignore
@@ -1,0 +1,25 @@
+# Rhythmguard ignore file (auto-discovered by `rhythmguard audit .`, used by
+# scripts/design-system/check-rhythmguard.mjs → npm run audit:rhythm:check).
+#
+# Generated / build / scratch design-sync artifacts. These are gitignored and
+# present only in local working trees; left unignored, rhythmguard walks
+# thousands of generated CSS/template files and the pre-commit hook never
+# finishes (observed 51 min CPU). Mirrors .stylelintignore and the ESLint
+# flat-config ignores. Rhythmguard already skips node_modules/dist/build/
+# coverage/out/.vercel by default, so only the repo-specific dirs are listed.
+#
+# NOTE: .design-sync also holds authored root files (ds-i18n-entry.tsx,
+# satoshi-fonts.css) that MUST stay audited, so only its generated subdirs are
+# listed here — never the whole directory.
+
+storybook-static
+.ds-sync
+ds-bundle
+.design-sync/sb-reference
+.design-sync/.cache
+
+# Generated design-sync globals bundle (gitignored; emitted into packages/react
+# by the DS sync). Present locally but absent from the clean-tree baseline, so
+# it must be excluded to keep the missing-token contract matching. Also listed
+# in .stylelintignore.
+packages/react/_ds-sync-globals.css

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,6 +37,16 @@ export default [
       "dist/",
       "packages/*/dist/",
       "storybook-static/",
+      // Generated / build / scratch design-sync artifacts (gitignored, present
+      // only in local working trees). Left unignored, ESLint crawls thousands
+      // of generated CSS/TS files here and never finishes the pre-commit hook.
+      // Mirrors .stylelintignore + .rhythmguardignore. NOTE: .design-sync also
+      // holds authored root files (ds-i18n-entry.tsx, satoshi-fonts.css) that
+      // MUST stay linted, so only its generated subdirs are ignored here.
+      ".ds-sync/",
+      "ds-bundle/",
+      ".design-sync/sb-reference/",
+      ".design-sync/.cache/",
       "coverage/",
       ".vercel/",
       "*.min.js",


### PR DESCRIPTION
Completes the generated-artifact ignore work started in #1319 (`.stylelintignore`).

## Problem
The pre-commit hook's `lint` (`eslint .`) and `audit:rhythm:check` (`rhythmguard audit .`) steps hung for **40-50+ min** in any working tree containing the untracked design-sync build output. ESLint stalled parsing a **5 MB single-line minified bundle** (`.design-sync/sb-reference/assets/index.es-*.js`); Rhythmguard walked thousands of generated CSS/template files. This forced local commits to use `--no-verify`.

## Fix
- `eslint.config.mjs`: ignore `.ds-sync/`, `ds-bundle/`, `.design-sync/sb-reference/`, `.design-sync/.cache/` — only the **generated** subdirs of `.design-sync` (its authored root files stay linted).
- `.rhythmguardignore` (auto-read by `rhythmguard audit .`): same generated dirs + `packages/react/_ds-sync-globals.css`.

## Verification
Full pre-commit hook runs clean with **no `--no-verify`**: `check:contrast`, `lint:css`, `audit:rhythm:check` (~3s), `typecheck`, `lint` (~6s, 0 errors). Previously eslint alone exceeded 240s.

These dirs are gitignored, so CI/Vercel (clean checkouts) were never affected — purely a local dev-experience fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
