### PR TITLE
fix(ds): GridBlock honors columns={3} and columns={4}

### DIFF
--- a/nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/DSharpDesignSystem/DSharpDesignSystemPage.tsx
@@ -2122,7 +2122,7 @@ export function DSharpDesignSystemPage({ nav }: { nav?: React.ReactNode }) {
 
       {/* Outcome */}
       <GridBlock
-        columns={4}
+        columns={2}
         gap="none"
         maxWidth="lg"
         spacing="comfortable"

--- a/nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/LlmComponentSchema/LlmComponentSchemaPage.tsx
@@ -345,7 +345,7 @@ export function LlmComponentSchemaPage({ nav }: { nav?: React.ReactNode }) {
 
       {/* Metrics */}
       <GridBlock
-        columns={4}
+        columns={2}
         gap="none"
         maxWidth="lg"
         spacing="comfortable"

--- a/nextjs-app/shared/components/pages/Work/ProjectSpine/ProjectSpinePage.tsx
+++ b/nextjs-app/shared/components/pages/Work/ProjectSpine/ProjectSpinePage.tsx
@@ -230,7 +230,7 @@ export function ProjectSpinePage({ nav }: { nav?: React.ReactNode }) {
 
       {/* Metrics */}
       <GridBlock
-        columns={4}
+        columns={2}
         gap="none"
         maxWidth="lg"
         spacing="comfortable"

--- a/nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/Rhythmguard/RhythmguardPage.tsx
@@ -291,7 +291,7 @@ export function RhythmguardPage({ nav }: { nav?: React.ReactNode }) {
 
       {/* Metrics */}
       <GridBlock
-        columns={4}
+        columns={2}
         gap="none"
         maxWidth="lg"
         spacing="comfortable"

--- a/nextjs-app/shared/components/pages/Work/SapBuildApps/SapBuildAppsPage.tsx
+++ b/nextjs-app/shared/components/pages/Work/SapBuildApps/SapBuildAppsPage.tsx
@@ -383,7 +383,7 @@ export function SapBuildAppsPage({ nav }: { nav?: React.ReactNode }) {
       />
 
       <GridBlock
-        columns={4}
+        columns={2}
         gap="none"
         maxWidth="lg"
         spacing="comfortable"

--- a/nextjs-app/shared/patterns/GridBlock/GridBlock.module.css
+++ b/nextjs-app/shared/patterns/GridBlock/GridBlock.module.css
@@ -10,6 +10,18 @@
   gap: var(--space-layout-32, 2rem);
 }
 
+.grid3Col {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-layout-32, 2rem);
+}
+
+.grid4Col {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-layout-32, 2rem);
+}
+
 .noGap {
   gap: 0;
 }
@@ -46,7 +58,9 @@
     margin-block-start: var(--space-layout-32, 2rem);
   }
 
-  .grid2Col > .col + .col {
+  .grid2Col > .col + .col,
+  .grid3Col > .col + .col,
+  .grid4Col > .col + .col {
     margin-inline-start: var(--space-layout-32, 2rem);
   }
 
@@ -66,6 +80,19 @@
   .grid2Col {
     grid-template-columns: 1fr;
     row-gap: 2rem;
+  }
+
+  /* 3- and 4-column grids drop to two columns on tablet */
+
+  .grid3Col,
+  .grid4Col {
+    grid-template-columns: repeat(2, 1fr);
+    row-gap: var(--space-layout-32, 2rem);
+  }
+
+  .grid3Col.responsiveGap,
+  .grid4Col.responsiveGap {
+    gap: var(--space-layout-32, 2rem);
   }
 
   .grid2Col.responsiveGap {
@@ -92,5 +119,13 @@
 
   .caption {
     display: block;
+  }
+}
+
+/* Mobile: 3- and 4-column grids stack to a single column */
+@media (width < 768px) {
+  .grid3Col,
+  .grid4Col {
+    grid-template-columns: 1fr;
   }
 }

--- a/nextjs-app/shared/patterns/GridBlock/GridBlock.test.tsx
+++ b/nextjs-app/shared/patterns/GridBlock/GridBlock.test.tsx
@@ -45,6 +45,23 @@ describe("GridBlock", () => {
     expect(container.querySelector(`.${styles.grid1Col}`)).toBeInTheDocument();
   });
 
+  it("applies 3 columns when specified", () => {
+    const { container } = render(
+      <GridBlock cells={[textCell, textCell, textCell]} columns={3} />,
+    );
+    expect(container.querySelector(`.${styles.grid3Col}`)).toBeInTheDocument();
+  });
+
+  it("applies 4 columns when specified", () => {
+    const { container } = render(
+      <GridBlock
+        cells={[textCell, textCell, textCell, textCell]}
+        columns={4}
+      />,
+    );
+    expect(container.querySelector(`.${styles.grid4Col}`)).toBeInTheDocument();
+  });
+
   it("applies light background color", () => {
     const { container } = render(
       <GridBlock cells={[textCell]} backgroundColor="light" />,
@@ -102,7 +119,9 @@ describe("GridBlock", () => {
       innerPadding: true,
     };
     const { container } = render(<GridBlock cells={[cellWithPadding]} />);
-    expect(container.querySelector(`.${styles.innerPadding}`)).toBeInTheDocument();
+    expect(
+      container.querySelector(`.${styles.innerPadding}`),
+    ).toBeInTheDocument();
   });
 
   it("applies mixBlendMode to images when specified", () => {

--- a/nextjs-app/shared/patterns/GridBlock/GridBlock.tsx
+++ b/nextjs-app/shared/patterns/GridBlock/GridBlock.tsx
@@ -85,7 +85,14 @@ function GridBlock({
   className = "",
   as = "section",
 }: GridBlockProps) {
-  const gridClassName = columns === 1 ? styles.grid1Col : styles.grid2Col;
+  const gridClassName =
+    columns === 1
+      ? styles.grid1Col
+      : columns === 3
+        ? styles.grid3Col
+        : columns === 4
+          ? styles.grid4Col
+          : styles.grid2Col;
   const gapClassName =
     gap === "none" ? styles.noGap : gap === "small" ? styles.smallGap : "";
 
@@ -104,7 +111,12 @@ function GridBlock({
     >
       <PageLayout maxWidth={maxWidth} spacing={spacing} as={as}>
         <div
-          className={[gridClassName, gapClassName, responsiveGapClass, className]
+          className={[
+            gridClassName,
+            gapClassName,
+            responsiveGapClass,
+            className,
+          ]
             .filter(Boolean)
             .join(" ")}
         >

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-compact-spacing.dark.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-compact-spacing.dark.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-example",
+  "storyId": "patterns-gridblock-compact-spacing",
   "mode": "dark",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:24.384Z",
+  "capturedAt": "2026-07-30T09:05:23.758Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-compact-spacing.forced-colors.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-compact-spacing.forced-colors.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-forced-colors",
+  "storyId": "patterns-gridblock-compact-spacing",
   "mode": "forced-colors",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:28.313Z",
+  "capturedAt": "2026-07-30T09:05:28.233Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-compact-spacing.light.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-compact-spacing.light.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-example",
-  "mode": "dark",
+  "storyId": "patterns-gridblock-compact-spacing",
+  "mode": "light",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:24.384Z",
+  "capturedAt": "2026-07-30T09:05:17.962Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-default.dark.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-default.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-gridblock-default",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:37:49.415Z",
-  "runner": "backfill",
+  "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
+  "capturedAt": "2026-07-30T09:05:22.513Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-default.forced-colors.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-default.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "patterns-gridblock-default",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:45:06.216Z",
-  "runner": "backfill",
+  "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
+  "capturedAt": "2026-07-30T09:05:28.059Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-default.light.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-default.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-gridblock-default",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:29:21.743Z",
-  "runner": "backfill",
+  "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
+  "capturedAt": "2026-07-30T09:05:16.726Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-example.forced-colors.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-example.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "patterns-gridblock-example",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:45:06.626Z",
-  "runner": "backfill",
+  "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
+  "capturedAt": "2026-07-30T09:05:28.291Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-example.light.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-example.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-gridblock-example",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:29:22.404Z",
-  "runner": "backfill",
+  "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
+  "capturedAt": "2026-07-30T09:05:18.587Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-forced-colors.dark.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-forced-colors.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-gridblock-forced-colors",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:37:50.195Z",
-  "runner": "backfill",
+  "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
+  "capturedAt": "2026-07-30T09:05:24.575Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-forced-colors.light.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-forced-colors.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-gridblock-forced-colors",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:29:22.735Z",
-  "runner": "backfill",
+  "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
+  "capturedAt": "2026-07-30T09:05:18.776Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-images-only.dark.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-images-only.dark.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-example",
+  "storyId": "patterns-gridblock-images-only",
   "mode": "dark",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:24.384Z",
+  "capturedAt": "2026-07-30T09:05:23.157Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-images-only.forced-colors.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-images-only.forced-colors.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-forced-colors",
+  "storyId": "patterns-gridblock-images-only",
   "mode": "forced-colors",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:28.313Z",
+  "capturedAt": "2026-07-30T09:05:28.170Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-images-only.light.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-images-only.light.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-example",
-  "mode": "dark",
+  "storyId": "patterns-gridblock-images-only",
+  "mode": "light",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:24.384Z",
+  "capturedAt": "2026-07-30T09:05:17.363Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-mixed-content.dark.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-mixed-content.dark.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-example",
+  "storyId": "patterns-gridblock-mixed-content",
   "mode": "dark",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:24.384Z",
+  "capturedAt": "2026-07-30T09:05:23.989Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-mixed-content.forced-colors.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-mixed-content.forced-colors.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-forced-colors",
+  "storyId": "patterns-gridblock-mixed-content",
   "mode": "forced-colors",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:28.313Z",
+  "capturedAt": "2026-07-30T09:05:28.252Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-mixed-content.light.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-mixed-content.light.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-example",
-  "mode": "dark",
+  "storyId": "patterns-gridblock-mixed-content",
+  "mode": "light",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:24.384Z",
+  "capturedAt": "2026-07-30T09:05:18.173Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-no-gap.dark.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-no-gap.dark.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-example",
+  "storyId": "patterns-gridblock-no-gap",
   "mode": "dark",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:24.384Z",
+  "capturedAt": "2026-07-30T09:05:23.558Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-no-gap.forced-colors.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-no-gap.forced-colors.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-forced-colors",
+  "storyId": "patterns-gridblock-no-gap",
   "mode": "forced-colors",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:28.313Z",
+  "capturedAt": "2026-07-30T09:05:28.212Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-no-gap.light.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-no-gap.light.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-example",
-  "mode": "dark",
+  "storyId": "patterns-gridblock-no-gap",
+  "mode": "light",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:24.384Z",
+  "capturedAt": "2026-07-30T09:05:17.759Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-playground.dark.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-playground.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-gridblock-playground",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:37:49.685Z",
-  "runner": "backfill",
+  "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
+  "capturedAt": "2026-07-30T09:05:24.177Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-playground.forced-colors.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-playground.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "patterns-gridblock-playground",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:45:06.429Z",
-  "runner": "backfill",
+  "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
+  "capturedAt": "2026-07-30T09:05:28.271Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-playground.light.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-playground.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-gridblock-playground",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:29:22.069Z",
-  "runner": "backfill",
+  "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
+  "capturedAt": "2026-07-30T09:05:18.361Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-single-column.dark.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-single-column.dark.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-example",
+  "storyId": "patterns-gridblock-single-column",
   "mode": "dark",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:24.384Z",
+  "capturedAt": "2026-07-30T09:05:22.960Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-single-column.forced-colors.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-single-column.forced-colors.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-forced-colors",
+  "storyId": "patterns-gridblock-single-column",
   "mode": "forced-colors",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:28.313Z",
+  "capturedAt": "2026-07-30T09:05:28.145Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-single-column.light.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-single-column.light.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-example",
-  "mode": "dark",
+  "storyId": "patterns-gridblock-single-column",
+  "mode": "light",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:24.384Z",
+  "capturedAt": "2026-07-30T09:05:17.149Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-text-and-images.dark.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-text-and-images.dark.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-example",
+  "storyId": "patterns-gridblock-text-and-images",
   "mode": "dark",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:24.384Z",
+  "capturedAt": "2026-07-30T09:05:22.735Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-text-and-images.forced-colors.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-text-and-images.forced-colors.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-forced-colors",
+  "storyId": "patterns-gridblock-text-and-images",
   "mode": "forced-colors",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:28.313Z",
+  "capturedAt": "2026-07-30T09:05:28.096Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-text-and-images.light.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-text-and-images.light.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-example",
-  "mode": "dark",
+  "storyId": "patterns-gridblock-text-and-images",
+  "mode": "light",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:24.384Z",
+  "capturedAt": "2026-07-30T09:05:16.951Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-three-columns.dark.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-three-columns.dark.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-example",
+  "storyId": "patterns-gridblock-three-columns",
   "mode": "dark",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:24.384Z",
+  "capturedAt": "2026-07-30T09:05:23.351Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-three-columns.forced-colors.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-three-columns.forced-colors.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-forced-colors",
+  "storyId": "patterns-gridblock-three-columns",
   "mode": "forced-colors",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:28.313Z",
+  "capturedAt": "2026-07-30T09:05:28.192Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-three-columns.light.json
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-evidence__/patterns-gridblock-three-columns.light.json
@@ -1,8 +1,8 @@
 {
-  "storyId": "patterns-gridblock-example",
-  "mode": "dark",
+  "storyId": "patterns-gridblock-three-columns",
+  "mode": "light",
   "sourceSHA": "fe73fe1bd95b40f985c28db4bd3c72d2675de414",
-  "capturedAt": "2026-07-30T09:05:24.384Z",
+  "capturedAt": "2026-07-30T09:05:17.558Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--compact-spacing.dark.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--compact-spacing.dark.yaml
@@ -1,0 +1,2 @@
+- paragraph: Compact design for tight layouts
+- paragraph: Minimal spacing between elements

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--compact-spacing.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--compact-spacing.forced-colors.yaml
@@ -1,0 +1,2 @@
+- paragraph: Compact design for tight layouts
+- paragraph: Minimal spacing between elements

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--compact-spacing.light.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--compact-spacing.light.yaml
@@ -1,0 +1,2 @@
+- paragraph: Compact design for tight layouts
+- paragraph: Minimal spacing between elements

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--images-only.dark.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--images-only.dark.yaml
@@ -1,0 +1,8 @@
+- figure "Research and discovery phase":
+  - img "Research findings"
+- figure "Collaborative goal setting":
+  - img "Goal setting workshop"
+- figure "User journey mapping":
+  - img "User journey map"
+- figure "High-fidelity prototype":
+  - img "Prototype detail"

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--images-only.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--images-only.forced-colors.yaml
@@ -1,0 +1,8 @@
+- figure "Research and discovery phase":
+  - img "Research findings"
+- figure "Collaborative goal setting":
+  - img "Goal setting workshop"
+- figure "User journey mapping":
+  - img "User journey map"
+- figure "High-fidelity prototype":
+  - img "Prototype detail"

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--images-only.light.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--images-only.light.yaml
@@ -1,0 +1,8 @@
+- figure "Research and discovery phase":
+  - img "Research findings"
+- figure "Collaborative goal setting":
+  - img "Goal setting workshop"
+- figure "User journey mapping":
+  - img "User journey map"
+- figure "High-fidelity prototype":
+  - img "Prototype detail"

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--mixed-content.dark.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--mixed-content.dark.yaml
@@ -1,0 +1,5 @@
+- figure "System architecture overview":
+  - img "Component structure diagram"
+- paragraph: Component Architecture
+- paragraph: A well-structured component library ensures consistency and maintainability across the entire design system.
+- paragraph: Each component is built with accessibility, performance, and reusability in mind.

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--mixed-content.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--mixed-content.forced-colors.yaml
@@ -1,0 +1,5 @@
+- figure "System architecture overview":
+  - img "Component structure diagram"
+- paragraph: Component Architecture
+- paragraph: A well-structured component library ensures consistency and maintainability across the entire design system.
+- paragraph: Each component is built with accessibility, performance, and reusability in mind.

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--mixed-content.light.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--mixed-content.light.yaml
@@ -1,0 +1,5 @@
+- figure "System architecture overview":
+  - img "Component structure diagram"
+- paragraph: Component Architecture
+- paragraph: A well-structured component library ensures consistency and maintainability across the entire design system.
+- paragraph: Each component is built with accessibility, performance, and reusability in mind.

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--no-gap.dark.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--no-gap.dark.yaml
@@ -1,0 +1,4 @@
+- paragraph: Seamless Layout
+- paragraph: Content blocks can be arranged without gaps for a more compact, unified appearance.
+- paragraph: Flexible Spacing
+- paragraph: The gap property controls spacing between cells, with options from none to large.

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--no-gap.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--no-gap.forced-colors.yaml
@@ -1,0 +1,4 @@
+- paragraph: Seamless Layout
+- paragraph: Content blocks can be arranged without gaps for a more compact, unified appearance.
+- paragraph: Flexible Spacing
+- paragraph: The gap property controls spacing between cells, with options from none to large.

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--no-gap.light.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--no-gap.light.yaml
@@ -1,0 +1,4 @@
+- paragraph: Seamless Layout
+- paragraph: Content blocks can be arranged without gaps for a more compact, unified appearance.
+- paragraph: Flexible Spacing
+- paragraph: The gap property controls spacing between cells, with options from none to large.

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--single-column.dark.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--single-column.dark.yaml
@@ -1,0 +1,6 @@
+- paragraph: Project Overview
+- paragraph: This comprehensive case study explores the design and development process behind a major digital transformation initiative.
+- figure "Early wireframes and information architecture":
+  - img "Project wireframes"
+- paragraph: Research Phase
+- paragraph: Initial research involved stakeholder interviews, user testing, and competitive analysis to establish a solid foundation for the project.

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--single-column.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--single-column.forced-colors.yaml
@@ -1,0 +1,6 @@
+- paragraph: Project Overview
+- paragraph: This comprehensive case study explores the design and development process behind a major digital transformation initiative.
+- figure "Early wireframes and information architecture":
+  - img "Project wireframes"
+- paragraph: Research Phase
+- paragraph: Initial research involved stakeholder interviews, user testing, and competitive analysis to establish a solid foundation for the project.

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--single-column.light.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--single-column.light.yaml
@@ -1,0 +1,6 @@
+- paragraph: Project Overview
+- paragraph: This comprehensive case study explores the design and development process behind a major digital transformation initiative.
+- figure "Early wireframes and information architecture":
+  - img "Project wireframes"
+- paragraph: Research Phase
+- paragraph: Initial research involved stakeholder interviews, user testing, and competitive analysis to establish a solid foundation for the project.

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--text-and-images.dark.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--text-and-images.dark.yaml
@@ -1,0 +1,8 @@
+- paragraph: Mobile-First Design
+- paragraph: Every interface is crafted with mobile users in mind, ensuring seamless experiences across all device sizes and contexts.
+- figure "Mobile interface example":
+  - img "Mobile interface example"
+- figure "Desktop interface example":
+  - img "Desktop interface example"
+- paragraph: Responsive Excellence
+- paragraph: Interfaces adapt intelligently to different screen sizes, maintaining usability and aesthetic quality across platforms.

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--text-and-images.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--text-and-images.forced-colors.yaml
@@ -1,0 +1,8 @@
+- paragraph: Mobile-First Design
+- paragraph: Every interface is crafted with mobile users in mind, ensuring seamless experiences across all device sizes and contexts.
+- figure "Mobile interface example":
+  - img "Mobile interface example"
+- figure "Desktop interface example":
+  - img "Desktop interface example"
+- paragraph: Responsive Excellence
+- paragraph: Interfaces adapt intelligently to different screen sizes, maintaining usability and aesthetic quality across platforms.

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--text-and-images.light.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--text-and-images.light.yaml
@@ -1,0 +1,8 @@
+- paragraph: Mobile-First Design
+- paragraph: Every interface is crafted with mobile users in mind, ensuring seamless experiences across all device sizes and contexts.
+- figure "Mobile interface example":
+  - img "Mobile interface example"
+- figure "Desktop interface example":
+  - img "Desktop interface example"
+- paragraph: Responsive Excellence
+- paragraph: Interfaces adapt intelligently to different screen sizes, maintaining usability and aesthetic quality across platforms.

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--three-columns.dark.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--three-columns.dark.yaml
@@ -1,0 +1,6 @@
+- paragraph: Discover
+- paragraph: Research and understand user needs through interviews and analysis.
+- paragraph: Define
+- paragraph: Synthesize insights to define problems and opportunities.
+- paragraph: Deliver
+- paragraph: Build, test, and iterate on solutions with real users.

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--three-columns.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--three-columns.forced-colors.yaml
@@ -1,0 +1,6 @@
+- paragraph: Discover
+- paragraph: Research and understand user needs through interviews and analysis.
+- paragraph: Define
+- paragraph: Synthesize insights to define problems and opportunities.
+- paragraph: Deliver
+- paragraph: Build, test, and iterate on solutions with real users.

--- a/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--three-columns.light.yaml
+++ b/nextjs-app/shared/patterns/GridBlock/__a11y-snapshots__/patterns-gridblock--three-columns.light.yaml
@@ -1,0 +1,6 @@
+- paragraph: Discover
+- paragraph: Research and understand user needs through interviews and analysis.
+- paragraph: Define
+- paragraph: Synthesize insights to define problems and opportunities.
+- paragraph: Deliver
+- paragraph: Build, test, and iterate on solutions with real users.


### PR DESCRIPTION
## Summary

GridBlock typed `columns` as `1 | 2 | 3 | 4` but mapped every value except 1 to `grid2Col`, so `columns={3}` and `columns={4}` silently rendered two columns.

- `GridBlock.tsx` now maps `columns={3}` → `grid3Col` and `columns={4}` → `grid4Col`.
- `GridBlock.module.css` adds the two classes with responsive collapse following the ProcessBlock breakpoint convention: full column count ≥1024px, two columns below 1024px, one column below 768px. Gaps use `var(--space-layout-32, 2rem)` tokens, and the `@supports not (gap)` fallback covers the new classes.
- The five Work metrics sections that depended on the buggy 2-col rendering (Rhythmguard, LlmComponentSchema, DSharpDesignSystem, SapBuildApps, ProjectSpine) switch from `columns={4}` to `columns={2}`, so their 2×2 layout is pixel-identical. Other `columns={3|4}` usages in those files are ProcessBlock/TeamBlock and are untouched.
- Adds unit tests for the 3- and 4-column class mapping. The existing `ThreeColumns` Storybook story now actually renders three columns as named.

## Design system (if UI / shared / tokens touched)

- [ ] Opened the relevant **Migration board** in Storybook and approved the green **Proposed** row (if migrating off shadcn) — N/A, no shadcn migration in scope
- [x] `npm run ds:health` passes locally (pre-existing `audit:agent-experience` findings on DataTable/PixelLoop/Table primitives, unrelated to this change)
- [ ] If migration surfaces changed: `npm run test:migration:visual` — N/A, no migration surfaces changed
- [x] Deferred items unchanged (Modal / Lightbox / EnhancedContactForm unless explicitly in scope)

Docs: [`docs/DS_AUTOMATION_STRATEGY.md`](docs/DS_AUTOMATION_STRATEGY.md) · [`docs/SHADCN_TO_DT_MIGRATION.md`](docs/SHADCN_TO_DT_MIGRATION.md)

## Test plan

- [x] `npm run typecheck && npm run lint && npm test` (2842 tests / 350 files) — plus `lint:all`, `build`, `build:tokens`, `check:contract-props`, `check:consumers`
- [ ] Visual check in Storybook for affected stories / themes — not run in this environment; the five updated pages keep their exact current rendering by design (`columns={4}` → `columns={2}` matches the old buggy mapping), and only the `ThreeColumns` story renders differently (now correctly 3-col)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNwjSkM3exX8Y5L6NQjAcN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNwjSkM3exX8Y5L6NQjAcN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated metric and outcome sections across several project pages to use a more readable two-column layout.
  * Improved grid responsiveness, with three- and four-column layouts adapting to two columns on tablets and stacking on mobile.
  * Added support for distinct one-, two-, three-, and four-column grid presentations.
* **Tests**
  * Expanded coverage to verify three- and four-column grid layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->