### PR TITLE
feat(ds): PixelLoop D/T initials in glyph pool + single-formation cycle mode

### DIFF
--- a/nextjs-app/shared/components/PixelLoop/PixelLoop.contract.json
+++ b/nextjs-app/shared/components/PixelLoop/PixelLoop.contract.json
@@ -5,7 +5,7 @@
     "tier": "atom",
     "group": "display",
     "status": "alpha",
-    "description": "Decorative constellation loop with rounded-dot and 45-degree vector-stroke variants.",
+    "description": "Decorative constellation loop with rounded-dot and 45-degree vector-stroke variants; the glyph pool includes the studio D and T initials.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1490-2401&m=dev",
     "radixPrimitive": null,
     "element": "div",
@@ -71,7 +71,7 @@
     "governance": {
         "owner": "design-system",
         "lastReviewed": "2026-07-23",
-        "note": "The Primary Studio reference informed the compact modular format, while original 5x5 bitmap artwork, round marks, row-aware choreography, and timing establish a distinct implementation. Supports one, two, or three rows of three glyph grids. Alpha while forced-colors and light/dark verification remain pending outside the supplied Storybook contexts."
+        "note": "The Primary Studio reference informed the compact modular format, while original 5x5 vector cell-grid artwork, round marks, row-aware choreography, and timing establish a distinct implementation. Supports one, two, or three rows of three glyph grids. Alpha while forced-colors and light/dark verification remain pending outside the supplied Storybook contexts."
     },
     "props": {
         "size": {
@@ -102,6 +102,11 @@
             "optional": true,
             "type": "boolean",
             "description": "Runs the six-frame loop. Disable for a deliberate static composition."
+        },
+        "cycle": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Renders a single glyph cell (one row, one column) that steps through the whole glyph pool one formation at a time. Ignores rows."
         }
     },
     "forbiddenUse": [

--- a/nextjs-app/shared/components/PixelLoop/PixelLoop.mdx
+++ b/nextjs-app/shared/components/PixelLoop/PixelLoop.mdx
@@ -8,8 +8,9 @@ import * as Stories from "./PixelLoop.stories";
 **Status:** alpha · **Tier:** atom · **Group:** display
 
 A six-frame decorative constellation loop for expressive hero and editorial
-compositions. Each drawing is locked to a strict 5 × 5 bitmap; rounded-dot and
-vector-stroke variants travel around it without a client-side animation runtime.
+compositions. Each drawing is locked to a strict 5 × 5 cell grid and rendered as
+vector SVG (never raster); rounded-dot and vector-stroke variants travel around
+it without a client-side animation runtime.
 
 ## In use
 
@@ -33,6 +34,15 @@ Use `rows={1}`, `rows={2}`, or `rows={3}` to render three, six, or nine strict
 <Canvas of={Stories.OneRow} />
 
 <Canvas of={Stories.ThreeRows} />
+
+The glyph pool includes the studio **D** and **T** initials alongside the
+abstract constellations, so they appear as the leading glyphs of the animated
+field with the identical grid, dot scale, and drawing language.
+
+Use `cycle` for a single cell (one row, one column) that steps through the whole
+pool one formation at a time.
+
+<Canvas of={Stories.SingleColumn} />
 
 ## Static use
 

--- a/nextjs-app/shared/components/PixelLoop/PixelLoop.module.css
+++ b/nextjs-app/shared/components/PixelLoop/PixelLoop.module.css
@@ -27,6 +27,83 @@
   block-size: calc(var(--pixel-loop-unit) * 5);
 }
 
