### PR TITLE
fix(ds): recapture a11y evidence staled by #1365; doc-semantics gate back to 0

### DIFF
--- a/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-default.dark.json
+++ b/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-default.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "layout-card-default",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:36:51.674Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:34:08.627Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-default.forced-colors.json
+++ b/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-default.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "layout-card-default",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:44:25.503Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:45:38.033Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-default.light.json
+++ b/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-default.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "layout-card-default",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:29:11.636Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:11:52.554Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-example.dark.json
+++ b/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-example.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "layout-card-example",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:36:52.217Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:34:09.369Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-example.forced-colors.json
+++ b/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-example.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "layout-card-example",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:44:25.954Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:45:38.134Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-example.light.json
+++ b/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-example.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "layout-card-example",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:29:12.199Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:11:53.057Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-forced-colors.dark.json
+++ b/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-forced-colors.dark.json
@@ -1,14 +1,10 @@
 {
   "storyId": "layout-card-forced-colors",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:36:52.460Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:34:09.439Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
       "passed": true
     }

--- a/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-forced-colors.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "layout-card-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:44:26.181Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:45:38.175Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-forced-colors.light.json
+++ b/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-forced-colors.light.json
@@ -1,14 +1,10 @@
 {
   "storyId": "layout-card-forced-colors",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:29:12.454Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:11:53.088Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
       "passed": true
     }

