### PR TITLE
feat(ds): Kbd keyboard-key primary variant + uppercase caps

### DIFF
--- a/nextjs-app/shared/components/Kbd/Kbd.contract.json
+++ b/nextjs-app/shared/components/Kbd/Kbd.contract.json
@@ -9,6 +9,14 @@
     "radixPrimitive": null,
     "element": "kbd",
     "variants": {
+        "variant": {
+            "values": [
+                "primary",
+                "secondary"
+            ],
+            "default": "primary",
+            "propSourced": true
+        },
         "size": {
             "values": [
                 "sm",
@@ -43,11 +51,18 @@
         "colors": [
             "--color-border",
             "--color-surface",
-            "--color-text"
+            "--color-text",
+            "--color-neutral-bg",
+            "--color-neutral-text"
         ],
         "spacing": [
             "--space-internal-2",
-            "--space-internal-6"
+            "--space-internal-6",
+            "--space-internal-8",
+            "--space-internal-12",
+            "--space-layout-24",
+            "--space-layout-32",
+            "--space-layout-40"
         ],
         "typography": [
             "--font-mono"
@@ -65,6 +80,15 @@
                 "lg"
             ],
             "description": "Size token."
+        },
+        "variant": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "primary",
+                "secondary"
+            ],
+            "description": "Visual style. `primary` is a filled light-gray keycap with a bottom edge\nthat reads like a physical key; `secondary` is the flatter outlined chip."
         }
     },
     "displayName": "Kbd",

--- a/nextjs-app/shared/components/Kbd/Kbd.module.css
+++ b/nextjs-app/shared/components/Kbd/Kbd.module.css
@@ -2,41 +2,73 @@
   display: inline-flex;
   padding-block: var(--space-internal-2);
   padding-inline: var(--space-internal-6);
-  min-inline-size: 1.5em;
   justify-content: center;
   align-items: center;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  background-color: var(--color-surface);
+  border-radius: var(--radius-md);
   font-family: var(--font-mono);
   line-height: 1.2;
+
+  /* Keycaps read like physical keys: ESC / ENTER / SPACE, not Esc / Enter.
+     Visual only — the DOM text (and screen-reader name) is unchanged. */
+  text-transform: uppercase;
   white-space: nowrap;
   color: var(--color-text);
+}
+
+/* Primary: a filled light-gray keycap with a darker bottom edge, so it reads
+   like a physical key (Astryx-style). Only a bottom border — no full outline. */
+
+.primary {
+  border-block-end: 2px solid var(--color-border);
+  background-color: var(--color-neutral-bg);
+  color: var(--color-neutral-text);
+}
+
+/* Secondary: the flatter outlined chip (the original Kbd look). */
+
+.secondary {
+  border: 1px solid var(--color-border);
+  background-color: var(--color-surface);
   border-block-end-width: 2px;
 }
 
+:global(.themeHCW) .primary,
+:global(.themeHCB) .primary {
+  /* Invert the primary keycap so it contrasts with the page instead of blending
+     in — a dark keycap on HCW's white page, a light keycap on HCB's black page
+     (swapping the two vs. the plain neutral pairing). */
+  background-color: var(--color-neutral-text);
+  color: var(--color-neutral-bg);
+}
+
 .sm {
+  /* min-inline-size == block-size so a single-key cap is at least square
+     (width >= height), like a physical keycap; multi-char keys grow wider. */
   padding-inline: var(--space-internal-6);
   block-size: var(--space-layout-24);
+  min-inline-size: var(--space-layout-24);
   font-size: 0.75rem; /* 12px */
 }
 
 .md {
   padding-inline: var(--space-internal-8);
   block-size: var(--space-layout-32);
-  border-radius: var(--radius-md);
+  min-inline-size: var(--space-layout-32);
   font-size: 0.875rem; /* 14px */
 }
 
 .lg {
   padding-inline: var(--space-internal-12);
   block-size: var(--space-layout-40);
+  min-inline-size: var(--space-layout-40);
   border-radius: var(--radius-lg);
   font-size: 1rem; /* 16px */
 }
 
 @media (forced-colors: active) {
   .kbd {
-    border-color: ButtonText;
+    /* Both variants get a full outline so the keycap stays visible when the
+       system palette overrides author colors. */
+    border: 1px solid ButtonText;
   }
 }