+.cycleRoot {
+  /* Step time per formation; total cycle covers all 11 pool glyphs. */
+  --pixel-loop-cycle-step: calc(var(--duration-fast) * 3);
+
+  display: block;
+  position: relative;
+  block-size: var(--pixel-loop-unit);
+  inline-size: var(--pixel-loop-unit);
+}
+
+.cycleGlyph {
+  position: absolute;
+  inset: 0;
+  animation: pixel-loop-cycle calc(var(--pixel-loop-cycle-step) * 11) step-end
+    infinite;
+  opacity: 0;
+  fill: currentcolor;
+}
+
+.cycleGlyph:first-child {
+  opacity: 1;
+}
+
+.paused .cycleGlyph {
+  animation-play-state: paused;
+}
+
+.cycleGlyph:nth-child(2) {
+  animation-delay: calc(var(--pixel-loop-cycle-step) * 1);
+}
+
+.cycleGlyph:nth-child(3) {
+  animation-delay: calc(var(--pixel-loop-cycle-step) * 2);
+}
+
+.cycleGlyph:nth-child(4) {
+  animation-delay: calc(var(--pixel-loop-cycle-step) * 3);
+}
+
+.cycleGlyph:nth-child(5) {
+  animation-delay: calc(var(--pixel-loop-cycle-step) * 4);
+}
+
+.cycleGlyph:nth-child(6) {
+  animation-delay: calc(var(--pixel-loop-cycle-step) * 5);
+}
+
+.cycleGlyph:nth-child(7) {
+  animation-delay: calc(var(--pixel-loop-cycle-step) * 6);
+}
+
+.cycleGlyph:nth-child(8) {
+  animation-delay: calc(var(--pixel-loop-cycle-step) * 7);
+}
+
+.cycleGlyph:nth-child(9) {
+  animation-delay: calc(var(--pixel-loop-cycle-step) * 8);
+}
+
+.cycleGlyph:nth-child(10) {
+  animation-delay: calc(var(--pixel-loop-cycle-step) * 9);
+}
+
+.cycleGlyph:nth-child(11) {
+  animation-delay: calc(var(--pixel-loop-cycle-step) * 10);
+}
+
+@keyframes pixel-loop-cycle {
+  0% {
+    opacity: 1;
+  }
+
+  9.0909% {
+    opacity: 0;
+  }
+}
+
 .row {
   inline-size: 100%;
 }
@@ -325,7 +402,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .glyph {
+  .glyph,
+  .cycleGlyph {
     animation: none;
   }
 }

--- a/nextjs-app/shared/components/PixelLoop/PixelLoop.spec.md
+++ b/nextjs-app/shared/components/PixelLoop/PixelLoop.spec.md
@@ -11,8 +11,9 @@ the artwork and choreography are deliberately distinct.
 
 - The default `md` size is 100 × 60 CSS pixels: 20-pixel glyphs separated by
   20-pixel gaps.
-- Every constellation is authored as a literal 5 × 5 bitmap. Marks may only
-  occupy the 25 cell centers at 2, 6, 10, 14, and 18 SVG units.
+- Every constellation is authored as a literal 5 × 5 on/off cell grid and
+  rendered as vector SVG marks (never raster). Marks may only occupy the 25 cell
+  centers at 2, 6, 10, 14, and 18 SVG units.
 - `dots` uses 2.5-unit fully rounded circles, leaving 1.5 units of breathing
   room inside every 4-unit cell.
 - `strokes` replaces each circle with a short, 1.5-unit round-capped 45° vector
@@ -23,7 +24,14 @@ the artwork and choreography are deliberately distinct.
   1.2-second loop.
 - `rows={3}` renders nine grids in three rows. Each row uses the
   600-millisecond horizontal cycle with a one-beat phase offset.
+- `cycle` renders a single glyph cell (one row, one column) that steps through
+  the entire glyph pool one formation at a time on a discrete step-end loop.
+  Reduced motion and `animate={false}` hold the first glyph.
 - Frame changes are discrete. Glyphs do not fade, slide, scale, or interpolate.
+- The glyph pool leads with the studio **D** and **T** initials, authored as
+  full 5 × 5 cell grids exactly like every other constellation (same 4-unit cells,
+  same 2.5-unit dots or 45° strokes). They therefore appear as the first glyphs
+  of the animated field and share its dot scale and spacing.
 - The graphic inherits `--color-text`; consumers do not need a color prop.
 - `sm`, `md`, and `lg` scale both glyphs and gaps together.
 

--- a/nextjs-app/shared/components/PixelLoop/PixelLoop.stories.tsx
+++ b/nextjs-app/shared/components/PixelLoop/PixelLoop.stories.tsx
@@ -56,10 +56,20 @@ const meta = {
         category: "Layout",
       },
     },