--- a/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-playground.dark.json
+++ b/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-playground.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "layout-card-playground",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:36:51.949Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:34:08.998Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-playground.forced-colors.json
+++ b/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-playground.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "layout-card-playground",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:44:25.726Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:45:38.088Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-playground.light.json
+++ b/nextjs-app/shared/components/Card/__a11y-evidence__/layout-card-playground.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "layout-card-playground",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:29:11.907Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:11:52.807Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-default.dark.json
+++ b/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-default.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-chat-markdownmessage-default",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:39:26.265Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:30:12.278Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-default.forced-colors.json
+++ b/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-default.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-chat-markdownmessage-default",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:41:21.743Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:42:45.583Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-default.light.json
+++ b/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-default.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-chat-markdownmessage-default",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:31:35.638Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:15:36.341Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-example.dark.json
+++ b/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-example.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-chat-markdownmessage-example",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:39:26.845Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:30:13.067Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-example.forced-colors.json
+++ b/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-example.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-chat-markdownmessage-example",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:41:22.171Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:42:45.660Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-example.light.json
+++ b/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-example.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-chat-markdownmessage-example",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:31:36.143Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:15:37.000Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-forced-colors.dark.json
+++ b/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-forced-colors.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-chat-markdownmessage-forced-colors",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:39:27.096Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:30:13.463Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-forced-colors.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-chat-markdownmessage-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:41:22.379Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:42:45.693Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-forced-colors.light.json
+++ b/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-forced-colors.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-chat-markdownmessage-forced-colors",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:31:36.383Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:15:37.322Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-playground.dark.json
+++ b/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-playground.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-chat-markdownmessage-playground",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:39:26.558Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:30:12.680Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-playground.forced-colors.json
+++ b/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-playground.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-chat-markdownmessage-playground",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:41:21.958Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:42:45.628Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-playground.light.json
+++ b/nextjs-app/shared/components/MarkdownMessage/__a11y-evidence__/site-chat-markdownmessage-playground.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-chat-markdownmessage-playground",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:31:35.893Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:15:36.677Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-default.dark.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-default.dark.json
@@ -1,14 +1,10 @@
 {
   "storyId": "site-newsletterwaitlist-default",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:39:29.358Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:55:57.353Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
       "passed": true
     }

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-default.forced-colors.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-default.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-newsletterwaitlist-default",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:45:16.670Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:56:02.364Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-default.light.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-default.light.json
@@ -1,14 +1,10 @@
 {
   "storyId": "site-newsletterwaitlist-default",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:31:30.513Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:54:23.965Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
       "passed": true
     }

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-disabled.dark.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-disabled.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-newsletterwaitlist-disabled",
+  "mode": "dark",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:55:58.170Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-disabled.forced-colors.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-disabled.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "site-newsletterwaitlist-disabled",
+  "mode": "forced-colors",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:56:02.413Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-disabled.light.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-disabled.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-newsletterwaitlist-disabled",
+  "mode": "light",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:54:24.810Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-example.dark.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-example.dark.json
@@ -1,14 +1,10 @@
 {
   "storyId": "site-newsletterwaitlist-example",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:39:29.808Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:55:58.671Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
       "passed": true
     }

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-example.forced-colors.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-example.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-newsletterwaitlist-example",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:45:17.073Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:56:02.550Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-example.light.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-example.light.json
@@ -1,14 +1,10 @@
 {
   "storyId": "site-newsletterwaitlist-example",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:31:30.976Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:54:25.364Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
       "passed": true
     }

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-forced-colors.dark.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-forced-colors.dark.json
@@ -1,14 +1,10 @@
 {
   "storyId": "site-newsletterwaitlist-forced-colors",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:39:30.058Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:55:58.708Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
       "passed": true
     }

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-forced-colors.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-newsletterwaitlist-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:45:17.277Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:56:02.575Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-forced-colors.light.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-forced-colors.light.json
@@ -1,14 +1,10 @@
 {
   "storyId": "site-newsletterwaitlist-forced-colors",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:31:31.239Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:54:25.404Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
       "passed": true
     }

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-kitchen-sink.dark.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-kitchen-sink.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-newsletterwaitlist-kitchen-sink",
+  "mode": "dark",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:55:58.625Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-kitchen-sink.forced-colors.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-kitchen-sink.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "site-newsletterwaitlist-kitchen-sink",
+  "mode": "forced-colors",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:56:02.498Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-kitchen-sink.light.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-kitchen-sink.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-newsletterwaitlist-kitchen-sink",
+  "mode": "light",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:54:25.318Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-playground.dark.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-playground.dark.json
@@ -1,14 +1,10 @@
 {
   "storyId": "site-newsletterwaitlist-playground",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:39:29.592Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:55:58.646Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
       "passed": true
     }

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-playground.forced-colors.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-playground.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-newsletterwaitlist-playground",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:45:16.865Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:56:02.525Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-playground.light.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-playground.light.json
@@ -1,14 +1,10 @@
 {
   "storyId": "site-newsletterwaitlist-playground",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:31:30.732Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:54:25.339Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
       "passed": true
     }

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-with-callbacks.dark.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-with-callbacks.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-newsletterwaitlist-with-callbacks",
+  "mode": "dark",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:55:58.410Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-with-callbacks.forced-colors.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-with-callbacks.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "site-newsletterwaitlist-with-callbacks",
+  "mode": "forced-colors",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:56:02.470Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-with-callbacks.light.json
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-evidence__/site-newsletterwaitlist-with-callbacks.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-newsletterwaitlist-with-callbacks",
+  "mode": "light",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:54:25.086Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-snapshots__/site-newsletterwaitlist--disabled.dark.yaml
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-snapshots__/site-newsletterwaitlist--disabled.dark.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- button "Join the waitlist" [disabled]

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-snapshots__/site-newsletterwaitlist--disabled.forced-colors.yaml
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-snapshots__/site-newsletterwaitlist--disabled.forced-colors.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- button "Join the waitlist" [disabled]

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-snapshots__/site-newsletterwaitlist--disabled.light.yaml
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-snapshots__/site-newsletterwaitlist--disabled.light.yaml
@@ -1,0 +1,2 @@
+- status: Work in progress (beta)
+- button "Join the waitlist" [disabled]

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-snapshots__/site-newsletterwaitlist--kitchen-sink.dark.yaml
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-snapshots__/site-newsletterwaitlist--kitchen-sink.dark.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- heading "Default State" [level=3]
+- button "Join the waitlist"
+- heading "Disabled" [level=3]
+- button "Join the waitlist" [disabled]

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-snapshots__/site-newsletterwaitlist--kitchen-sink.forced-colors.yaml
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-snapshots__/site-newsletterwaitlist--kitchen-sink.forced-colors.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- heading "Default State" [level=3]
+- button "Join the waitlist"
+- heading "Disabled" [level=3]
+- button "Join the waitlist" [disabled]

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-snapshots__/site-newsletterwaitlist--kitchen-sink.light.yaml
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-snapshots__/site-newsletterwaitlist--kitchen-sink.light.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (beta)
+- heading "Default State" [level=3]
+- button "Join the waitlist"
+- heading "Disabled" [level=3]
+- button "Join the waitlist" [disabled]

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-snapshots__/site-newsletterwaitlist--with-callbacks.dark.yaml
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-snapshots__/site-newsletterwaitlist--with-callbacks.dark.yaml
@@ -1,0 +1,8 @@
+- status: Work in progress (beta)
+- heading "Dunno when there's something stellar to send newsletters about, but you'll be among the first to know if and when that happens." [level=2]
+- paragraph: We promise not to spam you with annoying and useless content 🤞 So you get our product launches, design systems, and AI updates first.
+- text: Email address
+- textbox "Email address":
+  - /placeholder: name@email.com
+- button "Cancel"
+- button "Notify me" [disabled]

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-snapshots__/site-newsletterwaitlist--with-callbacks.forced-colors.yaml
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-snapshots__/site-newsletterwaitlist--with-callbacks.forced-colors.yaml
@@ -1,0 +1,8 @@
+- status: Work in progress (beta)
+- heading "Dunno when there's something stellar to send newsletters about, but you'll be among the first to know if and when that happens." [level=2]
+- paragraph: We promise not to spam you with annoying and useless content 🤞 So you get our product launches, design systems, and AI updates first.
+- text: Email address
+- textbox "Email address":
+  - /placeholder: name@email.com
+- button "Cancel"
+- button "Notify me" [disabled]

