### PR TITLE
fix(deps): patch brace-expansion + postcss high advisories via scoped overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18512,9 +18512,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -31188,34 +31188,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/no-case": {

--- a/package.json
+++ b/package.json
@@ -324,7 +324,13 @@
     },
     "fast-uri": "^3.1.4",
     "tmp": "^0.2.6",
-    "shell-quote": "^1.9.0"
+    "shell-quote": "^1.9.0",
+    "minimatch@3.1.5": {
+      "brace-expansion": "^1.1.16"
+    },
+    "next": {
+      "postcss": "^8.5.22"
+    }
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",


### PR DESCRIPTION
Clears the two Dependabot **HIGH** advisories that have safe, non-major fixes.

## Fixes
- **brace-expansion ReDoS** (`<1.1.16`): the vulnerable `1.1.15` came only from `minimatch@3.1.5` (eslint's tree). Scoped override `"minimatch@3.1.5": { "brace-expansion": "^1.1.16" }` bumps just that path; unaffected 2.x/5.x instances untouched.
- **postcss XSS** (`<8.5.10`): the vulnerable `8.4.31` was `next@16.2.11`'s bundled postcss. Override `"next": { "postcss": "^8.5.22" }` routes it to the already-present patched `8.5.22`.

## Lockfile safety
Surgical: `brace-expansion 1.1.15→1.1.16` + removal of next's nested `postcss@8.4.31`. The 196 cross-platform optional binaries and all other resolutions are **untouched** (0 platform entries added/removed). Verified `npm ci` passes on **linux/amd64** (Vercel, via Docker) and **macOS**; `npm audit` no longer lists brace-expansion or postcss (26→24, high 11→9).

## Deferred (not in this PR)
The remaining ~17 advisories require a `sanity` 4→5 major migration + dev-tooling majors (`@lhci/cli`, `@storybook/test-runner`, `@modelcontextprotocol/sdk`, `@vercel/node`). Held for a dedicated migration PR per the dependabot policy; none are runtime-exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