+    cycle: {
+      control: "boolean",
+      description:
+        "One row, one column: a single cell that steps through the whole glyph pool one formation at a time. Ignores rows.",
+      table: {
+        defaultValue: { summary: "false" },
+        category: "Layout",
+      },
+    },
     className: { table: { disable: true } },
   },
   args: {
     animate: true,
+    cycle: false,
     rows: 2,
     size: "md",
     variant: "dots",
@@ -134,6 +144,18 @@ export const VectorStrokes: Story = {
       description: {
         story:
           "An alternate drawing language made from short, round-capped vector strokes set at 45 degrees.",
+      },
+    },
+  },
+};
+
+export const SingleColumn: Story = {
+  args: { cycle: true, size: "lg" },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "One row, one column. A single glyph cell steps through the whole pool one formation at a time, starting with the D and T initials.",
       },
     },
   },

--- a/nextjs-app/shared/components/PixelLoop/PixelLoop.test.tsx
+++ b/nextjs-app/shared/components/PixelLoop/PixelLoop.test.tsx
@@ -7,7 +7,7 @@ import styles from "./PixelLoop.module.css";
 expect.extend(toHaveNoViolations);
 
 describe("PixelLoop", () => {
-  it("renders six original dot constellations as a decorative graphic", () => {
+  it("renders six dot constellations led by the studio initials", () => {
     const { container } = render(<PixelLoop />);
     const root = container.firstElementChild;
     const glyphs = container.querySelectorAll("svg");
@@ -20,7 +20,8 @@ describe("PixelLoop", () => {
     expect(glyphs).toHaveLength(6);
     const dots = container.querySelectorAll("circle");
 
-    expect(dots).toHaveLength(44);
+    // Field leads with D (6 dots) and T (5 dots) followed by four constellations.
+    expect(dots).toHaveLength(39);
     expect(container.querySelectorAll("line")).toHaveLength(0);
     dots.forEach((dot) => {
       expect([2, 6, 10, 14, 18]).toContain(Number(dot.getAttribute("cx")));
@@ -42,7 +43,8 @@ describe("PixelLoop", () => {
     expect(root).toHaveClass(styles.rows1);
     expect(container.querySelectorAll(`.${styles.row}`)).toHaveLength(1);
     expect(container.querySelectorAll("svg")).toHaveLength(3);
-    expect(container.querySelectorAll("circle")).toHaveLength(19);
+    // D (6) + T (5) + first constellation (5).
+    expect(container.querySelectorAll("circle")).toHaveLength(16);
   });
 
   it("renders the three-row animation with nine 5x5 glyph grids", () => {
@@ -67,7 +69,7 @@ describe("PixelLoop", () => {
 
     expect(root).toHaveAttribute("data-variant", "strokes");
     expect(container.querySelectorAll("circle")).toHaveLength(0);
-    expect(strokes).toHaveLength(44);
+    expect(strokes).toHaveLength(39);
     strokes.forEach((stroke) => {
       const x1 = Number(stroke.getAttribute("x1"));
       const x2 = Number(stroke.getAttribute("x2"));
@@ -82,6 +84,52 @@ describe("PixelLoop", () => {
       expect(stroke).toHaveAttribute("stroke-width", "1.5");
       expect(stroke).toHaveAttribute("stroke-linecap", "round");
     });
+  });
+
+  it("includes the D and T initials as the first two glyphs in the pool", () => {
+    const { container } = render(<PixelLoop rows={1} />);
+    const glyphs = container.querySelectorAll("svg");
+
+    const positions = (glyph: Element) =>
+      new Set(
+        [...glyph.querySelectorAll("circle")].map(
+          (dot) => `${dot.getAttribute("cx")},${dot.getAttribute("cy")}`,
+        ),
+      );
+
+    // D: left stem plus a top, bottom, and right-middle dot, spanning the grid.
+    const dCells = positions(glyphs[0]);
+    ["2,2", "10,2", "2,10", "18,10", "2,18", "10,18"].forEach((cell) =>
+      expect(dCells.has(cell)).toBe(true),
+    );
+
+    // T: full top bar plus a centered stem, spanning the grid.
+    const tCells = positions(glyphs[1]);
+    ["2,2", "10,2", "18,2", "10,10", "10,18"].forEach((cell) =>
+      expect(tCells.has(cell)).toBe(true),
+    );
+  });
+
+  it("cycles the whole pool through one stacked cell in cycle mode", () => {
+    const { container } = render(<PixelLoop cycle />);
+    const root = container.firstElementChild;
+    const glyphs = container.querySelectorAll("svg");
+
+    expect(root).toHaveAttribute("data-cycle", "true");
+    expect(root).not.toHaveAttribute("data-rows");
+    expect(root).toHaveClass(styles.cycleRoot);
+    // Every pool glyph is stacked in the single cell so it can step through them.
+    expect(glyphs).toHaveLength(11);
+    glyphs.forEach((glyph) => {
+      expect(glyph).toHaveClass(styles.cycleGlyph);
+      expect(glyph).toHaveAttribute("viewBox", "0 0 20 20");
+    });
+  });
+
+  it("keeps the cycle cell out of the accessibility tree", async () => {
+    const { container } = render(<PixelLoop cycle />);
+
+    expect(await axe(container)).toHaveNoViolations();
   });
 
   it("can hold the first frame without removing the artwork", () => {

--- a/nextjs-app/shared/components/PixelLoop/PixelLoop.tsx
+++ b/nextjs-app/shared/components/PixelLoop/PixelLoop.tsx
@@ -5,7 +5,15 @@ import styles from "./PixelLoop.module.css";
 const CELL_SIZE = 4;
 const CELL_CENTER = CELL_SIZE / 2;
 
-const GLYPH_BITMAPS = [
+/**
+ * Each glyph is a 5x5 grid of on (`#`) / off (`.`) cells. These are geometry
+ * definitions only — they are rendered as vector SVG marks (`<circle>` dots or
+ * `<line>` strokes), never as raster images.
+ */
+const GLYPH_GRIDS = [
+  // Studio initials, spanning the full 5x5 grid like every other glyph.
+  ["#.#..", ".....", "#...#", ".....", "#.#.."],
+  ["#.#.#", ".....", "..#..", ".....", "..#.."],
   ["#....", ".#...", "..#..", "...#.", "....#"],
   ["....#", "...#.", "..#..", ".#...", "#...."],
   ["..#..", "..#..", "#####", "..#..", "..#.."],
@@ -17,8 +25,8 @@ const GLYPH_BITMAPS = [
   ["#.#.#", ".#.#.", "#.#.#", ".#.#.", "#.#.#"],
 ] as const;
 
-function getActiveCells(bitmap: readonly string[]) {
-  return bitmap.flatMap((row, rowIndex) =>
+function getActiveCells(grid: readonly string[]) {
+  return grid.flatMap((row, rowIndex) =>
     [...row].flatMap((cell, columnIndex) =>
       cell === "#"
         ? [
@@ -29,6 +37,23 @@ function getActiveCells(bitmap: readonly string[]) {
           ]
         : [],
     ),
+  );
+}
+
+function renderMark(x: number, y: number, variant: PixelLoopVariant) {
+  return variant === "dots" ? (
+    <circle key={`${x}-${y}`} cx={x} cy={y} r="1.25" />
+  ) : (
+    <line
+      key={`${x}-${y}`}
+      x1={x - 1}
+      y1={y + 1}
+      x2={x + 1}
+      y2={y - 1}
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
   );
 }
 
@@ -48,6 +73,11 @@ export interface PixelLoopProps extends Omit<
   rows?: PixelLoopRows;
   /** Runs the six-frame loop. Disable for a deliberate static composition. @default true */
   animate?: boolean;
+  /**
+   * Renders a single glyph cell (one row, one column) that steps through the
+   * whole glyph pool one formation at a time. Ignores `rows`. @default false
+   */
+  cycle?: boolean;
 }
 
 /**
@@ -61,6 +91,7 @@ export const PixelLoop = React.forwardRef<HTMLDivElement, PixelLoopProps>(
     {
       animate = true,
       className,
+      cycle = false,
       rows = 2,
       size = "md",
       variant = "dots",
@@ -68,9 +99,43 @@ export const PixelLoop = React.forwardRef<HTMLDivElement, PixelLoopProps>(
     },
     ref,
   ) => {
-    const visibleBitmaps = GLYPH_BITMAPS.slice(0, rows * 3);
+    if (cycle) {
+      return (
+        <div
+          {...rest}
+          ref={ref}
+          className={cn(
+            styles.root,
+            styles[size],
+            styles.cycleRoot,
+            !animate && styles.paused,
+            className,
+          )}
+          aria-hidden="true"
+          data-animated={animate}
+          data-cycle="true"
+          data-size={size}
+          data-variant={variant}
+        >
+          {GLYPH_GRIDS.map((grid, index) => (
+            <svg
+              key={index}
+              className={styles.cycleGlyph}
+              viewBox="0 0 20 20"
+              focusable="false"
+            >
+              {getActiveCells(grid).map(({ x, y }) =>
+                renderMark(x, y, variant),
+              )}
+            </svg>
+          ))}
+        </div>
+      );
+    }
+
+    const visibleGrids = GLYPH_GRIDS.slice(0, rows * 3);
     const rowGroups = Array.from({ length: rows }, (_, rowIndex) =>
-      visibleBitmaps.slice(rowIndex * 3, rowIndex * 3 + 3),
+      visibleGrids.slice(rowIndex * 3, rowIndex * 3 + 3),
     );
 
     return (
@@ -90,12 +155,12 @@ export const PixelLoop = React.forwardRef<HTMLDivElement, PixelLoopProps>(
         data-size={size}
         data-variant={variant}
       >
-        {rowGroups.map((bitmaps, rowIndex) => (
+        {rowGroups.map((grids, rowIndex) => (
           <div
             key={rowIndex}
             className={cn(styles.row, styles[`row${rowIndex + 1}`])}
           >
-            {bitmaps.map((bitmap, columnIndex) => {
+            {grids.map((grid, columnIndex) => {
               const glyphIndex = rowIndex * 3 + columnIndex;
               const animationClass =
                 rows === 2
@@ -109,21 +174,8 @@ export const PixelLoop = React.forwardRef<HTMLDivElement, PixelLoopProps>(
                   viewBox="0 0 20 20"
                   focusable="false"
                 >
-                  {getActiveCells(bitmap).map(({ x, y }) =>
-                    variant === "dots" ? (
-                      <circle key={`${x}-${y}`} cx={x} cy={y} r="1.25" />
-                    ) : (
-                      <line
-                        key={`${x}-${y}`}
-                        x1={x - 1}
-                        y1={y + 1}
-                        x2={x + 1}
-                        y2={y - 1}
-                        stroke="currentColor"
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                      />
-                    ),
+                  {getActiveCells(grid).map(({ x, y }) =>
+                    renderMark(x, y, variant),
                   )}
                 </svg>
               );

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-27T05:58:08.331Z",
+  "generatedAt": "2026-07-27T09:29:24.520Z",
   "summary": {
     "componentCount": 177,
     "statusCounts": {
@@ -23920,8 +23920,8 @@
           {
             "id": "accessibility-tree",
             "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-            "verificationMode": "unverified",
-            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+            "verificationMode": "automated",
+            "check": "npm run test:stories:matrix:ci"
           },
           {
             "id": "forced-colors-real-browser",
@@ -23932,8 +23932,8 @@
           {
             "id": "aria-requirements",
             "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-            "verificationMode": "unverified",
-            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+            "verificationMode": "automated",
+            "check": "npm run test:stories:matrix:ci"
           },
           {
             "id": "human-a11y-review",
@@ -35823,7 +35823,7 @@
         "tier": "atom",
         "group": "display",
         "status": "alpha",
-        "description": "Decorative constellation loop with rounded-dot and 45-degree vector-stroke variants.",
+        "description": "Decorative constellation loop with rounded-dot and 45-degree vector-stroke variants; the glyph pool includes the studio D and T initials.",
         "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1490-2401&m=dev",
         "radixPrimitive": null,
         "element": "div",
@@ -35889,7 +35889,7 @@
         "governance": {
           "owner": "design-system",
           "lastReviewed": "2026-07-23",
-          "note": "The Primary Studio reference informed the compact modular format, while original 5x5 bitmap artwork, round marks, row-aware choreography, and timing establish a distinct implementation. Supports one, two, or three rows of three glyph grids. Alpha while forced-colors and light/dark verification remain pending outside the supplied Storybook contexts."
+          "note": "The Primary Studio reference informed the compact modular format, while original 5x5 vector cell-grid artwork, round marks, row-aware choreography, and timing establish a distinct implementation. Supports one, two, or three rows of three glyph grids. Alpha while forced-colors and light/dark verification remain pending outside the supplied Storybook contexts."
         },
         "props": {
           "size": {
@@ -35920,6 +35920,11 @@
             "optional": true,
             "type": "boolean",
             "description": "Runs the six-frame loop. Disable for a deliberate static composition."
+          },
+          "cycle": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Renders a single glyph cell (one row, one column) that steps through the whole glyph pool one formation at a time. Ignores rows."
           }
         },
         "forbiddenUse": [
@@ -35928,7 +35933,7 @@
           "replace the stepped rotation with smooth motion."
         ]
       },
-      "spec": "# PixelLoop\n\n## Intent\n\nPixelLoop is a compact decorative motion signature for hero and editorial\ncompositions. It uses six original 20 × 20 constellations in a three-column,\ntwo-row field. The Primary Studio reference informed the modular format, but\nthe artwork and choreography are deliberately distinct.\n\n## Visual and motion contract\n\n- The default `md` size is 100 × 60 CSS pixels: 20-pixel glyphs separated by\n  20-pixel gaps.\n- Every constellation is authored as a literal 5 × 5 bitmap. Marks may only\n  occupy the 25 cell centers at 2, 6, 10, 14, and 18 SVG units.\n- `dots` uses 2.5-unit fully rounded circles, leaving 1.5 units of breathing\n  room inside every 4-unit cell.\n- `strokes` replaces each circle with a short, 1.5-unit round-capped 45° vector\n  mark that also stays within its cell boundary.\n- `rows={1}` renders three grids in one row and cycles them every 200\n  milliseconds on a 600-millisecond loop.\n- `rows={2}` preserves the six-grid clockwise perimeter choreography on a\n  1.2-second loop.\n- `rows={3}` renders nine grids in three rows. Each row uses the\n  600-millisecond horizontal cycle with a one-beat phase offset.\n- Frame changes are discrete. Glyphs do not fade, slide, scale, or interpolate.\n- The graphic inherits `--color-text`; consumers do not need a color prop.\n- `sm`, `md`, and `lg` scale both glyphs and gaps together.\n\n## Interaction contract\n\n- Keyboard: none; the component is never focusable.\n- Pointer: none; the component has no hover or click behavior.\n- Screen readers: the root is `aria-hidden` because the loop is ornamental.\n- Reduced motion: `prefers-reduced-motion: reduce` freezes the first frame.\n- `animate={false}` also freezes the first frame for intentional static use.\n\n## Do / don't\n\n- Do use it as a visual accent alongside real page content.\n- Do choose the row count to suit the available composition width and height.\n- Do let the inherited text color adapt it to its surrounding composition.\n- Don't use it to communicate loading, progress, status, or instructions.\n- Don't add labels or interaction to the glyphs.\n- Don't replace the stepped rotation with smooth motion.\n\n## Design notes\n\n- Tokens: `--color-text`, `--space-layout-4`, `--space-layout-16`,\n  `--space-layout-32`, and `--duration-fast`.\n- Figma:\n  [DT Site stuff, node 1490:2401](https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1490-2401&m=dev)\n- Reference:\n  [Primary Studio](https://www.primary.studio/)\n",
+      "spec": "# PixelLoop\n\n## Intent\n\nPixelLoop is a compact decorative motion signature for hero and editorial\ncompositions. It uses six original 20 × 20 constellations in a three-column,\ntwo-row field. The Primary Studio reference informed the modular format, but\nthe artwork and choreography are deliberately distinct.\n\n## Visual and motion contract\n\n- The default `md` size is 100 × 60 CSS pixels: 20-pixel glyphs separated by\n  20-pixel gaps.\n- Every constellation is authored as a literal 5 × 5 on/off cell grid and\n  rendered as vector SVG marks (never raster). Marks may only occupy the 25 cell\n  centers at 2, 6, 10, 14, and 18 SVG units.\n- `dots` uses 2.5-unit fully rounded circles, leaving 1.5 units of breathing\n  room inside every 4-unit cell.\n- `strokes` replaces each circle with a short, 1.5-unit round-capped 45° vector\n  mark that also stays within its cell boundary.\n- `rows={1}` renders three grids in one row and cycles them every 200\n  milliseconds on a 600-millisecond loop.\n- `rows={2}` preserves the six-grid clockwise perimeter choreography on a\n  1.2-second loop.\n- `rows={3}` renders nine grids in three rows. Each row uses the\n  600-millisecond horizontal cycle with a one-beat phase offset.\n- `cycle` renders a single glyph cell (one row, one column) that steps through\n  the entire glyph pool one formation at a time on a discrete step-end loop.\n  Reduced motion and `animate={false}` hold the first glyph.\n- Frame changes are discrete. Glyphs do not fade, slide, scale, or interpolate.\n- The glyph pool leads with the studio **D** and **T** initials, authored as\n  full 5 × 5 cell grids exactly like every other constellation (same 4-unit cells,\n  same 2.5-unit dots or 45° strokes). They therefore appear as the first glyphs\n  of the animated field and share its dot scale and spacing.\n- The graphic inherits `--color-text`; consumers do not need a color prop.\n- `sm`, `md`, and `lg` scale both glyphs and gaps together.\n\n## Interaction contract\n\n- Keyboard: none; the component is never focusable.\n- Pointer: none; the component has no hover or click behavior.\n- Screen readers: the root is `aria-hidden` because the loop is ornamental.\n- Reduced motion: `prefers-reduced-motion: reduce` freezes the first frame.\n- `animate={false}` also freezes the first frame for intentional static use.\n\n## Do / don't\n\n- Do use it as a visual accent alongside real page content.\n- Do choose the row count to suit the available composition width and height.\n- Do let the inherited text color adapt it to its surrounding composition.\n- Don't use it to communicate loading, progress, status, or instructions.\n- Don't add labels or interaction to the glyphs.\n- Don't replace the stepped rotation with smooth motion.\n\n## Design notes\n\n- Tokens: `--color-text`, `--space-layout-4`, `--space-layout-16`,\n  `--space-layout-32`, and `--duration-fast`.\n- Figma:\n  [DT Site stuff, node 1490:2401](https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1490-2401&m=dev)\n- Reference:\n  [Primary Studio](https://www.primary.studio/)\n",
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/PixelLoop",
@@ -35970,6 +35975,11 @@
             "optional": true,
             "type": "boolean",
             "description": "Runs the six-frame loop. Disable for a deliberate static composition."
+          },
+          "cycle": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Renders a single glyph cell (one row, one column) that steps through the\nwhole glyph pool one formation at a time. Ignores `rows`."
           }
         },
         "propRelationships": [],
@@ -36022,7 +36032,7 @@
         ],
         "composesWith": [],
         "prefersOver": [],
-        "declaredPropCount": 4,
+        "declaredPropCount": 5,
         "guidelines": [
           {
             "level": "should",
@@ -36182,7 +36192,7 @@
         "governance": {
           "owner": "design-system",
           "lastReviewed": "2026-07-23",
-          "note": "The Primary Studio reference informed the compact modular format, while original 5x5 bitmap artwork, round marks, row-aware choreography, and timing establish a distinct implementation. Supports one, two, or three rows of three glyph grids. Alpha while forced-colors and light/dark verification remain pending outside the supplied Storybook contexts."
+          "note": "The Primary Studio reference informed the compact modular format, while original 5x5 vector cell-grid artwork, round marks, row-aware choreography, and timing establish a distinct implementation. Supports one, two, or three rows of three glyph grids. Alpha while forced-colors and light/dark verification remain pending outside the supplied Storybook contexts."
         },
         "content": null
       }

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-27T05:58:08.059Z",
+  "generatedAt": "2026-07-27T09:29:24.220Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -12602,8 +12602,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified",
-          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+          "verificationMode": "automated",
+          "check": "npm run test:stories:matrix:ci"
         },
         {
           "id": "forced-colors-real-browser",
@@ -12614,8 +12614,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified",
-          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+          "verificationMode": "automated",
+          "check": "npm run test:stories:matrix:ci"
         },
         {
           "id": "human-a11y-review",
@@ -19089,6 +19089,11 @@
           "optional": true,
           "type": "boolean",
           "description": "Runs the six-frame loop. Disable for a deliberate static composition."
+        },
+        "cycle": {
+          "optional": true,
+          "type": "boolean",
+          "description": "Renders a single glyph cell (one row, one column) that steps through the\nwhole glyph pool one formation at a time. Ignores `rows`."
         }
       },
       "propRelationships": [],
@@ -19141,7 +19146,7 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 4,
+      "declaredPropCount": 5,
       "guidelines": [
         {
           "level": "should",
@@ -19301,7 +19306,7 @@
       "governance": {
         "owner": "design-system",
         "lastReviewed": "2026-07-23",
-        "note": "The Primary Studio reference informed the compact modular format, while original 5x5 bitmap artwork, round marks, row-aware choreography, and timing establish a distinct implementation. Supports one, two, or three rows of three glyph grids. Alpha while forced-colors and light/dark verification remain pending outside the supplied Storybook contexts."
+        "note": "The Primary Studio reference informed the compact modular format, while original 5x5 vector cell-grid artwork, round marks, row-aware choreography, and timing establish a distinct implementation. Supports one, two, or three rows of three glyph grids. Alpha while forced-colors and light/dark verification remain pending outside the supplied Storybook contexts."
       },
       "content": null
     },

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -11778,7 +11778,7 @@
       "group": "display",
       "tier": 2,
       "status": "alpha",
-      "description": "Decorative constellation loop with rounded-dot and 45-degree vector-stroke variants.",
+      "description": "Decorative constellation loop with rounded-dot and 45-degree vector-stroke variants; the glyph pool includes the studio D and T initials.",
       "dense": "",
       "keywords": [],
       "importLine": "import { PixelLoop } from \"@dt/PixelLoop\";",
@@ -11800,6 +11800,11 @@
         },
         {
           "name": "animate",
+          "type": "boolean",
+          "required": false
+        },
+        {
+          "name": "cycle",
           "type": "boolean",
           "required": false
         }
@@ -11833,6 +11838,11 @@
           "optional": true,
           "type": "boolean",
           "description": "Runs the six-frame loop. Disable for a deliberate static composition."
+        },
+        "cycle": {
+          "optional": true,
+          "type": "boolean",
+          "description": "Renders a single glyph cell (one row, one column) that steps through the whole glyph pool one formation at a time. Ignores rows."
         }
       },
       "composesWith": [],


### PR DESCRIPTION
## Summary

Adds the studio **D** and **T** initials to `PixelLoop` and a new single-formation display mode.

- **D and T added to the glyph pool** (`GLYPH_GRIDS`) as full 5x5 vector cell grids, rendered edge-to-edge identically to the other constellations. They lead the animated field. No new prop for this; every existing variant renders them.
- **New `cycle` prop**: a one-row, one-column cell that steps through the whole pool one formation at a time. Pure CSS, discrete `step-end` (matches the component's no-runtime philosophy), freezes on the first glyph under reduced-motion / `animate={false}`. Exposed via a new `SingleColumn` story.
- **Renamed `GLYPH_BITMAPS` to `GLYPH_GRIDS`** and clarified in code/spec/mdx that these are on/off cell-grid definitions rendered as **vector SVG** (`<circle>` / `<line>`), never raster.
- Regenerated agent manifest, component blocks, and docs registry.

Component stays `alpha` (WIP badge intact).

## Verification (all local, exit 0)

- `npm run typecheck`, `npm run lint`, `npm test` (full suite), `npm run build`
- `npm run build:tokens`, `npm run check:contract-props`, `npm run check:consumers`
- `npm run validate:components`
- Storybook (live, DOM-measured): D/T render at the same 32px footprint as the other glyphs (coords span 2 to 18); cycle mode shows exactly **1** glyph at any instant, stepping sequentially on a 6.6s loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cycle mode that displays glyph formations sequentially in a single cell.
  * Added D and T initials to the glyph pool.
  * Added a Storybook example for single-column cycling.
  * Added support for dot and vector-stroke rendering across the glyph pool.

* **Accessibility**
  * Reduced-motion settings now disable cycling animations and preserve a static glyph.

* **Documentation**
  * Clarified the 5×5 grid-based, vector-rendered design and cycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->