### PR TITLE
chore(release): @digitaltableteur/react 0.1.19 — export SlideButton

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.1.19 - 2026-07-24
+
+- Exposes the `SlideButton` call-to-action from the root and actions-family
+  entrypoints: a pill link whose icon disc slides across the button on hover
+  while the label shifts and the disc rolls a full turn, all suppressed under
+  `prefers-reduced-motion`. Renders a real `<a href>`, with configurable
+  `label`, `href`, `icon` (Phosphor name) and `iconSide` (`left` | `right`).
+  Type-only export: `SlideButtonProps`.
+
 ## 0.1.18 - 2026-07-22
 
 - Exposes the `Logo` content atom from the root and content-family

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/react",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": false,
   "description": "React components and host adapters for the Digitaltableteur design system.",
   "type": "module",

--- a/packages/react/public-api.manifest.json
+++ b/packages/react/public-api.manifest.json
@@ -1,6 +1,6 @@
 {
   "packageName": "@digitaltableteur/react",
-  "packageVersion": "0.1.18",
+  "packageVersion": "0.1.19",
   "packageExports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -159,6 +159,7 @@
     "SelectOption",
     "Skeleton",
     "SkipLink",
+    "SlideButton",
     "Spacer",
     "Spinner",
     "SplitButton",
@@ -208,6 +209,7 @@
       "ButtonGroup",
       "FilterChip",
       "IconButton",
+      "SlideButton",
       "SplitButton"
     ],
     "consent": [
@@ -376,6 +378,8 @@
       "FilterChipProps",
       "IconButton",
       "IconButtonProps",
+      "SlideButton",
+      "SlideButtonProps",
       "SplitButton",
       "SplitButtonOption",
       "SplitButtonProps"

--- a/packages/react/src/actions.ts
+++ b/packages/react/src/actions.ts
@@ -16,6 +16,8 @@ export {
   IconButton,
   type IconButtonProps,
 } from "../../../nextjs-app/shared/components/IconButton";
+export { SlideButton } from "../../../nextjs-app/shared/components/SlideButton/SlideButton";
+export type { SlideButtonProps } from "../../../nextjs-app/shared/components/SlideButton/SlideButton";
 export { default as SplitButton } from "../../../nextjs-app/shared/components/SplitButton/SplitButton";
 export type {
   SplitButtonOption,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -279,6 +279,8 @@ export {
 } from "../../../nextjs-app/shared/components/SkipLink";
 export { default as Skeleton } from "../../../nextjs-app/shared/components/Skeleton/Skeleton";
 export type { SkeletonProps } from "../../../nextjs-app/shared/components/Skeleton";
+export { SlideButton } from "../../../nextjs-app/shared/components/SlideButton/SlideButton";
+export type { SlideButtonProps } from "../../../nextjs-app/shared/components/SlideButton/SlideButton";
 export {
   Spinner,
   type SpinnerProps,


### PR DESCRIPTION
Prep for publishing `@digitaltableteur/react@0.1.19`.

- Exports `SlideButton` + `SlideButtonProps` from the root and `actions` family entrypoints.
- Public API manifest 132 → 133. Additive, no breaking changes.
- Verified: `check:react-package` (1.57 MiB, topology 47.6%), `check:react-public-api` (133), `check:react-public-surface` (0 alpha), SSR import, typecheck, lint.

The publish workflow (`ds-publish.yml`, OIDC) runs after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)