### PR TITLE
chore(husky): remove deprecated hook header from pre-push (husky v10 prep)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
 changed=$(git diff --name-only HEAD @{push} 2>/dev/null || git diff --name-only --cached)
 # Registry dogfood gate: app-side imports of package territory must resolve
 # from the npm registry (two-module-instance context splits, #1019).


### PR DESCRIPTION
husky 9.1.x printed a DEPRECATED warning on every push and will fail in v10 because `.husky/pre-push` still carried the legacy header:

```sh
#!/usr/bin/env sh
. "$(dirname "$0")/_/husky.sh"
```

In husky v9.1+ the git-invoked wrapper (`.husky/_/pre-push` → sources `.husky/_/h`) sets up the environment and runs the user hook, so the user hook must not carry the shebang or source `_/husky.sh`. Removed both lines; hook body unchanged, still parses under `sh -n`.

`.husky/pre-commit` had only a bare shebang (not the deprecated source line) and was not flagged, so it is left as-is.

## Verification
Pushed this branch: the pre-push hook runs and the DEPRECATED warning no longer appears. Full pre-commit gate passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
