### PR TITLE
chore(release): tokens 0.1.4 + tokens-css 0.1.5 — radius/elevation tokens

### DIFF
--- a/packages/tokens-css/CHANGELOG.md
+++ b/packages/tokens-css/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.5 - 2026-07-24
+
+- Adds the radius and elevation custom properties from the token sweep:
+  `--radius-xl`, `--radius-circle`, and the `--shadow-sm` / `--shadow-md` /
+  `--shadow-lg` / `--shadow-xl` elevation ramp. Additive; existing radius
+  custom properties are unchanged.
+
 ## 0.1.4 - 2026-07-22
 
 - Adds the seven high-contrast legibility custom properties

--- a/packages/tokens-css/package.json
+++ b/packages/tokens-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/tokens-css",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": false,
   "description": "Theme-complete Digitaltableteur token CSS generated from production variables.css.",
   "type": "module",

--- a/packages/tokens/CHANGELOG.md
+++ b/packages/tokens/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.4 - 2026-07-24
+
+- Adds the radius scale extension and elevation ramp shipped in the token
+  sweep: `radius.xl`, `radius.circle`, and the `shadow.sm` / `shadow.md` /
+  `shadow.lg` / `shadow.xl` elevation tokens (token count 192 → 198). Additive;
+  the existing `radius.sm` / `radius.md` / `radius.lg` numbering is unchanged.
+
 ## 0.1.3 - 2026-07-22
 
 - Adds seven semantic tokens from the high-contrast legibility round:

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/tokens",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": false,
   "description": "CSS-sourced Digitaltableteur design tokens generated from production variables.css.",
   "type": "module",


### PR DESCRIPTION
Republish token packages to close drift (192 → 198): adds radius.xl/circle + shadow.sm/md/lg/xl. Additive. Prereq for react@0.1.19 (SlideButton) publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new radius tokens for extra-large and circular designs.
  * Added small through extra-large elevation/shadow tokens.
  * Expanded the token set from 192 to 198 entries while preserving existing radius tokens.

* **Documentation**
  * Updated changelogs to document the new radius and elevation tokens.

* **Chores**
  * Released updated token packages with the latest version increments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->