### PR TITLE
feat(ds): PixelLoop cross-fades the full pool (+20 patterns, distributed cells)

### DIFF
--- a/nextjs-app/shared/components/PixelLoop/PixelLoop.mdx
+++ b/nextjs-app/shared/components/PixelLoop/PixelLoop.mdx
@@ -7,10 +7,11 @@ import * as Stories from "./PixelLoop.stories";
 
 **Status:** alpha · **Tier:** atom · **Group:** display
 
-A six-frame decorative constellation loop for expressive hero and editorial
-compositions. Each drawing is locked to a strict 5 × 5 cell grid and rendered as
-vector SVG (never raster); rounded-dot and vector-stroke variants travel around
-it without a client-side animation runtime.
+A decorative constellation loop for expressive hero and editorial compositions.
+The field's cells each cross-fade through their own slice of the glyph pool, and
+together they cover every variant over time. Each drawing is locked to a strict
+5 × 5 cell grid and rendered as vector SVG (never raster); rounded-dot and
+vector-stroke variants render without a client-side animation runtime.
 
 ## In use
 
@@ -28,16 +29,17 @@ Use `size="sm" | "md" | "lg"` to scale the complete composition and
 `variant="dots" | "strokes"` to choose fully rounded points or short 45° vector
 marks. The loop inherits its color from the surrounding text color.
 
-Use `rows={1}`, `rows={2}`, or `rows={3}` to render three, six, or nine strict
-5 × 5 glyph grids. Two rows is the default.
+Use `rows={1}`, `rows={2}`, or `rows={3}` to render three, six, or nine cells.
+Each cell cross-fades through its own slice of the pool, so the field shows
+different glyphs at once and covers them all over time. Two rows is the default.
 
 <Canvas of={Stories.OneRow} />
 
 <Canvas of={Stories.ThreeRows} />
 
 The glyph pool includes the studio **D** and **T** initials alongside the
-abstract constellations, so they appear as the leading glyphs of the animated
-field with the identical grid, dot scale, and drawing language.
+abstract constellations, with the identical grid, dot scale, and drawing
+language, so they appear in the field like any other variant.
 
 Use `cycle` for a single cell (one row, one column) that steps through the whole
 pool one formation at a time.

--- a/nextjs-app/shared/components/PixelLoop/PixelLoop.module.css
+++ b/nextjs-app/shared/components/PixelLoop/PixelLoop.module.css
@@ -1,6 +1,9 @@
 .root {
   --pixel-loop-unit: calc(var(--space-layout-16) + var(--space-layout-4));
 
+  /* Step time per formation; cell cycle = step x that cell's glyph count. */
+  --pixel-loop-cycle-step: calc(var(--duration-fast) * 3);
+
   inline-size: calc(var(--pixel-loop-unit) * 5);
   color: var(--color-text);
 }
@@ -13,10 +16,14 @@
 }
 
 .rows1 {
+  --pixel-loop-fade-name: pixel-loop-fade-11;
+
   block-size: var(--pixel-loop-unit);
 }
 
 .rows2 {
+  --pixel-loop-fade-name: pixel-loop-fade-6;
+
   display: flex;
   block-size: calc(var(--pixel-loop-unit) * 3);
   flex-wrap: wrap;
@@ -24,84 +31,9 @@
 }
 
 .rows3 {
+  --pixel-loop-fade-name: pixel-loop-fade-4;
+
   block-size: calc(var(--pixel-loop-unit) * 5);
-}
-
-.cycleRoot {
-  /* Step time per formation; total cycle covers all 11 pool glyphs. */
-  --pixel-loop-cycle-step: calc(var(--duration-fast) * 3);
-
-  display: block;
-  position: relative;
-  block-size: var(--pixel-loop-unit);
-  inline-size: var(--pixel-loop-unit);
-}
-
-.cycleGlyph {
-  position: absolute;
-  inset: 0;
-  animation: pixel-loop-cycle calc(var(--pixel-loop-cycle-step) * 11) step-end
-    infinite;
-  opacity: 0;
-  fill: currentcolor;
-}
-
-.cycleGlyph:first-child {
-  opacity: 1;
-}
-
-.paused .cycleGlyph {
-  animation-play-state: paused;
-}
-
-.cycleGlyph:nth-child(2) {
-  animation-delay: calc(var(--pixel-loop-cycle-step) * 1);
-}
-
-.cycleGlyph:nth-child(3) {
-  animation-delay: calc(var(--pixel-loop-cycle-step) * 2);
-}
-
-.cycleGlyph:nth-child(4) {
-  animation-delay: calc(var(--pixel-loop-cycle-step) * 3);
-}
-
-.cycleGlyph:nth-child(5) {
-  animation-delay: calc(var(--pixel-loop-cycle-step) * 4);
-}
-
-.cycleGlyph:nth-child(6) {
-  animation-delay: calc(var(--pixel-loop-cycle-step) * 5);
-}
-
-.cycleGlyph:nth-child(7) {
-  animation-delay: calc(var(--pixel-loop-cycle-step) * 6);
-}
-
-.cycleGlyph:nth-child(8) {
-  animation-delay: calc(var(--pixel-loop-cycle-step) * 7);
-}
-
-.cycleGlyph:nth-child(9) {
-  animation-delay: calc(var(--pixel-loop-cycle-step) * 8);
-}
-
-.cycleGlyph:nth-child(10) {
-  animation-delay: calc(var(--pixel-loop-cycle-step) * 9);
-}
-
-.cycleGlyph:nth-child(11) {
-  animation-delay: calc(var(--pixel-loop-cycle-step) * 10);
-}
-
-@keyframes pixel-loop-cycle {
-  0% {
-    opacity: 1;
-  }
-
-  9.0909% {
-    opacity: 0;
-  }
 }
 
 .row {
@@ -131,279 +63,105 @@
   --pixel-loop-unit: var(--space-layout-32);
 }
 
