### PR TITLE
feat(ds): Phase 1 PR 1 — emit a11y evidence records (non-breaking)

### DIFF
--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -6,7 +6,9 @@ import * as fs from "fs";
 import * as path from "path";
 import { PNG } from "pngjs";
 import pixelmatch from "pixelmatch";
+import AxeBuilder from "@axe-core/playwright";
 import { captureStoryAccessibilityTree } from "../scripts/design-system/a11y-snapshot-capture-lib.mjs";
+import { writeEvidenceRecord } from "../scripts/design-system/a11y-evidence-lib.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -366,6 +368,58 @@ async function captureAccessibilityTree(
   }
 }
 
+// Phase 1 (prove-a11y) PR 1 — EMIT. Write an evidence record next to each
+// snapshot recording the real axe pass/fail + provenance, so a later phase can
+// generate `verificationMode: automated` from a proven run instead of a
+// hand-set contract boolean. Gated on the same write flags as snapshots, so CI
+// enforce runs stay read-only and this changes nothing downstream yet.
+const EMIT_A11Y_EVIDENCE = UPDATE_AT || BOOTSTRAP_AT;
+
+async function captureA11yEvidence(
+  page: import("playwright").Page,
+  rawStoryId: string,
+  storyId: string,
+) {
+  if (!EMIT_A11Y_EVIDENCE) return;
+  const componentDir = (await loadStoryDirMap()).get(rawStoryId);
+  if (!componentDir) return;
+
+  const suffix = snapshotVariantSuffix();
+  const mode = suffix ? suffix.slice(1) : "light";
+  const forced = FORCED_COLORS === "active";
+
+  try {
+    let axe = new AxeBuilder({ page })
+      .include("#storybook-root")
+      .exclude("[data-axe-ignore]");
+    // Mirror .storybook/preview.tsx: under forced-colors the UA overrides author
+    // colors, so color-contrast is not a meaningful author-side check.
+    if (forced) axe = axe.disableRules(["color-contrast"]);
+    const results = await axe.analyze();
+    const axeViolations = results.violations.length;
+
+    writeEvidenceRecord(componentDir, storyId, suffix, {
+      mode,
+      runner: process.env.DT_A11Y_RUNNER ?? null,
+      checks: {
+        "axe-no-violations": { passed: axeViolations === 0, axeViolations },
+        // captureAccessibilityTree threw if the committed tree drifted or a
+        // required snapshot was missing, so reaching here means the tree holds.
+        "accessibility-tree": { passed: true },
+        ...(forced
+          ? { "forced-colors-real-browser": { passed: axeViolations === 0 } }
+          : {}),
+      },
+    });
+  } catch (err) {
+    // Emission must never break a capture run (non-breaking PR). Surface it and
+    // move on; the absence of a record is itself the honest signal downstream.
+    console.warn(
+      `[a11y-evidence] skipped ${storyId}${suffix}: ${(err as Error).message}`,
+    );
+  }
+}
+
 const config: TestRunnerConfig = {
   // The iframe page is loaded once per worker by `defaultPrepare`, so the preview
   // module's `parameters.a11y` IIFE only sees `matchMedia('(forced-colors: active)')`
@@ -458,6 +512,9 @@ const config: TestRunnerConfig = {
 
     // AT-tree snapshots are the DSharp-style gate for Phase 2.
     await captureAccessibilityTree(page, context.id, { betaMatrix });
+
+    // Phase 1 (prove-a11y): record the real axe pass/fail + provenance beside it.
+    await captureA11yEvidence(page, context.id, storyId);
 
     // Visual pixel diffs are opt-in (Phase 4). Running them on every story makes
     // the matrix flaky while Vite is still optimizing dependencies.

--- a/scripts/design-system/a11y-evidence-lib.mjs
+++ b/scripts/design-system/a11y-evidence-lib.mjs
@@ -1,0 +1,153 @@
+/**
+ * A11y evidence records — the test result, not a human, is the source of truth.
+ *
+ * The contract records accessibility as booleans (accessibilityTreeVerified,
+ * realBrowserForcedColorsVerified, …). `derive-a11y-criteria.mjs` trusts those
+ * booleans and stamps a criterion `automated` without ever reading a run. An
+ * evidence record closes that gap: it ties a (story, mode) to a real browser
+ * pass with provenance — `{ passed, sourceSHA, capturedAt }` — so "automated"
+ * can mean "a browser proved this at commit X on date Y".
+ *
+ * Phase 1 PR 1 (emit) only WRITES and can READ + judge freshness. It is
+ * deliberately NOT yet consumed by derive-a11y-criteria.mjs — that flip is PR 2
+ * (the honest ratchet spike). See docs/AGENTIC_DS_PHASE1_PROVE_A11Y.md.
+ */
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export const EVIDENCE_DIRNAME = "__a11y-evidence__";
+
+/** Mirrors STALE_DAYS in check-doc-semantics.mjs — the time-window fallback. */
+export const STALE_DAYS = 180;
+
+let cachedSha;
+
+/**
+ * The commit the evidence was captured at. Prefer the CI-provided SHA; fall
+ * back to the working tree's HEAD; never throw (records still write with
+ * "unknown", which `isEvidenceFresh` treats as never-fresh via the time gate).
+ */
+export function sourceSha() {
+  if (cachedSha !== undefined) return cachedSha;
+  const envSha = process.env.GITHUB_SHA || process.env.DT_SOURCE_SHA;
+  if (envSha && envSha.trim()) {
+    cachedSha = envSha.trim();
+    return cachedSha;
+  }
+  try {
+    cachedSha = execFileSync("git", ["rev-parse", "HEAD"], {
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    cachedSha = "unknown";
+  }
+  return cachedSha;
+}
+
+export function evidenceDir(componentDir) {
+  return path.join(componentDir, EVIDENCE_DIRNAME);
+}
+
+/** File name mirrors the AT-snapshot naming: `<storyId><suffix>.json`. */
+export function evidenceFile(componentDir, storyId, suffix = "") {
+  return path.join(evidenceDir(componentDir), `${storyId}${suffix}.json`);
+}
+
+/**
+ * Write one record per (story, mode). A single record holds every check proven
+ * in that run, so one browser pass writes one artifact rather than N.
+ *
+ * @param {string} componentDir absolute component directory
+ * @param {string} storyId sanitized story id (matches the snapshot file stem)
+ * @param {string} suffix mode suffix, e.g. "" | ".dark" | ".forced-colors"
+ * @param {{ mode: string, runner?: string, checks: Record<string, { passed: boolean, [k: string]: unknown }>, capturedAt?: string }} data
+ */
+export function writeEvidenceRecord(componentDir, storyId, suffix, data) {
+  const dir = evidenceDir(componentDir);
+  fs.mkdirSync(dir, { recursive: true });
+  const record = {
+    storyId,
+    mode: data.mode,
+    sourceSHA: sourceSha(),
+    capturedAt: data.capturedAt ?? new Date().toISOString(),
+    runner: data.runner ?? null,
+    checks: data.checks,
+  };
+  fs.writeFileSync(
+    evidenceFile(componentDir, storyId, suffix),
+    `${JSON.stringify(record, null, 2)}\n`,
+  );
+  return record;
+}
+
+/** Read every evidence record committed for a component (never throws). */
+export function readEvidenceRecords(componentDir) {
+  const dir = evidenceDir(componentDir);
+  let files;
+  try {
+    files = fs.readdirSync(dir).filter((f) => f.endsWith(".json"));
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const f of files) {
+    try {
+      out.push(JSON.parse(fs.readFileSync(path.join(dir, f), "utf8")));
+    } catch {
+      // A corrupt record is not evidence; skip it rather than fail the read.
+    }
+  }
+  return out;
+}
+
+/**
+ * Freshness (roadmap Track A, option 2 — SHA ancestry + path guard):
+ * a record is fresh iff no file under the component directory changed after the
+ * record's `sourceSHA`. If git can't answer (unknown SHA, shallow clone), fall
+ * back to a `capturedAt` time window so a missing git history never silently
+ * upgrades stale evidence to fresh.
+ *
+ * @param {string} componentDir absolute component directory
+ * @param {{ sourceSHA?: string, capturedAt?: string }} record
+ * @param {{ now?: number, staleDays?: number, gitChangedSince?: (sha: string, dir: string) => boolean | null }} [opts]
+ * @returns {boolean}
+ */
+export function isEvidenceFresh(componentDir, record, opts = {}) {
+  const staleDays = opts.staleDays ?? STALE_DAYS;
+  const sha = record?.sourceSHA;
+
+  if (sha && sha !== "unknown") {
+    const changedSince = opts.gitChangedSince ?? defaultGitChangedSince;
+    try {
+      const changed = changedSince(sha, componentDir);
+      if (changed === true) return false; // source moved after the evidence
+      if (changed === false) return true; // evidence still reflects the source
+      // null => git couldn't answer; fall through to the time window.
+    } catch {
+      // fall through to the time window
+    }
+  }
+
+  const capturedAt = record?.capturedAt ? Date.parse(record.capturedAt) : NaN;
+  if (Number.isNaN(capturedAt)) return false;
+  const now = opts.now ?? Date.now();
+  return now - capturedAt <= staleDays * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * @returns {boolean | null} true if any tracked file under `componentDir`
+ * changed in `sha..HEAD`, false if none did, null if git couldn't answer.
+ */
+function defaultGitChangedSince(sha, componentDir) {
+  try {
+    const out = execFileSync(
+      "git",
+      ["log", "--oneline", `${sha}..HEAD`, "--", componentDir],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    );
+    return out.trim().length > 0;
+  } catch {
+    return null;
+  }
+}

--- a/scripts/design-system/a11y-evidence-lib.test.mjs
+++ b/scripts/design-system/a11y-evidence-lib.test.mjs
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  EVIDENCE_DIRNAME,
+  STALE_DAYS,
+  evidenceFile,
+  isEvidenceFresh,
+  readEvidenceRecords,
+  writeEvidenceRecord,
+} from "./a11y-evidence-lib.mjs";
+
+let tmp;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "a11y-evidence-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("writeEvidenceRecord / readEvidenceRecords", () => {
+  it("round-trips a record with provenance under __a11y-evidence__", () => {
+    const written = writeEvidenceRecord(tmp, "components-button--playground", "", {
+      mode: "light",
+      runner: "test:stories:matrix:ci",
+      capturedAt: "2026-07-26T00:00:00.000Z",
+      checks: { "axe-no-violations": { passed: true, axeViolations: 0 } },
+    });
+
+    expect(written.sourceSHA).toBeTruthy();
+    const file = evidenceFile(tmp, "components-button--playground", "");
+    expect(file).toContain(`${EVIDENCE_DIRNAME}${path.sep}components-button--playground.json`);
+    expect(fs.existsSync(file)).toBe(true);
+
+    const [record] = readEvidenceRecords(tmp);
+    expect(record.storyId).toBe("components-button--playground");
+    expect(record.mode).toBe("light");
+    expect(record.checks["axe-no-violations"]).toEqual({ passed: true, axeViolations: 0 });
+    expect(record.capturedAt).toBe("2026-07-26T00:00:00.000Z");
+  });
+
+  it("keeps one file per (story, mode) via the suffix", () => {
+    writeEvidenceRecord(tmp, "x--y", "", { mode: "light", checks: {} });
+    writeEvidenceRecord(tmp, "x--y", ".forced-colors", { mode: "forced-colors", checks: {} });
+    expect(readEvidenceRecords(tmp)).toHaveLength(2);
+  });
+
+  it("returns [] for a component with no evidence dir", () => {
+    expect(readEvidenceRecords(path.join(tmp, "nope"))).toEqual([]);
+  });
+});
+
+describe("isEvidenceFresh — SHA path guard (option 2)", () => {
+  it("is fresh when nothing under the component dir changed since the SHA", () => {
+    const fresh = isEvidenceFresh(tmp, { sourceSHA: "abc123", capturedAt: "2000-01-01T00:00:00Z" }, {
+      gitChangedSince: () => false,
+    });
+    expect(fresh).toBe(true); // git wins over the (stale) time window
+  });
+
+  it("is stale when a source file changed after the SHA", () => {
+    const fresh = isEvidenceFresh(tmp, { sourceSHA: "abc123", capturedAt: new Date().toISOString() }, {
+      gitChangedSince: () => true,
+    });
+    expect(fresh).toBe(false); // git wins over the (recent) time window
+  });
+});
+
+describe("isEvidenceFresh — time-window fallback", () => {
+  const now = Date.parse("2026-07-26T00:00:00Z");
+
+  it("falls back to the window when git cannot answer (null)", () => {
+    const recent = new Date(now - 10 * 86_400_000).toISOString();
+    expect(
+      isEvidenceFresh(tmp, { sourceSHA: "abc", capturedAt: recent }, { now, gitChangedSince: () => null }),
+    ).toBe(true);
+  });
+
+  it("treats an unknown SHA as never-git-fresh, then applies the window", () => {
+    const old = new Date(now - (STALE_DAYS + 1) * 86_400_000).toISOString();
+    expect(isEvidenceFresh(tmp, { sourceSHA: "unknown", capturedAt: old }, { now })).toBe(false);
+
+    const recent = new Date(now - 1 * 86_400_000).toISOString();
+    expect(isEvidenceFresh(tmp, { sourceSHA: "unknown", capturedAt: recent }, { now })).toBe(true);
+  });
+
+  it("is not fresh without a parseable capturedAt", () => {
+    expect(isEvidenceFresh(tmp, { sourceSHA: "unknown" }, { now })).toBe(false);
+  });
+});


### PR DESCRIPTION
Track A (prove-a11y) step 1 of 3. Records the real axe pass/fail + AT-tree provenance the browser run already produces but currently discards, so a later PR can generate `verificationMode: automated` from a proven run instead of a hand-set contract boolean.

**Non-breaking:** emission is gated on the snapshot write flags (`DT_UPDATE/BOOTSTRAP_A11Y_SNAPSHOTS`); CI enforce runs are unchanged and nothing reads the records yet.

- `a11y-evidence-lib.mjs` — write/read + freshness (git path-guard with STALE_DAYS fallback) + `sourceSha()`.
- `test-runner.ts` postVisit — axe via `@axe-core/playwright` → `__a11y-evidence__/<story>.<mode>.json`.
- `a11y-evidence-lib.test.mjs` — 8 browser-free unit tests.

**Verified:** unit 8/8, typecheck, lint, test (2744), build all exit 0; a scoped real capture (Button, 91 story tests) wrote valid provenance-stamped records. Full backfill is a dedicated follow-up; PR 2 flips the consumer + ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)