### PR TITLE
feat(web-components): add dt-slide-button + dt-scroll-indicator (0.10.0)

### DIFF
--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.10.0 - 2026-07-24
+
+- Adds two native custom elements (fleet 85 -> 87):
+  - `dt-slide-button` — pill call-to-action whose icon disc slides across on
+    hover while the label shifts and the disc rolls a full turn (all motion
+    reduced-motion gated). Attributes: `label`, `href`, `icon`, `icon-side`.
+  - `dt-scroll-indicator` — animated hero-footer affordance that scrolls a
+    named target into view, with `chevron` / `arrow` / `mouse` icons and CSS
+    motion presets (`bounce` / `pulse` / `fade` / `none`) suppressed under
+    `prefers-reduced-motion`. Attributes: `label`, `target-id`, `variant`,
+    `position`, `motion`, `speed`, `distance`.
+
 ## 0.9.0 - 2026-07-22
 
 - BREAKING: renames the `dt-logo` `badge` attribute/property to `background`

--- a/packages/web-components/custom-elements.json
+++ b/packages/web-components/custom-elements.json
@@ -1128,6 +1128,216 @@
         },
         {
           "kind": "class",
+          "name": "DtSlideButtonElement",
+          "description": "Pill call-to-action whose icon disc slides across on hover while the label shifts and the disc rolls.",
+          "customElement": true,
+          "tagName": "dt-slide-button",
+          "members": [
+            {
+              "kind": "field",
+              "name": "label",
+              "description": "Visible label; also the accessible name.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "href",
+              "description": "Destination the anchor points to.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "icon",
+              "description": "Phosphor icon name for the sliding disc.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "iconSide",
+              "description": "Side the disc rests on before it slides.",
+              "type": {
+                "text": "string"
+              }
+            }
+          ],
+          "attributes": [
+            {
+              "name": "label",
+              "fieldName": "label",
+              "description": "Visible label; also the accessible name.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "href",
+              "fieldName": "href",
+              "description": "Destination the anchor points to.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "icon",
+              "fieldName": "icon",
+              "description": "Phosphor icon name for the sliding disc.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "icon-side",
+              "fieldName": "iconSide",
+              "description": "Side the disc rests on before it slides.",
+              "type": {
+                "text": "string"
+              }
+            }
+          ],
+          "events": [],
+          "dtSourceComponent": "SlideButton",
+          "dtBackend": "native",
+          "dtContractStatus": "stable",
+          "dtImplementationStatus": "beta",
+          "dtImplementationConsumers": []
+        },
+        {
+          "kind": "class",
+          "name": "DtScrollIndicatorElement",
+          "description": "Animated hero-footer affordance that scrolls to a named target; motion is CSS-driven and reduced-motion gated.",
+          "customElement": true,
+          "tagName": "dt-scroll-indicator",
+          "members": [
+            {
+              "kind": "field",
+              "name": "label",
+              "description": "Optional visible label; names the destination.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "targetId",
+              "description": "Element id scrolled into view on activation.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "variant",
+              "description": "Icon treatment: chevron, arrow or mouse.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "position",
+              "description": "Horizontal placement: center, left or right.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "motion",
+              "description": "Motion hint: bounce, pulse, fade or none.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "speed",
+              "description": "Duration of one motion half-cycle, in seconds.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "distance",
+              "description": "Vertical travel of the bounce motion, in pixels.",
+              "type": {
+                "text": "string"
+              }
+            }
+          ],
+          "attributes": [
+            {
+              "name": "label",
+              "fieldName": "label",
+              "description": "Optional visible label; names the destination.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "target-id",
+              "fieldName": "targetId",
+              "description": "Element id scrolled into view on activation.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "variant",
+              "fieldName": "variant",
+              "description": "Icon treatment: chevron, arrow or mouse.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "position",
+              "fieldName": "position",
+              "description": "Horizontal placement: center, left or right.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "motion",
+              "fieldName": "motion",
+              "description": "Motion hint: bounce, pulse, fade or none.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "speed",
+              "fieldName": "speed",
+              "description": "Duration of one motion half-cycle, in seconds.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "distance",
+              "fieldName": "distance",
+              "description": "Vertical travel of the bounce motion, in pixels.",
+              "type": {
+                "text": "string"
+              }
+            }
+          ],
+          "events": [],
+          "dtSourceComponent": "ScrollIndicator",
+          "dtBackend": "native",
+          "dtContractStatus": "stable",
+          "dtImplementationStatus": "beta",
+          "dtImplementationConsumers": []
+        },
+        {
+          "kind": "class",
           "name": "DtSpinnerElement",
           "description": "Indeterminate loading indicator.",
           "customElement": true,

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/web-components",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": false,
   "description": "Framework-neutral custom elements for the Digitaltableteur design system.",
   "type": "module",

--- a/packages/web-components/src/generated/element-contracts.ts
+++ b/packages/web-components/src/generated/element-contracts.ts
@@ -91,6 +91,23 @@ export type DtSkipLinkElementContract = HTMLElement & {
   label?: string;
 };
 
+export type DtSlideButtonElementContract = HTMLElement & {
+  label?: string;
+  href?: string;
+  icon?: string;
+  iconSide?: string;
+};
+
+export type DtScrollIndicatorElementContract = HTMLElement & {
+  label?: string;
+  targetId?: string;
+  variant?: string;
+  position?: string;
+  motion?: string;
+  speed?: string;
+  distance?: string;
+};
+
 export type DtSpinnerElementContract = HTMLElement & {
   label?: string;
   size?: string;
@@ -902,6 +919,8 @@ export const elementMigrationManifest = [
   { tagName: "dt-link", sourceComponent: "Link", backend: "native", contractStatus: "stable", implementationStatus: "beta", implementationConsumers: [] },
   { tagName: "dt-nav-link", sourceComponent: "NavLink", backend: "native", contractStatus: "stable", implementationStatus: "beta", implementationConsumers: [] },
   { tagName: "dt-skip-link", sourceComponent: "SkipLink", backend: "native", contractStatus: "stable", implementationStatus: "beta", implementationConsumers: [] },
+  { tagName: "dt-slide-button", sourceComponent: "SlideButton", backend: "native", contractStatus: "stable", implementationStatus: "beta", implementationConsumers: [] },
+  { tagName: "dt-scroll-indicator", sourceComponent: "ScrollIndicator", backend: "native", contractStatus: "stable", implementationStatus: "beta", implementationConsumers: [] },
   { tagName: "dt-spinner", sourceComponent: "Spinner", backend: "native", contractStatus: "stable", implementationStatus: "beta", implementationConsumers: [] },
   { tagName: "dt-progress", sourceComponent: "Progress", backend: "native", contractStatus: "stable", implementationStatus: "beta", implementationConsumers: [] },
   { tagName: "dt-status-dot", sourceComponent: "StatusDot", backend: "native", contractStatus: "stable", implementationStatus: "beta", implementationConsumers: [] },
@@ -991,6 +1010,8 @@ declare global {
     "dt-link": DtLinkElementContract;
     "dt-nav-link": DtNavLinkElementContract;
     "dt-skip-link": DtSkipLinkElementContract;
+    "dt-slide-button": DtSlideButtonElementContract;
+    "dt-scroll-indicator": DtScrollIndicatorElementContract;
     "dt-spinner": DtSpinnerElementContract;
     "dt-progress": DtProgressElementContract;
     "dt-status-dot": DtStatusDotElementContract;

--- a/packages/web-components/src/native.ts
+++ b/packages/web-components/src/native.ts
@@ -50,7 +50,9 @@ import { DtPaginationElement } from "./native/pagination";
 import { DtPersonCardElement } from "./native/person-card";
 import { DtProgressElement } from "./native/progress";
 import { DtReadingProgressElement } from "./native/reading-progress";
+import { DtScrollIndicatorElement } from "./native/scroll-indicator";
 import { DtSkipLinkElement } from "./native/skip-link";
+import { DtSlideButtonElement } from "./native/slide-button";
 import { DtSpinnerElement } from "./native/spinner";
 import { DtSpacerElement } from "./native/spacer";
 import { DtStatusDotElement } from "./native/status-dot";
@@ -387,6 +389,7 @@ export type { DtValueCardVariant } from "./native/value-card";
 export const nativeElementDefinitions = [
   ["dt-icon", DtIconElement],
   ["dt-button", DtButtonElement],
+  ["dt-slide-button", DtSlideButtonElement],
   ["dt-icon-button", DtIconButtonElement],
   ["dt-button-group", DtButtonGroupElement],
   ["dt-filter-chip", DtFilterChipElement],
@@ -398,6 +401,7 @@ export const nativeElementDefinitions = [
   ["dt-nav-link", DtNavLinkElement],
   ["dt-nav-menu-list", DtNavMenuListElement],
   ["dt-language-switcher", DtLanguageSwitcherElement],
+  ["dt-scroll-indicator", DtScrollIndicatorElement],
   ["dt-skip-link", DtSkipLinkElement],
   ["dt-badge", DtBadgeElement],
   ["dt-avatar", DtAvatarElement],

--- a/packages/web-components/src/native/scroll-indicator.ts
+++ b/packages/web-components/src/native/scroll-indicator.ts
@@ -1,0 +1,152 @@
+import {
+  DigitaltableteurElement,
+  enumAttribute,
+  reflectAttribute,
+  stringAttribute,
+} from "./base";
+
+const VARIANTS = ["arrow", "mouse", "chevron"] as const;
+const POSITIONS = ["center", "left", "right"] as const;
+const MOTIONS = ["bounce", "pulse", "fade", "none"] as const;
+export type DtScrollIndicatorVariant = (typeof VARIANTS)[number];
+export type DtScrollIndicatorPosition = (typeof POSITIONS)[number];
+export type DtScrollIndicatorMotion = (typeof MOTIONS)[number];
+
+// Inline SVGs matching the React ScrollIndicator exactly (chevron = lucide
+// ChevronDown; arrow + mouse = its bespoke inline paths), so the native twin
+// needs no phosphor icon-registry entries and renders identical geometry.
+const iconMarkup: Record<DtScrollIndicatorVariant, string> = {
+  chevron:
+    '<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>',
+  arrow:
+    '<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14M5 12l7 7 7-7"/></svg>',
+  mouse:
+    '<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="6" y="3" width="12" height="18" rx="6"/><line x1="12" y1="7" x2="12" y2="11"/></svg>',
+};
+
+// Mirrors nextjs-app/shared/components/ScrollIndicator: a hero-footer button
+// that scrolls a target into view, with a looping motion hint on the icon.
+// The React twin drives motion with GSAP; the native twin uses CSS keyframes.
+// Both suppress motion under prefers-reduced-motion.
+const styles = `
+  :host { display: contents; }
+  :host([hidden]) { display: none; }
+  .root {
+    position: absolute;
+    inset-block-end: 2rem;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    border: 0;
+    background: transparent;
+    color: color-mix(in srgb, var(--color-foreground) 70%, transparent);
+    cursor: pointer;
+    transition: color 200ms ease;
+  }
+  .center { inset-inline: 0; margin-inline: auto; inline-size: fit-content; }
+  .left { inset-inline-start: 2rem; }
+  .right { inset-inline-end: 2rem; }
+  .root:hover { color: var(--color-foreground); }
+  .root:focus-visible { outline: none; box-shadow: 0 0 0 2px var(--color-background, #fff), 0 0 0 4px var(--color-primary); border-radius: 0.25rem; }
+  .label { font-family: var(--primary-body-font); font-size: 0.75rem; letter-spacing: 0.02em; }
+  .icon { display: block; }
+  .icon svg { inline-size: 1.5rem; block-size: 1.5rem; }
+  .bounce .icon { animation: dt-si-bounce var(--dt-si-speed, 0.6s) ease-in-out infinite alternate; }
+  .pulse .icon { animation: dt-si-pulse var(--dt-si-speed, 0.6s) ease-in-out infinite alternate; }
+  .fade .icon { animation: dt-si-fade var(--dt-si-speed, 0.6s) ease-in-out infinite alternate; }
+  .root:hover .icon { animation-play-state: paused; }
+  @keyframes dt-si-bounce { from { transform: translateY(0); } to { transform: translateY(var(--dt-si-distance, 8px)); } }
+  @keyframes dt-si-pulse { from { transform: scale(1); } to { transform: scale(1.12); } }
+  @keyframes dt-si-fade { from { opacity: 1; } to { opacity: 0.35; } }
+  @media (prefers-reduced-motion: reduce) {
+    .bounce .icon, .pulse .icon, .fade .icon { animation: none; }
+  }
+`;
+
+export class DtScrollIndicatorElement extends DigitaltableteurElement {
+  static observedAttributes = [
+    "label",
+    "target-id",
+    "variant",
+    "position",
+    "motion",
+    "speed",
+    "distance",
+  ];
+
+  connectedCallback(): void {
+    this.render();
+    this.observeLightDom(() => this.render());
+  }
+  attributeChangedCallback(): void {
+    if (this.isConnected) this.render();
+  }
+
+  get label(): string {
+    return stringAttribute(this, "label");
+  }
+  set label(value: string) {
+    reflectAttribute(this, "label", value || null);
+  }
+  get targetId(): string {
+    return stringAttribute(this, "target-id");
+  }
+  set targetId(value: string) {
+    reflectAttribute(this, "target-id", value || null);
+  }
+  get variant(): DtScrollIndicatorVariant {
+    return enumAttribute(this, "variant", VARIANTS, "chevron");
+  }
+  set variant(value: DtScrollIndicatorVariant) {
+    reflectAttribute(this, "variant", value);
+  }
+  get position(): DtScrollIndicatorPosition {
+    return enumAttribute(this, "position", POSITIONS, "center");
+  }
+  set position(value: DtScrollIndicatorPosition) {
+    reflectAttribute(this, "position", value);
+  }
+  get motion(): DtScrollIndicatorMotion {
+    return enumAttribute(this, "motion", MOTIONS, "bounce");
+  }
+  set motion(value: DtScrollIndicatorMotion) {
+    reflectAttribute(this, "motion", value);
+  }
+
+  private handleClick = (): void => {
+    const id = this.targetId;
+    if (!id) return;
+    const target = this.ownerDocument.getElementById(id);
+    target?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  private render(): void {
+    const doc = this.ownerDocument;
+    const speed = stringAttribute(this, "speed");
+    const distance = stringAttribute(this, "distance");
+    if (speed) this.style.setProperty("--dt-si-speed", `${speed}s`);
+    if (distance) this.style.setProperty("--dt-si-distance", `${distance}px`);
+
+    const button = doc.createElement("button");
+    button.type = "button";
+    button.className = `root ${this.position} ${this.motion}`;
+    button.setAttribute("aria-label", this.label || "Scroll to content");
+    button.addEventListener("click", this.handleClick);
+
+    if (this.label) {
+      const label = doc.createElement("span");
+      label.className = "label";
+      label.textContent = this.label;
+      button.appendChild(label);
+    }
+
+    const iconWrap = doc.createElement("span");
+    iconWrap.className = "icon";
+    iconWrap.setAttribute("aria-hidden", "true");
+    iconWrap.innerHTML = iconMarkup[this.variant];
+    button.appendChild(iconWrap);
+
+    this.replaceShadow(styles, button);
+  }
+}

--- a/packages/web-components/src/native/slide-button.ts
+++ b/packages/web-components/src/native/slide-button.ts
@@ -1,0 +1,148 @@
+import {
+  DigitaltableteurElement,
+  enumAttribute,
+  reflectAttribute,
+  stringAttribute,
+} from "./base";
+
+const ICON_SIDES = ["left", "right"] as const;
+export type DtSlideButtonIconSide = (typeof ICON_SIDES)[number];
+
+// Mirrors nextjs-app/shared/components/SlideButton/SlideButton.module.css:
+// a primary pill whose icon disc slides across on hover while the label shifts
+// and the disc rolls a full turn. All motion is gated behind reduced motion.
+const styles = `
+  :host { display: inline-flex; vertical-align: middle; }
+  :host([hidden]) { display: none; }
+  .root {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    block-size: 2.75rem;
+    border-radius: var(--radius-full, 9999px);
+    background-color: var(--color-primary);
+    color: var(--color-primary-foreground, var(--color-white, #fff));
+    font-family: var(--primary-body-font);
+    font-weight: var(--font-weight-medium, 500);
+    font-size: 1rem;
+    text-decoration: none;
+    cursor: pointer;
+    padding-block: 0.375rem;
+    padding-inline: 0.375rem 1.25rem;
+  }
+  .root.reverse { padding-inline: 1.25rem 0.375rem; }
+  .root:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--color-background, #fff), 0 0 0 4px var(--color-ring, var(--color-primary));
+  }
+  .label {
+    position: relative;
+    z-index: 1;
+    white-space: nowrap;
+    padding-inline: 2.75rem 1.25rem;
+    transition: padding 300ms var(--ease-out-cubic, ease-out);
+  }
+  .root.reverse .label { padding-inline: 1.25rem 2.75rem; }
+  .icon-track {
+    position: absolute;
+    inset-block: 0;
+    margin-block: auto;
+    inset-inline-start: 0.375rem;
+    z-index: 2;
+    inline-size: 2rem;
+    block-size: 2rem;
+    transition: inset-inline-start 600ms var(--ease-out-cubic, ease-out);
+  }
+  .root.reverse .icon-track { inset-inline-start: calc(100% - 2.375rem); }
+  .disc {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: 2rem;
+    block-size: 2rem;
+    border-radius: var(--radius-circle, 50%);
+    background-color: var(--logo-background);
+    animation: dt-slide-button-roll-back 600ms var(--ease-out-cubic, ease-out);
+  }
+  .disc dt-icon { color: var(--color-foreground); inline-size: 1.25rem; block-size: 1.25rem; }
+  @media (hover: hover) and (pointer: fine) {
+    .root:hover .label { padding-inline: 1.25rem 2.75rem; }
+    .root.reverse:hover .label { padding-inline: 2.75rem 1.25rem; }
+    .root:hover .icon-track { inset-inline-start: calc(100% - 2.375rem); }
+    .root.reverse:hover .icon-track { inset-inline-start: 0.375rem; }
+    .root:hover .disc { animation: dt-slide-button-roll 600ms var(--ease-out-cubic, ease-out); }
+  }
+  @keyframes dt-slide-button-roll { from { transform: rotate(0); } to { transform: rotate(360deg); } }
+  @keyframes dt-slide-button-roll-back { from { transform: rotate(360deg); } to { transform: rotate(0); } }
+  @media (prefers-reduced-motion: reduce) {
+    .label, .icon-track { transition: none; }
+    .disc, .root:hover .disc { animation: none; }
+    .root:hover .label { padding-inline: 2.75rem 1.25rem; }
+    .root.reverse:hover .label { padding-inline: 1.25rem 2.75rem; }
+    .root:hover .icon-track { inset-inline-start: 0.375rem; }
+    .root.reverse:hover .icon-track { inset-inline-start: calc(100% - 2.375rem); }
+  }
+`;
+
+export class DtSlideButtonElement extends DigitaltableteurElement {
+  static observedAttributes = ["label", "href", "icon", "icon-side"];
+
+  connectedCallback(): void {
+    this.render();
+    this.observeLightDom(() => this.render());
+  }
+  attributeChangedCallback(): void {
+    if (this.isConnected) this.render();
+  }
+
+  get label(): string {
+    return stringAttribute(this, "label");
+  }
+  set label(value: string) {
+    reflectAttribute(this, "label", value || null);
+  }
+  get href(): string {
+    return stringAttribute(this, "href");
+  }
+  set href(value: string) {
+    reflectAttribute(this, "href", value || null);
+  }
+  get icon(): string {
+    return stringAttribute(this, "icon", "lightning");
+  }
+  set icon(value: string) {
+    reflectAttribute(this, "icon", value || null);
+  }
+  get iconSide(): DtSlideButtonIconSide {
+    return enumAttribute(this, "icon-side", ICON_SIDES, "left");
+  }
+  set iconSide(value: DtSlideButtonIconSide) {
+    reflectAttribute(this, "icon-side", value);
+  }
+
+  private render(): void {
+    const doc = this.ownerDocument;
+    const anchor = doc.createElement("a");
+    anchor.className = this.iconSide === "right" ? "root reverse" : "root";
+    if (this.href) anchor.setAttribute("href", this.href);
+    anchor.setAttribute("aria-label", this.label);
+
+    const label = doc.createElement("span");
+    label.className = "label";
+    label.textContent = this.label;
+
+    const track = doc.createElement("span");
+    track.className = "icon-track";
+    track.setAttribute("aria-hidden", "true");
+    const disc = doc.createElement("span");
+    disc.className = "disc";
+    const icon = doc.createElement("dt-icon");
+    icon.setAttribute("name", this.icon || "lightning");
+    icon.setAttribute("weight", "fill");
+    disc.appendChild(icon);
+    track.appendChild(disc);
+
+    anchor.append(label, track);
+    this.replaceShadow(styles, anchor);
+  }
+}

--- a/packages/web-components/web-components.config.mjs
+++ b/packages/web-components/web-components.config.mjs
@@ -273,6 +273,81 @@ const elementDefinitions = [
     events: [],
   },
   {
+    tagName: "dt-slide-button",
+    sourceComponent: "SlideButton",
+    contract: "SlideButton",
+    defaultBackend: "native",
+    nativeClassName: "DtSlideButtonElement",
+    description:
+      "Pill call-to-action whose icon disc slides across on hover while the label shifts and the disc rolls.",
+    storyParity: storyParity(),
+    props: [
+      nativeProp("label", "string", "Visible label; also the accessible name."),
+      nativeProp("href", "string", "Destination the anchor points to."),
+      nativeProp("icon", "string", "Phosphor icon name for the sliding disc."),
+      nativeProp(
+        "iconSide",
+        "string",
+        "Side the disc rests on before it slides.",
+        {
+          attributeName: "icon-side",
+        },
+      ),
+    ],
+    events: [],
+  },
+  {
+    tagName: "dt-scroll-indicator",
+    sourceComponent: "ScrollIndicator",
+    contract: "ScrollIndicator",
+    defaultBackend: "native",
+    nativeClassName: "DtScrollIndicatorElement",
+    description:
+      "Animated hero-footer affordance that scrolls to a named target; motion is CSS-driven and reduced-motion gated.",
+    storyParity: storyParity(),
+    props: [
+      nativeProp(
+        "label",
+        "string",
+        "Optional visible label; names the destination.",
+      ),
+      nativeProp(
+        "targetId",
+        "string",
+        "Element id scrolled into view on activation.",
+        {
+          attributeName: "target-id",
+        },
+      ),
+      nativeProp(
+        "variant",
+        "string",
+        "Icon treatment: chevron, arrow or mouse.",
+      ),
+      nativeProp(
+        "position",
+        "string",
+        "Horizontal placement: center, left or right.",
+      ),
+      nativeProp(
+        "motion",
+        "string",
+        "Motion hint: bounce, pulse, fade or none.",
+      ),
+      nativeProp(
+        "speed",
+        "string",
+        "Duration of one motion half-cycle, in seconds.",
+      ),
+      nativeProp(
+        "distance",
+        "string",
+        "Vertical travel of the bounce motion, in pixels.",
+      ),
+    ],
+    events: [],
+  },
+  {
     tagName: "dt-spinner",
     adapterClassName: "DtSpinnerReactElement",
     sourceComponent: "Spinner",

--- a/scripts/design-system/check-web-components.mjs
+++ b/scripts/design-system/check-web-components.mjs
@@ -174,7 +174,11 @@ const maxPackedFiles = 40 + tags.length * 2;
 // +1 kB for accumulated shared-chunk + custom-elements manifest drift since the
 // 0.9.0 round: measured 1,854,659 bytes unpacked, ~34 bytes over the prior
 // ceiling.
-const sharedBundleAndManifestCeiling = 1_318_000;
+// +10 kB for dt-slide-button + dt-scroll-indicator (86th/87th tags): the pill
+// slide/roll animation and the scroll-indicator motion presets carry more
+// shadow-DOM CSS than the flat per-tag allowance; measured 1,875,138 bytes
+// unpacked, ~6.9 kB over the per-tag-scaled ceiling.
+const sharedBundleAndManifestCeiling = 1_328_000;
 // Attribute metadata and complete property-member metadata both scale with
 // each public element. Keep the member allowance explicit so fieldName never
 // points at an undeclared Custom Elements Manifest member.

--- a/scripts/design-system/native-stylelint-baseline.json
+++ b/scripts/design-system/native-stylelint-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "npm run lint:css:update",
-  "templateCount": 84,
-  "warningCount": 575,
+  "templateCount": 86,
+  "warningCount": 626,
   "warnings": [
     {
       "column": 21,
@@ -3433,6 +3433,69 @@
       "id": "packages/web-components/src/native/reading-progress.ts::rhythmguard/prefer-token::Unexpected raw scale value \"100%\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::1"
     },
     {
+      "column": 140,
+      "file": "packages/web-components/src/native/scroll-indicator.ts",
+      "line": 51,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"0.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/scroll-indicator.ts::rhythmguard/prefer-token::Unexpected raw scale value \"0.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::1"
+    },
+    {
+      "column": 10,
+      "file": "packages/web-components/src/native/scroll-indicator.ts",
+      "line": 40,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/scroll-indicator.ts::rhythmguard/prefer-token::Unexpected raw scale value \"0.5rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::1"
+    },
+    {
+      "column": 22,
+      "file": "packages/web-components/src/native/scroll-indicator.ts",
+      "line": 36,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"2rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/scroll-indicator.ts::rhythmguard/prefer-token::Unexpected raw scale value \"2rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::1"
+    },
+    {
+      "column": 31,
+      "file": "packages/web-components/src/native/scroll-indicator.ts",
+      "line": 48,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"2rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/scroll-indicator.ts::rhythmguard/prefer-token::Unexpected raw scale value \"2rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::2"
+    },
+    {
+      "column": 30,
+      "file": "packages/web-components/src/native/scroll-indicator.ts",
+      "line": 49,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"2rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/scroll-indicator.ts::rhythmguard/prefer-token::Unexpected raw scale value \"2rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::3"
+    },
+    {
+      "column": 113,
+      "file": "packages/web-components/src/native/scroll-indicator.ts",
+      "line": 59,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"8px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/scroll-indicator.ts::rhythmguard/prefer-token::Unexpected raw scale value \"8px\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::1"
+    },
+    {
+      "column": 87,
+      "file": "packages/web-components/src/native/scroll-indicator.ts",
+      "line": 52,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"0.02em\". Use scale values (nearest: 0px or 2px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/scroll-indicator.ts::rhythmguard/use-scale::Unexpected off-scale value \"0.02em\". Use scale values (nearest: 0px or 2px). (rhythmguard/use-scale)::1"
+    },
+    {
       "column": 60,
       "file": "packages/web-components/src/native/section-nav.ts",
       "line": 48,
@@ -4106,6 +4169,402 @@
       "severity": "warning",
       "text": "Unexpected off-scale value \"0.375rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
       "id": "packages/web-components/src/native/skip-link.ts::rhythmguard/use-scale::Unexpected off-scale value \"0.375rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)::1"
+    },
+    {
+      "column": 20,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 30,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"0.375rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"0.375rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::1"
+    },
+    {
+      "column": 21,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 31,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"0.375rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"0.375rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::2"
+    },
+    {
+      "column": 43,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 33,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"0.375rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"0.375rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::3"
+    },
+    {
+      "column": 25,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 50,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"0.375rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"0.375rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::4"
+    },
+    {
+      "column": 59,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 72,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"0.375rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"0.375rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::5"
+    },
+    {
+      "column": 51,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 82,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"0.375rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"0.375rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::6"
+    },
+    {
+      "column": 30,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 31,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::1"
+    },
+    {
+      "column": 35,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 33,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::2"
+    },
+    {
+      "column": 29,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 42,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::3"
+    },
+    {
+      "column": 42,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 45,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::4"
+    },
+    {
+      "column": 42,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 69,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::5"
+    },
+    {
+      "column": 58,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 70,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::6"
+    },
+    {
+      "column": 50,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 80,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::7"
+    },
+    {
+      "column": 50,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 81,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"1.25rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::8"
+    },
+    {
+      "column": 21,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 42,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"2.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"2.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::1"
+    },
+    {
+      "column": 50,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 45,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"2.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"2.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::2"
+    },
+    {
+      "column": 50,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 69,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"2.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"2.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::3"
+    },
+    {
+      "column": 50,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 70,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"2.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"2.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::4"
+    },
+    {
+      "column": 42,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 80,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"2.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"2.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::5"
+    },
+    {
+      "column": 58,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 81,
+      "rule": "rhythmguard/prefer-token",
+      "severity": "warning",
+      "text": "Unexpected raw scale value \"2.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/prefer-token::Unexpected raw scale value \"2.75rem\". Use design tokens for scale decisions. (rhythmguard/prefer-token)::6"
+    },
+    {
+      "column": 20,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 30,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"0.375rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"0.375rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)::1"
+    },
+    {
+      "column": 21,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 31,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"0.375rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"0.375rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)::2"
+    },
+    {
+      "column": 43,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 33,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"0.375rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"0.375rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)::3"
+    },
+    {
+      "column": 25,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 50,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"0.375rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"0.375rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)::4"
+    },
+    {
+      "column": 59,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 72,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"0.375rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"0.375rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)::5"
+    },
+    {
+      "column": 51,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 82,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"0.375rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"0.375rem\". Use scale values (nearest: 4px or 8px). (rhythmguard/use-scale)::6"
+    },
+    {
+      "column": 30,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 31,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)::1"
+    },
+    {
+      "column": 35,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 33,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)::2"
+    },
+    {
+      "column": 29,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 42,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)::3"
+    },
+    {
+      "column": 42,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 45,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)::4"
+    },
+    {
+      "column": 64,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 67,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)::5"
+    },
+    {
+      "column": 85,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 67,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)::6"
+    },
+    {
+      "column": 42,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 69,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)::7"
+    },
+    {
+      "column": 58,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 70,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)::8"
+    },
+    {
+      "column": 50,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 80,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)::9"
+    },
+    {
+      "column": 50,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 81,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"1.25rem\". Use scale values (nearest: 16px or 24px). (rhythmguard/use-scale)::10"
+    },
+    {
+      "column": 17,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 21,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"2.75rem\". Use scale values (nearest: 4px or 48px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"2.75rem\". Use scale values (nearest: 4px or 48px). (rhythmguard/use-scale)::1"
+    },
+    {
+      "column": 21,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 42,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"2.75rem\". Use scale values (nearest: 4px or 48px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"2.75rem\". Use scale values (nearest: 4px or 48px). (rhythmguard/use-scale)::2"
+    },
+    {
+      "column": 50,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 45,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"2.75rem\". Use scale values (nearest: 4px or 48px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"2.75rem\". Use scale values (nearest: 4px or 48px). (rhythmguard/use-scale)::3"
+    },
+    {
+      "column": 50,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 69,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"2.75rem\". Use scale values (nearest: 4px or 48px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"2.75rem\". Use scale values (nearest: 4px or 48px). (rhythmguard/use-scale)::4"
+    },
+    {
+      "column": 50,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 70,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"2.75rem\". Use scale values (nearest: 4px or 48px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"2.75rem\". Use scale values (nearest: 4px or 48px). (rhythmguard/use-scale)::5"
+    },
+    {
+      "column": 42,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 80,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"2.75rem\". Use scale values (nearest: 4px or 48px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"2.75rem\". Use scale values (nearest: 4px or 48px). (rhythmguard/use-scale)::6"
+    },
+    {
+      "column": 58,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 81,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"2.75rem\". Use scale values (nearest: 4px or 48px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"2.75rem\". Use scale values (nearest: 4px or 48px). (rhythmguard/use-scale)::7"
+    },
+    {
+      "column": 39,
+      "file": "packages/web-components/src/native/slide-button.ts",
+      "line": 22,
+      "rule": "rhythmguard/use-scale",
+      "severity": "warning",
+      "text": "Unexpected off-scale value \"9999px\". Use scale values (nearest: 64px or 64px). (rhythmguard/use-scale)",
+      "id": "packages/web-components/src/native/slide-button.ts::rhythmguard/use-scale::Unexpected off-scale value \"9999px\". Use scale values (nearest: 64px or 64px). (rhythmguard/use-scale)::1"
     },
     {
       "column": 85,

--- a/tests/web-components/web-components.test.ts
+++ b/tests/web-components/web-components.test.ts
@@ -97,6 +97,7 @@ import { defineElementSet } from "../../packages/web-components/src/registry";
 const NATIVE_TAGS = [
   "dt-icon",
   "dt-button",
+  "dt-slide-button",
   "dt-icon-button",
   "dt-button-group",
   "dt-filter-chip",
@@ -108,6 +109,7 @@ const NATIVE_TAGS = [
   "dt-nav-link",
   "dt-nav-menu-list",
   "dt-language-switcher",
+  "dt-scroll-indicator",
   "dt-skip-link",
   "dt-badge",
   "dt-avatar",
@@ -356,6 +358,52 @@ describe("native action and content elements", () => {
     element.disabled = false;
     element.click();
     expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders SlideButton as a pill anchor with a label and icon disc", () => {
+    const element = document.createElement("dt-slide-button");
+    element.setAttribute("label", "Start your sprint");
+    element.setAttribute("href", "/contact");
+    element.setAttribute("icon", "lightning");
+    document.body.append(element);
+
+    const anchor = element.shadowRoot?.querySelector("a.root");
+    expect(anchor).toHaveAttribute("href", "/contact");
+    expect(anchor).toHaveAttribute("aria-label", "Start your sprint");
+    expect(element.shadowRoot?.querySelector(".label")?.textContent).toBe(
+      "Start your sprint",
+    );
+    expect(element.shadowRoot?.querySelector(".disc dt-icon")).toBeTruthy();
+
+    element.setAttribute("icon-side", "right");
+    expect(element.shadowRoot?.querySelector("a.root")).toHaveClass("reverse");
+  });
+
+  it("renders ScrollIndicator and scrolls its target into view on click", () => {
+    const target = document.createElement("div");
+    target.id = "next-scroll-target";
+    target.scrollIntoView = vi.fn();
+    document.body.append(target);
+
+    const element = document.createElement("dt-scroll-indicator");
+    element.setAttribute("label", "See our work");
+    element.setAttribute("target-id", "next-scroll-target");
+    element.setAttribute("variant", "arrow");
+    document.body.append(element);
+
+    const button = element.shadowRoot?.querySelector("button.root");
+    expect(button).toHaveAttribute("aria-label", "See our work");
+    expect(element.shadowRoot?.querySelector(".label")?.textContent).toBe(
+      "See our work",
+    );
+    expect(element.shadowRoot?.querySelector(".icon svg")).toBeTruthy();
+
+    (button as HTMLButtonElement).click();
+    expect(target.scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "start",
+    });
+    target.remove();
   });
 
   it("reacts when Button slot content is added after connection", async () => {


### PR DESCRIPTION
Native twins for SlideButton + ScrollIndicator (fleet 85 -> 87). Render smoke tests + CEM regenerated. Prep for the web-components 0.10.0 publish. Full local gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)