-.glyph {
+/*
+ * A fade cell stacks a set of glyphs and cross-fades one at a time. The cycle
+ * mode is one cell holding the whole pool; the loop is a rows x 3 grid of cells,
+ * each owning a distinct slice so the field covers the pool across its cells.
+ */
+
+.cycleRoot,
+.loopCell {
+  display: block;
+  position: relative;
   block-size: var(--pixel-loop-unit);
   inline-size: var(--pixel-loop-unit);
+}
+
+.cycleRoot {
+  --pixel-loop-fade-name: pixel-loop-fade-31;
+}
+
+.loopCell {
   flex: 0 0 var(--pixel-loop-unit);
-  animation-duration: calc(var(--duration-fast) * 6);
+}
+
+.fadeGlyph {
+  position: absolute;
+  inset: 0;
+
+  /*
+   * One keyframe per cell size lights each glyph for 1 / count of the cycle,
+   * selected by --pixel-loop-fade-name (keyframe stops cannot read variables).
+   * Count comes from the inline --*-count; per-glyph phase from --*-index.
+   */
+  animation-name: var(--pixel-loop-fade-name);
+  animation-duration: calc(
+    var(--pixel-loop-cycle-step) * var(--pixel-loop-cycle-count)
+  );
   animation-timing-function: step-end;
+  opacity: 0;
+  animation-delay: calc(
+    var(--pixel-loop-cycle-step) * var(--pixel-loop-cycle-index)
+  );
   animation-iteration-count: infinite;
   fill: currentcolor;
 }
 
-.glyph1 {
-  animation-name: pixel-loop-1;
+.fadeGlyph:first-child {
+  opacity: 1;
 }
 
-.glyph2 {
-  animation-name: pixel-loop-2;
-}
-
-.glyph3 {
-  animation-name: pixel-loop-3;
-}
-
-.glyph4 {
-  animation-name: pixel-loop-4;
-}
-
-.glyph5 {
-  animation-name: pixel-loop-5;
-}
-
-.glyph6 {
-  animation-name: pixel-loop-6;
-}
-
-.rowGlyph1 {
-  animation-name: pixel-loop-row-1;
-}
-
-.rowGlyph2 {
-  animation-name: pixel-loop-row-2;
-}
-
-.rowGlyph3 {
-  animation-name: pixel-loop-row-3;
-}
-
-.rows1 .glyph,
-.rows3 .glyph {
-  animation-duration: calc(var(--duration-fast) * 3);
-}
-
-.paused .glyph {
+.paused .fadeGlyph {
   animation-play-state: paused;
 }
 
-.rows3 .row2 .glyph {
-  animation-delay: calc(var(--duration-fast) * -1);
-}
-
-.rows3 .row3 .glyph {
-  animation-delay: calc(var(--duration-fast) * -2);
-}
-
-@keyframes pixel-loop-row-1 {
-  0%,
-  100% {
-    order: 1;
+/*
+ * Visible window = 100 / glyphs-in-cell. cycle mode holds the whole pool (31);
+ * loop cells hold ceil(31 / cells) = 11 (1 row), 6 (2 rows), or 4 (3 rows).
+ * Update these percentages if the pool size or those slice lengths change.
+ */
+@keyframes pixel-loop-fade-31 {
+  0% {
+    opacity: 1;
   }
 
-  33.333% {
-    order: 2;
-  }
-
-  66.666% {
-    order: 3;
+  3.2258% {
+    opacity: 0;
   }
 }
 
-@keyframes pixel-loop-row-2 {
-  0%,
-  100% {
-    order: 2;
+@keyframes pixel-loop-fade-11 {
+  0% {
+    opacity: 1;
   }
 
-  33.333% {
-    order: 3;
-  }
-
-  66.666% {
-    order: 1;
+  9.0909% {
+    opacity: 0;
   }
 }
 
-@keyframes pixel-loop-row-3 {
-  0%,
-  100% {
-    order: 3;
+@keyframes pixel-loop-fade-6 {
+  0% {
+    opacity: 1;
   }
 
-  33.333% {
-    order: 1;
-  }
-
-  66.666% {
-    order: 2;
+  16.6667% {
+    opacity: 0;
   }
 }
 
-@keyframes pixel-loop-1 {
-  0%,
-  100% {
-    order: 1;
+@keyframes pixel-loop-fade-4 {
+  0% {
+    opacity: 1;
   }
 
-  16.666% {
-    order: 2;
-  }
-
-  33.333% {
-    order: 3;
-  }
-
-  50% {
-    order: 6;
-  }
-
-  66.666% {
-    order: 5;
-  }
-
-  83.333% {
-    order: 4;
-  }
-}
-
-@keyframes pixel-loop-2 {
-  0%,
-  100% {
-    order: 2;
-  }
-
-  16.666% {
-    order: 3;
-  }
-
-  33.333% {
-    order: 6;
-  }
-
-  50% {
-    order: 5;
-  }
-
-  66.666% {
-    order: 4;
-  }
-
-  83.333% {
-    order: 1;
-  }
-}
-
-@keyframes pixel-loop-3 {
-  0%,
-  100% {
-    order: 3;
-  }
-
-  16.666% {
-    order: 6;
-  }
-
-  33.333% {
-    order: 5;
-  }
-
-  50% {
-    order: 4;
-  }
-
-  66.666% {
-    order: 1;
-  }
-
-  83.333% {
-    order: 2;
-  }
-}
-
-@keyframes pixel-loop-4 {
-  0%,
-  100% {
-    order: 4;
-  }
-
-  16.666% {
-    order: 1;
-  }
-
-  33.333% {
-    order: 2;
-  }
-
-  50% {
-    order: 3;
-  }
-
-  66.666% {
-    order: 6;
-  }
-
-  83.333% {
-    order: 5;
-  }
-}
-
-@keyframes pixel-loop-5 {
-  0%,
-  100% {
-    order: 5;
-  }
-
-  16.666% {
-    order: 4;
-  }
-
-  33.333% {
-    order: 1;
-  }
-
-  50% {
-    order: 2;
-  }
-
-  66.666% {
-    order: 3;
-  }
-
-  83.333% {
-    order: 6;
-  }
-}
-
-@keyframes pixel-loop-6 {
-  0%,
-  100% {
-    order: 6;
-  }
-
-  16.666% {
-    order: 5;
-  }
-
-  33.333% {
-    order: 4;
-  }
-
-  50% {
-    order: 1;
-  }
-
-  66.666% {
-    order: 2;
-  }
-
-  83.333% {
-    order: 3;
+  25% {
+    opacity: 0;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .glyph,
-  .cycleGlyph {
+  .fadeGlyph {
     animation: none;
   }
 }

--- a/nextjs-app/shared/components/PixelLoop/PixelLoop.spec.md
+++ b/nextjs-app/shared/components/PixelLoop/PixelLoop.spec.md
@@ -3,9 +3,10 @@
 ## Intent
 
 PixelLoop is a compact decorative motion signature for hero and editorial
-compositions. It uses six original 20 × 20 constellations in a three-column,
-two-row field. The Primary Studio reference informed the modular format, but
-the artwork and choreography are deliberately distinct.
+compositions. It lays out a three-column field of cells; each cell continuously
+cross-fades through its own slice of the pool of 20 × 20 constellations, and the
+cells together cover every variant. The Primary Studio reference informed the
+modular format, but the artwork and choreography are deliberately distinct.
 
 ## Visual and motion contract
 
@@ -18,20 +19,21 @@ the artwork and choreography are deliberately distinct.
   room inside every 4-unit cell.
 - `strokes` replaces each circle with a short, 1.5-unit round-capped 45° vector
   mark that also stays within its cell boundary.
-- `rows={1}` renders three grids in one row and cycles them every 200
-  milliseconds on a 600-millisecond loop.
-- `rows={2}` preserves the six-grid clockwise perimeter choreography on a
-  1.2-second loop.
-- `rows={3}` renders nine grids in three rows. Each row uses the
-  600-millisecond horizontal cycle with a one-beat phase offset.
-- `cycle` renders a single glyph cell (one row, one column) that steps through
-  the entire glyph pool one formation at a time on a discrete step-end loop.
-  Reduced motion and `animate={false}` hold the first glyph.
-- Frame changes are discrete. Glyphs do not fade, slide, scale, or interpolate.
-- The glyph pool leads with the studio **D** and **T** initials, authored as
-  full 5 × 5 cell grids exactly like every other constellation (same 4-unit cells,
-  same 2.5-unit dots or 45° strokes). They therefore appear as the first glyphs
-  of the animated field and share its dot scale and spacing.
+- `rows={1}`, `rows={2}`, and `rows={3}` render three, six, or nine cells. Each
+  cell owns a distinct slice of the pool (pool indices `i` where
+  `i % cellCount === cellIndex`) and cross-fades through it one glyph at a time
+  (600 ms per glyph, discrete step-end). Because the slices partition the pool,
+  the cells collectively show every variant. Cells are time-offset so they change
+  in a wave rather than in unison.
+- `cycle` renders a single cell (one row, one column) that holds the whole pool
+  and steps through it the same way. Reduced motion and `animate={false}` hold
+  the first glyph.
+- Every cell shows exactly one glyph at any instant; over a full cycle it steps
+  through all of them. Changes are discrete: glyphs do not slide, scale, or
+  interpolate.
+- The glyph pool includes the studio **D** and **T** initials, authored as full
+  5 × 5 cell grids exactly like every other constellation (same 4-unit cells,
+  same 2.5-unit dots or 45° strokes), so they share its dot scale and spacing.
 - The graphic inherits `--color-text`; consumers do not need a color prop.
 - `sm`, `md`, and `lg` scale both glyphs and gaps together.
 
@@ -50,7 +52,7 @@ the artwork and choreography are deliberately distinct.
 - Do let the inherited text color adapt it to its surrounding composition.
 - Don't use it to communicate loading, progress, status, or instructions.
 - Don't add labels or interaction to the glyphs.
-- Don't replace the stepped rotation with smooth motion.
+- Don't replace the stepped cross-fade with smooth motion.
 
 ## Design notes
 

--- a/nextjs-app/shared/components/PixelLoop/PixelLoop.stories.tsx
+++ b/nextjs-app/shared/components/PixelLoop/PixelLoop.stories.tsx
@@ -32,7 +32,7 @@ const meta = {
     },
     animate: {
       control: "boolean",
-      description: "Runs the discrete six-frame perimeter orbit.",
+      description: "Runs the discrete cross-fade through the glyph pool.",
       table: {
         defaultValue: { summary: "true" },
         category: "Motion",
@@ -119,7 +119,7 @@ export const OneRow: Story = {
     docs: {
       description: {
         story:
-          "Three 5x5 glyph grids in one row, cycling horizontally on a 600ms loop.",
+          "One row of three cells; each cross-fades through its own slice of the pool, so the three show different glyphs at once.",
       },
     },
   },
@@ -131,7 +131,7 @@ export const ThreeRows: Story = {
     docs: {
       description: {
         story:
-          "Nine 5x5 glyph grids across three rows, with each row offset by one animation beat.",
+          "Nine cells across three rows, each cross-fading through its own slice of the pool on a staggered wave.",
       },
     },
   },

--- a/nextjs-app/shared/components/PixelLoop/PixelLoop.test.tsx
+++ b/nextjs-app/shared/components/PixelLoop/PixelLoop.test.tsx
@@ -6,10 +6,15 @@ import styles from "./PixelLoop.module.css";
 
 expect.extend(toHaveNoViolations);
 
+const POOL_SIZE = 31;
+// ceil(POOL_SIZE / cellCount) glyphs stacked per cell.
+const SLOTS_BY_ROWS = { 1: 11, 2: 6, 3: 4 } as const;
+
 describe("PixelLoop", () => {
-  it("renders six dot constellations led by the studio initials", () => {
+  it("renders a six-cell field that distributes the pool", () => {
     const { container } = render(<PixelLoop />);
     const root = container.firstElementChild;
+    const cells = container.querySelectorAll(`.${styles.loopCell}`);
     const glyphs = container.querySelectorAll("svg");
 
     expect(root).toHaveAttribute("aria-hidden", "true");
@@ -17,48 +22,55 @@ describe("PixelLoop", () => {
     expect(root).toHaveAttribute("data-size", "md");
     expect(root).toHaveAttribute("data-variant", "dots");
     expect(root).toHaveAttribute("data-animated", "true");
-    expect(glyphs).toHaveLength(6);
-    const dots = container.querySelectorAll("circle");
 
-    // Field leads with D (6 dots) and T (5 dots) followed by four constellations.
-    expect(dots).toHaveLength(39);
+    // Six cells, each cross-fading its own slice of the pool.
+    expect(cells).toHaveLength(6);
+    expect(glyphs).toHaveLength(6 * SLOTS_BY_ROWS[2]);
     expect(container.querySelectorAll("line")).toHaveLength(0);
-    dots.forEach((dot) => {
-      expect([2, 6, 10, 14, 18]).toContain(Number(dot.getAttribute("cx")));
-      expect([2, 6, 10, 14, 18]).toContain(Number(dot.getAttribute("cy")));
-      expect(dot).toHaveAttribute("r", "1.25");
-      expect(dot).not.toHaveAttribute("stroke");
+
+    cells.forEach((cell) => {
+      expect(cell).toHaveStyle({
+        "--pixel-loop-cycle-count": String(SLOTS_BY_ROWS[2]),
+      });
+      expect(cell.querySelectorAll("svg")).toHaveLength(SLOTS_BY_ROWS[2]);
     });
     glyphs.forEach((glyph) => {
+      expect(glyph).toHaveClass(styles.fadeGlyph);
       expect(glyph).toHaveAttribute("viewBox", "0 0 20 20");
       expect(glyph).toHaveAttribute("focusable", "false");
     });
   });
 
-  it("renders the one-row animation with three 5x5 glyph grids", () => {
+  it("distributes the pool with one row of three cells", () => {
     const { container } = render(<PixelLoop rows={1} />);
     const root = container.firstElementChild;
 
     expect(root).toHaveAttribute("data-rows", "1");
     expect(root).toHaveClass(styles.rows1);
     expect(container.querySelectorAll(`.${styles.row}`)).toHaveLength(1);
-    expect(container.querySelectorAll("svg")).toHaveLength(3);
-    // D (6) + T (5) + first constellation (5).
-    expect(container.querySelectorAll("circle")).toHaveLength(16);
+    expect(container.querySelectorAll(`.${styles.loopCell}`)).toHaveLength(3);
+    expect(container.querySelectorAll("svg")).toHaveLength(3 * SLOTS_BY_ROWS[1]);
   });
 
-  it("renders the three-row animation with nine 5x5 glyph grids", () => {
+  it("distributes the pool across three rows of three cells", () => {
     const { container } = render(<PixelLoop rows={3} />);
     const root = container.firstElementChild;
-    const marks = container.querySelectorAll("circle");
 
     expect(root).toHaveAttribute("data-rows", "3");
     expect(root).toHaveClass(styles.rows3);
     expect(container.querySelectorAll(`.${styles.row}`)).toHaveLength(3);
-    expect(container.querySelectorAll("svg")).toHaveLength(9);
-    marks.forEach((dot) => {
-      expect([2, 6, 10, 14, 18]).toContain(Number(dot.getAttribute("cx")));
-      expect([2, 6, 10, 14, 18]).toContain(Number(dot.getAttribute("cy")));
+    expect(container.querySelectorAll(`.${styles.loopCell}`)).toHaveLength(9);
+    expect(container.querySelectorAll("svg")).toHaveLength(9 * SLOTS_BY_ROWS[3]);
+  });
+
+  it("indexes each stacked glyph so the cross-fade can step through them", () => {
+    const { container } = render(<PixelLoop rows={1} />);
+    const firstCell = container.querySelector(`.${styles.loopCell}`);
+    const glyphs = firstCell!.querySelectorAll("svg");
+
+    expect(glyphs).toHaveLength(SLOTS_BY_ROWS[1]);
+    glyphs.forEach((glyph, index) => {
+      expect(glyph).toHaveStyle({ "--pixel-loop-cycle-index": String(index) });
     });
   });
 
@@ -69,16 +81,14 @@ describe("PixelLoop", () => {
 
     expect(root).toHaveAttribute("data-variant", "strokes");
     expect(container.querySelectorAll("circle")).toHaveLength(0);
-    expect(strokes).toHaveLength(39);
+    expect(strokes.length).toBeGreaterThan(0);
     strokes.forEach((stroke) => {
       const x1 = Number(stroke.getAttribute("x1"));
       const x2 = Number(stroke.getAttribute("x2"));
       const y1 = Number(stroke.getAttribute("y1"));
       const y2 = Number(stroke.getAttribute("y2"));
-      const dx = x2 - x1;
-      const dy = y2 - y1;
 
-      expect(Math.abs(dx)).toBe(Math.abs(dy));
+      expect(Math.abs(x2 - x1)).toBe(Math.abs(y2 - y1));
       expect([2, 6, 10, 14, 18]).toContain((x1 + x2) / 2);
       expect([2, 6, 10, 14, 18]).toContain((y1 + y2) / 2);
       expect(stroke).toHaveAttribute("stroke-width", "1.5");
@@ -86,25 +96,24 @@ describe("PixelLoop", () => {
     });
   });
 
-  it("includes the D and T initials as the first two glyphs in the pool", () => {
+  it("opens the first two cells with the D and T studio initials", () => {
     const { container } = render(<PixelLoop rows={1} />);
-    const glyphs = container.querySelectorAll("svg");
+    const cells = container.querySelectorAll(`.${styles.loopCell}`);
 
-    const positions = (glyph: Element) =>
+    const firstGlyphCells = (cell: Element) =>
       new Set(
-        [...glyph.querySelectorAll("circle")].map(
+        [...cell.querySelector("svg")!.querySelectorAll("circle")].map(
           (dot) => `${dot.getAttribute("cx")},${dot.getAttribute("cy")}`,
         ),
       );
 
-    // D: left stem plus a top, bottom, and right-middle dot, spanning the grid.
-    const dCells = positions(glyphs[0]);
+    // Cell 0 owns pool index 0 (D); cell 1 owns pool index 1 (T).
+    const dCells = firstGlyphCells(cells[0]);
     ["2,2", "10,2", "2,10", "18,10", "2,18", "10,18"].forEach((cell) =>
       expect(dCells.has(cell)).toBe(true),
     );
 
-    // T: full top bar plus a centered stem, spanning the grid.
-    const tCells = positions(glyphs[1]);
+    const tCells = firstGlyphCells(cells[1]);
     ["2,2", "10,2", "18,2", "10,10", "10,18"].forEach((cell) =>
       expect(tCells.has(cell)).toBe(true),
     );
@@ -118,11 +127,12 @@ describe("PixelLoop", () => {
     expect(root).toHaveAttribute("data-cycle", "true");
     expect(root).not.toHaveAttribute("data-rows");
     expect(root).toHaveClass(styles.cycleRoot);
-    // Every pool glyph is stacked in the single cell so it can step through them.
-    expect(glyphs).toHaveLength(11);
-    glyphs.forEach((glyph) => {
-      expect(glyph).toHaveClass(styles.cycleGlyph);
+    expect(glyphs).toHaveLength(POOL_SIZE);
+    expect(root).toHaveStyle({ "--pixel-loop-cycle-count": String(POOL_SIZE) });
+    glyphs.forEach((glyph, index) => {
+      expect(glyph).toHaveClass(styles.fadeGlyph);
       expect(glyph).toHaveAttribute("viewBox", "0 0 20 20");
+      expect(glyph).toHaveStyle({ "--pixel-loop-cycle-index": String(index) });
     });
   });
 
@@ -138,7 +148,7 @@ describe("PixelLoop", () => {
 
     expect(root).toHaveAttribute("data-animated", "false");
     expect(root).toHaveClass(styles.paused);
-    expect(container.querySelectorAll("svg")).toHaveLength(6);
+    expect(container.querySelectorAll("svg")).toHaveLength(6 * SLOTS_BY_ROWS[2]);
   });
 
   it("applies the selected scale and forwards safe container props", () => {

--- a/nextjs-app/shared/components/PixelLoop/PixelLoop.tsx
+++ b/nextjs-app/shared/components/PixelLoop/PixelLoop.tsx
@@ -23,6 +23,27 @@ const GLYPH_GRIDS = [
   [".###.", "#...#", "#...#", "#...#", ".###."],
   ["#.#.#", ".....", ".#.#.", ".....", "#.#.#"],
   ["#.#.#", ".#.#.", "#.#.#", ".#.#.", "#.#.#"],
+  // Additional decorative constellations to widen the pool.
+  ["..#..", ".###.", "##.##", "##.##", "....."],
+  [".#...", "##.#.", "..##.", "##.#.", ".#..."],
+  ["#...#", "..#..", ".#.#.", "..#..", "#####"],
+  [".#.#.", "#.#.#", "#.#.#", "..#..", ".###."],
+  ["..#..", "#...#", "#...#", "#...#", "##.##"],
+  [".##..", "#.#.#", "#...#", "#.#.#", "..##."],
+  [".####", "#..#.", ".....", ".#..#", "####."],
+  [".#.#.", ".#.#.", "##.##", ".#.#.", ".#.#."],
+  [".###.", "..#..", "#...#", "..#..", ".###."],
+  ["..#..", ".####", "#...#", "####.", "..#.."],
+  ["#...#", "#...#", ".#.#.", "#...#", "#...#"],
+  [".#..#", "...#.", ".#...", "...#.", ".#..#"],
+  ["#.#.#", "#...#", ".#.#.", "#...#", "#.#.#"],
+  ["..##.", "....#", "#..##", "....#", "..##."],
+  [".###.", "#.###", ".....", "###.#", ".###."],
+  ["#..##", "..##.", "#.#.#", ".##..", "##..#"],
+  ["....#", "##.#.", "#.#..", "##.#.", "....#"],
+  ["..#..", "..##.", "##.##", ".##..", "..#.."],
+  ["#....", ".#..#", "##..#", ".#..#", "#...."],
+  ["###..", "...##", "#.#.#", "...##", "###.."],
 ] as const;
 
 function getActiveCells(grid: readonly string[]) {
@@ -57,6 +78,31 @@ function renderMark(x: number, y: number, variant: PixelLoopVariant) {
   );
 }
 
+/**
+ * Stacks a list of grids in one cell and cross-fades one at a time. `phase` is a
+ * sub-step time offset (0..1) so sibling cells swap in a wave rather than at
+ * once. The number of grids sets the cell's `--pixel-loop-cycle-count`.
+ */
+function renderFadeGlyphs(
+  grids: readonly (readonly string[])[],
+  variant: PixelLoopVariant,
+  phase = 0,
+) {
+  return grids.map((grid, position) => (
+    <svg
+      key={position}
+      className={styles.fadeGlyph}
+      viewBox="0 0 20 20"
+      focusable="false"
+      style={
+        { "--pixel-loop-cycle-index": position + phase } as React.CSSProperties
+      }
+    >
+      {getActiveCells(grid).map(({ x, y }) => renderMark(x, y, variant))}
+    </svg>
+  ));
+}
+
 export type PixelLoopSize = "sm" | "md" | "lg";
 export type PixelLoopVariant = "dots" | "strokes";
 export type PixelLoopRows = 1 | 2 | 3;
@@ -69,9 +115,9 @@ export interface PixelLoopProps extends Omit<
   size?: PixelLoopSize;
   /** Rounded dots or short, round-capped 45-degree strokes. @default "dots" */
   variant?: PixelLoopVariant;
-  /** Number of three-glyph rows in the animated field. @default 2 */
+  /** Number of three-cell rows in the field. @default 2 */
   rows?: PixelLoopRows;
-  /** Runs the six-frame loop. Disable for a deliberate static composition. @default true */
+  /** Runs the cross-fade cycle. Disable for a deliberate static composition. @default true */
   animate?: boolean;
   /**
    * Renders a single glyph cell (one row, one column) that steps through the
@@ -81,7 +127,9 @@ export interface PixelLoopProps extends Omit<
 }
 
 /**
- * Decorative six-frame constellation loop for expressive editorial compositions.
+ * Decorative constellation loop for expressive editorial compositions. Every
+ * cell continuously cross-fades through the whole glyph pool, so all variants
+ * appear over time.
  *
  * The graphic inherits its foreground color and becomes static when the user
  * requests reduced motion.
@@ -99,6 +147,8 @@ export const PixelLoop = React.forwardRef<HTMLDivElement, PixelLoopProps>(
     },
     ref,
   ) => {
+    const poolCount = GLYPH_GRIDS.length;
+
     if (cycle) {
       return (
         <div
@@ -116,26 +166,28 @@ export const PixelLoop = React.forwardRef<HTMLDivElement, PixelLoopProps>(
           data-cycle="true"
           data-size={size}
           data-variant={variant}
+          style={{ "--pixel-loop-cycle-count": poolCount } as React.CSSProperties}
         >
-          {GLYPH_GRIDS.map((grid, index) => (
-            <svg
-              key={index}
-              className={styles.cycleGlyph}
-              viewBox="0 0 20 20"
-              focusable="false"
-            >
-              {getActiveCells(grid).map(({ x, y }) =>
-                renderMark(x, y, variant),
-              )}
-            </svg>
-          ))}
+          {renderFadeGlyphs(GLYPH_GRIDS, variant)}
         </div>
       );
     }
 
-    const visibleGrids = GLYPH_GRIDS.slice(0, rows * 3);
+    const cellCount = rows * 3;
+    // Each cell owns a distinct slice of the pool (indices i where i % cellCount
+    // === cellIndex), padded to a common length so every cell shares one
+    // cross-fade cadence. The whole pool is covered across the cells.
+    const slotCount = Math.ceil(poolCount / cellCount);
+    const cells = Array.from({ length: cellCount }, (_, cellIndex) => {
+      const slice = GLYPH_GRIDS.filter((_, i) => i % cellCount === cellIndex);
+      const grids = Array.from(
+        { length: slotCount },
+        (_, slot) => slice[slot % slice.length],
+      );
+      return { cellIndex, grids };
+    });
     const rowGroups = Array.from({ length: rows }, (_, rowIndex) =>
-      visibleGrids.slice(rowIndex * 3, rowIndex * 3 + 3),
+      cells.slice(rowIndex * 3, rowIndex * 3 + 3),
     );
 
     return (
@@ -155,31 +207,26 @@ export const PixelLoop = React.forwardRef<HTMLDivElement, PixelLoopProps>(
         data-size={size}
         data-variant={variant}
       >
-        {rowGroups.map((grids, rowIndex) => (
+        {rowGroups.map((groupCells, rowIndex) => (
           <div
             key={rowIndex}
             className={cn(styles.row, styles[`row${rowIndex + 1}`])}
           >
-            {grids.map((grid, columnIndex) => {
-              const glyphIndex = rowIndex * 3 + columnIndex;
-              const animationClass =
-                rows === 2
-                  ? styles[`glyph${glyphIndex + 1}`]
-                  : styles[`rowGlyph${columnIndex + 1}`];
-
-              return (
-                <svg
-                  key={glyphIndex}
-                  className={cn(styles.glyph, animationClass)}
-                  viewBox="0 0 20 20"
-                  focusable="false"
-                >
-                  {getActiveCells(grid).map(({ x, y }) =>
-                    renderMark(x, y, variant),
-                  )}
-                </svg>
-              );
-            })}
+            {groupCells.map((cell) => (
+              <div
+                key={cell.cellIndex}
+                className={styles.loopCell}
+                style={
+                  { "--pixel-loop-cycle-count": slotCount } as React.CSSProperties
+                }
+              >
+                {renderFadeGlyphs(
+                  cell.grids,
+                  variant,
+                  cell.cellIndex / cellCount,
+                )}
+              </div>
+            ))}
           </div>
         ))}
       </div>

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-07-27T09:29:24.520Z",
+  "generatedAt": "2026-07-29T21:18:26.803Z",
   "summary": {
     "componentCount": 177,
     "statusCounts": {
@@ -35933,7 +35933,7 @@
           "replace the stepped rotation with smooth motion."
         ]
       },
-      "spec": "# PixelLoop\n\n## Intent\n\nPixelLoop is a compact decorative motion signature for hero and editorial\ncompositions. It uses six original 20 × 20 constellations in a three-column,\ntwo-row field. The Primary Studio reference informed the modular format, but\nthe artwork and choreography are deliberately distinct.\n\n## Visual and motion contract\n\n- The default `md` size is 100 × 60 CSS pixels: 20-pixel glyphs separated by\n  20-pixel gaps.\n- Every constellation is authored as a literal 5 × 5 on/off cell grid and\n  rendered as vector SVG marks (never raster). Marks may only occupy the 25 cell\n  centers at 2, 6, 10, 14, and 18 SVG units.\n- `dots` uses 2.5-unit fully rounded circles, leaving 1.5 units of breathing\n  room inside every 4-unit cell.\n- `strokes` replaces each circle with a short, 1.5-unit round-capped 45° vector\n  mark that also stays within its cell boundary.\n- `rows={1}` renders three grids in one row and cycles them every 200\n  milliseconds on a 600-millisecond loop.\n- `rows={2}` preserves the six-grid clockwise perimeter choreography on a\n  1.2-second loop.\n- `rows={3}` renders nine grids in three rows. Each row uses the\n  600-millisecond horizontal cycle with a one-beat phase offset.\n- `cycle` renders a single glyph cell (one row, one column) that steps through\n  the entire glyph pool one formation at a time on a discrete step-end loop.\n  Reduced motion and `animate={false}` hold the first glyph.\n- Frame changes are discrete. Glyphs do not fade, slide, scale, or interpolate.\n- The glyph pool leads with the studio **D** and **T** initials, authored as\n  full 5 × 5 cell grids exactly like every other constellation (same 4-unit cells,\n  same 2.5-unit dots or 45° strokes). They therefore appear as the first glyphs\n  of the animated field and share its dot scale and spacing.\n- The graphic inherits `--color-text`; consumers do not need a color prop.\n- `sm`, `md`, and `lg` scale both glyphs and gaps together.\n\n## Interaction contract\n\n- Keyboard: none; the component is never focusable.\n- Pointer: none; the component has no hover or click behavior.\n- Screen readers: the root is `aria-hidden` because the loop is ornamental.\n- Reduced motion: `prefers-reduced-motion: reduce` freezes the first frame.\n- `animate={false}` also freezes the first frame for intentional static use.\n\n## Do / don't\n\n- Do use it as a visual accent alongside real page content.\n- Do choose the row count to suit the available composition width and height.\n- Do let the inherited text color adapt it to its surrounding composition.\n- Don't use it to communicate loading, progress, status, or instructions.\n- Don't add labels or interaction to the glyphs.\n- Don't replace the stepped rotation with smooth motion.\n\n## Design notes\n\n- Tokens: `--color-text`, `--space-layout-4`, `--space-layout-16`,\n  `--space-layout-32`, and `--duration-fast`.\n- Figma:\n  [DT Site stuff, node 1490:2401](https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1490-2401&m=dev)\n- Reference:\n  [Primary Studio](https://www.primary.studio/)\n",
+      "spec": "# PixelLoop\n\n## Intent\n\nPixelLoop is a compact decorative motion signature for hero and editorial\ncompositions. It lays out a three-column field of cells; each cell continuously\ncross-fades through its own slice of the pool of 20 × 20 constellations, and the\ncells together cover every variant. The Primary Studio reference informed the\nmodular format, but the artwork and choreography are deliberately distinct.\n\n## Visual and motion contract\n\n- The default `md` size is 100 × 60 CSS pixels: 20-pixel glyphs separated by\n  20-pixel gaps.\n- Every constellation is authored as a literal 5 × 5 on/off cell grid and\n  rendered as vector SVG marks (never raster). Marks may only occupy the 25 cell\n  centers at 2, 6, 10, 14, and 18 SVG units.\n- `dots` uses 2.5-unit fully rounded circles, leaving 1.5 units of breathing\n  room inside every 4-unit cell.\n- `strokes` replaces each circle with a short, 1.5-unit round-capped 45° vector\n  mark that also stays within its cell boundary.\n- `rows={1}`, `rows={2}`, and `rows={3}` render three, six, or nine cells. Each\n  cell owns a distinct slice of the pool (pool indices `i` where\n  `i % cellCount === cellIndex`) and cross-fades through it one glyph at a time\n  (600 ms per glyph, discrete step-end). Because the slices partition the pool,\n  the cells collectively show every variant. Cells are time-offset so they change\n  in a wave rather than in unison.\n- `cycle` renders a single cell (one row, one column) that holds the whole pool\n  and steps through it the same way. Reduced motion and `animate={false}` hold\n  the first glyph.\n- Every cell shows exactly one glyph at any instant; over a full cycle it steps\n  through all of them. Changes are discrete: glyphs do not slide, scale, or\n  interpolate.\n- The glyph pool includes the studio **D** and **T** initials, authored as full\n  5 × 5 cell grids exactly like every other constellation (same 4-unit cells,\n  same 2.5-unit dots or 45° strokes), so they share its dot scale and spacing.\n- The graphic inherits `--color-text`; consumers do not need a color prop.\n- `sm`, `md`, and `lg` scale both glyphs and gaps together.\n\n## Interaction contract\n\n- Keyboard: none; the component is never focusable.\n- Pointer: none; the component has no hover or click behavior.\n- Screen readers: the root is `aria-hidden` because the loop is ornamental.\n- Reduced motion: `prefers-reduced-motion: reduce` freezes the first frame.\n- `animate={false}` also freezes the first frame for intentional static use.\n\n## Do / don't\n\n- Do use it as a visual accent alongside real page content.\n- Do choose the row count to suit the available composition width and height.\n- Do let the inherited text color adapt it to its surrounding composition.\n- Don't use it to communicate loading, progress, status, or instructions.\n- Don't add labels or interaction to the glyphs.\n- Don't replace the stepped cross-fade with smooth motion.\n\n## Design notes\n\n- Tokens: `--color-text`, `--space-layout-4`, `--space-layout-16`,\n  `--space-layout-32`, and `--duration-fast`.\n- Figma:\n  [DT Site stuff, node 1490:2401](https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1490-2401&m=dev)\n- Reference:\n  [Primary Studio](https://www.primary.studio/)\n",
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/PixelLoop",
@@ -35945,7 +35945,7 @@
       },
       "agent": {
         "preferredImport": "@dt/PixelLoop",
-        "intent": "PixelLoop is a compact decorative motion signature for hero and editorial compositions. It uses six original 20 × 20 constellations in a three-column, two-row field. The Primary Studio reference informed the modular for…",
+        "intent": "PixelLoop is a compact decorative motion signature for hero and editorial compositions. It lays out a three-column field of cells; each cell continuously cross-fades through its own slice of the pool of 20 × 20 constell…",
         "props": {
           "size": {
             "optional": true,
@@ -35969,12 +35969,12 @@
           "rows": {
             "optional": true,
             "type": "PixelLoopRows",
-            "description": "Number of three-glyph rows in the animated field."
+            "description": "Number of three-cell rows in the field."
           },
           "animate": {
             "optional": true,
             "type": "boolean",
-            "description": "Runs the six-frame loop. Disable for a deliberate static composition."
+            "description": "Runs the cross-fade cycle. Disable for a deliberate static composition."
           },
           "cycle": {
             "optional": true,
@@ -36010,7 +36010,7 @@
         "avoidWhen": [
           "use it to communicate loading, progress, status, or instructions.",
           "add labels or interaction to the glyphs.",
-          "replace the stepped rotation with smooth motion."
+          "replace the stepped cross-fade with smooth motion."
         ],
         "requiredA11y": [
           "The decorative container and all six glyphs are hidden from assistive technology.",
@@ -36028,7 +36028,7 @@
         "forbiddenUse": [
           "use it to communicate loading, progress, status, or instructions.",
           "add labels or interaction to the glyphs.",
-          "replace the stepped rotation with smooth motion."
+          "replace the stepped cross-fade with smooth motion."
         ],
         "composesWith": [],
         "prefersOver": [],
@@ -36071,7 +36071,7 @@
           },
           {
             "level": "should-not",
-            "guidance": "replace the stepped rotation with smooth motion.",
+            "guidance": "replace the stepped cross-fade with smooth motion.",
             "rationale": null,
             "rationaleSource": null,
             "source": "spec.md#do-dont"

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-27T09:29:24.220Z",
+  "generatedAt": "2026-07-29T21:18:26.409Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -19059,7 +19059,7 @@
     },
     "PixelLoop": {
       "preferredImport": "@dt/PixelLoop",
-      "intent": "PixelLoop is a compact decorative motion signature for hero and editorial compositions. It uses six original 20 × 20 constellations in a three-column, two-row field. The Primary Studio reference informed the modular for…",
+      "intent": "PixelLoop is a compact decorative motion signature for hero and editorial compositions. It lays out a three-column field of cells; each cell continuously cross-fades through its own slice of the pool of 20 × 20 constell…",
       "props": {
         "size": {
           "optional": true,
@@ -19083,12 +19083,12 @@
         "rows": {
           "optional": true,
           "type": "PixelLoopRows",
-          "description": "Number of three-glyph rows in the animated field."
+          "description": "Number of three-cell rows in the field."
         },
         "animate": {
           "optional": true,
           "type": "boolean",
-          "description": "Runs the six-frame loop. Disable for a deliberate static composition."
+          "description": "Runs the cross-fade cycle. Disable for a deliberate static composition."
         },
         "cycle": {
           "optional": true,
@@ -19124,7 +19124,7 @@
       "avoidWhen": [
         "use it to communicate loading, progress, status, or instructions.",
         "add labels or interaction to the glyphs.",
-        "replace the stepped rotation with smooth motion."
+        "replace the stepped cross-fade with smooth motion."
       ],
       "requiredA11y": [
         "The decorative container and all six glyphs are hidden from assistive technology.",
@@ -19142,7 +19142,7 @@
       "forbiddenUse": [
         "use it to communicate loading, progress, status, or instructions.",
         "add labels or interaction to the glyphs.",
-        "replace the stepped rotation with smooth motion."
+        "replace the stepped cross-fade with smooth motion."
       ],
       "composesWith": [],
       "prefersOver": [],
@@ -19185,7 +19185,7 @@
         },
         {
           "level": "should-not",
-          "guidance": "replace the stepped rotation with smooth motion.",
+          "guidance": "replace the stepped cross-fade with smooth motion.",
           "rationale": null,
           "rationaleSource": null,
           "source": "spec.md#do-dont"


### PR DESCRIPTION
## Summary

Grows the `PixelLoop` glyph pool and reworks its motion so the whole pool is always in play.

- **+20 patterns** — 20 generated symmetric 5x5 vector constellations added to the pool (11 -> 31), deduped against the existing set, density 7-15, edge-spanning.
- **Loop cross-fades the pool** — the fixed perimeter orbit is replaced: every cell now cross-fades through the pool one glyph at a time (discrete step-end, reduced-motion safe). All variants appear over time instead of a fixed first-6 selection.
- **Distributed rendering (lean)** — each cell owns a distinct slice of the pool (`i % cellCount === cellIndex`), padded to a common length. The slices partition the pool, so the field covers every variant while rendering **~36 SVGs** at the default `rows=2` (was 186 for the whole-pool-per-cell approach).
- **Wave, not flash** — a per-glyph phase (inline `--pixel-loop-cycle-index`) staggers sibling cells so they change in a wave.
- **`cycle` mode** reuses the same fade mechanism (one cell holding the whole pool).

The visible window is `1 / glyphs-in-cell`, and keyframe stops cannot read CSS variables, so cell size is selected via a `--pixel-loop-fade-name` var mapping to four keyframes (`fade-31/11/6/4`). The `100 / count` formula is documented for future pool resizes.

Component stays `alpha` (WIP badge intact).

## Verification (all local, exit 0)

- `npm run typecheck`, `npm run lint`, `npm test` (full suite, 2833 tests), `npm run build`
- `npm run build:tokens`, `npm run check:contract-props`, `npm run check:consumers`, `npm run validate:components`
- Storybook (live, DOM-measured): default field = 6 cells x 6 glyphs = 36 SVGs; 6 distinct glyphs visible; exactly 1 per cell; all 31 distinct patterns present across the cells; cycle mode still steps one-at-a-time through 31; pure vector, 0 raster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - PixelLoop now displays a larger variety of decorative constellation glyphs.
  - Animations use stepped cross-fades across grid cells, creating a staggered wave effect.
  - Row settings provide distributed cell layouts with multiple glyphs visible at once.
  - Cycle mode now transitions through the complete constellation collection.

- **Accessibility**
  - Reduced-motion and disabled-animation modes remain supported, holding the display on a stable glyph.

- **Documentation**
  - Updated component guidance and Storybook descriptions to reflect the new visual behavior and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->