### PR TITLE
feat(ds): separate Table sub-components; row-header a11y + DataTable fixes + VirtualList docs

### DIFF
--- a/nextjs-app/shared/components/DataTable/DataTable.stories.tsx
+++ b/nextjs-app/shared/components/DataTable/DataTable.stories.tsx
@@ -22,6 +22,8 @@ const columns: DataTableColumn<Person>[] = [
     header: "Name",
     accessor: (row) => row.name,
     sortable: true,
+    // The identifying column: each row's Name cell is a <th scope="row">.
+    rowHeader: true,
   },
   {
     id: "role",

--- a/nextjs-app/shared/components/DataTable/DataTable.test.tsx
+++ b/nextjs-app/shared/components/DataTable/DataTable.test.tsx
@@ -81,6 +81,34 @@ describe("DataTable", () => {
     expect(screen.getByText("Nothing to review")).toBeInTheDocument();
   });
 
+  it("renders a rowHeader column as a scoped row header", () => {
+    renderTable({
+      columns: [
+        { id: "name", header: "Name", accessor: (row) => row.name, rowHeader: true },
+        { id: "score", header: "Score", accessor: (row) => row.score },
+      ],
+    });
+    const rowHeaders = screen.getAllByRole("rowheader");
+    expect(rowHeaders).toHaveLength(2);
+    expect(rowHeaders[0]).toHaveAttribute("scope", "row");
+  });
+
+  it("returns to the first page when the sort changes", async () => {
+    const user = userEvent.setup();
+    const many = Array.from({ length: 6 }, (_, i) => ({
+      id: `r${i}`,
+      name: `Name ${i}`,
+      score: i,
+    }));
+    renderTable({ data: many, pageSize: 2 });
+    // Page to the end.
+    await user.click(screen.getByRole("button", { name: "Last page" }));
+    expect(screen.getByText(/of 6/)).toHaveTextContent("5–6 of 6");
+    // Sorting re-orders the set and resets to page 1.
+    await user.click(screen.getByRole("button", { name: "Name" }));
+    expect(screen.getByText(/of 6/)).toHaveTextContent("1–2 of 6");
+  });
+
   it("has no automated accessibility violations", async () => {
     const { container } = renderTable({ onSelectionChange: () => undefined });
     expect(await axe(container)).toHaveNoViolations();

--- a/nextjs-app/shared/components/DataTable/DataTable.tsx
+++ b/nextjs-app/shared/components/DataTable/DataTable.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import React, { useCallback, useMemo } from "react";
-import { Table, TableCell, TableHeaderCell, TableRow } from "@dt/Table";
+import { Table } from "@dt/Table";
+import { TableRow } from "@dt/TableRow";
+import { TableHeaderCell } from "@dt/TableHeaderCell";
+import { TableCell } from "@dt/TableCell";
 import Checkbox from "@dt/Checkbox";
 import { IconButton } from "@dt/IconButton";
 import {
@@ -24,8 +27,14 @@ export type DataTableColumn<Row> = {
   accessor?: (row: Row) => React.ReactNode;
   /** Custom cell renderer. */
   cell?: (row: Row) => React.ReactNode;
+  /** Comparable sort value; falls back to `accessor`. Use when `cell` renders
+   * custom markup but the column still needs a sortable value. */
+  sortValue?: (row: Row) => string | number | null | undefined;
   /** Enables the three-state ascending/descending/unsorted cycle. */
   sortable?: boolean;
+  /** Marks this column as the row header (`<th scope="row">`) so screen readers
+   * announce it as the row's context with every other cell. Use one per table. */
+  rowHeader?: boolean;
   /** Cell alignment. @default "start" */
   align?: "start" | "center" | "end";
   /** Right-align with tabular figures for numeric columns. */
@@ -102,29 +111,15 @@ export function DataTable<Row>({
   }, [columns]);
 
   const getSortValue = useCallback(
-    (row: Row, columnId: string) => columnsById.get(columnId)?.accessor?.(row),
+    (row: Row, columnId: string) => {
+      const column = columnsById.get(columnId);
+      return column?.sortValue?.(row) ?? column?.accessor?.(row);
+    },
     [columnsById],
   );
 
-  const { sortedRows, toggleSort, getColumnSort } = useTableSortable({
-    rows: data,
-    getSortValue,
-    sort,
-    defaultSort,
-    onSortChange,
-  });
-
-  const selectionEnabled =
-    selectedRowIds !== undefined ||
-    defaultSelectedRowIds !== undefined ||
-    onSelectionChange !== undefined;
-
-  const selection = useTableSelection({
-    rowIds: data.map(getRowId),
-    selectedIds: selectedRowIds,
-    defaultSelectedIds: defaultSelectedRowIds,
-    onSelectionChange,
-  });
+  const { sort: currentSort, sortedRows, toggleSort, getColumnSort } =
+    useTableSortable({ rows: data, getSortValue, sort, defaultSort, onSortChange });
 
   const pagination = useTablePagination({
     rows: sortedRows,
@@ -132,6 +127,30 @@ export function DataTable<Row>({
   });
 
   const displayedRows = pageSize ? pagination.pageRows : sortedRows;
+
+  const selectionEnabled =
+    selectedRowIds !== undefined ||
+    defaultSelectedRowIds !== undefined ||
+    onSelectionChange !== undefined;
+
+  // Select-all / indeterminate are scoped to the displayed page, so paginated
+  // tables don't silently toggle rows the user can't see.
+  const selection = useTableSelection({
+    rowIds: displayedRows.map(getRowId),
+    selectedIds: selectedRowIds,
+    defaultSelectedIds: defaultSelectedRowIds,
+    onSelectionChange,
+  });
+
+  // A sort re-orders the whole set, so return to the first page.
+  const { setPage } = pagination;
+  const handleSort = useCallback(
+    (columnId: string) => {
+      toggleSort(columnId);
+      setPage(0);
+    },
+    [toggleSort, setPage],
+  );
   const columnCount = columns.length + (selectionEnabled ? 1 : 0);
 
   return (
@@ -148,7 +167,6 @@ export function DataTable<Row>({
             {selectionEnabled ? (
               <TableHeaderCell className={styles.selectionCell} align="center">
                 <Checkbox
-                  label="Select all rows"
                   aria-label="Select all rows"
                   showLabel={false}
                   checked={selection.allSelected}
@@ -163,7 +181,7 @@ export function DataTable<Row>({
                 align={column.align ?? (column.numeric ? "end" : "start")}
                 sortable={column.sortable}
                 sortDirection={getColumnSort(column.id)}
-                onSort={() => toggleSort(column.id)}
+                onSort={() => handleSort(column.id)}
               >
                 {column.header}
               </TableHeaderCell>
@@ -186,7 +204,6 @@ export function DataTable<Row>({
                   {selectionEnabled ? (
                     <TableCell className={styles.selectionCell} align="center">
                       <Checkbox
-                        label={`Select ${getRowLabel(row)}`}
                         aria-label={`Select ${getRowLabel(row)}`}
                         showLabel={false}
                         checked={selected}
@@ -194,15 +211,27 @@ export function DataTable<Row>({
                       />
                     </TableCell>
                   ) : null}
-                  {columns.map((column) => (
-                    <TableCell
-                      key={column.id}
-                      align={column.align}
-                      numeric={column.numeric}
-                    >
-                      {column.cell?.(row) ?? column.accessor?.(row) ?? null}
-                    </TableCell>
-                  ))}
+                  {columns.map((column) => {
+                    const content =
+                      column.cell?.(row) ?? column.accessor?.(row) ?? null;
+                    return column.rowHeader ? (
+                      <TableHeaderCell
+                        key={column.id}
+                        scope="row"
+                        align={column.align}
+                      >
+                        {content}
+                      </TableHeaderCell>
+                    ) : (
+                      <TableCell
+                        key={column.id}
+                        align={column.align}
+                        numeric={column.numeric}
+                      >
+                        {content}
+                      </TableCell>
+                    );
+                  })}
                 </TableRow>
               );
             })

--- a/nextjs-app/shared/components/Table/Table.contract.json
+++ b/nextjs-app/shared/components/Table/Table.contract.json
@@ -5,7 +5,7 @@
   "tier": "molecule",
   "group": "data-display",
   "status": "alpha",
-  "description": "Composable table primitives (Table, TableRow, TableHeaderCell, TableCell) with density, striping, a sticky header, and a three-state sort control. The presentational layer beneath DataTable; pair with the useTable* hooks for behavior.",
+  "description": "The composable table root: a scroll wrapper around a semantic table with density, striping, and a sticky header. Compose with the sibling TableRow, TableHeaderCell, and TableCell components. The presentational layer beneath DataTable; pair with the useTable* hooks for behavior.",
   "figma": null,
   "radixPrimitive": null,
   "element": "table",
@@ -28,12 +28,7 @@
   },
   "slots": [],
   "asChild": false,
-  "subParts": [
-    { "name": "Table", "element": "table" },
-    { "name": "TableRow", "element": "tr" },
-    { "name": "TableHeaderCell", "element": "th" },
-    { "name": "TableCell", "element": "td" }
-  ],
+  "subParts": [],
   "requiredStories": ["Default", "Playground", "Example", "ForcedColors"],
   "a11y": {
     "keyboard": ["Tab", "Space", "Enter"],
@@ -111,5 +106,5 @@
     "omit a meaningful caption",
     "put interactive sort logic in the cell instead of the useTable* hooks"
   ],
-  "composesWith": ["DataTable", "Checkbox", "Icon", "IconButton"]
+  "composesWith": ["TableRow", "TableHeaderCell", "TableCell", "DataTable"]
 }

--- a/nextjs-app/shared/components/Table/Table.module.css
+++ b/nextjs-app/shared/components/Table/Table.module.css
@@ -52,6 +52,19 @@
   vertical-align: middle;
 }
 
+/* scope="row" headers name a row (data, not a column label): render like a body cell with slight emphasis. */
+.headerCell[scope="row"] {
+  padding-block: var(--space-internal-12);
+  border-block-end: 1px solid var(--color-border-light);
+  background: transparent;
+  font-size: var(--font-size-text-s);
+  font-weight: 500;
+  letter-spacing: normal;
+  text-transform: none;
+  white-space: normal;
+  color: var(--color-text);
+}
+
 .cell {
   padding: var(--space-internal-12) var(--space-internal-16);
   border-block-end: 1px solid var(--color-border-light);
@@ -159,7 +172,8 @@
   font-size: var(--font-size-text-m);
 }
 
-.row:last-child .cell {
+.row:last-child .cell,
+.row:last-child .headerCell[scope="row"] {
   border-block-end: 0;
 }
 

--- a/nextjs-app/shared/components/Table/Table.stories.tsx
+++ b/nextjs-app/shared/components/Table/Table.stories.tsx
@@ -1,12 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import React from "react";
-import {
-  Table,
-  TableCell,
-  TableHeaderCell,
-  TableRow,
-  type TableSortDirection,
-} from "./Table";
+import { Table, type TableSortDirection } from "./Table";
+import { TableRow } from "@dt/TableRow";
+import { TableHeaderCell } from "@dt/TableHeaderCell";
+import { TableCell } from "@dt/TableCell";
 import Checkbox from "../Checkbox/Checkbox";
 import { useTableSelection } from "../../hooks/useTableSelection";
 import contract from "./Table.contract.json";

--- a/nextjs-app/shared/components/Table/Table.test.tsx
+++ b/nextjs-app/shared/components/Table/Table.test.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import { axe, toHaveNoViolations } from "jest-axe";
-import { Table, TableCell, TableHeaderCell, TableRow } from "./Table";
+import { Table } from "./Table";
+import { TableRow } from "@dt/TableRow";
+import { TableHeaderCell } from "@dt/TableHeaderCell";
+import { TableCell } from "@dt/TableCell";
 
 expect.extend(toHaveNoViolations);
 

--- a/nextjs-app/shared/components/Table/Table.tsx
+++ b/nextjs-app/shared/components/Table/Table.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { cn } from "../../lib/cn";
-import Icon from "../Icon/Icon";
 import styles from "./Table.module.css";
 
 export type TableSize = "sm" | "md" | "lg";
@@ -25,9 +24,9 @@ export interface TableProps
 
 /**
  * Composable table root: a scroll wrapper around a semantic `<table>`. Compose
- * with native `<thead>`/`<tbody>` plus `TableRow`, `TableHeaderCell`, and
- * `TableCell`. Presentational only — sorting/selection logic lives in the
- * `useTable*` hooks and `DataTable`.
+ * with native `<thead>`/`<tbody>` plus the sibling `TableRow`,
+ * `TableHeaderCell`, and `TableCell` components. Presentational only — sorting
+ * and selection logic live in the `useTable*` hooks and `DataTable`.
  */
 export const Table = React.forwardRef<HTMLTableElement, TableProps>(
   (
@@ -65,101 +64,5 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
   ),
 );
 Table.displayName = "Table";
-
-export interface TableRowProps
-  extends React.HTMLAttributes<HTMLTableRowElement> {
-  /** Renders the selected surface and sets `data-selected`. Visual only. */
-  selected?: boolean;
-}
-
-/** Table row. Works inside `<thead>` and `<tbody>`. */
-export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
-  ({ selected, className, ...rest }, ref) => (
-    <tr
-      ref={ref}
-      className={cn(styles.row, className)}
-      data-selected={selected || undefined}
-      {...rest}
-    />
-  ),
-);
-TableRow.displayName = "TableRow";
-
-export interface TableHeaderCellProps
-  extends Omit<React.ThHTMLAttributes<HTMLTableCellElement>, "align"> {
-  /** Cell content alignment. @default "start" */
-  align?: TableAlign;
-  /** Renders the sort affordance and toggles on click. */
-  sortable?: boolean;
-  /** Current sort state; drives `aria-sort` and the caret icon. @default "none" */
-  sortDirection?: TableSortDirection;
-  /** Called when a sortable header is activated. */
-  onSort?: () => void;
-}
-
-const SORT_ICON: Record<TableSortDirection, string> = {
-  none: "caret-up-down",
-  ascending: "caret-up",
-  descending: "caret-down",
-};
-
-/** Header cell (`<th scope="col">`) with an optional three-state sort control. */
-export const TableHeaderCell = React.forwardRef<
-  HTMLTableCellElement,
-  TableHeaderCellProps
->(
-  (
-    { align = "start", sortable, sortDirection = "none", onSort, className, children, ...rest },
-    ref,
-  ) => {
-    const active = sortDirection !== "none";
-    return (
-      <th
-        ref={ref}
-        scope="col"
-        className={cn(styles.headerCell, className)}
-        data-align={align}
-        aria-sort={active ? sortDirection : undefined}
-        {...rest}
-      >
-        {sortable ? (
-          <button type="button" className={styles.sortButton} onClick={onSort}>
-            <span>{children}</span>
-            <Icon
-              name={SORT_ICON[sortDirection]}
-              size="sm"
-              className={cn(styles.sortIcon, active && styles.sortIconActive)}
-            />
-          </button>
-        ) : (
-          children
-        )}
-      </th>
-    );
-  },
-);
-TableHeaderCell.displayName = "TableHeaderCell";
-
-export interface TableCellProps
-  extends Omit<React.TdHTMLAttributes<HTMLTableCellElement>, "align"> {
-  /** Cell content alignment. @default "start" */
-  align?: TableAlign;
-  /** Right-align and tabular-figure numeric values. */
-  numeric?: boolean;
-}
-
-/** Data cell (`<td>`). */
-export const TableCell = React.forwardRef<
-  HTMLTableCellElement,
-  TableCellProps
->(({ align, numeric, className, ...rest }, ref) => (
-  <td
-    ref={ref}
-    className={cn(styles.cell, numeric && styles.numeric, className)}
-    data-align={align ?? (numeric ? "end" : "start")}
-    {...rest}
-  />
-));
-TableCell.displayName = "TableCell";
 
 export default Table;

--- a/nextjs-app/shared/components/Table/index.ts
+++ b/nextjs-app/shared/components/Table/index.ts
@@ -1,15 +1,6 @@
-export {
-  default,
-  Table,
-  TableRow,
-  TableHeaderCell,
-  TableCell,
-} from "./Table";
+export { default, Table } from "./Table";
 export type {
   TableProps,
-  TableRowProps,
-  TableHeaderCellProps,
-  TableCellProps,
   TableSize,
   TableAlign,
   TableSortDirection,

--- a/nextjs-app/shared/components/TableCell/TableCell.contract.json
+++ b/nextjs-app/shared/components/TableCell/TableCell.contract.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+  "schemaVersion": 2,
+  "name": "TableCell",
+  "tier": "atom",
+  "group": "data-display",
+  "status": "alpha",
+  "description": "A table data cell (<td>) for the Table family. align controls text alignment; numeric right-aligns with tabular figures so columns line up on the decimal.",
+  "figma": null,
+  "radixPrimitive": null,
+  "element": "td",
+  "variants": {
+    "align": {
+      "values": ["start", "center", "end"],
+      "default": "start",
+      "propSourced": true
+    },
+    "numeric": {
+      "values": ["true", "false"],
+      "default": "false",
+      "propSourced": true
+    }
+  },
+  "slots": [],
+  "asChild": false,
+  "subParts": [],
+  "requiredStories": ["Default", "Playground", "Example", "ForcedColors"],
+  "a11y": {
+    "keyboard": [],
+    "ariaRequirements": [
+      "native <td> semantics; no ARIA of its own",
+      "pairs with TableHeaderCell scope=col/row so cells inherit column and row context"
+    ],
+    "reducedMotion": true,
+    "reviewed": true,
+    "reviewedNote": "2026-07-27 — native td; alignment and numeric tabular figures verified; axe asserted inside a table in the unit test.",
+    "forcedColorsVerified": false,
+    "accessibilityTreeVerified": false
+  },
+  "tokens": {
+    "colors": ["--color-border-light"],
+    "spacing": ["--space-internal-8", "--space-internal-12", "--space-internal-16", "--space-layout-24"]
+  },
+  "lightDarkVerified": false,
+  "dense": "table td; align start/center/end, numeric = tabular figures right-aligned",
+  "keywords": ["table", "cell", "td", "numeric"],
+  "props": {
+    "align": {
+      "optional": true,
+      "type": "union",
+      "values": ["start", "center", "end"],
+      "description": "Cell content alignment."
+    },
+    "numeric": {
+      "optional": true,
+      "type": "boolean",
+      "description": "Right-align with tabular figures for numeric values."
+    }
+  },
+  "forbiddenUse": [
+    "render it outside a table row",
+    "use it for a header — use TableHeaderCell so column/row context is announced"
+  ],
+  "composesWith": ["Table", "TableRow", "TableHeaderCell"]
+}

--- a/nextjs-app/shared/components/TableCell/TableCell.spec.md
+++ b/nextjs-app/shared/components/TableCell/TableCell.spec.md
@@ -1,0 +1,37 @@
+# TableCell
+
+A table data cell (`<td>`) for the Table family.
+
+## Intent
+
+The body cell of the composable `Table`. `align` sets text alignment; `numeric`
+right-aligns with tabular figures so numbers line up on the decimal. It pairs
+with `TableHeaderCell` (`scope="col"`/`"row"`) so cells inherit their column and
+row context for assistive tech.
+
+## Interaction contract
+
+- Presentational: native `<td>`, no ARIA of its own.
+- `numeric` defaults the alignment to `end`; an explicit `align` overrides it.
+- Native attributes pass through, so `colSpan` (e.g. an empty-state cell that
+  spans the table) works as usual.
+
+## Do / don't
+
+Do:
+
+- Use `numeric` for figures so columns align.
+- Let `TableHeaderCell scope="row"` name the row; keep other cells as
+  `TableCell`.
+
+Don't:
+
+- Use `TableCell` for a header — use `TableHeaderCell` so context is announced.
+- Render it outside a table row.
+
+## Design notes
+
+- Padding scales with the `Table` root's density (`sm`/`md`/`lg`); the row
+  divider and last-row border come from the shared `Table.module.css`.
+- `numeric` applies `font-variant-numeric: tabular-nums`.
+- Forced-colors: borders map to `CanvasText`.

--- a/nextjs-app/shared/components/TableCell/TableCell.stories.tsx
+++ b/nextjs-app/shared/components/TableCell/TableCell.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Table } from "@dt/Table";
+import { TableRow } from "@dt/TableRow";
+import { TableHeaderCell } from "@dt/TableHeaderCell";
+import { TableCell } from "./TableCell";
+import contract from "./TableCell.contract.json";
+
+const meta = {
+  title: "Data display/TableCell",
+  component: TableCell,
+  parameters: {
+    layout: "padded",
+    a11y: { test: "error" },
+    contractStatus: contract.status,
+    docs: { description: { component: contract.description } },
+  },
+  tags: ["alpha", "autodocs"],
+  args: { children: "Ada Lovelace", numeric: false },
+  argTypes: {
+    align: { control: "inline-radio", options: ["start", "center", "end"] },
+    numeric: { control: "boolean", description: "Tabular figures, end-aligned." },
+  },
+  render: (args) => (
+    <Table caption="Contributors">
+      <thead>
+        <TableRow>
+          <TableHeaderCell>Name</TableHeaderCell>
+          <TableHeaderCell align="end">Projects</TableHeaderCell>
+        </TableRow>
+      </thead>
+      <tbody>
+        <TableRow>
+          <TableCell {...args} />
+          <TableCell numeric>8</TableCell>
+        </TableRow>
+      </tbody>
+    </Table>
+  ),
+} satisfies Meta<typeof TableCell>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Playground: Story = {};
+
+export const Example: Story = {
+  tags: ["example"],
+  parameters: {
+    docs: {
+      description: {
+        story: "numeric cells right-align with tabular figures so columns line up on the decimal.",
+      },
+    },
+  },
+  render: () => (
+    <Table caption="Numbers">
+      <thead>
+        <TableRow>
+          <TableHeaderCell>Metric</TableHeaderCell>
+          <TableHeaderCell align="end">Value</TableHeaderCell>
+        </TableRow>
+      </thead>
+      <tbody>
+        <TableRow>
+          <TableCell>Requests</TableCell>
+          <TableCell numeric>1,204</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>Errors</TableCell>
+          <TableCell numeric>12</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>Latency</TableCell>
+          <TableCell numeric>98</TableCell>
+        </TableRow>
+      </tbody>
+    </Table>
+  ),
+};
+
+export const ForcedColors: Story = { globals: { forcedColors: "active" } };

--- a/nextjs-app/shared/components/TableCell/TableCell.test.tsx
+++ b/nextjs-app/shared/components/TableCell/TableCell.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { TableCell } from "./TableCell";
+
+expect.extend(toHaveNoViolations);
+
+const inRow = (cell: React.ReactNode) => (
+  <table>
+    <caption>People</caption>
+    <tbody>
+      <tr>{cell}</tr>
+    </tbody>
+  </table>
+);
+
+describe("TableCell", () => {
+  it("renders a native td", () => {
+    render(inRow(<TableCell>Ada</TableCell>));
+    expect(screen.getByRole("cell", { name: "Ada" }).tagName).toBe("TD");
+  });
+
+  it("defaults numeric cells to end alignment", () => {
+    render(inRow(<TableCell numeric>8</TableCell>));
+    expect(screen.getByRole("cell", { name: "8" })).toHaveAttribute(
+      "data-align",
+      "end",
+    );
+  });
+
+  it("respects an explicit align over numeric", () => {
+    render(
+      inRow(
+        <TableCell numeric align="center">
+          8
+        </TableCell>,
+      ),
+    );
+    expect(screen.getByRole("cell", { name: "8" })).toHaveAttribute(
+      "data-align",
+      "center",
+    );
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(
+      inRow(
+        <>
+          <TableCell>Ada</TableCell>
+          <TableCell numeric>8</TableCell>
+        </>,
+      ),
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/TableCell/TableCell.tsx
+++ b/nextjs-app/shared/components/TableCell/TableCell.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { cn } from "../../lib/cn";
+import type { TableAlign } from "../Table/Table";
+import styles from "../Table/Table.module.css";
+
+export type { TableAlign };
+
+export interface TableCellProps
+  extends Omit<React.TdHTMLAttributes<HTMLTableCellElement>, "align"> {
+  /** Cell content alignment. @default "start" */
+  align?: TableAlign;
+  /** Right-align and tabular-figure numeric values. */
+  numeric?: boolean;
+}
+
+/** Data cell (`<td>`); compose inside a `TableRow`. */
+export const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  TableCellProps
+>(({ align, numeric, className, ...rest }, ref) => (
+  <td
+    ref={ref}
+    className={cn(styles.cell, numeric && styles.numeric, className)}
+    data-align={align ?? (numeric ? "end" : "start")}
+    {...rest}
+  />
+));
+TableCell.displayName = "TableCell";
+
+export default TableCell;

--- a/nextjs-app/shared/components/TableCell/index.ts
+++ b/nextjs-app/shared/components/TableCell/index.ts
@@ -1,0 +1,2 @@
+export { default, TableCell } from "./TableCell";
+export type { TableCellProps } from "./TableCell";

--- a/nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.contract.json
+++ b/nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.contract.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+  "schemaVersion": 2,
+  "name": "TableHeaderCell",
+  "tier": "atom",
+  "group": "data-display",
+  "status": "alpha",
+  "description": "A table header cell (<th>). scope=col (default) carries an optional three-state DS-Icon sort control and aria-sort; scope=row marks the identifying cell of a body row so screen readers announce the row context with every other cell.",
+  "figma": null,
+  "radixPrimitive": null,
+  "element": "th",
+  "variants": {
+    "align": {
+      "values": ["start", "center", "end"],
+      "default": "start",
+      "propSourced": true
+    },
+    "scope": {
+      "values": ["col", "row"],
+      "default": "col",
+      "propSourced": true
+    }
+  },
+  "slots": [],
+  "asChild": false,
+  "subParts": [],
+  "requiredStories": ["Default", "Playground", "Example", "ForcedColors"],
+  "a11y": {
+    "keyboard": [],
+    "ariaRequirements": [
+      "native <th> with an explicit scope (col or row)",
+      "sortable column headers expose aria-sort and toggle via an inner button",
+      "the sort caret is decorative (aria-hidden); state is carried by aria-sort, never the icon alone"
+    ],
+    "reducedMotion": true,
+    "reviewed": true,
+    "reviewedNote": "2026-07-27 — th with explicit scope; aria-sort on active column headers; decorative caret; row-header (scope=row) verified to name its row; axe asserted inside a table in the unit test.",
+    "forcedColorsVerified": false,
+    "accessibilityTreeVerified": false
+  },
+  "tokens": {
+    "colors": ["--color-muted", "--color-primary", "--color-border", "--color-light-bg", "--color-neutral-bg"],
+    "spacing": ["--space-internal-6", "--space-internal-8", "--space-internal-12", "--space-internal-16", "--space-layout-24"],
+    "radii": ["--radius-sm"]
+  },
+  "lightDarkVerified": false,
+  "dense": "th with scope col/row; col carries the three-state sort caret + aria-sort, row names its data row",
+  "keywords": ["table", "header", "th", "sort", "scope", "column", "row"],
+  "props": {
+    "align": {
+      "optional": true,
+      "type": "union",
+      "values": ["start", "center", "end"],
+      "description": "Cell content alignment."
+    },
+    "scope": {
+      "optional": true,
+      "type": "union",
+      "values": ["col", "row"],
+      "description": "Header scope; row names the identifying cell of a body row."
+    },
+    "sortable": {
+      "optional": true,
+      "type": "boolean",
+      "description": "Renders the sort control (column headers only)."
+    },
+    "sortDirection": {
+      "optional": true,
+      "type": "union",
+      "values": ["ascending", "descending", "none"],
+      "description": "Current sort state; drives aria-sort and the caret."
+    },
+    "onSort": {
+      "optional": true,
+      "type": "() => void",
+      "description": "Called when a sortable header is activated."
+    }
+  },
+  "forbiddenUse": [
+    "render it outside a table",
+    "make a scope=row header sortable — row headers are not sort controls",
+    "convey sort state with the caret colour alone"
+  ],
+  "composesWith": ["Table", "TableRow", "TableCell", "Icon"]
+}

--- a/nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.spec.md
+++ b/nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.spec.md
@@ -1,0 +1,44 @@
+# TableHeaderCell
+
+A table header cell (`<th>`) for the Table family.
+
+## Intent
+
+Header cell with an explicit `scope`. `scope="col"` (default) labels a column
+and can carry a three-state sort control; `scope="row"` marks the identifying
+cell of a body row so a screen reader announces the row context ("Ada
+Lovelace") along with every other cell in that row — the accessibility feature a
+plain `<td>` grid can't provide.
+
+## Interaction contract
+
+- Column headers (`scope="col"`) with `sortable` render an inner `<button>` and
+  expose `aria-sort` only while actively sorted. Wire `sortDirection`/`onSort`
+  from `useTableSortable`.
+- The sort caret is a DS `Icon` (`caret-up-down` unsorted / `caret-up` asc /
+  `caret-down` desc), decorative (`aria-hidden`); state is carried by
+  `aria-sort`, never the icon alone.
+- Row headers (`scope="row"`) never render a sort control — they name a row,
+  they are not interactive.
+
+## Do / don't
+
+Do:
+
+- Use `scope="row"` on the identifying cell of each body row for accessible
+  data tables.
+- Drive sorting with `useTableSortable`.
+
+Don't:
+
+- Make a `scope="row"` header sortable.
+- Convey sort state with the caret colour alone.
+- Render it outside a table.
+
+## Design notes
+
+- Quiet column headers: small uppercase `--font-size-text-xs` labels in
+  `--color-muted`; the active sort caret uses `--color-primary`, the unsorted
+  one `--color-muted` so a sorted column reads at a glance and clears ≥3:1
+  contrast in every theme.
+- Padding/borders/sticky behaviour come from the shared `Table.module.css`.

--- a/nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.stories.tsx
+++ b/nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.stories.tsx
@@ -1,0 +1,125 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Table } from "@dt/Table";
+import { TableRow } from "@dt/TableRow";
+import { TableCell } from "@dt/TableCell";
+import { TableHeaderCell } from "./TableHeaderCell";
+import contract from "./TableHeaderCell.contract.json";
+
+const meta = {
+  title: "Data display/TableHeaderCell",
+  component: TableHeaderCell,
+  parameters: {
+    layout: "padded",
+    a11y: { test: "error" },
+    contractStatus: contract.status,
+    docs: { description: { component: contract.description } },
+  },
+  tags: ["alpha", "autodocs"],
+  args: {
+    children: "Name",
+    align: "start",
+    scope: "col",
+    sortable: true,
+    sortDirection: "ascending",
+  },
+  argTypes: {
+    align: { control: "inline-radio", options: ["start", "center", "end"] },
+    scope: { control: "inline-radio", options: ["col", "row"] },
+    sortable: { control: "boolean" },
+    sortDirection: {
+      control: "radio",
+      options: ["ascending", "descending", "none"],
+    },
+  },
+  render: (args) => (
+    <Table caption="Contributors">
+      <thead>
+        <TableRow>
+          <TableHeaderCell {...args} />
+          <TableHeaderCell>Role</TableHeaderCell>
+        </TableRow>
+      </thead>
+      <tbody>
+        <TableRow>
+          <TableCell>Ada Lovelace</TableCell>
+          <TableCell>Engineer</TableCell>
+        </TableRow>
+      </tbody>
+    </Table>
+  ),
+} satisfies Meta<typeof TableHeaderCell>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Playground: Story = {};
+
+export const Example: Story = {
+  tags: ["example"],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The three-state sort control: caret-up-down (unsorted, muted), caret-up (ascending), caret-down (descending).",
+      },
+    },
+  },
+  render: () => (
+    <Table caption="Sort states">
+      <thead>
+        <TableRow>
+          <TableHeaderCell sortable sortDirection="ascending">
+            Name
+          </TableHeaderCell>
+          <TableHeaderCell sortable sortDirection="none">
+            Role
+          </TableHeaderCell>
+          <TableHeaderCell sortable sortDirection="descending" align="end">
+            Projects
+          </TableHeaderCell>
+        </TableRow>
+      </thead>
+      <tbody>
+        <TableRow>
+          <TableCell>Ada</TableCell>
+          <TableCell>Engineer</TableCell>
+          <TableCell numeric>8</TableCell>
+        </TableRow>
+      </tbody>
+    </Table>
+  ),
+};
+
+export const RowHeader: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "scope=row names the identifying cell of each body row, so screen readers announce the person with every other cell.",
+      },
+    },
+  },
+  render: () => (
+    <Table caption="People">
+      <thead>
+        <TableRow>
+          <TableHeaderCell>Name</TableHeaderCell>
+          <TableHeaderCell>Role</TableHeaderCell>
+        </TableRow>
+      </thead>
+      <tbody>
+        <TableRow>
+          <TableHeaderCell scope="row">Ada Lovelace</TableHeaderCell>
+          <TableCell>Engineer</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableHeaderCell scope="row">Dieter Rams</TableHeaderCell>
+          <TableCell>Designer</TableCell>
+        </TableRow>
+      </tbody>
+    </Table>
+  ),
+};
+
+export const ForcedColors: Story = { globals: { forcedColors: "active" } };

--- a/nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.test.tsx
+++ b/nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.test.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { TableHeaderCell } from "./TableHeaderCell";
+
+expect.extend(toHaveNoViolations);
+
+const inHeadRow = (cell: React.ReactNode) => (
+  <table>
+    <caption>People</caption>
+    <thead>
+      <tr>{cell}</tr>
+    </thead>
+  </table>
+);
+
+describe("TableHeaderCell", () => {
+  it("defaults to a column header", () => {
+    render(inHeadRow(<TableHeaderCell>Name</TableHeaderCell>));
+    expect(screen.getByRole("columnheader", { name: "Name" })).toHaveAttribute(
+      "scope",
+      "col",
+    );
+  });
+
+  it("supports a row header (scope=row)", () => {
+    render(
+      <table>
+        <caption>People</caption>
+        <tbody>
+          <tr>
+            <TableHeaderCell scope="row">Ada</TableHeaderCell>
+            <td>Engineer</td>
+          </tr>
+        </tbody>
+      </table>,
+    );
+    expect(screen.getByRole("rowheader", { name: "Ada" })).toHaveAttribute(
+      "scope",
+      "row",
+    );
+  });
+
+  it("exposes aria-sort and toggles via a button when sortable", async () => {
+    const user = userEvent.setup();
+    const onSort = vi.fn();
+    render(
+      inHeadRow(
+        <TableHeaderCell sortable sortDirection="ascending" onSort={onSort}>
+          Name
+        </TableHeaderCell>,
+      ),
+    );
+    expect(screen.getByRole("columnheader")).toHaveAttribute(
+      "aria-sort",
+      "ascending",
+    );
+    await user.click(screen.getByRole("button", { name: "Name" }));
+    expect(onSort).toHaveBeenCalledOnce();
+  });
+
+  it("does not render a sort control on a row header", () => {
+    render(
+      <table>
+        <caption>People</caption>
+        <tbody>
+          <tr>
+            <TableHeaderCell scope="row" sortable>
+              Ada
+            </TableHeaderCell>
+          </tr>
+        </tbody>
+      </table>,
+    );
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(
+      inHeadRow(
+        <TableHeaderCell sortable sortDirection="descending">
+          Score
+        </TableHeaderCell>,
+      ),
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.tsx
+++ b/nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { cn } from "../../lib/cn";
+import Icon from "../Icon/Icon";
+import type { TableAlign, TableSortDirection } from "../Table/Table";
+import styles from "../Table/Table.module.css";
+
+export type { TableAlign, TableSortDirection };
+
+export interface TableHeaderCellProps
+  extends Omit<React.ThHTMLAttributes<HTMLTableCellElement>, "align" | "scope"> {
+  /** Cell content alignment. @default "start" */
+  align?: TableAlign;
+  /**
+   * Header scope. `col` (default) labels a column; `row` makes the cell the
+   * accessible name for its row — use it on the identifying cell of each body
+   * row so screen readers announce the row context with every other cell.
+   * @default "col"
+   */
+  scope?: "col" | "row";
+  /** Renders the sort affordance and toggles on click. Only for column headers. */
+  sortable?: boolean;
+  /** Current sort state; drives `aria-sort` and the caret icon. @default "none" */
+  sortDirection?: TableSortDirection;
+  /** Called when a sortable header is activated. */
+  onSort?: () => void;
+}
+
+const SORT_ICON: Record<TableSortDirection, string> = {
+  none: "caret-up-down",
+  ascending: "caret-up",
+  descending: "caret-down",
+};
+
+/**
+ * Header cell (`<th>`). `scope="col"` (default) carries an optional three-state
+ * sort control; `scope="row"` marks the identifying cell of a body row.
+ */
+export const TableHeaderCell = React.forwardRef<
+  HTMLTableCellElement,
+  TableHeaderCellProps
+>(
+  (
+    {
+      align = "start",
+      scope = "col",
+      sortable,
+      sortDirection = "none",
+      onSort,
+      className,
+      children,
+      ...rest
+    },
+    ref,
+  ) => {
+    const isColumn = scope === "col";
+    const active = isColumn && sortDirection !== "none";
+    return (
+      <th
+        ref={ref}
+        scope={scope}
+        className={cn(styles.headerCell, className)}
+        data-align={align}
+        aria-sort={active ? sortDirection : undefined}
+        {...rest}
+      >
+        {isColumn && sortable ? (
+          <button type="button" className={styles.sortButton} onClick={onSort}>
+            <span>{children}</span>
+            <Icon
+              name={SORT_ICON[sortDirection]}
+              size="sm"
+              className={cn(styles.sortIcon, active && styles.sortIconActive)}
+            />
+          </button>
+        ) : (
+          children
+        )}
+      </th>
+    );
+  },
+);
+TableHeaderCell.displayName = "TableHeaderCell";
+
+export default TableHeaderCell;

--- a/nextjs-app/shared/components/TableHeaderCell/index.ts
+++ b/nextjs-app/shared/components/TableHeaderCell/index.ts
@@ -1,0 +1,2 @@
+export { default, TableHeaderCell } from "./TableHeaderCell";
+export type { TableHeaderCellProps } from "./TableHeaderCell";

--- a/nextjs-app/shared/components/TableRow/TableRow.contract.json
+++ b/nextjs-app/shared/components/TableRow/TableRow.contract.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+  "schemaVersion": 2,
+  "name": "TableRow",
+  "tier": "atom",
+  "group": "data-display",
+  "status": "alpha",
+  "description": "A table row (<tr>) for the Table family. Works in <thead> and <tbody>; selected renders the selection surface. Presentational — semantics belong to the surrounding table.",
+  "figma": null,
+  "radixPrimitive": null,
+  "element": "tr",
+  "variants": {
+    "selected": {
+      "values": ["true", "false"],
+      "default": "false",
+      "propSourced": true
+    }
+  },
+  "slots": [],
+  "asChild": false,
+  "subParts": [],
+  "requiredStories": ["Default", "Playground", "Example", "ForcedColors"],
+  "a11y": {
+    "keyboard": [],
+    "ariaRequirements": [
+      "native <tr> semantics; no ARIA of its own",
+      "selection is visual only (data-selected); the row's selection state belongs to a checkbox or the consuming app"
+    ],
+    "reducedMotion": true,
+    "reviewed": true,
+    "reviewedNote": "2026-07-27 — native tr; hover/zebra/selection tint are presentational; axe asserted inside a table in the unit test.",
+    "forcedColorsVerified": false,
+    "accessibilityTreeVerified": false
+  },
+  "tokens": {
+    "colors": ["--color-border-light", "--color-primary", "--color-light-bg"],
+    "spacing": []
+  },
+  "lightDarkVerified": false,
+  "dense": "table row; works in thead/tbody, selected surface, hover + zebra via the Table root",
+  "keywords": ["table", "row", "tr"],
+  "props": {
+    "selected": {
+      "optional": true,
+      "type": "boolean",
+      "description": "Renders the selected surface and sets data-selected. Visual only."
+    }
+  },
+  "forbiddenUse": [
+    "render it outside a table",
+    "rely on selected for semantics — pair it with a checkbox or aria-selected on the consuming structure"
+  ],
+  "composesWith": ["Table", "TableCell", "TableHeaderCell"]
+}

--- a/nextjs-app/shared/components/TableRow/TableRow.spec.md
+++ b/nextjs-app/shared/components/TableRow/TableRow.spec.md
@@ -1,0 +1,37 @@
+# TableRow
+
+A table row (`<tr>`) for the Table family.
+
+## Intent
+
+One of the composable `Table` parts (`Table` root, `TableRow`,
+`TableHeaderCell`, `TableCell`). Works in both `<thead>` and `<tbody>`. Its only
+prop, `selected`, renders the selection surface and sets `data-selected` — the
+hover, zebra-stripe, and selection-tint treatments are cross-cutting styles
+supplied by the `Table` root, so a row only looks striped/selected inside one.
+
+## Interaction contract
+
+- Presentational: no ARIA, no events of its own.
+- `selected` is **visual only**. The semantic selection state belongs to a
+  checkbox in the row or to the consuming application (`aria-selected` on a grid,
+  etc.) — never to the row's appearance alone.
+
+## Do / don't
+
+Do:
+
+- Compose it inside a `Table` root, in `<thead>` or `<tbody>`.
+- Pair `selected` with a real selection control (a `Checkbox`).
+
+Don't:
+
+- Render it outside a table.
+- Treat `selected` as the source of truth for selection.
+
+## Design notes
+
+- The row itself is unstyled; the border, hover, zebra, and selection tint come
+  from `Table.module.css` (shared across the family) so the whole table reads as
+  one system.
+- Forced-colors: borders map to `CanvasText` via the shared stylesheet.

--- a/nextjs-app/shared/components/TableRow/TableRow.stories.tsx
+++ b/nextjs-app/shared/components/TableRow/TableRow.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Table } from "@dt/Table";
+import { TableCell } from "@dt/TableCell";
+import { TableHeaderCell } from "@dt/TableHeaderCell";
+import { TableRow } from "./TableRow";
+import contract from "./TableRow.contract.json";
+
+const people = [
+  { name: "Ada Lovelace", role: "Engineer" },
+  { name: "Dieter Rams", role: "Designer" },
+  { name: "Grace Hopper", role: "Engineer" },
+];
+
+const meta = {
+  title: "Data display/TableRow",
+  component: TableRow,
+  parameters: {
+    layout: "padded",
+    a11y: { test: "error" },
+    contractStatus: contract.status,
+    docs: { description: { component: contract.description } },
+  },
+  tags: ["alpha", "autodocs"],
+  args: { selected: false },
+  argTypes: {
+    selected: { control: "boolean", description: "Selected surface (visual only)." },
+  },
+  render: (args) => (
+    <Table caption="Contributors">
+      <thead>
+        <TableRow>
+          <TableHeaderCell>Name</TableHeaderCell>
+          <TableHeaderCell>Role</TableHeaderCell>
+        </TableRow>
+      </thead>
+      <tbody>
+        <TableRow {...args}>
+          <TableCell>Ada Lovelace</TableCell>
+          <TableCell>Engineer</TableCell>
+        </TableRow>
+      </tbody>
+    </Table>
+  ),
+} satisfies Meta<typeof TableRow>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Playground: Story = {};
+
+export const Example: Story = {
+  tags: ["example"],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Rows in context: the middle row is selected; the hover, zebra, and selection surfaces come from the Table root.",
+      },
+    },
+  },
+  render: () => (
+    <Table caption="Contributors" striped>
+      <thead>
+        <TableRow>
+          <TableHeaderCell>Name</TableHeaderCell>
+          <TableHeaderCell>Role</TableHeaderCell>
+        </TableRow>
+      </thead>
+      <tbody>
+        {people.map((person, index) => (
+          <TableRow key={person.name} selected={index === 1}>
+            <TableCell>{person.name}</TableCell>
+            <TableCell>{person.role}</TableCell>
+          </TableRow>
+        ))}
+      </tbody>
+    </Table>
+  ),
+};
+
+export const ForcedColors: Story = { globals: { forcedColors: "active" } };

--- a/nextjs-app/shared/components/TableRow/TableRow.test.tsx
+++ b/nextjs-app/shared/components/TableRow/TableRow.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { TableRow } from "./TableRow";
+
+expect.extend(toHaveNoViolations);
+
+const inTable = (row: React.ReactNode) => (
+  <table>
+    <caption>People</caption>
+    <tbody>{row}</tbody>
+  </table>
+);
+
+describe("TableRow", () => {
+  it("renders a native tr", () => {
+    render(inTable(<TableRow><td>Ada</td></TableRow>));
+    expect(screen.getByRole("row")).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Ada" }).parentElement?.tagName).toBe(
+      "TR",
+    );
+  });
+
+  it("marks the selected surface with data-selected", () => {
+    const { rerender } = render(inTable(<TableRow><td>Ada</td></TableRow>));
+    expect(screen.getByRole("row")).not.toHaveAttribute("data-selected");
+    rerender(inTable(<TableRow selected><td>Ada</td></TableRow>));
+    expect(screen.getByRole("row")).toHaveAttribute("data-selected");
+  });
+
+  it("has no axe violations", async () => {
+    const { container } = render(
+      inTable(
+        <TableRow selected>
+          <td>Ada</td>
+          <td>Engineer</td>
+        </TableRow>,
+      ),
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/nextjs-app/shared/components/TableRow/TableRow.tsx
+++ b/nextjs-app/shared/components/TableRow/TableRow.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { cn } from "../../lib/cn";
+// Shared across the Table family: striping, hover, selection tint, and the
+// last-row border are cross-cutting selectors that live in one stylesheet.
+import styles from "../Table/Table.module.css";
+
+export interface TableRowProps
+  extends React.HTMLAttributes<HTMLTableRowElement> {
+  /** Renders the selected surface and sets `data-selected`. Visual only. */
+  selected?: boolean;
+}
+
+/** Table row. Works inside `<thead>` and `<tbody>`; compose with a `Table` root. */
+export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
+  ({ selected, className, ...rest }, ref) => (
+    <tr
+      ref={ref}
+      className={cn(styles.row, className)}
+      data-selected={selected || undefined}
+      {...rest}
+    />
+  ),
+);
+TableRow.displayName = "TableRow";
+
+export default TableRow;

--- a/nextjs-app/shared/components/TableRow/index.ts
+++ b/nextjs-app/shared/components/TableRow/index.ts
@@ -1,0 +1,2 @@
+export { default, TableRow } from "./TableRow";
+export type { TableRowProps } from "./TableRow";

--- a/nextjs-app/shared/components/VirtualList/VirtualList.spec.md
+++ b/nextjs-app/shared/components/VirtualList/VirtualList.spec.md
@@ -27,3 +27,31 @@ range plus a small overscan buffer.
 - A full-height spacer preserves the browser's native scroll range.
 - Rendered items are translated to their calculated vertical offset.
 - Viewport height and item offsets are intentionally runtime inline values.
+- Rows render as `VirtualListItem` (which composes `ListItem`), supplied via
+  `getItemProps`; the viewport is `role="list"`, each row `role="listitem"`.
+
+## Accessibility limitations
+
+Windowing has inherent accessibility trade-offs; know them before reaching for
+it:
+
+- **Off-screen rows are not in the DOM.** Only the visible window (+ overscan)
+  is mounted, so a screen-reader virtual cursor cannot navigate to item 500
+  until it scrolls into view. `aria-posinset`/`aria-setsize` announce each
+  row's true position, but do not make unmounted rows reachable. If a surface
+  needs full screen-reader traversal of the whole set, prefer a plain
+  (non-virtualized) list or provide search/filter to shrink the set.
+- **Keep items non-interactive.** Rows are presentational. Don't place focusable
+  content (links, buttons, inputs) inside `getItemProps` chrome — a focused row
+  can unmount on scroll and drop focus. Interactive virtualization needs a
+  focus-management layer this component does not yet provide.
+- **The viewport is the keyboard target.** It is `tabIndex={0}` so keyboard
+  users can scroll it with the arrow / Page keys; the rows themselves are not
+  in the tab order.
+
+## Layout requirement
+
+The rows are absolutely positioned, so the viewport takes its width from its
+container. Render VirtualList inside a block/flex context that gives it a width;
+in a shrink-to-fit container (a centered flex item, inline-block) it collapses
+to zero width and only its border shows.

--- a/nextjs-app/shared/components/index.ts
+++ b/nextjs-app/shared/components/index.ts
@@ -222,17 +222,17 @@ export {
 } from "./ArticleContent";
 export {
   Table,
-  TableRow,
-  TableHeaderCell,
-  TableCell,
   type TableProps,
-  type TableRowProps,
-  type TableHeaderCellProps,
-  type TableCellProps,
   type TableSize,
   type TableAlign,
   type TableSortDirection,
 } from "./Table";
+export { TableRow, type TableRowProps } from "./TableRow";
+export {
+  TableHeaderCell,
+  type TableHeaderCellProps,
+} from "./TableHeaderCell";
+export { TableCell, type TableCellProps } from "./TableCell";
 export {
   TableOfContents,
   type TableOfContentsProps,

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,18 +1,18 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-27T05:19:22.232Z",
+  "generatedAt": "2026-07-27T05:58:08.331Z",
   "summary": {
-    "componentCount": 174,
+    "componentCount": 177,
     "statusCounts": {
       "beta": 40,
       "stable": 104,
-      "alpha": 29,
+      "alpha": 32,
       "deprecated": 1
     },
     "honestBetaDocDebt": 0,
-    "catalogCompletenessPercent": 90.6,
-    "codebaseComponentCount": 192,
-    "usageCoveragePercent": 93.1,
+    "catalogCompletenessPercent": 90.8,
+    "codebaseComponentCount": 195,
+    "usageCoveragePercent": 93.2,
     "componentsWithProductionUsage": 36,
     "notReadyForStablePromotion": false
   },
@@ -57,15 +57,15 @@
   },
   "catalogCoverage": {
     "description": "Catalog completeness across the codebase. componentCount above is the catalog count; this block reveals how much of the codebase that catalog actually represents.",
-    "totalComponentsInCodebase": 192,
-    "inCatalog": 174,
+    "totalComponentsInCodebase": 195,
+    "inCatalog": 177,
     "outOfCatalog": 18,
-    "catalogCompletenessPercent": 90.6,
+    "catalogCompletenessPercent": 90.8,
     "artifactCoverage": {
-      "stories": 158,
-      "tests": 159,
+      "stories": 161,
+      "tests": 162,
       "mdx": 4,
-      "spec": 174
+      "spec": 177
     },
     "outOfCatalogByBucket": {
       "catalog-gap": 0,
@@ -77,21 +77,21 @@
   },
   "usageCoverage": {
     "description": "Auto-detected import evidence from app/** and nextjs-app/**. Separate from contract.consumers[], which remains the stable-promotion gate for shipping-product proof.",
-    "catalogedComponents": 174,
-    "withAnyUsage": 162,
+    "catalogedComponents": 177,
+    "withAnyUsage": 165,
     "withProductionUsage": 36,
-    "uniqueImportedComponents": 162,
-    "totalEvidenceRows": 797,
-    "aliasImportFiles": 411,
-    "relativeImportFiles": 419,
+    "uniqueImportedComponents": 165,
+    "totalEvidenceRows": 820,
+    "aliasImportFiles": 429,
+    "relativeImportFiles": 424,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
   },
   "relationshipGraph": {
     "description": "Merged static composesWith policy + co-import evidence (see generate-relationship-graph.mjs).",
-    "generatedAt": "2026-07-26T21:11:27.134Z",
+    "generatedAt": "2026-07-27T05:57:59.042Z",
     "coImportMinFiles": 3,
-    "nodesWithComposesWith": 87,
+    "nodesWithComposesWith": 90,
     "regenerate": "npm run build:relationship-graph or npm run build:tokens",
     "path": "nextjs-app/shared/foundations/dist/relationship-graph.json"
   },
@@ -102,14 +102,14 @@
   "dsharpParity": {
     "description": "Comparison against DSharp as of 2026-05-26. Breadth is close, maturity is not. This block walks back the earlier parity overclaim.",
     "contractCount": {
-      "digitaltableteur": 174,
+      "digitaltableteur": 177,
       "dsharp": 112
     },
     "statusMix": {
       "digitaltableteur": {
         "beta": 40,
         "stable": 104,
-        "alpha": 29,
+        "alpha": 32,
         "deprecated": 1
       },
       "dsharp": {
@@ -23920,8 +23920,8 @@
           {
             "id": "accessibility-tree",
             "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:matrix:ci"
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
           },
           {
             "id": "forced-colors-real-browser",
@@ -23932,8 +23932,8 @@
           {
             "id": "aria-requirements",
             "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:matrix:ci"
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
           },
           {
             "id": "human-a11y-review",
@@ -24460,10 +24460,10 @@
         "composesWith": [
           "NavLink",
           "ThemeProvider",
-          "Card",
-          "Select",
-          "TextInput",
-          "Title"
+          "Table",
+          "TableRow",
+          "TableHeaderCell",
+          "TableCell"
         ],
         "prefersOver": [],
         "declaredPropCount": 7,
@@ -48866,7 +48866,7 @@
         "tier": "molecule",
         "group": "data-display",
         "status": "alpha",
-        "description": "Composable table primitives (Table, TableRow, TableHeaderCell, TableCell) with density, striping, a sticky header, and a three-state sort control. The presentational layer beneath DataTable; pair with the useTable* hooks for behavior.",
+        "description": "The composable table root: a scroll wrapper around a semantic table with density, striping, and a sticky header. Compose with the sibling TableRow, TableHeaderCell, and TableCell components. The presentational layer beneath DataTable; pair with the useTable* hooks for behavior.",
         "figma": null,
         "radixPrimitive": null,
         "element": "table",
@@ -48899,24 +48899,7 @@
         },
         "slots": [],
         "asChild": false,
-        "subParts": [
-          {
-            "name": "Table",
-            "element": "table"
-          },
-          {
-            "name": "TableRow",
-            "element": "tr"
-          },
-          {
-            "name": "TableHeaderCell",
-            "element": "th"
-          },
-          {
-            "name": "TableCell",
-            "element": "td"
-          }
-        ],
+        "subParts": [],
         "requiredStories": [
           "Default",
           "Playground",
@@ -49019,20 +49002,20 @@
           "put interactive sort logic in the cell instead of the useTable* hooks"
         ],
         "composesWith": [
-          "DataTable",
-          "Checkbox",
-          "Icon",
-          "IconButton"
+          "TableRow",
+          "TableHeaderCell",
+          "TableCell",
+          "DataTable"
         ]
       },
       "spec": "# Table\n\nComposable table primitives — `Table`, `TableRow`, `TableHeaderCell`, and\n`TableCell` — that render semantic `<table>` markup with design-system chrome.\nThey are the presentational layer beneath `DataTable`; behavior (sorting,\nselection, pagination) lives in the `useTable*` hooks.\n\n## Intent\n\nGive the design system a low-level, composable table so product surfaces can\nassemble bespoke tables from DS-styled parts, while `DataTable` provides the\nbatteries-included configuration on top. Compose with native `<thead>` and\n`<tbody>`:\n\n- **Table** — scroll wrapper + `<table>` with the `<caption>`; owns density\n  (`sm`/`md`/`lg`), `striped`, and `stickyHeader`.\n- **TableRow** — `<tr>`; `selected` renders the selected surface and sets\n  `data-selected`.\n- **TableHeaderCell** — `<th scope=\"col\">`; `sortable` + `sortDirection` render\n  a sort button whose caret is a DS `Icon` (`caret-up-down` unsorted,\n  `caret-up` ascending, `caret-down` descending).\n- **TableCell** — `<td>`; `align` and `numeric` (tabular figures, end-aligned).\n\n## Interaction contract\n\n- Sortable headers toggle via an inner `<button>`; drive the actual sort with\n  `useTableSortable` and pass the resulting `sortDirection`/`onSort`.\n- `aria-sort` is exposed only while a column is actively sorted; the caret is\n  decorative (`aria-hidden`) and never the sole carrier of state.\n- Row selection is presentational here (`selected`) — the state lives in\n  `useTableSelection`; render a DS `Checkbox` in the leading cell.\n\n## Do / don't\n\nDo:\n\n- Give every table a concise `caption`.\n- Drive sorting/selection with the `useTable*` hooks rather than local state.\n- Use `numeric` for figures so columns align on the decimal.\n\nDon't:\n\n- Use Table for page layout.\n- Put sort logic inside a cell instead of the hooks.\n- Rely on the caret color alone to convey sort state.\n\n## Design notes\n\n- Quiet header: small uppercase `--font-size-text-xs` labels in `--color-muted`\n  on a `--color-light-bg` surface, with hairline (`1px`) row dividers.\n- The active sort caret uses `--color-primary`; the unsorted caret sits at\n  `--color-muted` so a sorted column reads at a glance while the unsorted\n  affordance still clears ≥3:1 non-text contrast in every theme (including\n  HCB, where `--color-border` would fail).\n- Density scales header/cell padding across `sm`/`md`/`lg`.\n- Forced-colors: borders map to `CanvasText`, the focus ring to `Highlight`.\n",
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Table",
-        "importCount": 3,
+        "importCount": 8,
         "productionImportCount": 0,
         "patternImportCount": 0,
-        "componentImportCount": 2,
+        "componentImportCount": 4,
         "evidence": [
           {
             "path": "nextjs-app/shared/components/DataTable/DataTable.tsx",
@@ -49045,6 +49028,36 @@
             "importKind": "relative",
             "importPath": "./Table",
             "context": "component"
+          },
+          {
+            "path": "nextjs-app/shared/components/TableCell/TableCell.tsx",
+            "importKind": "relative",
+            "importPath": "../Table/Table",
+            "context": "component"
+          },
+          {
+            "path": "nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.tsx",
+            "importKind": "relative",
+            "importPath": "../Table/Table",
+            "context": "component"
+          },
+          {
+            "path": "nextjs-app/shared/components/TableCell/TableCell.stories.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Table",
+            "context": "story"
+          },
+          {
+            "path": "nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.stories.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Table",
+            "context": "story"
+          },
+          {
+            "path": "nextjs-app/shared/components/TableRow/TableRow.stories.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Table",
+            "context": "story"
           },
           {
             "path": "nextjs-app/shared/hooks/useTableSortable.ts",
@@ -49130,6 +49143,9 @@
         "replacementFor": [],
         "forbiddenUse": [],
         "composesWith": [
+          "TableRow",
+          "TableHeaderCell",
+          "TableCell",
           "Checkbox",
           "IconButton"
         ],
@@ -49222,6 +49238,713 @@
             "origin": "authored",
             "authorship": "human-authored",
             "from": "Table.spec.md"
+          },
+          "requiredA11y": {
+            "origin": "authored",
+            "authorship": "human-authored",
+            "from": "contract.json"
+          },
+          "keyboard": {
+            "origin": "authored",
+            "authorship": "human-authored",
+            "from": "contract.json"
+          },
+          "a11yCriteria": {
+            "origin": "derived",
+            "authorship": "mixed",
+            "from": "contract.a11y + derive-a11y-criteria.mjs"
+          },
+          "compositionRules": {
+            "origin": "derived",
+            "authorship": "mixed",
+            "from": "avoidWhen filter"
+          },
+          "forbiddenUse": {
+            "origin": "derived",
+            "authorship": "mixed",
+            "from": "avoidWhen + replacement policy"
+          },
+          "replacementFor": {
+            "origin": "derived",
+            "authorship": "mixed",
+            "from": "replacement policy"
+          }
+        },
+        "governance": null,
+        "content": null
+      }
+    },
+    {
+      "name": "TableCell",
+      "contract": {
+        "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+        "schemaVersion": 2,
+        "name": "TableCell",
+        "tier": "atom",
+        "group": "data-display",
+        "status": "alpha",
+        "description": "A table data cell (<td>) for the Table family. align controls text alignment; numeric right-aligns with tabular figures so columns line up on the decimal.",
+        "figma": null,
+        "radixPrimitive": null,
+        "element": "td",
+        "variants": {
+          "align": {
+            "values": [
+              "start",
+              "center",
+              "end"
+            ],
+            "default": "start",
+            "propSourced": true
+          },
+          "numeric": {
+            "values": [
+              "true",
+              "false"
+            ],
+            "default": "false",
+            "propSourced": true
+          }
+        },
+        "slots": [],
+        "asChild": false,
+        "subParts": [],
+        "requiredStories": [
+          "Default",
+          "Playground",
+          "Example",
+          "ForcedColors"
+        ],
+        "a11y": {
+          "keyboard": [],
+          "ariaRequirements": [
+            "native <td> semantics; no ARIA of its own",
+            "pairs with TableHeaderCell scope=col/row so cells inherit column and row context"
+          ],
+          "reducedMotion": true,
+          "reviewed": true,
+          "reviewedNote": "2026-07-27 — native td; alignment and numeric tabular figures verified; axe asserted inside a table in the unit test.",
+          "forcedColorsVerified": false,
+          "accessibilityTreeVerified": false
+        },
+        "tokens": {
+          "colors": [
+            "--color-border-light"
+          ],
+          "spacing": [
+            "--space-internal-8",
+            "--space-internal-12",
+            "--space-internal-16",
+            "--space-layout-24"
+          ]
+        },
+        "lightDarkVerified": false,
+        "dense": "table td; align start/center/end, numeric = tabular figures right-aligned",
+        "keywords": [
+          "table",
+          "cell",
+          "td",
+          "numeric"
+        ],
+        "props": {
+          "align": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "start",
+              "center",
+              "end"
+            ],
+            "description": "Cell content alignment."
+          },
+          "numeric": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Right-align with tabular figures for numeric values."
+          }
+        },
+        "forbiddenUse": [
+          "render it outside a table row",
+          "use it for a header — use TableHeaderCell so column/row context is announced"
+        ],
+        "composesWith": [
+          "Table",
+          "TableRow",
+          "TableHeaderCell"
+        ]
+      },
+      "spec": "# TableCell\n\nA table data cell (`<td>`) for the Table family.\n\n## Intent\n\nThe body cell of the composable `Table`. `align` sets text alignment; `numeric`\nright-aligns with tabular figures so numbers line up on the decimal. It pairs\nwith `TableHeaderCell` (`scope=\"col\"`/`\"row\"`) so cells inherit their column and\nrow context for assistive tech.\n\n## Interaction contract\n\n- Presentational: native `<td>`, no ARIA of its own.\n- `numeric` defaults the alignment to `end`; an explicit `align` overrides it.\n- Native attributes pass through, so `colSpan` (e.g. an empty-state cell that\n  spans the table) works as usual.\n\n## Do / don't\n\nDo:\n\n- Use `numeric` for figures so columns align.\n- Let `TableHeaderCell scope=\"row\"` name the row; keep other cells as\n  `TableCell`.\n\nDon't:\n\n- Use `TableCell` for a header — use `TableHeaderCell` so context is announced.\n- Render it outside a table row.\n\n## Design notes\n\n- Padding scales with the `Table` root's density (`sm`/`md`/`lg`); the row\n  divider and last-row border come from the shared `Table.module.css`.\n- `numeric` applies `font-variant-numeric: tabular-nums`.\n- Forced-colors: borders map to `CanvasText`.\n",
+      "documentationDebt": false,
+      "usage": {
+        "publicImport": "@dt/TableCell",
+        "importCount": 6,
+        "productionImportCount": 0,
+        "patternImportCount": 0,
+        "componentImportCount": 2,
+        "evidence": [
+          {
+            "path": "nextjs-app/shared/components/DataTable/DataTable.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TableCell",
+            "context": "component"
+          },
+          {
+            "path": "nextjs-app/shared/components/index.ts",
+            "importKind": "relative",
+            "importPath": "./TableCell",
+            "context": "component"
+          },
+          {
+            "path": "nextjs-app/shared/components/Table/Table.stories.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TableCell",
+            "context": "story"
+          },
+          {
+            "path": "nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.stories.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TableCell",
+            "context": "story"
+          },
+          {
+            "path": "nextjs-app/shared/components/TableRow/TableRow.stories.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TableCell",
+            "context": "story"
+          },
+          {
+            "path": "nextjs-app/shared/components/Table/Table.test.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TableCell",
+            "context": "test"
+          }
+        ]
+      },
+      "agent": {
+        "preferredImport": "@dt/TableCell",
+        "intent": "The body cell of the composable `Table`. `align` sets text alignment; `numeric` right-aligns with tabular figures so numbers line up on the decimal. It pairs with `TableHeaderCell` (`scope=\"col\"`/`\"row\"`) so cells inher…",
+        "props": {
+          "align": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "center",
+              "end",
+              "start"
+            ],
+            "description": "Cell content alignment."
+          },
+          "numeric": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Right-align and tabular-figure numeric values."
+          }
+        },
+        "propRelationships": [],
+        "variants": {
+          "align": {
+            "values": [
+              "center",
+              "end",
+              "start"
+            ],
+            "default": "center"
+          }
+        },
+        "cvaVariants": {},
+        "variantsFnName": null,
+        "useWhen": [],
+        "avoidWhen": [],
+        "requiredA11y": [
+          "native <td> semantics; no ARIA of its own",
+          "pairs with TableHeaderCell scope=col/row so cells inherit column and row context"
+        ],
+        "keyboard": [],
+        "compositionRules": [],
+        "canonicalExamples": [
+          "Default",
+          "Playground",
+          "Example",
+          "ForcedColors"
+        ],
+        "replacementFor": [],
+        "forbiddenUse": [],
+        "composesWith": [
+          "TableRow",
+          "TableHeaderCell",
+          "Table",
+          "Checkbox",
+          "IconButton"
+        ],
+        "prefersOver": [],
+        "declaredPropCount": 2,
+        "guidelines": [],
+        "a11yCriteria": [
+          {
+            "id": "axe-no-violations",
+            "statement": "Required stories produce no axe violations at the configured severity.",
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
+          },
+          {
+            "id": "accessibility-tree",
+            "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+          },
+          {
+            "id": "forced-colors-real-browser",
+            "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+            "verificationMode": "unverified"
+          },
+          {
+            "id": "aria-requirements",
+            "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+          },
+          {
+            "id": "human-a11y-review",
+            "statement": "A human completed an end-to-end accessibility review of this component.",
+            "verificationMode": "manual",
+            "note": "2026-07-27 — native td; alignment and numeric tabular figures verified; axe asserted inside a table in the unit test."
+          }
+        ],
+        "docOrigin": {
+          "props": {
+            "origin": "generated",
+            "authorship": "machine-generated",
+            "from": "TypeScript AST"
+          },
+          "variants": {
+            "origin": "generated",
+            "authorship": "machine-generated",
+            "from": "TypeScript AST"
+          },
+          "cvaVariants": {
+            "origin": "generated",
+            "authorship": "machine-generated",
+            "from": "TypeScript AST"
+          },
+          "propRelationships": {
+            "origin": "generated",
+            "authorship": "machine-generated",
+            "from": "TypeScript AST"
+          },
+          "canonicalExamples": {
+            "origin": "generated",
+            "authorship": "machine-generated",
+            "from": "stories.tsx"
+          },
+          "declaredPropCount": {
+            "origin": "generated",
+            "authorship": "machine-generated",
+            "from": "TypeScript AST"
+          },
+          "intent": {
+            "origin": "authored",
+            "authorship": "human-authored",
+            "from": "TableCell.spec.md"
+          },
+          "useWhen": {
+            "origin": "authored",
+            "authorship": "human-authored",
+            "from": "TableCell.spec.md"
+          },
+          "avoidWhen": {
+            "origin": "authored",
+            "authorship": "human-authored",
+            "from": "TableCell.spec.md"
+          },
+          "guidelines": {
+            "origin": "authored",
+            "authorship": "human-authored",
+            "from": "TableCell.spec.md"
+          },
+          "requiredA11y": {
+            "origin": "authored",
+            "authorship": "human-authored",
+            "from": "contract.json"
+          },
+          "keyboard": {
+            "origin": "authored",
+            "authorship": "human-authored",
+            "from": "contract.json"
+          },
+          "a11yCriteria": {
+            "origin": "derived",
+            "authorship": "mixed",
+            "from": "contract.a11y + derive-a11y-criteria.mjs"
+          },
+          "compositionRules": {
+            "origin": "derived",
+            "authorship": "mixed",
+            "from": "avoidWhen filter"
+          },
+          "forbiddenUse": {
+            "origin": "derived",
+            "authorship": "mixed",
+            "from": "avoidWhen + replacement policy"
+          },
+          "replacementFor": {
+            "origin": "derived",
+            "authorship": "mixed",
+            "from": "replacement policy"
+          }
+        },
+        "governance": null,
+        "content": null
+      }
+    },
+    {
+      "name": "TableHeaderCell",
+      "contract": {
+        "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+        "schemaVersion": 2,
+        "name": "TableHeaderCell",
+        "tier": "atom",
+        "group": "data-display",
+        "status": "alpha",
+        "description": "A table header cell (<th>). scope=col (default) carries an optional three-state DS-Icon sort control and aria-sort; scope=row marks the identifying cell of a body row so screen readers announce the row context with every other cell.",
+        "figma": null,
+        "radixPrimitive": null,
+        "element": "th",
+        "variants": {
+          "align": {
+            "values": [
+              "start",
+              "center",
+              "end"
+            ],
+            "default": "start",
+            "propSourced": true
+          },
+          "scope": {
+            "values": [
+              "col",
+              "row"
+            ],
+            "default": "col",
+            "propSourced": true
+          }
+        },
+        "slots": [],
+        "asChild": false,
+        "subParts": [],
+        "requiredStories": [
+          "Default",
+          "Playground",
+          "Example",
+          "ForcedColors"
+        ],
+        "a11y": {
+          "keyboard": [],
+          "ariaRequirements": [
+            "native <th> with an explicit scope (col or row)",
+            "sortable column headers expose aria-sort and toggle via an inner button",
+            "the sort caret is decorative (aria-hidden); state is carried by aria-sort, never the icon alone"
+          ],
+          "reducedMotion": true,
+          "reviewed": true,
+          "reviewedNote": "2026-07-27 — th with explicit scope; aria-sort on active column headers; decorative caret; row-header (scope=row) verified to name its row; axe asserted inside a table in the unit test.",
+          "forcedColorsVerified": false,
+          "accessibilityTreeVerified": false
+        },
+        "tokens": {
+          "colors": [
+            "--color-muted",
+            "--color-primary",
+            "--color-border",
+            "--color-light-bg",
+            "--color-neutral-bg"
+          ],
+          "spacing": [
+            "--space-internal-6",
+            "--space-internal-8",
+            "--space-internal-12",
+            "--space-internal-16",
+            "--space-layout-24"
+          ],
+          "radii": [
+            "--radius-sm"
+          ]
+        },
+        "lightDarkVerified": false,
+        "dense": "th with scope col/row; col carries the three-state sort caret + aria-sort, row names its data row",
+        "keywords": [
+          "table",
+          "header",
+          "th",
+          "sort",
+          "scope",
+          "column",
+          "row"
+        ],
+        "props": {
+          "align": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "start",
+              "center",
+              "end"
+            ],
+            "description": "Cell content alignment."
+          },
+          "scope": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "col",
+              "row"
+            ],
+            "description": "Header scope; row names the identifying cell of a body row."
+          },
+          "sortable": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Renders the sort control (column headers only)."
+          },
+          "sortDirection": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "ascending",
+              "descending",
+              "none"
+            ],
+            "description": "Current sort state; drives aria-sort and the caret."
+          },
+          "onSort": {
+            "optional": true,
+            "type": "() => void",
+            "description": "Called when a sortable header is activated."
+          }
+        },
+        "forbiddenUse": [
+          "render it outside a table",
+          "make a scope=row header sortable — row headers are not sort controls",
+          "convey sort state with the caret colour alone"
+        ],
+        "composesWith": [
+          "Table",
+          "TableRow",
+          "TableCell",
+          "Icon"
+        ]
+      },
+      "spec": "# TableHeaderCell\n\nA table header cell (`<th>`) for the Table family.\n\n## Intent\n\nHeader cell with an explicit `scope`. `scope=\"col\"` (default) labels a column\nand can carry a three-state sort control; `scope=\"row\"` marks the identifying\ncell of a body row so a screen reader announces the row context (\"Ada\nLovelace\") along with every other cell in that row — the accessibility feature a\nplain `<td>` grid can't provide.\n\n## Interaction contract\n\n- Column headers (`scope=\"col\"`) with `sortable` render an inner `<button>` and\n  expose `aria-sort` only while actively sorted. Wire `sortDirection`/`onSort`\n  from `useTableSortable`.\n- The sort caret is a DS `Icon` (`caret-up-down` unsorted / `caret-up` asc /\n  `caret-down` desc), decorative (`aria-hidden`); state is carried by\n  `aria-sort`, never the icon alone.\n- Row headers (`scope=\"row\"`) never render a sort control — they name a row,\n  they are not interactive.\n\n## Do / don't\n\nDo:\n\n- Use `scope=\"row\"` on the identifying cell of each body row for accessible\n  data tables.\n- Drive sorting with `useTableSortable`.\n\nDon't:\n\n- Make a `scope=\"row\"` header sortable.\n- Convey sort state with the caret colour alone.\n- Render it outside a table.\n\n## Design notes\n\n- Quiet column headers: small uppercase `--font-size-text-xs` labels in\n  `--color-muted`; the active sort caret uses `--color-primary`, the unsorted\n  one `--color-muted` so a sorted column reads at a glance and clears ≥3:1\n  contrast in every theme.\n- Padding/borders/sticky behaviour come from the shared `Table.module.css`.\n",
+      "documentationDebt": false,
+      "usage": {
+        "publicImport": "@dt/TableHeaderCell",
+        "importCount": 6,
+        "productionImportCount": 0,
+        "patternImportCount": 0,
+        "componentImportCount": 2,
+        "evidence": [
+          {
+            "path": "nextjs-app/shared/components/DataTable/DataTable.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TableHeaderCell",
+            "context": "component"
+          },
+          {
+            "path": "nextjs-app/shared/components/index.ts",
+            "importKind": "relative",
+            "importPath": "./TableHeaderCell",
+            "context": "component"
+          },
+          {
+            "path": "nextjs-app/shared/components/Table/Table.stories.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TableHeaderCell",
+            "context": "story"
+          },
+          {
+            "path": "nextjs-app/shared/components/TableCell/TableCell.stories.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TableHeaderCell",
+            "context": "story"
+          },
+          {
+            "path": "nextjs-app/shared/components/TableRow/TableRow.stories.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TableHeaderCell",
+            "context": "story"
+          },
+          {
+            "path": "nextjs-app/shared/components/Table/Table.test.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TableHeaderCell",
+            "context": "test"
+          }
+        ]
+      },
+      "agent": {
+        "preferredImport": "@dt/TableHeaderCell",
+        "intent": "Header cell with an explicit `scope`. `scope=\"col\"` (default) labels a column and can carry a three-state sort control; `scope=\"row\"` marks the identifying cell of a body row so a screen reader announces the row context…",
+        "props": {
+          "align": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "center",
+              "end",
+              "start"
+            ],
+            "description": "Cell content alignment."
+          },
+          "scope": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "row",
+              "col"
+            ],
+            "description": "Header scope. `col` (default) labels a column; `row` makes the cell the\naccessible name for its row — use it on the identifying cell of each body\nrow so screen readers announce the row context with every other cell."
+          },
+          "sortable": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Renders the sort affordance and toggles on click. Only for column headers."
+          },
+          "sortDirection": {
+            "optional": true,
+            "type": "union",
+            "values": [
+              "none",
+              "ascending",
+              "descending"
+            ],
+            "description": "Current sort state; drives `aria-sort` and the caret icon."
+          },
+          "onSort": {
+            "optional": true,
+            "type": "() => void",
+            "description": "Called when a sortable header is activated."
+          }
+        },
+        "propRelationships": [],
+        "variants": {
+          "align": {
+            "values": [
+              "center",
+              "end",
+              "start"
+            ],
+            "default": "center"
+          }
+        },
+        "cvaVariants": {},
+        "variantsFnName": null,
+        "useWhen": [],
+        "avoidWhen": [],
+        "requiredA11y": [
+          "native <th> with an explicit scope (col or row)",
+          "sortable column headers expose aria-sort and toggle via an inner button",
+          "the sort caret is decorative (aria-hidden); state is carried by aria-sort, never the icon alone"
+        ],
+        "keyboard": [],
+        "compositionRules": [],
+        "canonicalExamples": [
+          "Default",
+          "Playground",
+          "Example",
+          "ForcedColors"
+        ],
+        "replacementFor": [],
+        "forbiddenUse": [],
+        "composesWith": [
+          "TableRow",
+          "TableCell",
+          "Table",
+          "Checkbox",
+          "IconButton"
+        ],
+        "prefersOver": [],
+        "declaredPropCount": 5,
+        "guidelines": [],
+        "a11yCriteria": [
+          {
+            "id": "axe-no-violations",
+            "statement": "Required stories produce no axe violations at the configured severity.",
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
+          },
+          {
+            "id": "accessibility-tree",
+            "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+          },
+          {
+            "id": "forced-colors-real-browser",
+            "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+            "verificationMode": "unverified"
+          },
+          {
+            "id": "aria-requirements",
+            "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+          },
+          {
+            "id": "human-a11y-review",
+            "statement": "A human completed an end-to-end accessibility review of this component.",
+            "verificationMode": "manual",
+            "note": "2026-07-27 — th with explicit scope; aria-sort on active column headers; decorative caret; row-header (scope=row) verified to name its row; axe asserted inside a table in the unit test."
+          }
+        ],
+        "docOrigin": {
+          "props": {
+            "origin": "generated",
+            "authorship": "machine-generated",
+            "from": "TypeScript AST"
+          },
+          "variants": {
+            "origin": "generated",
+            "authorship": "machine-generated",
+            "from": "TypeScript AST"
+          },
+          "cvaVariants": {
+            "origin": "generated",
+            "authorship": "machine-generated",
+            "from": "TypeScript AST"
+          },
+          "propRelationships": {
+            "origin": "generated",
+            "authorship": "machine-generated",
+            "from": "TypeScript AST"
+          },
+          "canonicalExamples": {
+            "origin": "generated",
+            "authorship": "machine-generated",
+            "from": "stories.tsx"
+          },
+          "declaredPropCount": {
+            "origin": "generated",
+            "authorship": "machine-generated",
+            "from": "TypeScript AST"
+          },
+          "intent": {
+            "origin": "authored",
+            "authorship": "human-authored",
+            "from": "TableHeaderCell.spec.md"
+          },
+          "useWhen": {
+            "origin": "authored",
+            "authorship": "human-authored",
+            "from": "TableHeaderCell.spec.md"
+          },
+          "avoidWhen": {
+            "origin": "authored",
+            "authorship": "human-authored",
+            "from": "TableHeaderCell.spec.md"
+          },
+          "guidelines": {
+            "origin": "authored",
+            "authorship": "human-authored",
+            "from": "TableHeaderCell.spec.md"
           },
           "requiredA11y": {
             "origin": "authored",
@@ -49563,6 +50286,286 @@
             "origin": "authored",
             "authorship": "human-authored",
             "from": "TableOfContents.spec.md"
+          },
+          "requiredA11y": {
+            "origin": "authored",
+            "authorship": "human-authored",
+            "from": "contract.json"
+          },
+          "keyboard": {
+            "origin": "authored",
+            "authorship": "human-authored",
+            "from": "contract.json"
+          },
+          "a11yCriteria": {
+            "origin": "derived",
+            "authorship": "mixed",
+            "from": "contract.a11y + derive-a11y-criteria.mjs"
+          },
+          "compositionRules": {
+            "origin": "derived",
+            "authorship": "mixed",
+            "from": "avoidWhen filter"
+          },
+          "forbiddenUse": {
+            "origin": "derived",
+            "authorship": "mixed",
+            "from": "avoidWhen + replacement policy"
+          },
+          "replacementFor": {
+            "origin": "derived",
+            "authorship": "mixed",
+            "from": "replacement policy"
+          }
+        },
+        "governance": null,
+        "content": null
+      }
+    },
+    {
+      "name": "TableRow",
+      "contract": {
+        "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+        "schemaVersion": 2,
+        "name": "TableRow",
+        "tier": "atom",
+        "group": "data-display",
+        "status": "alpha",
+        "description": "A table row (<tr>) for the Table family. Works in <thead> and <tbody>; selected renders the selection surface. Presentational — semantics belong to the surrounding table.",
+        "figma": null,
+        "radixPrimitive": null,
+        "element": "tr",
+        "variants": {
+          "selected": {
+            "values": [
+              "true",
+              "false"
+            ],
+            "default": "false",
+            "propSourced": true
+          }
+        },
+        "slots": [],
+        "asChild": false,
+        "subParts": [],
+        "requiredStories": [
+          "Default",
+          "Playground",
+          "Example",
+          "ForcedColors"
+        ],
+        "a11y": {
+          "keyboard": [],
+          "ariaRequirements": [
+            "native <tr> semantics; no ARIA of its own",
+            "selection is visual only (data-selected); the row's selection state belongs to a checkbox or the consuming app"
+          ],
+          "reducedMotion": true,
+          "reviewed": true,
+          "reviewedNote": "2026-07-27 — native tr; hover/zebra/selection tint are presentational; axe asserted inside a table in the unit test.",
+          "forcedColorsVerified": false,
+          "accessibilityTreeVerified": false
+        },
+        "tokens": {
+          "colors": [
+            "--color-border-light",
+            "--color-primary",
+            "--color-light-bg"
+          ],
+          "spacing": []
+        },
+        "lightDarkVerified": false,
+        "dense": "table row; works in thead/tbody, selected surface, hover + zebra via the Table root",
+        "keywords": [
+          "table",
+          "row",
+          "tr"
+        ],
+        "props": {
+          "selected": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Renders the selected surface and sets data-selected. Visual only."
+          }
+        },
+        "forbiddenUse": [
+          "render it outside a table",
+          "rely on selected for semantics — pair it with a checkbox or aria-selected on the consuming structure"
+        ],
+        "composesWith": [
+          "Table",
+          "TableCell",
+          "TableHeaderCell"
+        ]
+      },
+      "spec": "# TableRow\n\nA table row (`<tr>`) for the Table family.\n\n## Intent\n\nOne of the composable `Table` parts (`Table` root, `TableRow`,\n`TableHeaderCell`, `TableCell`). Works in both `<thead>` and `<tbody>`. Its only\nprop, `selected`, renders the selection surface and sets `data-selected` — the\nhover, zebra-stripe, and selection-tint treatments are cross-cutting styles\nsupplied by the `Table` root, so a row only looks striped/selected inside one.\n\n## Interaction contract\n\n- Presentational: no ARIA, no events of its own.\n- `selected` is **visual only**. The semantic selection state belongs to a\n  checkbox in the row or to the consuming application (`aria-selected` on a grid,\n  etc.) — never to the row's appearance alone.\n\n## Do / don't\n\nDo:\n\n- Compose it inside a `Table` root, in `<thead>` or `<tbody>`.\n- Pair `selected` with a real selection control (a `Checkbox`).\n\nDon't:\n\n- Render it outside a table.\n- Treat `selected` as the source of truth for selection.\n\n## Design notes\n\n- The row itself is unstyled; the border, hover, zebra, and selection tint come\n  from `Table.module.css` (shared across the family) so the whole table reads as\n  one system.\n- Forced-colors: borders map to `CanvasText` via the shared stylesheet.\n",
+      "documentationDebt": false,
+      "usage": {
+        "publicImport": "@dt/TableRow",
+        "importCount": 6,
+        "productionImportCount": 0,
+        "patternImportCount": 0,
+        "componentImportCount": 2,
+        "evidence": [
+          {
+            "path": "nextjs-app/shared/components/DataTable/DataTable.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TableRow",
+            "context": "component"
+          },
+          {
+            "path": "nextjs-app/shared/components/index.ts",
+            "importKind": "relative",
+            "importPath": "./TableRow",
+            "context": "component"
+          },
+          {
+            "path": "nextjs-app/shared/components/Table/Table.stories.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TableRow",
+            "context": "story"
+          },
+          {
+            "path": "nextjs-app/shared/components/TableCell/TableCell.stories.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TableRow",
+            "context": "story"
+          },
+          {
+            "path": "nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.stories.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TableRow",
+            "context": "story"
+          },
+          {
+            "path": "nextjs-app/shared/components/Table/Table.test.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TableRow",
+            "context": "test"
+          }
+        ]
+      },
+      "agent": {
+        "preferredImport": "@dt/TableRow",
+        "intent": "One of the composable `Table` parts (`Table` root, `TableRow`, `TableHeaderCell`, `TableCell`). Works in both `<thead>` and `<tbody>`. Its only prop, `selected`, renders the selection surface and sets `data-selected` — …",
+        "props": {
+          "selected": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Renders the selected surface and sets `data-selected`. Visual only."
+          }
+        },
+        "propRelationships": [],
+        "variants": {},
+        "cvaVariants": {},
+        "variantsFnName": null,
+        "useWhen": [],
+        "avoidWhen": [],
+        "requiredA11y": [
+          "native <tr> semantics; no ARIA of its own",
+          "selection is visual only (data-selected); the row's selection state belongs to a checkbox or the consuming app"
+        ],
+        "keyboard": [],
+        "compositionRules": [],
+        "canonicalExamples": [
+          "Default",
+          "Playground",
+          "Example",
+          "ForcedColors"
+        ],
+        "replacementFor": [],
+        "forbiddenUse": [],
+        "composesWith": [
+          "TableHeaderCell",
+          "TableCell",
+          "Table",
+          "Checkbox",
+          "IconButton"
+        ],
+        "prefersOver": [],
+        "declaredPropCount": 1,
+        "guidelines": [],
+        "a11yCriteria": [
+          {
+            "id": "axe-no-violations",
+            "statement": "Required stories produce no axe violations at the configured severity.",
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
+          },
+          {
+            "id": "accessibility-tree",
+            "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+          },
+          {
+            "id": "forced-colors-real-browser",
+            "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+            "verificationMode": "unverified"
+          },
+          {
+            "id": "aria-requirements",
+            "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+          },
+          {
+            "id": "human-a11y-review",
+            "statement": "A human completed an end-to-end accessibility review of this component.",
+            "verificationMode": "manual",
+            "note": "2026-07-27 — native tr; hover/zebra/selection tint are presentational; axe asserted inside a table in the unit test."
+          }
+        ],
+        "docOrigin": {
+          "props": {
+            "origin": "generated",
+            "authorship": "machine-generated",
+            "from": "TypeScript AST"
+          },
+          "variants": {
+            "origin": "generated",
+            "authorship": "machine-generated",
+            "from": "TypeScript AST"
+          },
+          "cvaVariants": {
+            "origin": "generated",
+            "authorship": "machine-generated",
+            "from": "TypeScript AST"
+          },
+          "propRelationships": {
+            "origin": "generated",
+            "authorship": "machine-generated",
+            "from": "TypeScript AST"
+          },
+          "canonicalExamples": {
+            "origin": "generated",
+            "authorship": "machine-generated",
+            "from": "stories.tsx"
+          },
+          "declaredPropCount": {
+            "origin": "generated",
+            "authorship": "machine-generated",
+            "from": "TypeScript AST"
+          },
+          "intent": {
+            "origin": "authored",
+            "authorship": "human-authored",
+            "from": "TableRow.spec.md"
+          },
+          "useWhen": {
+            "origin": "authored",
+            "authorship": "human-authored",
+            "from": "TableRow.spec.md"
+          },
+          "avoidWhen": {
+            "origin": "authored",
+            "authorship": "human-authored",
+            "from": "TableRow.spec.md"
+          },
+          "guidelines": {
+            "origin": "authored",
+            "authorship": "human-authored",
+            "from": "TableRow.spec.md"
           },
           "requiredA11y": {
             "origin": "authored",
@@ -56501,7 +57504,7 @@
           "TreeView"
         ]
       },
-      "spec": "# VirtualList\n\n## Intent\n\nKeep long, fixed-row collections responsive by rendering only the visible\nrange plus a small overscan buffer.\n\n## Interaction contract\n\n- Scroll position determines the rendered range.\n- The viewport keeps list semantics and each rendered item reports its\n  position and total set size.\n- `onRangeChange` reports both the visible and overscanned boundaries.\n- `initialScrollOffset` restores a known position without making scroll state\n  controlled.\n\n## Do / don't\n\n- Do provide an accurate fixed `itemHeight`.\n- Do keep item keys stable across filtering and updates.\n- Don't use VirtualList for short collections where normal rendering is\n  simpler.\n- Don't use it when row heights are unknown or highly variable.\n\n## Design notes\n\n- A full-height spacer preserves the browser's native scroll range.\n- Rendered items are translated to their calculated vertical offset.\n- Viewport height and item offsets are intentionally runtime inline values.\n",
+      "spec": "# VirtualList\n\n## Intent\n\nKeep long, fixed-row collections responsive by rendering only the visible\nrange plus a small overscan buffer.\n\n## Interaction contract\n\n- Scroll position determines the rendered range.\n- The viewport keeps list semantics and each rendered item reports its\n  position and total set size.\n- `onRangeChange` reports both the visible and overscanned boundaries.\n- `initialScrollOffset` restores a known position without making scroll state\n  controlled.\n\n## Do / don't\n\n- Do provide an accurate fixed `itemHeight`.\n- Do keep item keys stable across filtering and updates.\n- Don't use VirtualList for short collections where normal rendering is\n  simpler.\n- Don't use it when row heights are unknown or highly variable.\n\n## Design notes\n\n- A full-height spacer preserves the browser's native scroll range.\n- Rendered items are translated to their calculated vertical offset.\n- Viewport height and item offsets are intentionally runtime inline values.\n- Rows render as `VirtualListItem` (which composes `ListItem`), supplied via\n  `getItemProps`; the viewport is `role=\"list\"`, each row `role=\"listitem\"`.\n\n## Accessibility limitations\n\nWindowing has inherent accessibility trade-offs; know them before reaching for\nit:\n\n- **Off-screen rows are not in the DOM.** Only the visible window (+ overscan)\n  is mounted, so a screen-reader virtual cursor cannot navigate to item 500\n  until it scrolls into view. `aria-posinset`/`aria-setsize` announce each\n  row's true position, but do not make unmounted rows reachable. If a surface\n  needs full screen-reader traversal of the whole set, prefer a plain\n  (non-virtualized) list or provide search/filter to shrink the set.\n- **Keep items non-interactive.** Rows are presentational. Don't place focusable\n  content (links, buttons, inputs) inside `getItemProps` chrome — a focused row\n  can unmount on scroll and drop focus. Interactive virtualization needs a\n  focus-management layer this component does not yet provide.\n- **The viewport is the keyboard target.** It is `tabIndex={0}` so keyboard\n  users can scroll it with the arrow / Page keys; the rows themselves are not\n  in the tab order.\n\n## Layout requirement\n\nThe rows are absolutely positioned, so the viewport takes its width from its\ncontainer. Render VirtualList inside a block/flex context that gives it a width;\nin a shrink-to-fit container (a centered flex item, inline-block) it collapses\nto zero width and only its border shows.\n",
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/VirtualList",
@@ -56814,7 +57817,8 @@
         "tokens": {
           "colors": [
             "--color-border-light"
-          ]
+          ],
+          "spacing": []
         },
         "lightDarkVerified": false,
         "dense": "windowed list row; role=listitem + aria-posinset/aria-setsize, composes ListItem chrome; positioning arrives from VirtualList via style",

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-27T05:19:21.943Z",
+  "generatedAt": "2026-07-27T05:58:08.059Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -12602,8 +12602,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:matrix:ci"
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
         },
         {
           "id": "forced-colors-real-browser",
@@ -12614,8 +12614,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:matrix:ci"
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
         },
         {
           "id": "human-a11y-review",
@@ -12811,10 +12811,10 @@
       "composesWith": [
         "NavLink",
         "ThemeProvider",
-        "Card",
-        "Select",
-        "TextInput",
-        "Title"
+        "Table",
+        "TableRow",
+        "TableHeaderCell",
+        "TableCell"
       ],
       "prefersOver": [],
       "declaredPropCount": 7,
@@ -26623,6 +26623,9 @@
       "replacementFor": [],
       "forbiddenUse": [],
       "composesWith": [
+        "TableRow",
+        "TableHeaderCell",
+        "TableCell",
         "Checkbox",
         "IconButton"
       ],
@@ -26715,6 +26718,381 @@
           "origin": "authored",
           "authorship": "human-authored",
           "from": "Table.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
+    },
+    "TableCell": {
+      "preferredImport": "@dt/TableCell",
+      "intent": "The body cell of the composable `Table`. `align` sets text alignment; `numeric` right-aligns with tabular figures so numbers line up on the decimal. It pairs with `TableHeaderCell` (`scope=\"col\"`/`\"row\"`) so cells inher…",
+      "props": {
+        "align": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "center",
+            "end",
+            "start"
+          ],
+          "description": "Cell content alignment."
+        },
+        "numeric": {
+          "optional": true,
+          "type": "boolean",
+          "description": "Right-align and tabular-figure numeric values."
+        }
+      },
+      "propRelationships": [],
+      "variants": {
+        "align": {
+          "values": [
+            "center",
+            "end",
+            "start"
+          ],
+          "default": "center"
+        }
+      },
+      "cvaVariants": {},
+      "variantsFnName": null,
+      "useWhen": [],
+      "avoidWhen": [],
+      "requiredA11y": [
+        "native <td> semantics; no ARIA of its own",
+        "pairs with TableHeaderCell scope=col/row so cells inherit column and row context"
+      ],
+      "keyboard": [],
+      "compositionRules": [],
+      "canonicalExamples": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+      ],
+      "replacementFor": [],
+      "forbiddenUse": [],
+      "composesWith": [
+        "TableRow",
+        "TableHeaderCell",
+        "Table",
+        "Checkbox",
+        "IconButton"
+      ],
+      "prefersOver": [],
+      "declaredPropCount": 2,
+      "guidelines": [],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-27 — native td; alignment and numeric tabular figures verified; axe asserted inside a table in the unit test."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TableCell.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TableCell.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TableCell.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TableCell.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
+    },
+    "TableHeaderCell": {
+      "preferredImport": "@dt/TableHeaderCell",
+      "intent": "Header cell with an explicit `scope`. `scope=\"col\"` (default) labels a column and can carry a three-state sort control; `scope=\"row\"` marks the identifying cell of a body row so a screen reader announces the row context…",
+      "props": {
+        "align": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "center",
+            "end",
+            "start"
+          ],
+          "description": "Cell content alignment."
+        },
+        "scope": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "row",
+            "col"
+          ],
+          "description": "Header scope. `col` (default) labels a column; `row` makes the cell the\naccessible name for its row — use it on the identifying cell of each body\nrow so screen readers announce the row context with every other cell."
+        },
+        "sortable": {
+          "optional": true,
+          "type": "boolean",
+          "description": "Renders the sort affordance and toggles on click. Only for column headers."
+        },
+        "sortDirection": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "none",
+            "ascending",
+            "descending"
+          ],
+          "description": "Current sort state; drives `aria-sort` and the caret icon."
+        },
+        "onSort": {
+          "optional": true,
+          "type": "() => void",
+          "description": "Called when a sortable header is activated."
+        }
+      },
+      "propRelationships": [],
+      "variants": {
+        "align": {
+          "values": [
+            "center",
+            "end",
+            "start"
+          ],
+          "default": "center"
+        }
+      },
+      "cvaVariants": {},
+      "variantsFnName": null,
+      "useWhen": [],
+      "avoidWhen": [],
+      "requiredA11y": [
+        "native <th> with an explicit scope (col or row)",
+        "sortable column headers expose aria-sort and toggle via an inner button",
+        "the sort caret is decorative (aria-hidden); state is carried by aria-sort, never the icon alone"
+      ],
+      "keyboard": [],
+      "compositionRules": [],
+      "canonicalExamples": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+      ],
+      "replacementFor": [],
+      "forbiddenUse": [],
+      "composesWith": [
+        "TableRow",
+        "TableCell",
+        "Table",
+        "Checkbox",
+        "IconButton"
+      ],
+      "prefersOver": [],
+      "declaredPropCount": 5,
+      "guidelines": [],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-27 — th with explicit scope; aria-sort on active column headers; decorative caret; row-header (scope=row) verified to name its row; axe asserted inside a table in the unit test."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TableHeaderCell.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TableHeaderCell.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TableHeaderCell.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TableHeaderCell.spec.md"
         },
         "requiredA11y": {
           "origin": "authored",
@@ -26935,6 +27313,162 @@
           "origin": "authored",
           "authorship": "human-authored",
           "from": "TableOfContents.spec.md"
+        },
+        "requiredA11y": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "keyboard": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "contract.json"
+        },
+        "a11yCriteria": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "contract.a11y + derive-a11y-criteria.mjs"
+        },
+        "compositionRules": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen filter"
+        },
+        "forbiddenUse": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "avoidWhen + replacement policy"
+        },
+        "replacementFor": {
+          "origin": "derived",
+          "authorship": "mixed",
+          "from": "replacement policy"
+        }
+      },
+      "governance": null,
+      "content": null
+    },
+    "TableRow": {
+      "preferredImport": "@dt/TableRow",
+      "intent": "One of the composable `Table` parts (`Table` root, `TableRow`, `TableHeaderCell`, `TableCell`). Works in both `<thead>` and `<tbody>`. Its only prop, `selected`, renders the selection surface and sets `data-selected` — …",
+      "props": {
+        "selected": {
+          "optional": true,
+          "type": "boolean",
+          "description": "Renders the selected surface and sets `data-selected`. Visual only."
+        }
+      },
+      "propRelationships": [],
+      "variants": {},
+      "cvaVariants": {},
+      "variantsFnName": null,
+      "useWhen": [],
+      "avoidWhen": [],
+      "requiredA11y": [
+        "native <tr> semantics; no ARIA of its own",
+        "selection is visual only (data-selected); the row's selection state belongs to a checkbox or the consuming app"
+      ],
+      "keyboard": [],
+      "compositionRules": [],
+      "canonicalExamples": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+      ],
+      "replacementFor": [],
+      "forbiddenUse": [],
+      "composesWith": [
+        "TableHeaderCell",
+        "TableCell",
+        "Table",
+        "Checkbox",
+        "IconButton"
+      ],
+      "prefersOver": [],
+      "declaredPropCount": 1,
+      "guidelines": [],
+      "a11yCriteria": [
+        {
+          "id": "axe-no-violations",
+          "statement": "Required stories produce no axe violations at the configured severity.",
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
+        },
+        {
+          "id": "accessibility-tree",
+          "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+        },
+        {
+          "id": "forced-colors-real-browser",
+          "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
+          "verificationMode": "unverified"
+        },
+        {
+          "id": "aria-requirements",
+          "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+        },
+        {
+          "id": "human-a11y-review",
+          "statement": "A human completed an end-to-end accessibility review of this component.",
+          "verificationMode": "manual",
+          "note": "2026-07-27 — native tr; hover/zebra/selection tint are presentational; axe asserted inside a table in the unit test."
+        }
+      ],
+      "docOrigin": {
+        "props": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "variants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "cvaVariants": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "propRelationships": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "canonicalExamples": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "stories.tsx"
+        },
+        "declaredPropCount": {
+          "origin": "generated",
+          "authorship": "machine-generated",
+          "from": "TypeScript AST"
+        },
+        "intent": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TableRow.spec.md"
+        },
+        "useWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TableRow.spec.md"
+        },
+        "avoidWhen": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TableRow.spec.md"
+        },
+        "guidelines": {
+          "origin": "authored",
+          "authorship": "human-authored",
+          "from": "TableRow.spec.md"
         },
         "requiredA11y": {
           "origin": "authored",

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -15774,7 +15774,7 @@
       "group": "data-display",
       "tier": 2,
       "status": "alpha",
-      "description": "Composable table primitives (Table, TableRow, TableHeaderCell, TableCell) with density, striping, a sticky header, and a three-state sort control. The presentational layer beneath DataTable; pair with the useTable* hooks for behavior.",
+      "description": "The composable table root: a scroll wrapper around a semantic table with density, striping, and a sticky header. Compose with the sibling TableRow, TableHeaderCell, and TableCell components. The presentational layer beneath DataTable; pair with the useTable* hooks for behavior.",
       "dense": "composable native table primitives; density, striping, sticky header, three-state DS-Icon sort caret; pairs with useTable* hooks",
       "keywords": [
         "table",
@@ -15856,10 +15856,10 @@
         }
       },
       "composesWith": [
-        "DataTable",
-        "Checkbox",
-        "Icon",
-        "IconButton"
+        "TableRow",
+        "TableHeaderCell",
+        "TableCell",
+        "DataTable"
       ],
       "prefersOver": [],
       "forbiddenUse": [
@@ -15907,6 +15907,199 @@
           "story": "Example",
           "description": null,
           "source": "export const Example: Story = {\n  tags: [\"example\"],\n  args: { striped: true },\n  render: (args) => (\n    <Table {...args} caption=\"Contributors (striped)\">\n      <Body />\n    </Table>\n  ),\n};"
+        }
+      ]
+    },
+    "TableCell": {
+      "name": "TableCell",
+      "group": "data-display",
+      "tier": 2,
+      "status": "alpha",
+      "description": "A table data cell (<td>) for the Table family. align controls text alignment; numeric right-aligns with tabular figures so columns line up on the decimal.",
+      "dense": "table td; align start/center/end, numeric = tabular figures right-aligned",
+      "keywords": [
+        "table",
+        "cell",
+        "td",
+        "numeric"
+      ],
+      "importLine": "import TableCell from \"@dt/TableCell\";",
+      "keyProps": [
+        {
+          "name": "align",
+          "type": "start | center | end",
+          "required": false
+        },
+        {
+          "name": "numeric",
+          "type": "boolean",
+          "required": false
+        }
+      ],
+      "props": {
+        "align": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "start",
+            "center",
+            "end"
+          ],
+          "description": "Cell content alignment."
+        },
+        "numeric": {
+          "optional": true,
+          "type": "boolean",
+          "description": "Right-align with tabular figures for numeric values."
+        }
+      },
+      "composesWith": [
+        "Table",
+        "TableRow",
+        "TableHeaderCell"
+      ],
+      "prefersOver": [],
+      "forbiddenUse": [
+        "render it outside a table row",
+        "use it for a header — use TableHeaderCell so column/row context is announced"
+      ],
+      "usage": null,
+      "tokens": {
+        "colors": [
+          "--color-border-light"
+        ],
+        "spacing": [
+          "--space-internal-8",
+          "--space-internal-12",
+          "--space-internal-16",
+          "--space-layout-24"
+        ]
+      },
+      "examples": [
+        {
+          "story": "Example",
+          "description": "numeric cells right-align with tabular figures so columns line up on the decimal.",
+          "source": "export const Example: Story = {\n  tags: [\"example\"],\n  parameters: {\n    docs: {\n      description: {\n        story: \"numeric cells right-align with tabular figures so columns line up on the decimal.\",\n      },\n    },\n  },\n  render: () => (\n    <Table caption=\"Numbers\">\n      <thead>\n        <TableRow>\n          <TableHeaderCell>Metric</TableHeaderCell>\n          <TableHeaderCell align=\"end\">Value</TableHeaderCell>\n        </TableRow>\n      </thead>\n      <tbody>\n        <TableRow>\n          <TableCell>Requests</TableCell>\n          <TableCell numeric>1,204</TableCell>\n        </TableRow>\n        <TableRow>\n          <TableCell>Errors</TableCell>\n          <TableCell numeric>12</TableCell>\n        </TableRow>\n        <TableRow>\n          <TableCell>Latency</TableCell>\n          <TableCell numeric>98</TableCell>\n        </TableRow>\n      </tbody>\n    </Table>\n  ),\n};"
+        }
+      ]
+    },
+    "TableHeaderCell": {
+      "name": "TableHeaderCell",
+      "group": "data-display",
+      "tier": 2,
+      "status": "alpha",
+      "description": "A table header cell (<th>). scope=col (default) carries an optional three-state DS-Icon sort control and aria-sort; scope=row marks the identifying cell of a body row so screen readers announce the row context with every other cell.",
+      "dense": "th with scope col/row; col carries the three-state sort caret + aria-sort, row names its data row",
+      "keywords": [
+        "table",
+        "header",
+        "th",
+        "sort",
+        "scope",
+        "column",
+        "row"
+      ],
+      "importLine": "import TableHeaderCell from \"@dt/TableHeaderCell\";",
+      "keyProps": [
+        {
+          "name": "align",
+          "type": "start | center | end",
+          "required": false
+        },
+        {
+          "name": "scope",
+          "type": "col | row",
+          "required": false
+        },
+        {
+          "name": "sortDirection",
+          "type": "ascending | descending | none",
+          "required": false
+        },
+        {
+          "name": "sortable",
+          "type": "boolean",
+          "required": false
+        }
+      ],
+      "props": {
+        "align": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "start",
+            "center",
+            "end"
+          ],
+          "description": "Cell content alignment."
+        },
+        "scope": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "col",
+            "row"
+          ],
+          "description": "Header scope; row names the identifying cell of a body row."
+        },
+        "sortable": {
+          "optional": true,
+          "type": "boolean",
+          "description": "Renders the sort control (column headers only)."
+        },
+        "sortDirection": {
+          "optional": true,
+          "type": "union",
+          "values": [
+            "ascending",
+            "descending",
+            "none"
+          ],
+          "description": "Current sort state; drives aria-sort and the caret."
+        },
+        "onSort": {
+          "optional": true,
+          "type": "() => void",
+          "description": "Called when a sortable header is activated."
+        }
+      },
+      "composesWith": [
+        "Table",
+        "TableRow",
+        "TableCell",
+        "Icon"
+      ],
+      "prefersOver": [],
+      "forbiddenUse": [
+        "render it outside a table",
+        "make a scope=row header sortable — row headers are not sort controls",
+        "convey sort state with the caret colour alone"
+      ],
+      "usage": null,
+      "tokens": {
+        "colors": [
+          "--color-muted",
+          "--color-primary",
+          "--color-border",
+          "--color-light-bg",
+          "--color-neutral-bg"
+        ],
+        "spacing": [
+          "--space-internal-6",
+          "--space-internal-8",
+          "--space-internal-12",
+          "--space-internal-16",
+          "--space-layout-24"
+        ],
+        "radii": [
+          "--radius-sm"
+        ]
+      },
+      "examples": [
+        {
+          "story": "Example",
+          "description": "The three-state sort control: caret-up-down (unsorted, muted), caret-up (ascending), caret-down (descending).",
+          "source": "export const Example: Story = {\n  tags: [\"example\"],\n  parameters: {\n    docs: {\n      description: {\n        story:\n          \"The three-state sort control: caret-up-down (unsorted, muted), caret-up (ascending), caret-down (descending).\",\n      },\n    },\n  },\n  render: () => (\n    <Table caption=\"Sort states\">\n      <thead>\n        <TableRow>\n          <TableHeaderCell sortable sortDirection=\"ascending\">\n            Name\n          </TableHeaderCell>\n          <TableHeaderCell sortable sortDirection=\"none\">\n            Role\n          </TableHeaderCell>\n          <TableHeaderCell sortable sortDirection=\"descending\" align=\"end\">\n            Projects\n          </TableHeaderCell>\n        </TableRow>\n      </thead>\n      <tbody>\n        <TableRow>\n          <TableCell>Ada</TableCell>\n          <TableCell>Engineer</TableCell>\n          <TableCell numeric>8</TableCell>\n        </TableRow>\n      </tbody>\n    </Table>\n  ),\n};"
         }
       ]
     },
