### PR TITLE
feat(ds): Phase 1 hardening — per-component a11y evidence gate + hc:ci on farm

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -10,8 +10,9 @@ jobs:
     runs-on: [self-hosted, digitaltableteur]
     # Backstop: the farm's dashboard collector is completion-only, so a hung job is INVISIBLE
     # on the fleet board while it zombies a runner slot (GitHub's default timeout is 6h). A
-    # clean run takes ~10 min; anything past 30 is wedged.
-    timeout-minutes: 30
+    # a clean run takes ~20 min (two real-Chromium passes: theme matrix + forced-colors);
+    # anything past 45 is wedged.
+    timeout-minutes: 45
     steps:
       # Full history so the a11y-evidence freshness path-guard (a11y-evidence-lib.mjs
       # `isEvidenceFresh`) can run `git log <evidenceSHA>..HEAD` per component. A shallow
@@ -77,6 +78,11 @@ jobs:
       # container each run — the same proven pattern as petritapanilahdelma's ci.yml on this farm.
       - run: npx playwright install chromium --with-deps
       - run: npm run test:stories:matrix:ci
+      # Forced-colors real-browser pass (was weekly-only). Now that forced-colors
+      # AT evidence is load-bearing for the a11y evidence gate, enforce the
+      # forced-colors snapshot diff per PR too. Boots its own Storybook, so it is
+      # a second ~10-min Chromium pass — hence timeout-minutes 45 above.
+      - run: npm run test:stories:hc:ci
       # Controls-operability ratchet: drives the real Controls panel per component
       # (Human-Simulated audit) against its own Storybook boot. Raise --min in
       # audit:controls:ci as remediation batches land; end state is --min 100.

--- a/scripts/design-system/validate-components.ts
+++ b/scripts/design-system/validate-components.ts
@@ -14,6 +14,7 @@ import { VARIANT_PROP_NAMES } from './cva-sync-lib.mjs'
 import { validateContractSchema } from './contract-schema-lib.mjs'
 import { docFieldErrors } from './doc-fields-rules.mjs'
 import { docTierFor } from './doc-tiers.mjs'
+import { deriveA11yCriteria } from './derive-a11y-criteria.mjs'
 
 type VariantMap = Record<string, { values: string[]; default: string | null }>
 
@@ -622,6 +623,31 @@ export function validateComponentsDir(root: string): ValidationResult {
             // Windows-specific system-color values, which Chromium emulates).
             if ((manifest.a11y as any).realBrowserForcedColorsVerified !== true) {
                 errors.push(`${name}.contract.json: stable requires a11y.realBrowserForcedColorsVerified to be true (run npm run test:stories:hc; flip to true after that pass succeeds for every required story)`)
+            }
+
+            // Per-component evidence hard-gate (Phase 1 prove-a11y). The booleans
+            // above assert; this proves. A stable component's axe + accessibility-
+            // tree criteria must resolve to `automated` — i.e. a FRESH, PASSING
+            // evidence record backs each one (derive-a11y-criteria + the
+            // __a11y-evidence__ records), not a hand-set boolean. This is the
+            // per-component promotion barrier; check:doc-semantics enforces the
+            // same globally as a ratchet, but a component must not reach stable on
+            // trust alone. forced-colors is checked more leniently below: real-
+            // browser forced-colors axe is not cleanly separable from the AT-tree
+            // gate (axe is disabled under forced-colors), so the boolean-backed
+            // `manual` fallback is tolerated there; only a true gap is blocked.
+            const a11yCriteria = deriveA11yCriteria(manifest, { componentDir: dir })
+            for (const id of ['axe-no-violations', 'accessibility-tree']) {
+                const criterion = a11yCriteria.find((c) => c.id === id)
+                // A criterion the contract exempts (e.g. axeTestExempt) is not emitted;
+                // only gate the ones that apply to this component.
+                if (criterion && criterion.verificationMode !== 'automated') {
+                    errors.push(`${name}.contract.json: stable requires fresh passing a11y evidence for '${id}' (currently ${criterion.verificationMode}${criterion.note ? `: ${criterion.note}` : ''}). Re-capture via DT_UPDATE_A11Y_SNAPSHOTS=1 npm run test:stories:matrix:ci, then commit the ${name}/__a11y-evidence__ records.`)
+                }
+            }
+            const forcedColorsCriterion = a11yCriteria.find((c) => c.id === 'forced-colors-real-browser')
+            if (forcedColorsCriterion && forcedColorsCriterion.verificationMode === 'unverified') {
+                errors.push(`${name}.contract.json: stable requires forced-colors verification for 'forced-colors-real-browser' (currently unverified${forcedColorsCriterion.note ? `: ${forcedColorsCriterion.note}` : ''}) — a passing forced-colors evidence record, or a11y.realBrowserForcedColorsVerified/forcedColorsVerified set after a real HC pass.`)
             }
 
             // Production-consumer evidence. "Used in shipping product" is


### PR DESCRIPTION
The two deferred Phase 1 items.

**1. Per-component evidence hard-gate** (`validate-components`): a stable component's `axe-no-violations` and `accessibility-tree` criteria must resolve to `automated` — a fresh, passing `__a11y-evidence__` record, not a hand-set boolean. This is the per-component promotion barrier complementing the global doc-semantics ratchet. `forced-colors-real-browser` is checked leniently (blocks only a true `unverified` gap; tolerates the boolean-backed `manual` fallback), because axe is disabled under forced-colors so its evidence isn't cleanly separable from the AT-tree gate.

**2. `test:stories:hc:ci` on the farm** (`pr-validation.yml`): forced-colors enforced per PR now that its AT evidence is load-bearing. Second ~10-min Chromium pass, so `timeout-minutes` 30 → 45.

**Deferred (documented):** cleanly separating forced-colors axe evidence so Select/SelectOption reach `automated` needs more careful emitter work — reading merged `storyContext.parameters.a11y` over-skips axe in light/dark. Those two stay `manual` (boolean-backed) for now.

**Verified:** validate:components, typecheck, check:generated, lint, test (2744), build all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated accessibility validation for stable component promotions.
  * Added verification checks for forced-colors support using real-browser evidence.

* **Bug Fixes**
  * Improved promotion safeguards by blocking components without current accessibility or forced-colors verification.

* **Tests**
  * Added an additional real-browser forced-colors test pass.
  * Increased validation workflow time limits to accommodate the expanded test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->