--- a/nextjs-app/shared/components/Kbd/Kbd.stories.tsx
+++ b/nextjs-app/shared/components/Kbd/Kbd.stories.tsx
@@ -13,6 +13,12 @@ const meta = {
     contractStatus: contract.status,
   },
   argTypes: {
+    variant: {
+      control: "radio",
+      options: ["primary", "secondary"],
+      description: "Filled keycap (primary) or flat outlined chip (secondary)",
+      table: { defaultValue: { summary: "primary" } },
+    },
     size: {
       control: "radio",
       options: ["sm", "md", "lg"],
@@ -70,6 +76,24 @@ export const Sizes: Story = {
   render: () => (
     <span>
       <Kbd size="sm">Shift</Kbd> <Kbd size="md">Shift</Kbd> <Kbd size="lg">Shift</Kbd>
+    </span>
+  ),
+};
+
+export const Variants: Story = {
+  tags: ["example"],
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story:
+          "primary is a filled keycap with a bottom edge that reads like a physical key; secondary is the flatter outlined chip.",
+      },
+    },
+  },
+  render: () => (
+    <span>
+      <Kbd variant="primary">Esc</Kbd> <Kbd variant="secondary">Esc</Kbd>
     </span>
   ),
 };

--- a/nextjs-app/shared/components/Kbd/Kbd.test.tsx
+++ b/nextjs-app/shared/components/Kbd/Kbd.test.tsx
@@ -26,10 +26,18 @@ describe("Kbd", () => {
     expect(el).toHaveClass("extra");
   });
 
-  it("has no axe violations", async () => {
+  it("defaults to the primary variant and applies the requested variant", () => {
+    const { rerender } = render(<Kbd>A</Kbd>);
+    expect(screen.getByText("A")).toHaveClass(styles.primary);
+    rerender(<Kbd variant="secondary">A</Kbd>);
+    expect(screen.getByText("A")).toHaveClass(styles.secondary);
+  });
+
+  it("has no axe violations in either variant", async () => {
     const { container } = render(
       <p>
-        Press <Kbd>⌘</Kbd> + <Kbd>K</Kbd> to open search.
+        Press <Kbd variant="primary">⌘</Kbd> + <Kbd variant="secondary">K</Kbd>{" "}
+        to open search.
       </p>,
     );
     expect(await axe(container)).toHaveNoViolations();

--- a/nextjs-app/shared/components/Kbd/Kbd.tsx
+++ b/nextjs-app/shared/components/Kbd/Kbd.tsx
@@ -4,17 +4,25 @@ import styles from "./Kbd.module.css";
 
 export type KbdSize = "sm" | "md" | "lg";
 
+export type KbdVariant = "primary" | "secondary";
+
 export interface KbdProps extends React.HTMLAttributes<HTMLElement> {
   /** Size token. @default "md" */
   size?: KbdSize;
+  /**
+   * Visual style. `primary` is a filled light-gray keycap with a bottom edge
+   * that reads like a physical key; `secondary` is the flatter outlined chip.
+   * @default "primary"
+   */
+  variant?: KbdVariant;
 }
 
 /** Keyboard key indicator: renders a semantic <kbd> styled as a keycap. */
 export const Kbd = React.forwardRef<HTMLElement, KbdProps>(
-  ({ size = "md", className, children, ...rest }, ref) => (
+  ({ size = "md", variant = "primary", className, children, ...rest }, ref) => (
     <kbd
       ref={ref}
-      className={cn(styles.kbd, styles[size], className)}
+      className={cn(styles.kbd, styles[variant], styles[size], className)}
       {...rest}
     >
       {children}

--- a/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-default.dark.json
+++ b/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-default.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "content-kbd-default",
   "mode": "dark",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:22.894Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:48.987Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-default.forced-colors.json
+++ b/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-default.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "content-kbd-default",
   "mode": "forced-colors",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:29.126Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:55.947Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-default.light.json
+++ b/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-default.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "content-kbd-default",
   "mode": "light",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:15.303Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:40.728Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-example.dark.json
+++ b/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-example.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "content-kbd-example",
   "mode": "dark",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:23.303Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:49.391Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-example.forced-colors.json
+++ b/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-example.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "content-kbd-example",
   "mode": "forced-colors",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:29.181Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:56.032Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-example.light.json
+++ b/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-example.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "content-kbd-example",
   "mode": "light",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:15.727Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:41.138Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-forced-colors.dark.json
+++ b/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-forced-colors.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "content-kbd-forced-colors",
   "mode": "dark",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:23.325Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:49.411Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-forced-colors.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "content-kbd-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:29.215Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:56.060Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-forced-colors.light.json
+++ b/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-forced-colors.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "content-kbd-forced-colors",
   "mode": "light",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:15.773Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:41.157Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-playground.dark.json
+++ b/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-playground.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "content-kbd-playground",
   "mode": "dark",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:23.107Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:49.193Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-playground.forced-colors.json
+++ b/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-playground.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "content-kbd-playground",
   "mode": "forced-colors",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:29.149Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:55.972Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-playground.light.json
+++ b/nextjs-app/shared/components/Kbd/__a11y-evidence__/content-kbd-playground.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "content-kbd-playground",
   "mode": "light",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:15.519Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:40.939Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-26T15:52:06.302Z",
+  "generatedAt": "2026-07-26T16:53:42.965Z",
   "summary": {
     "componentCount": 168,
     "statusCounts": {
@@ -24406,6 +24406,14 @@
         "radixPrimitive": null,
         "element": "kbd",
         "variants": {
+          "variant": {
+            "values": [
+              "primary",
+              "secondary"
+            ],
+            "default": "primary",
+            "propSourced": true
+          },
           "size": {
             "values": [
               "sm",
@@ -24440,11 +24448,18 @@
           "colors": [
             "--color-border",
             "--color-surface",
-            "--color-text"
+            "--color-text",
+            "--color-neutral-bg",
+            "--color-neutral-text"
           ],
           "spacing": [
             "--space-internal-2",
-            "--space-internal-6"
+            "--space-internal-6",
+            "--space-internal-8",
+            "--space-internal-12",
+            "--space-layout-24",
+            "--space-layout-32",
+            "--space-layout-40"
           ],
           "typography": [
             "--font-mono"
@@ -24462,6 +24477,15 @@
               "lg"
             ],
             "description": "Size token."
+          },
+          "variant": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "primary",
+              "secondary"
+            ],
+            "description": "Visual style. `primary` is a filled light-gray keycap with a bottom edge\nthat reads like a physical key; `secondary` is the flatter outlined chip."
           }
         },
         "displayName": "Kbd",
@@ -24551,6 +24575,15 @@
               "lg"
             ],
             "description": "Size token."
+          },
+          "variant": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "primary",
+              "secondary"
+            ],
+            "description": "Visual style. `primary` is a filled light-gray keycap with a bottom edge\nthat reads like a physical key; `secondary` is the flatter outlined chip."
           }
         },
         "propRelationships": [],
@@ -24562,6 +24595,13 @@
               "lg"
             ],
             "default": "sm"
+          },
+          "variant": {
+            "values": [
+              "primary",
+              "secondary"
+            ],
+            "default": "primary"
           }
         },
         "cvaVariants": {},