@@ -15992,6 +16185,60 @@
         "spacing": []
       },
       "examples": []
+    },
+    "TableRow": {
+      "name": "TableRow",
+      "group": "data-display",
+      "tier": 2,
+      "status": "alpha",
+      "description": "A table row (<tr>) for the Table family. Works in <thead> and <tbody>; selected renders the selection surface. Presentational — semantics belong to the surrounding table.",
+      "dense": "table row; works in thead/tbody, selected surface, hover + zebra via the Table root",
+      "keywords": [
+        "table",
+        "row",
+        "tr"
+      ],
+      "importLine": "import TableRow from \"@dt/TableRow\";",
+      "keyProps": [
+        {
+          "name": "selected",
+          "type": "boolean",
+          "required": false
+        }
+      ],
+      "props": {
+        "selected": {
+          "optional": true,
+          "type": "boolean",
+          "description": "Renders the selected surface and sets data-selected. Visual only."
+        }
+      },
+      "composesWith": [
+        "Table",
+        "TableCell",
+        "TableHeaderCell"
+      ],
+      "prefersOver": [],
+      "forbiddenUse": [
+        "render it outside a table",
+        "rely on selected for semantics — pair it with a checkbox or aria-selected on the consuming structure"
+      ],
+      "usage": null,
+      "tokens": {
+        "colors": [
+          "--color-border-light",
+          "--color-primary",
+          "--color-light-bg"
+        ],
+        "spacing": []
+      },
+      "examples": [
+        {
+          "story": "Example",
+          "description": "Rows in context: the middle row is selected; the hover, zebra, and selection surfaces come from the Table root.",
+          "source": "export const Example: Story = {\n  tags: [\"example\"],\n  parameters: {\n    docs: {\n      description: {\n        story:\n          \"Rows in context: the middle row is selected; the hover, zebra, and selection surfaces come from the Table root.\",\n      },\n    },\n  },\n  render: () => (\n    <Table caption=\"Contributors\" striped>\n      <thead>\n        <TableRow>\n          <TableHeaderCell>Name</TableHeaderCell>\n          <TableHeaderCell>Role</TableHeaderCell>\n        </TableRow>\n      </thead>\n      <tbody>\n        {people.map((person, index) => (\n          <TableRow key={person.name} selected={index === 1}>\n            <TableCell>{person.name}</TableCell>\n            <TableCell>{person.role}</TableCell>\n          </TableRow>\n        ))}\n      </tbody>\n    </Table>\n  ),\n};"
+        }
+      ]
     },
     "Tabs": {
       "name": "Tabs",
@@ -18408,7 +18655,8 @@
       "tokens": {
         "colors": [
           "--color-border-light"
-        ]
+        ],
+        "spacing": []
       },
       "examples": [
         {

--- a/scripts/design-system/a11y-evidence-lib.mjs
+++ b/scripts/design-system/a11y-evidence-lib.mjs
@@ -191,8 +191,10 @@ export function isA11yRelevantChange(changedFiles, getCssDiff) {
  * answer (shallow clone — callers then use the time window).
  *
  * Excluded outright (never invalidate): the component's own evidence/snapshot/
- * visual artifacts, and files that cannot affect the rendered a11y — contract
- * JSON, spec markdown, tests, and the index barrel.
+ * visual artifacts, files that cannot affect the rendered a11y — contract JSON,
+ * spec markdown, tests, and the index barrel — and auto-generated code
+ * (`*.discovered.*`, e.g. Icon's icon registry, which is regenerated whenever
+ * any component adds an icon usage and never changes the component's own a11y).
  */
 function defaultGitChangedSince(sha, componentDir) {
   const key = `${sha}::${componentDir}`;
@@ -208,6 +210,7 @@ function defaultGitChangedSince(sha, componentDir) {
       `:(exclude)${componentDir}/*.test.tsx`,
       `:(exclude)${componentDir}/*.test.ts`,
       `:(exclude)${componentDir}/index.ts`,
+      `:(exclude)${componentDir}/*.discovered.*`,
     ];
     const changed = execFileSync(
       "git",

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -1,6 +1,6 @@
 {
   "generatedBy": "npm run lint:css:update",
-  "warningCount": 2348,
+  "warningCount": 2349,
   "warnings": [
     {
       "file": ".storybook/blocks/A11ySection.module.css",
@@ -15394,12 +15394,21 @@
     },
     {
       "file": "nextjs-app/shared/components/Table/Table.module.css",
-      "line": 98,
+      "line": 56,
       "column": 1,
       "rule": "rule-empty-line-before",
       "severity": "warning",
       "text": "Expected empty line before rule (rule-empty-line-before)",
       "id": "nextjs-app/shared/components/Table/Table.module.css::rule-empty-line-before::Expected empty line before rule (rule-empty-line-before)::1"
+    },
+    {
+      "file": "nextjs-app/shared/components/Table/Table.module.css",
+      "line": 110,
+      "column": 1,
+      "rule": "rule-empty-line-before",
+      "severity": "warning",
+      "text": "Expected empty line before rule (rule-empty-line-before)",
+      "id": "nextjs-app/shared/components/Table/Table.module.css::rule-empty-line-before::Expected empty line before rule (rule-empty-line-before)::2"
     },
     {
       "file": "nextjs-app/shared/components/Tabs/Tabs.module.css",


### PR DESCRIPTION
## What

Acts on the deeper review of Table / DataTable / VirtualList.

### Table sub-components are now their own components (Astryx parity)
`TableRow`, `TableHeaderCell`, and `TableCell` are separated into their own folders — each with a contract, stories, test, and spec, and discoverable as standalone Storybook entries. They share the one `Table.module.css` (the striping / sticky-header / density / selection styles cross-cut row + cell + header, so splitting the stylesheet would only invite regressions); `Table` keeps just the root + shared types.

### Row-header accessibility (P1)
`TableHeaderCell` gains a **`scope`** prop. `scope="row"` makes the identifying cell of a body row a real `<th scope="row">` so screen readers announce the row's name ("Ada Lovelace") with every other cell — impossible before (all body cells were `<td>`). It's styled as **data, not a column label** (no uppercase/muted). `DataTable`'s new `column.rowHeader` wires it.

### DataTable fixes
- **Sort resets to page 1** (was: you could stay on a stale page after re-sorting).
- **Select-all / indeterminate are scoped to the visible page**, not silently across all pages.
- **`column.sortValue`** for a comparable value when `cell` renders custom markup.
- Dropped the redundant `Checkbox` `label` (it's a11y-named via `aria-label`).

### VirtualList
Documented the virtualization a11y limits: off-screen rows are unreachable to a screen-reader virtual cursor, rows must stay non-interactive (focus can unmount on scroll), and the viewport needs a width-bearing container.

### Tooling: end the Icon-evidence treadmill
`iconRegistry.discovered.ts` is auto-generated and changes whenever *any* component adds an icon — which kept invalidating Icon's a11y evidence (worsened by squash-merges rewriting the sourceSHA). The freshness guard now excludes `*.discovered.*`, so generated code no longer forces re-captures.

## Verification (all local, exit 0)
typecheck · lint · lint:css · check:contract-props · check:consumers · audit:snapshot-debt (0) · validate:components · build · **test 2829 passed** · a11y-evidence-lib unit tests. Row-header, separated stories, sort/pagination, and select-all verified in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated table row, header, and body cell components with semantic HTML and accessibility support.
  * Added sortable table headers, custom sort values, row headers, numeric alignment, and selected-row styling.
  * Data tables now reset to the first page after sorting and limit selection to visible rows.
* **Documentation**
  * Expanded table and virtual list usage, accessibility, and layout guidance.
* **Bug Fixes**
  * Improved table semantics and corrected pagination behavior when sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->