--- a/nextjs-app/shared/components/NewsletterWaitlist/__a11y-snapshots__/site-newsletterwaitlist--with-callbacks.light.yaml
+++ b/nextjs-app/shared/components/NewsletterWaitlist/__a11y-snapshots__/site-newsletterwaitlist--with-callbacks.light.yaml
@@ -1,0 +1,8 @@
+- status: Work in progress (beta)
+- heading "Dunno when there's something stellar to send newsletters about, but you'll be among the first to know if and when that happens." [level=2]
+- paragraph: We promise not to spam you with annoying and useless content 🤞 So you get our product launches, design systems, and AI updates first.
+- text: Email address
+- textbox "Email address":
+  - /placeholder: name@email.com
+- button "Cancel"
+- button "Notify me" [disabled]

--- a/nextjs-app/shared/components/ScrollIndicator/ScrollIndicator.stories.tsx
+++ b/nextjs-app/shared/components/ScrollIndicator/ScrollIndicator.stories.tsx
@@ -90,6 +90,7 @@ function HeroFrame({ children }: { children: React.ReactNode }) {
 }
 
 export const Default: Story = {
+  tags: ["beta-matrix"],
   args: { targetId: "next-section", label: "See our work" },
   render: (args) => (
     <HeroFrame>

--- a/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-default.dark.json
+++ b/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-default.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "navigation-scrollindicator-default",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:36:55.018Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:15.935Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-default.forced-colors.json
+++ b/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-default.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "navigation-scrollindicator-default",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:41:56.491Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:21.966Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-default.light.json
+++ b/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-default.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "navigation-scrollindicator-default",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:30:01.388Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:01:56.251Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-example.dark.json
+++ b/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-example.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "navigation-scrollindicator-example",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:36:55.512Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:16.372Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-example.forced-colors.json
+++ b/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-example.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "navigation-scrollindicator-example",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:41:56.926Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:22.024Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-example.light.json
+++ b/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-example.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "navigation-scrollindicator-example",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:30:02.025Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:01:56.664Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-forced-colors.dark.json
+++ b/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-forced-colors.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "navigation-scrollindicator-forced-colors",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:36:55.751Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:16.592Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-forced-colors.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "navigation-scrollindicator-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:41:57.144Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:22.067Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-forced-colors.light.json
+++ b/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-forced-colors.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "navigation-scrollindicator-forced-colors",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:30:02.329Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:01:56.863Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-playground.dark.json
+++ b/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-playground.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "navigation-scrollindicator-playground",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:36:55.240Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:16.156Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-playground.forced-colors.json
+++ b/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-playground.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "navigation-scrollindicator-playground",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:41:56.702Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:21.987Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-playground.light.json
+++ b/nextjs-app/shared/components/ScrollIndicator/__a11y-evidence__/navigation-scrollindicator-playground.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "navigation-scrollindicator-playground",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:30:01.725Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:01:56.468Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/ScrollIndicator/__a11y-snapshots__/navigation-scrollindicator--default.dark.yaml
+++ b/nextjs-app/shared/components/ScrollIndicator/__a11y-snapshots__/navigation-scrollindicator--default.dark.yaml
@@ -1,0 +1,2 @@
+- paragraph: Hero copy sits here. The indicator anchors to the bottom of this frame.
+- button "See our work"

--- a/nextjs-app/shared/components/ScrollIndicator/__a11y-snapshots__/navigation-scrollindicator--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/ScrollIndicator/__a11y-snapshots__/navigation-scrollindicator--default.forced-colors.yaml
@@ -1,0 +1,2 @@
+- paragraph: Hero copy sits here. The indicator anchors to the bottom of this frame.
+- button "See our work"

--- a/nextjs-app/shared/components/ScrollIndicator/__a11y-snapshots__/navigation-scrollindicator--default.light.yaml
+++ b/nextjs-app/shared/components/ScrollIndicator/__a11y-snapshots__/navigation-scrollindicator--default.light.yaml
@@ -1,0 +1,2 @@
+- paragraph: Hero copy sits here. The indicator anchors to the bottom of this frame.
+- button "See our work"

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-default.dark.json
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-default.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-sentrysummarycard-default",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:39:36.097Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:29:39.383Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-default.forced-colors.json
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-default.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-sentrysummarycard-default",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:45:21.920Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:44:55.995Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-default.light.json
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-default.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-sentrysummarycard-default",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:30:20.095Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:20:24.227Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-example.dark.json
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-example.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-sentrysummarycard-example",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:39:36.537Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:29:40.168Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-example.forced-colors.json
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-example.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-sentrysummarycard-example",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:45:22.380Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:44:56.090Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-example.light.json
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-example.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-sentrysummarycard-example",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:30:20.589Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:20:24.873Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-forced-colors.dark.json
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-forced-colors.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-sentrysummarycard-forced-colors",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:39:36.749Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:29:40.570Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-forced-colors.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-sentrysummarycard-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:45:22.590Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:44:56.130Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-forced-colors.light.json
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-forced-colors.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-sentrysummarycard-forced-colors",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:30:20.825Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:20:25.298Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-playground.dark.json
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-playground.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-sentrysummarycard-playground",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:39:36.322Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:29:39.785Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-playground.forced-colors.json
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-playground.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-sentrysummarycard-playground",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:45:22.163Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:44:56.030Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-playground.light.json
+++ b/nextjs-app/shared/components/SentrySummaryCard/__a11y-evidence__/site-sentrysummarycard-playground.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-sentrysummarycard-playground",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:30:20.347Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:20:24.547Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-default.dark.json
+++ b/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-default.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-servicesgrid-default",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:38:09.333Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:29:20.072Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-default.forced-colors.json
+++ b/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-default.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-servicesgrid-default",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:44:17.278Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:42:48.937Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-default.light.json
+++ b/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-default.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-servicesgrid-default",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:31:07.614Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:14:32.677Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-example.dark.json
+++ b/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-example.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-servicesgrid-example",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:38:09.832Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:29:20.999Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-example.forced-colors.json
+++ b/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-example.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-servicesgrid-example",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:44:17.710Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:42:49.699Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-example.light.json
+++ b/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-example.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-servicesgrid-example",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:31:08.154Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:14:33.209Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-forced-colors.dark.json
+++ b/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-forced-colors.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-servicesgrid-forced-colors",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:38:10.071Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:29:21.456Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-forced-colors.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-servicesgrid-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:44:17.916Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:42:49.772Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-forced-colors.light.json
+++ b/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-forced-colors.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-servicesgrid-forced-colors",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:31:08.449Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:14:33.520Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-playground.dark.json
+++ b/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-playground.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-servicesgrid-playground",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:38:09.581Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:29:20.514Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-playground.forced-colors.json
+++ b/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-playground.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-servicesgrid-playground",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:44:17.494Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:42:49.300Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-playground.light.json
+++ b/nextjs-app/shared/components/ServicesGrid/__a11y-evidence__/site-servicesgrid-playground.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-servicesgrid-playground",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:31:07.885Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:14:32.946Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/SlideButton/SlideButton.stories.tsx
+++ b/nextjs-app/shared/components/SlideButton/SlideButton.stories.tsx
@@ -69,6 +69,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  tags: ["beta-matrix"],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const link = canvas.getByRole("link", { name: "Start your sprint" });

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-default.dark.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-default.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "actions-slidebutton-default",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:37:43.083Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:12.609Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-default.forced-colors.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-default.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "actions-slidebutton-default",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:42:28.443Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:19.868Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-default.light.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-default.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "actions-slidebutton-default",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:32:41.527Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:01:53.095Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-example.dark.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-example.dark.json
@@ -1,14 +1,10 @@
 {
   "storyId": "actions-slidebutton-example",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:37:43.539Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:13.461Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
       "passed": true
     }

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-example.forced-colors.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-example.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "actions-slidebutton-example",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:42:28.871Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:20.013Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-example.light.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-example.light.json
@@ -1,14 +1,10 @@
 {
   "storyId": "actions-slidebutton-example",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:32:42.080Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:01:53.953Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
       "passed": true
     }

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-forced-colors.dark.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-forced-colors.dark.json
@@ -1,14 +1,10 @@
 {
   "storyId": "actions-slidebutton-forced-colors",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:37:43.767Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:13.494Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
       "passed": true
     }

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-forced-colors.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "actions-slidebutton-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:42:29.062Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:20.032Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-forced-colors.light.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-forced-colors.light.json
@@ -1,14 +1,10 @@
 {
   "storyId": "actions-slidebutton-forced-colors",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:32:42.413Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:01:53.970Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
       "passed": true
     }

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-icon-right.dark.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-icon-right.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "actions-slidebutton-icon-right",
+  "mode": "dark",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:12.815Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-icon-right.forced-colors.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-icon-right.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "actions-slidebutton-icon-right",
+  "mode": "forced-colors",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:19.890Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-icon-right.light.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-icon-right.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "actions-slidebutton-icon-right",
+  "mode": "light",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:01:53.312Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-icons.dark.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-icons.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "actions-slidebutton-icons",
+  "mode": "dark",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:13.009Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-icons.forced-colors.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-icons.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "actions-slidebutton-icons",
+  "mode": "forced-colors",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:19.929Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-icons.light.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-icons.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "actions-slidebutton-icons",
+  "mode": "light",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:01:53.520Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-in-context.dark.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-in-context.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "actions-slidebutton-in-context",
+  "mode": "dark",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:13.427Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-in-context.forced-colors.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-in-context.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "actions-slidebutton-in-context",
+  "mode": "forced-colors",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:19.973Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-in-context.light.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-in-context.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "actions-slidebutton-in-context",
+  "mode": "light",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:01:53.912Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-long-label.dark.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-long-label.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "actions-slidebutton-long-label",
+  "mode": "dark",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:13.203Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-long-label.forced-colors.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-long-label.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "actions-slidebutton-long-label",
+  "mode": "forced-colors",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:19.954Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-long-label.light.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-long-label.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "actions-slidebutton-long-label",
+  "mode": "light",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:01:53.728Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-playground.dark.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-playground.dark.json
@@ -1,14 +1,10 @@
 {
   "storyId": "actions-slidebutton-playground",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:37:43.318Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:13.444Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
       "passed": true
     }

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-playground.forced-colors.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-playground.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "actions-slidebutton-playground",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:42:28.683Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:02:19.992Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-playground.light.json
+++ b/nextjs-app/shared/components/SlideButton/__a11y-evidence__/actions-slidebutton-playground.light.json
@@ -1,14 +1,10 @@
 {
   "storyId": "actions-slidebutton-playground",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:32:41.786Z",
-  "runner": "backfill",
+  "sourceSHA": "603bb8cb8dc731534156897e8607a5851e99b148",
+  "capturedAt": "2026-07-30T09:01:53.931Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
       "passed": true
     }

--- a/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--default.dark.yaml
+++ b/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--default.dark.yaml
@@ -1,0 +1,2 @@
+- link "Start your sprint":
+  - /url: /contact?service=design-sprint

--- a/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--default.forced-colors.yaml
@@ -1,0 +1,2 @@
+- link "Start your sprint":
+  - /url: /contact?service=design-sprint

--- a/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--default.light.yaml
+++ b/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--default.light.yaml
@@ -1,0 +1,2 @@
+- link "Start your sprint":
+  - /url: /contact?service=design-sprint

--- a/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--icon-right.dark.yaml
+++ b/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--icon-right.dark.yaml
@@ -1,0 +1,2 @@
+- link "Start your sprint":
+  - /url: /contact?service=design-sprint

--- a/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--icon-right.forced-colors.yaml
+++ b/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--icon-right.forced-colors.yaml
@@ -1,0 +1,2 @@
+- link "Start your sprint":
+  - /url: /contact?service=design-sprint

--- a/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--icon-right.light.yaml
+++ b/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--icon-right.light.yaml
@@ -1,0 +1,2 @@
+- link "Start your sprint":
+  - /url: /contact?service=design-sprint

--- a/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--icons.dark.yaml
+++ b/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--icons.dark.yaml
@@ -1,0 +1,6 @@
+- link "Start your sprint":
+  - /url: "#sprint"
+- link "See the work":
+  - /url: "#work"
+- link "Read the story":
+  - /url: "#story"

--- a/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--icons.forced-colors.yaml
+++ b/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--icons.forced-colors.yaml
@@ -1,0 +1,6 @@
+- link "Start your sprint":
+  - /url: "#sprint"
+- link "See the work":
+  - /url: "#work"
+- link "Read the story":
+  - /url: "#story"

--- a/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--icons.light.yaml
+++ b/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--icons.light.yaml
@@ -1,0 +1,6 @@
+- link "Start your sprint":
+  - /url: "#sprint"
+- link "See the work":
+  - /url: "#work"
+- link "Read the story":
+  - /url: "#story"

--- a/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--in-context.dark.yaml
+++ b/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--in-context.dark.yaml
@@ -1,0 +1,2 @@
+- link "Start your sprint":
+  - /url: "#sprint"

--- a/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--in-context.forced-colors.yaml
+++ b/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--in-context.forced-colors.yaml
@@ -1,0 +1,2 @@
+- link "Start your sprint":
+  - /url: "#sprint"

--- a/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--in-context.light.yaml
+++ b/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--in-context.light.yaml
@@ -1,0 +1,2 @@
+- link "Start your sprint":
+  - /url: "#sprint"

--- a/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--long-label.dark.yaml
+++ b/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--long-label.dark.yaml
@@ -1,0 +1,4 @@
+- link "Book a discovery call with the team":
+  - /url: "#call"
+- link "Aloita suunnittelusprintti tänään":
+  - /url: "#fi"

--- a/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--long-label.forced-colors.yaml
+++ b/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--long-label.forced-colors.yaml
@@ -1,0 +1,4 @@
+- link "Book a discovery call with the team":
+  - /url: "#call"
+- link "Aloita suunnittelusprintti tänään":
+  - /url: "#fi"

--- a/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--long-label.light.yaml
+++ b/nextjs-app/shared/components/SlideButton/__a11y-snapshots__/actions-slidebutton--long-label.light.yaml
@@ -1,0 +1,4 @@
+- link "Book a discovery call with the team":
+  - /url: "#call"
+- link "Aloita suunnittelusprintti tänään":
+  - /url: "#fi"

--- a/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-default.dark.json
+++ b/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-default.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-transformingactioninput-default",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:34:00.998Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:25:26.923Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-default.forced-colors.json
+++ b/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-default.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-transformingactioninput-default",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:43:24.945Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:41:29.887Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-default.light.json
+++ b/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-default.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-transformingactioninput-default",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:26:46.417Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:16:05.419Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-example.dark.json
+++ b/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-example.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-transformingactioninput-example",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:34:01.545Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:25:27.745Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-example.forced-colors.json
+++ b/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-example.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-transformingactioninput-example",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:43:25.356Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:41:29.963Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-example.light.json
+++ b/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-example.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-transformingactioninput-example",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:26:47.049Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:16:06.051Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-forced-colors.dark.json
+++ b/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-forced-colors.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-transformingactioninput-forced-colors",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:34:01.826Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:25:28.337Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-forced-colors.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-transformingactioninput-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:43:25.569Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:41:29.997Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-forced-colors.light.json
+++ b/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-forced-colors.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-transformingactioninput-forced-colors",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:26:47.440Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:16:06.444Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-playground.dark.json
+++ b/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-playground.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-transformingactioninput-playground",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:34:01.291Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:25:27.330Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-playground.forced-colors.json
+++ b/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-playground.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-transformingactioninput-playground",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:43:25.155Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:41:29.933Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-playground.light.json
+++ b/nextjs-app/shared/components/TransformingActionInput/__a11y-evidence__/site-transformingactioninput-playground.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-transformingactioninput-playground",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:26:46.727Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:16:05.743Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/WipBadge/__a11y-evidence__/site-wipbadge-example.dark.json
+++ b/nextjs-app/shared/components/WipBadge/__a11y-evidence__/site-wipbadge-example.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-wipbadge-example",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:34:17.434Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:30:34.055Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/WipBadge/__a11y-evidence__/site-wipbadge-example.forced-colors.json
+++ b/nextjs-app/shared/components/WipBadge/__a11y-evidence__/site-wipbadge-example.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-wipbadge-example",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:45:27.549Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:46:38.125Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/WipBadge/__a11y-evidence__/site-wipbadge-example.light.json
+++ b/nextjs-app/shared/components/WipBadge/__a11y-evidence__/site-wipbadge-example.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-wipbadge-example",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:28:38.023Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:18:00.461Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/WipBadge/__a11y-evidence__/site-wipbadge-forced-colors.dark.json
+++ b/nextjs-app/shared/components/WipBadge/__a11y-evidence__/site-wipbadge-forced-colors.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-wipbadge-forced-colors",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:34:17.647Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:30:34.325Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/WipBadge/__a11y-evidence__/site-wipbadge-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/WipBadge/__a11y-evidence__/site-wipbadge-forced-colors.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-wipbadge-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:45:27.769Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:46:38.160Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/WipBadge/__a11y-evidence__/site-wipbadge-forced-colors.light.json
+++ b/nextjs-app/shared/components/WipBadge/__a11y-evidence__/site-wipbadge-forced-colors.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-wipbadge-forced-colors",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:28:38.306Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:18:00.750Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/WipBadge/__a11y-evidence__/site-wipbadge-playground.dark.json
+++ b/nextjs-app/shared/components/WipBadge/__a11y-evidence__/site-wipbadge-playground.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-wipbadge-playground",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:34:17.212Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:30:33.759Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/WipBadge/__a11y-evidence__/site-wipbadge-playground.forced-colors.json
+++ b/nextjs-app/shared/components/WipBadge/__a11y-evidence__/site-wipbadge-playground.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-wipbadge-playground",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:45:27.347Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:46:38.080Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/WipBadge/__a11y-evidence__/site-wipbadge-playground.light.json
+++ b/nextjs-app/shared/components/WipBadge/__a11y-evidence__/site-wipbadge-playground.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-wipbadge-playground",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:28:37.761Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:18:00.189Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-default.dark.json
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-default.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-contactinquirypanel-default",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:33:44.871Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:33:41.170Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-default.forced-colors.json
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-default.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "patterns-contactinquirypanel-default",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:40:52.584Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:45:51.167Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-default.light.json
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-default.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-contactinquirypanel-default",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:26:46.479Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:13:39.106Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-example.dark.json
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-example.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-contactinquirypanel-example",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:33:45.538Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:33:42.075Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-example.forced-colors.json
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-example.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "patterns-contactinquirypanel-example",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:40:53.068Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:45:51.265Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-example.light.json
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-example.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-contactinquirypanel-example",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:26:47.408Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:13:39.778Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-forced-colors.dark.json
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-forced-colors.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-contactinquirypanel-forced-colors",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:33:45.881Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:33:42.633Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-forced-colors.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "patterns-contactinquirypanel-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:40:53.333Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:45:51.307Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-forced-colors.light.json
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-forced-colors.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-contactinquirypanel-forced-colors",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:26:47.877Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:13:40.115Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-playground.dark.json
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-playground.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-contactinquirypanel-playground",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:33:45.205Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:33:41.579Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-playground.forced-colors.json
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-playground.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "patterns-contactinquirypanel-playground",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:40:52.814Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:45:51.223Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-playground.light.json
+++ b/nextjs-app/shared/patterns/ContactInquiryPanel/__a11y-evidence__/patterns-contactinquirypanel-playground.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-contactinquirypanel-playground",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:26:46.950Z",
-  "runner": "backfill",
+  "sourceSHA": "f1c1c5dec11fa297d838eb79e225188978d9e1fb",
+  "capturedAt": "2026-07-30T08:13:39.435Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--default.dark.yaml
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--default.dark.yaml
@@ -25,7 +25,7 @@
 - img "Portrait of Petri Lahdelma"
 - heading "New Business Inquiries" [level=2]
 - paragraph: Petri Lahdelma
-- paragraph: Founder, Head of Design
+- paragraph: Founder, Designer
 - link "Book a call":
   - /url: "#contact-form"
 - blockquote:

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--default.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--default.forced-colors.yaml
@@ -25,7 +25,7 @@
 - img "Portrait of Petri Lahdelma"
 - heading "New Business Inquiries" [level=2]
 - paragraph: Petri Lahdelma
-- paragraph: Founder, Head of Design
+- paragraph: Founder, Designer
 - link "Book a call":
   - /url: "#contact-form"
 - blockquote:

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--default.light.yaml
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--default.light.yaml
@@ -25,7 +25,7 @@
 - img "Portrait of Petri Lahdelma"
 - heading "New Business Inquiries" [level=2]
 - paragraph: Petri Lahdelma
-- paragraph: Founder, Head of Design
+- paragraph: Founder, Designer
 - link "Book a call":
   - /url: "#contact-form"
 - blockquote:

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--example.dark.yaml
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--example.dark.yaml
@@ -25,7 +25,7 @@
 - img "Portrait of Petri Lahdelma"
 - heading "New Business Inquiries" [level=2]
 - paragraph: Petri Lahdelma
-- paragraph: Founder, Head of Design
+- paragraph: Founder, Designer
 - link "Book a call":
   - /url: "#contact-form"
 - blockquote:

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--example.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--example.forced-colors.yaml
@@ -25,7 +25,7 @@
 - img "Portrait of Petri Lahdelma"
 - heading "New Business Inquiries" [level=2]
 - paragraph: Petri Lahdelma
-- paragraph: Founder, Head of Design
+- paragraph: Founder, Designer
 - link "Book a call":
   - /url: "#contact-form"
 - blockquote:

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--example.light.yaml
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--example.light.yaml
@@ -25,7 +25,7 @@
 - img "Portrait of Petri Lahdelma"
 - heading "New Business Inquiries" [level=2]
 - paragraph: Petri Lahdelma
-- paragraph: Founder, Head of Design
+- paragraph: Founder, Designer
 - link "Book a call":
   - /url: "#contact-form"
 - blockquote:

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--forced-colors.dark.yaml
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--forced-colors.dark.yaml
@@ -25,7 +25,7 @@
 - img "Portrait of Petri Lahdelma"
 - heading "New Business Inquiries" [level=2]
 - paragraph: Petri Lahdelma
-- paragraph: Founder, Head of Design
+- paragraph: Founder, Designer
 - link "Book a call":
   - /url: "#contact-form"
 - blockquote:

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--forced-colors.forced-colors.yaml
@@ -25,7 +25,7 @@
 - img "Portrait of Petri Lahdelma"
 - heading "New Business Inquiries" [level=2]
 - paragraph: Petri Lahdelma
-- paragraph: Founder, Head of Design
+- paragraph: Founder, Designer
 - link "Book a call":
   - /url: "#contact-form"
 - blockquote:

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--forced-colors.light.yaml
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--forced-colors.light.yaml
@@ -25,7 +25,7 @@
 - img "Portrait of Petri Lahdelma"
 - heading "New Business Inquiries" [level=2]
 - paragraph: Petri Lahdelma
-- paragraph: Founder, Head of Design
+- paragraph: Founder, Designer
 - link "Book a call":
   - /url: "#contact-form"
 - blockquote:

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--playground.dark.yaml
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--playground.dark.yaml
@@ -25,7 +25,7 @@
 - img "Portrait of Petri Lahdelma"
 - heading "New Business Inquiries" [level=2]
 - paragraph: Petri Lahdelma
-- paragraph: Founder, Head of Design
+- paragraph: Founder, Designer
 - link "Book a call":
   - /url: "#contact-form"
 - blockquote:

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--playground.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--playground.forced-colors.yaml
@@ -25,7 +25,7 @@
 - img "Portrait of Petri Lahdelma"
 - heading "New Business Inquiries" [level=2]
 - paragraph: Petri Lahdelma
-- paragraph: Founder, Head of Design
+- paragraph: Founder, Designer
 - link "Book a call":
   - /url: "#contact-form"
 - blockquote:

--- a/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--playground.light.yaml
+++ b/nextjs-app/shared/patterns/ContactPageContentEditorial/__a11y-snapshots__/patterns-contactpagecontenteditorial--playground.light.yaml
@@ -25,7 +25,7 @@
 - img "Portrait of Petri Lahdelma"
 - heading "New Business Inquiries" [level=2]
 - paragraph: Petri Lahdelma
-- paragraph: Founder, Head of Design
+- paragraph: Founder, Designer
 - link "Book a call":
   - /url: "#contact-form"
 - blockquote:


### PR DESCRIPTION

check-doc-semantics failed on main (18 unverified a11y criteria on
beta/stable, ceiling 0): #1365's phantom-token CSS renames touched 8
beta/stable components (Card, ContactInquiryPanel, WipBadge,
MarkdownMessage, NewsletterWaitlist, SentrySummaryCard, ServicesGrid,
TransformingActionInput), staling their SHA-path-guarded evidence.
check-doc-semantics is not in lint:all, so the local gate never saw it.

- Recaptured evidence for the 8 staled components in light/dark/
  forced-colors via the Storybook runner (DT_UPDATE_A11Y_SNAPSHOTS=1;
  verify-mode runs do not emit).
- Evidence for all other components restored untouched: the faithful
  runner (#1339) honors story-level axe opt-outs, so a blanket rerun
  strips grandfathered axe checks from 14 components whose matrix
  stories disable axe. Only the staled 8 needed new records.
- NewsletterWaitlist's matrix stories all disable axe; its axe evidence
  now comes from the non-matrix stories (kitchen-sink, with-callbacks,
  disabled) captured in all three modes with their AT snapshots.
- tag-beta-matrix-stories tagged two uncovered Default stories
  (ScrollIndicator, SlideButton); their snapshots are captured in all
  three modes.
- ContactPageContentEditorial AT snapshots updated for real copy drift
  ("Founder, Head of Design" -> "Founder, Designer").
- SentrySummaryCard snapshot rewrites discarded: local capture caught
  the loading skeleton (adds status "Loading content"), a race, not a
  regression.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

Verified: check-doc-semantics 0/0 on this branch; full local gate (typecheck, lint:all, 2840 tests, build) all exit 0; this branch pushed through the complete pre-push chain WITHOUT --no-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)