@@ -24598,7 +24638,7 @@
           "Icon"
         ],
         "prefersOver": [],
-        "declaredPropCount": 1,
+        "declaredPropCount": 2,
         "guidelines": [
           {
             "level": "should",

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-26T16:53:42.965Z",
+  "generatedAt": "2026-07-26T16:55:21.838Z",
   "summary": {
     "componentCount": 168,
     "statusCounts": {

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-26T16:40:37.419Z",
+  "generatedAt": "2026-07-26T16:55:21.545Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-26T15:52:06.017Z",
+  "generatedAt": "2026-07-26T16:40:37.419Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -12905,6 +12905,15 @@
             "lg"
           ],
           "description": "Size token."
+        },
+        "variant": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "primary",
+            "secondary"
+          ],
+          "description": "Visual style. `primary` is a filled light-gray keycap with a bottom edge\nthat reads like a physical key; `secondary` is the flatter outlined chip."
         }
       },
       "propRelationships": [],
@@ -12916,6 +12925,13 @@
             "lg"
           ],
           "default": "sm"
+        },
+        "variant": {
+          "values": [
+            "primary",
+            "secondary"
+          ],
+          "default": "primary"
         }
       },
       "cvaVariants": {},
@@ -12952,7 +12968,7 @@
         "Icon"
       ],
       "prefersOver": [],
-      "declaredPropCount": 1,
+      "declaredPropCount": 2,
       "guidelines": [
         {
           "level": "should",

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -8099,6 +8099,11 @@
           "name": "size",
           "type": "sm | md | lg",
           "required": false
+        },
+        {
+          "name": "variant",
+          "type": "primary | secondary",
+          "required": false
         }
       ],
       "props": {
@@ -8111,6 +8116,15 @@
             "lg"
           ],
           "description": "Size token."
+        },
+        "variant": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "primary",
+            "secondary"
+          ],
+          "description": "Visual style. `primary` is a filled light-gray keycap with a bottom edge\nthat reads like a physical key; `secondary` is the flatter outlined chip."
         }
       },
       "composesWith": [
@@ -8153,11 +8167,18 @@
         "colors": [
           "--color-border",
           "--color-surface",
-          "--color-text"
+          "--color-text",
+          "--color-neutral-bg",
+          "--color-neutral-text"
         ],
         "spacing": [
           "--space-internal-2",
-          "--space-internal-6"
+          "--space-internal-6",
+          "--space-internal-8",
+          "--space-internal-12",
+          "--space-layout-24",
+          "--space-layout-32",
+          "--space-layout-40"
         ],
         "typography": [
           "--font-mono"
@@ -8178,6 +8199,11 @@
           "story": "Sizes",
           "description": "sm/md/lg track the text ladder so keycaps sit well in prose of any size.",
           "source": "export const Sizes: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: {\n      description: { story: \"sm/md/lg track the text ladder so keycaps sit well in prose of any size.\" },\n    },\n  },\n  render: () => (\n    <span>\n      <Kbd size=\"sm\">Shift</Kbd> <Kbd size=\"md\">Shift</Kbd> <Kbd size=\"lg\">Shift</Kbd>\n    </span>\n  ),\n};"
+        },
+        {
+          "story": "Variants",
+          "description": "primary is a filled keycap with a bottom edge that reads like a physical key; secondary is the flatter outlined chip.",
+          "source": "export const Variants: Story = {\n  tags: [\"example\"],\n  parameters: {\n    controls: { disable: true },\n    docs: {\n      description: {\n        story:\n          \"primary is a filled keycap with a bottom edge that reads like a physical key; secondary is the flatter outlined chip.\",\n      },\n    },\n  },\n  render: () => (\n    <span>\n      <Kbd variant=\"primary\">Esc</Kbd> <Kbd variant=\"secondary\">Esc</Kbd>\n    </span>\n  ),\n};"
         },
         {
           "story": "KeyNames",

--- a/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-default.dark.json
+++ b/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-default.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "web-components-content-kbd-default",
   "mode": "dark",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:19.796Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:51.764Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-default.forced-colors.json
+++ b/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-default.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "web-components-content-kbd-default",
   "mode": "forced-colors",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:26.849Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:58.314Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-default.light.json
+++ b/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-default.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "web-components-content-kbd-default",
   "mode": "light",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:12.143Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:44.249Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-example.dark.json
+++ b/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-example.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "web-components-content-kbd-example",
   "mode": "dark",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:20.205Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:52.197Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-example.forced-colors.json
+++ b/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-example.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "web-components-content-kbd-example",
   "mode": "forced-colors",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:26.898Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:58.362Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-example.light.json
+++ b/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-example.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "web-components-content-kbd-example",
   "mode": "light",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:12.621Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:44.667Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-forced-colors.dark.json
+++ b/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-forced-colors.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "web-components-content-kbd-forced-colors",
   "mode": "dark",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:20.413Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:52.452Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-forced-colors.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "web-components-content-kbd-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:26.921Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:58.381Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-forced-colors.light.json
+++ b/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-forced-colors.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "web-components-content-kbd-forced-colors",
   "mode": "light",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:12.846Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:44.992Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-playground.dark.json
+++ b/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-playground.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "web-components-content-kbd-playground",
   "mode": "dark",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:20.007Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:51.996Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-playground.forced-colors.json
+++ b/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-playground.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "web-components-content-kbd-playground",
   "mode": "forced-colors",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:26.873Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:58.340Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-playground.light.json
+++ b/nextjs-app/shared/stories/WebComponents/Kbd/__a11y-evidence__/web-components-content-kbd-playground.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "web-components-content-kbd-playground",
   "mode": "light",
-  "sourceSHA": "b0365b012055115ee08ef5fc533942ff6e8aa62d",
-  "capturedAt": "2026-07-26T15:48:12.365Z",
+  "sourceSHA": "3d39becbbd8b7b5839cd2b2faa1832dd39619c08",
+  "capturedAt": "2026-07-26T16:54:44.470Z",
   "runner": "recapture",
   "checks": {
     "accessibility-tree": {


### PR DESCRIPTION
Reworks Kbd to read like a physical keyboard.

- **variant axis** (`primary` default | `secondary`). **primary** is a filled light-gray keycap (`--color-neutral-bg`) with **only a bottom border**, so it looks like a real key (Astryx-style). **secondary** is the original flat outlined chip.
- **HCW/HCB invert** the primary keycap so it contrasts the page instead of blending in — dark keycap on HCW's white page, light on HCB's black page. Verified live: HCW #000/#fff, HCB #fff/#000.
- **uppercase** labels (`text-transform`) so keys read ESC / ENTER / SPACE like physical keys — visual only, DOM text + screen-reader name unchanged.
- **min-inline-size == block-size** per size, so a single-key cap is at least square (width ≥ height).
- **sm/md share the 4px radius** (2px was too tight); lg keeps 8px.
- contract variant axis + props synced, token list updated; Kbd a11y evidence re-captured (axe + tree automated).

**Verified live** (all sizes/variants/themes) and full gate: validate:components, check:contract-props, check:consumers, check:contrast, check:doc-semantics (0), check:generated, typecheck, lint, lint:css, test (2755), build all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added primary and secondary visual variants for keyboard keycaps.
  * Primary styling is applied by default, with support for explicitly selecting the secondary outlined style.
  * Improved keycap sizing, uppercase presentation, and visibility in forced-color modes.

* **Documentation**
  * Added component examples showcasing both available variants.

* **Tests**
  * Expanded styling and accessibility coverage for both variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->