### PR TITLE
fix(ds): StoryBlock subtitle becomes a non-heading kicker at text-s

### DIFF
--- a/nextjs-app/shared/patterns/StoryBlock/StoryBlock.tsx
+++ b/nextjs-app/shared/patterns/StoryBlock/StoryBlock.tsx
@@ -123,13 +123,11 @@ const StoryBlock: React.FC<StoryBlockProps> = ({
         <div className={styles.grid1Col}>
           <div className={styles.col}>
             {subtitle && (
-              <Title
-                level={4}
-                size="xs"
-                className={styles.subtitle}
-              >
+              // Kicker, not a heading: it must not outrank or precede the real
+              // section title in the outline AT users navigate by.
+              <Text size="s" className={styles.subtitle}>
                 {subtitle}
-              </Title>
+              </Text>
             )}
             <Title level={4} size="s" className={styles.title}>
               {title}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-compact-spacing.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-compact-spacing.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "patterns-storyblock-compact-spacing",
+  "mode": "dark",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:39.735Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-compact-spacing.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-compact-spacing.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "patterns-storyblock-compact-spacing",
+  "mode": "forced-colors",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:44.971Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-compact-spacing.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-compact-spacing.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "patterns-storyblock-compact-spacing",
+  "mode": "light",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:32.973Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-default.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-default.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-storyblock-default",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:35:09.933Z",
-  "runner": "backfill",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:38.369Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-default.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-default.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "patterns-storyblock-default",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:42:09.658Z",
-  "runner": "backfill",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:44.786Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-default.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-default.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-storyblock-default",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:24:53.286Z",
-  "runner": "backfill",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:31.563Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-example.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-example.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-storyblock-example",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:35:10.443Z",
-  "runner": "backfill",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:40.819Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-example.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-example.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "patterns-storyblock-example",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:42:10.065Z",
-  "runner": "backfill",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:45.091Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-example.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-example.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-storyblock-example",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:24:53.771Z",
-  "runner": "backfill",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:34.047Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-forced-colors.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-forced-colors.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-storyblock-forced-colors",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:35:10.703Z",
-  "runner": "backfill",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:41.058Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-forced-colors.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "patterns-storyblock-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:42:10.283Z",
-  "runner": "backfill",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:45.119Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-forced-colors.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-forced-colors.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-storyblock-forced-colors",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:24:54.009Z",
-  "runner": "backfill",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:34.270Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-full-width.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-full-width.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "patterns-storyblock-full-width",
+  "mode": "dark",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:39.961Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-full-width.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-full-width.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "patterns-storyblock-full-width",
+  "mode": "forced-colors",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:44.995Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-full-width.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-full-width.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "patterns-storyblock-full-width",
+  "mode": "light",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:33.193Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-multiple-images-single-layout.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-multiple-images-single-layout.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "patterns-storyblock-multiple-images-single-layout",
+  "mode": "dark",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:40.185Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-multiple-images-single-layout.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-multiple-images-single-layout.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "patterns-storyblock-multiple-images-single-layout",
+  "mode": "forced-colors",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:45.019Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-multiple-images-single-layout.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-multiple-images-single-layout.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "patterns-storyblock-multiple-images-single-layout",
+  "mode": "light",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:33.419Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-playground.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-playground.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-storyblock-playground",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:35:10.182Z",
-  "runner": "backfill",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:40.607Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-playground.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-playground.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "patterns-storyblock-playground",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:42:09.852Z",
-  "runner": "backfill",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:45.067Z",
+  "runner": null,
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-playground.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-playground.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "patterns-storyblock-playground",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:24:53.533Z",
-  "runner": "backfill",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:33.845Z",
+  "runner": null,
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-rich-content.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-rich-content.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "patterns-storyblock-rich-content",
+  "mode": "dark",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:40.396Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-rich-content.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-rich-content.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "patterns-storyblock-rich-content",
+  "mode": "forced-colors",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:45.042Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-rich-content.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-rich-content.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "patterns-storyblock-rich-content",
+  "mode": "light",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:33.626Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-text-only.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-text-only.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "patterns-storyblock-text-only",
+  "mode": "dark",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:39.071Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-text-only.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-text-only.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "patterns-storyblock-text-only",
+  "mode": "forced-colors",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:44.901Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-text-only.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-text-only.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "patterns-storyblock-text-only",
+  "mode": "light",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:32.309Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-wide-layout.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-wide-layout.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "patterns-storyblock-wide-layout",
+  "mode": "dark",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:39.516Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-wide-layout.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-wide-layout.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "patterns-storyblock-wide-layout",
+  "mode": "forced-colors",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:44.950Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-wide-layout.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-wide-layout.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "patterns-storyblock-wide-layout",
+  "mode": "light",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:32.759Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-image-grid.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-image-grid.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "patterns-storyblock-with-image-grid",
+  "mode": "dark",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:38.854Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-image-grid.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-image-grid.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "patterns-storyblock-with-image-grid",
+  "mode": "forced-colors",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:44.846Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-image-grid.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-image-grid.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "patterns-storyblock-with-image-grid",
+  "mode": "light",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:32.062Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-light-background.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-light-background.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "patterns-storyblock-with-light-background",
+  "mode": "dark",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:39.295Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-light-background.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-light-background.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "patterns-storyblock-with-light-background",
+  "mode": "forced-colors",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:44.926Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-light-background.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-light-background.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "patterns-storyblock-with-light-background",
+  "mode": "light",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:32.530Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-single-image.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-single-image.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "patterns-storyblock-with-single-image",
+  "mode": "dark",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:38.618Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-single-image.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-single-image.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "patterns-storyblock-with-single-image",
+  "mode": "forced-colors",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:44.816Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-single-image.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-single-image.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "patterns-storyblock-with-single-image",
+  "mode": "light",
+  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
+  "capturedAt": "2026-07-30T09:59:31.836Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--compact-spacing.dark.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--compact-spacing.dark.yaml
@@ -1,0 +1,4 @@
+- region "Project Summary":
+  - paragraph: Quick Overview
+  - heading "Project Summary" [level=4]
+  - paragraph: A brief introduction to the project with compact spacing for dense content layouts.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--compact-spacing.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--compact-spacing.forced-colors.yaml
@@ -1,0 +1,4 @@
+- region "Project Summary":
+  - paragraph: Quick Overview
+  - heading "Project Summary" [level=4]
+  - paragraph: A brief introduction to the project with compact spacing for dense content layouts.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--compact-spacing.light.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--compact-spacing.light.yaml
@@ -1,0 +1,4 @@
+- region "Project Summary":
+  - paragraph: Quick Overview
+  - heading "Project Summary" [level=4]
+  - paragraph: A brief introduction to the project with compact spacing for dense content layouts.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--default.dark.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--default.dark.yaml
@@ -1,5 +1,5 @@
 - region "Building a Design System":
-  - heading "Project Overview" [level=4]
+  - paragraph: Project Overview
   - heading "Building a Design System" [level=4]
   - paragraph: Creating a comprehensive design system requires careful planning, collaboration across teams, and a deep understanding of user needs and technical constraints.
   - paragraph: This project involved extensive research, stakeholder workshops, and iterative development to establish a scalable foundation for digital products.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--default.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--default.forced-colors.yaml
@@ -1,5 +1,5 @@
 - region "Building a Design System":
-  - heading "Project Overview" [level=4]
+  - paragraph: Project Overview
   - heading "Building a Design System" [level=4]
   - paragraph: Creating a comprehensive design system requires careful planning, collaboration across teams, and a deep understanding of user needs and technical constraints.
   - paragraph: This project involved extensive research, stakeholder workshops, and iterative development to establish a scalable foundation for digital products.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--default.light.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--default.light.yaml
@@ -1,5 +1,5 @@
 - region "Building a Design System":
-  - heading "Project Overview" [level=4]
+  - paragraph: Project Overview
   - heading "Building a Design System" [level=4]
   - paragraph: Creating a comprehensive design system requires careful planning, collaboration across teams, and a deep understanding of user needs and technical constraints.
   - paragraph: This project involved extensive research, stakeholder workshops, and iterative development to establish a scalable foundation for digital products.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--example.dark.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--example.dark.yaml
@@ -1,5 +1,5 @@
 - region "Building a Design System":
-  - heading "Project Overview" [level=4]
+  - paragraph: Project Overview
   - heading "Building a Design System" [level=4]
   - paragraph: Creating a comprehensive design system requires careful planning, collaboration across teams, and a deep understanding of user needs and technical constraints.
   - paragraph: This project involved extensive research, stakeholder workshops, and iterative development to establish a scalable foundation for digital products.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--example.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--example.forced-colors.yaml
@@ -1,5 +1,5 @@
 - region "Building a Design System":
-  - heading "Project Overview" [level=4]
+  - paragraph: Project Overview
   - heading "Building a Design System" [level=4]
   - paragraph: Creating a comprehensive design system requires careful planning, collaboration across teams, and a deep understanding of user needs and technical constraints.
   - paragraph: This project involved extensive research, stakeholder workshops, and iterative development to establish a scalable foundation for digital products.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--example.light.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--example.light.yaml
@@ -1,5 +1,5 @@
 - region "Building a Design System":
-  - heading "Project Overview" [level=4]
+  - paragraph: Project Overview
   - heading "Building a Design System" [level=4]
   - paragraph: Creating a comprehensive design system requires careful planning, collaboration across teams, and a deep understanding of user needs and technical constraints.
   - paragraph: This project involved extensive research, stakeholder workshops, and iterative development to establish a scalable foundation for digital products.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--forced-colors.dark.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--forced-colors.dark.yaml
@@ -1,5 +1,5 @@
 - region "Building a Design System":
-  - heading "Project Overview" [level=4]
+  - paragraph: Project Overview
   - heading "Building a Design System" [level=4]
   - paragraph: Creating a comprehensive design system requires careful planning, collaboration across teams, and a deep understanding of user needs and technical constraints.
   - paragraph: This project involved extensive research, stakeholder workshops, and iterative development to establish a scalable foundation for digital products.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--forced-colors.forced-colors.yaml
@@ -1,5 +1,5 @@
 - region "Building a Design System":
-  - heading "Project Overview" [level=4]
+  - paragraph: Project Overview
   - heading "Building a Design System" [level=4]
   - paragraph: Creating a comprehensive design system requires careful planning, collaboration across teams, and a deep understanding of user needs and technical constraints.
   - paragraph: This project involved extensive research, stakeholder workshops, and iterative development to establish a scalable foundation for digital products.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--forced-colors.light.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--forced-colors.light.yaml
@@ -1,5 +1,5 @@
 - region "Building a Design System":
-  - heading "Project Overview" [level=4]
+  - paragraph: Project Overview
   - heading "Building a Design System" [level=4]
   - paragraph: Creating a comprehensive design system requires careful planning, collaboration across teams, and a deep understanding of user needs and technical constraints.
   - paragraph: This project involved extensive research, stakeholder workshops, and iterative development to establish a scalable foundation for digital products.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--full-width.dark.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--full-width.dark.yaml
@@ -1,0 +1,8 @@
+- region "Comprehensive Project Documentation":
+  - paragraph: Case Study
+  - heading "Comprehensive Project Documentation" [level=4]
+  - paragraph: Full-width layouts provide maximum space for content and images, ideal for detailed case studies and portfolio pieces.
+  - paragraph: This format works particularly well for projects that require extensive visual documentation and detailed narrative explanations.
+  - figure "The Helsinki Design System components page":
+    - img "Components page overview"
+    - paragraph: The Helsinki Design System components page

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--full-width.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--full-width.forced-colors.yaml
@@ -1,0 +1,8 @@
+- region "Comprehensive Project Documentation":
+  - paragraph: Case Study
+  - heading "Comprehensive Project Documentation" [level=4]
+  - paragraph: Full-width layouts provide maximum space for content and images, ideal for detailed case studies and portfolio pieces.
+  - paragraph: This format works particularly well for projects that require extensive visual documentation and detailed narrative explanations.
+  - figure "The Helsinki Design System components page":
+    - img "Components page overview"
+    - paragraph: The Helsinki Design System components page

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--full-width.light.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--full-width.light.yaml
@@ -1,0 +1,8 @@
+- region "Comprehensive Project Documentation":
+  - paragraph: Case Study
+  - heading "Comprehensive Project Documentation" [level=4]
+  - paragraph: Full-width layouts provide maximum space for content and images, ideal for detailed case studies and portfolio pieces.
+  - paragraph: This format works particularly well for projects that require extensive visual documentation and detailed narrative explanations.
+  - figure "The Helsinki Design System components page":
+    - img "Components page overview"
+    - paragraph: The Helsinki Design System components page

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--multiple-images-single-layout.dark.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--multiple-images-single-layout.dark.yaml
@@ -1,0 +1,10 @@
+- region "Design Evolution":
+  - paragraph: Visual Documentation
+  - heading "Design Evolution" [level=4]
+  - paragraph: Even with multiple images in a single-column layout, content remains clear and easy to follow.
+  - figure "Initial research findings":
+    - img "Research phase"
+    - paragraph: Initial research findings
+  - figure "Low-fidelity wireframes":
+    - img "Wireframe stage"
+    - paragraph: Low-fidelity wireframes

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--multiple-images-single-layout.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--multiple-images-single-layout.forced-colors.yaml
@@ -1,0 +1,10 @@
+- region "Design Evolution":
+  - paragraph: Visual Documentation
+  - heading "Design Evolution" [level=4]
+  - paragraph: Even with multiple images in a single-column layout, content remains clear and easy to follow.
+  - figure "Initial research findings":
+    - img "Research phase"
+    - paragraph: Initial research findings
+  - figure "Low-fidelity wireframes":
+    - img "Wireframe stage"
+    - paragraph: Low-fidelity wireframes

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--multiple-images-single-layout.light.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--multiple-images-single-layout.light.yaml
@@ -1,0 +1,10 @@
+- region "Design Evolution":
+  - paragraph: Visual Documentation
+  - heading "Design Evolution" [level=4]
+  - paragraph: Even with multiple images in a single-column layout, content remains clear and easy to follow.
+  - figure "Initial research findings":
+    - img "Research phase"
+    - paragraph: Initial research findings
+  - figure "Low-fidelity wireframes":
+    - img "Wireframe stage"
+    - paragraph: Low-fidelity wireframes

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--playground.dark.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--playground.dark.yaml
@@ -1,5 +1,5 @@
 - region "Building a Design System":
-  - heading "Project Overview" [level=4]
+  - paragraph: Project Overview
   - heading "Building a Design System" [level=4]
   - paragraph: Creating a comprehensive design system requires careful planning, collaboration across teams, and a deep understanding of user needs and technical constraints.
   - paragraph: This project involved extensive research, stakeholder workshops, and iterative development to establish a scalable foundation for digital products.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--playground.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--playground.forced-colors.yaml
@@ -1,5 +1,5 @@
 - region "Building a Design System":
-  - heading "Project Overview" [level=4]
+  - paragraph: Project Overview
   - heading "Building a Design System" [level=4]
   - paragraph: Creating a comprehensive design system requires careful planning, collaboration across teams, and a deep understanding of user needs and technical constraints.
   - paragraph: This project involved extensive research, stakeholder workshops, and iterative development to establish a scalable foundation for digital products.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--playground.light.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--playground.light.yaml
@@ -1,5 +1,5 @@
 - region "Building a Design System":
-  - heading "Project Overview" [level=4]
+  - paragraph: Project Overview
   - heading "Building a Design System" [level=4]
   - paragraph: Creating a comprehensive design system requires careful planning, collaboration across teams, and a deep understanding of user needs and technical constraints.
   - paragraph: This project involved extensive research, stakeholder workshops, and iterative development to establish a scalable foundation for digital products.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--rich-content.dark.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--rich-content.dark.yaml
@@ -1,0 +1,6 @@
+- region "Conclusion":
+  - paragraph: Design Process
+  - heading "Conclusion" [level=4]
+  - paragraph: The Helsinki Design System represents a comprehensive, user-centered effort to unify and elevate the quality of digital services across the City of Helsinki.
+  - paragraph: Through rigorous research, collaborative ideation, wireframing and an iterative component development pipeline, HDS establishes a foundation that is both accessible and scalable.
+  - paragraph: The system enables teams throughout the city to build services that are consistent, intuitive, and aligned with Helsinki's values of equality, transparency, and inclusion.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--rich-content.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--rich-content.forced-colors.yaml
@@ -1,0 +1,6 @@
+- region "Conclusion":
+  - paragraph: Design Process
+  - heading "Conclusion" [level=4]
+  - paragraph: The Helsinki Design System represents a comprehensive, user-centered effort to unify and elevate the quality of digital services across the City of Helsinki.
+  - paragraph: Through rigorous research, collaborative ideation, wireframing and an iterative component development pipeline, HDS establishes a foundation that is both accessible and scalable.
+  - paragraph: The system enables teams throughout the city to build services that are consistent, intuitive, and aligned with Helsinki's values of equality, transparency, and inclusion.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--rich-content.light.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--rich-content.light.yaml
@@ -1,0 +1,6 @@
+- region "Conclusion":
+  - paragraph: Design Process
+  - heading "Conclusion" [level=4]
+  - paragraph: The Helsinki Design System represents a comprehensive, user-centered effort to unify and elevate the quality of digital services across the City of Helsinki.
+  - paragraph: Through rigorous research, collaborative ideation, wireframing and an iterative component development pipeline, HDS establishes a foundation that is both accessible and scalable.
+  - paragraph: The system enables teams throughout the city to build services that are consistent, intuitive, and aligned with Helsinki's values of equality, transparency, and inclusion.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--text-only.dark.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--text-only.dark.yaml
@@ -1,0 +1,6 @@
+- region "Development and Testing":
+  - paragraph: Implementation
+  - heading "Development and Testing" [level=4]
+  - paragraph: The development phase involved building reusable components, establishing coding standards, and creating comprehensive documentation for the team.
+  - paragraph: Each component underwent rigorous testing for accessibility, performance, and cross-browser compatibility before being released to production.
+  - paragraph: Continuous integration and deployment pipelines ensured that updates could be shipped quickly and reliably without disrupting existing services.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--text-only.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--text-only.forced-colors.yaml
@@ -1,0 +1,6 @@
+- region "Development and Testing":
+  - paragraph: Implementation
+  - heading "Development and Testing" [level=4]
+  - paragraph: The development phase involved building reusable components, establishing coding standards, and creating comprehensive documentation for the team.
+  - paragraph: Each component underwent rigorous testing for accessibility, performance, and cross-browser compatibility before being released to production.
+  - paragraph: Continuous integration and deployment pipelines ensured that updates could be shipped quickly and reliably without disrupting existing services.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--text-only.light.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--text-only.light.yaml
@@ -1,0 +1,6 @@
+- region "Development and Testing":
+  - paragraph: Implementation
+  - heading "Development and Testing" [level=4]
+  - paragraph: The development phase involved building reusable components, establishing coding standards, and creating comprehensive documentation for the team.
+  - paragraph: Each component underwent rigorous testing for accessibility, performance, and cross-browser compatibility before being released to production.
+  - paragraph: Continuous integration and deployment pipelines ensured that updates could be shipped quickly and reliably without disrupting existing services.

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--wide-layout.dark.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--wide-layout.dark.yaml
@@ -1,0 +1,8 @@
+- region "System Infrastructure":
+  - paragraph: Technical Architecture
+  - heading "System Infrastructure" [level=4]
+  - paragraph: The technical foundation was built on modern frameworks and tools that prioritize performance, maintainability, and developer experience.
+  - paragraph: Modular architecture allows teams to adopt components incrementally while maintaining consistency across different projects and platforms.
+  - figure "Early frontpage and information architecture wireframes":
+    - img "System wireframes"
+    - paragraph: Early frontpage and information architecture wireframes

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--wide-layout.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--wide-layout.forced-colors.yaml
@@ -1,0 +1,8 @@
+- region "System Infrastructure":
+  - paragraph: Technical Architecture
+  - heading "System Infrastructure" [level=4]
+  - paragraph: The technical foundation was built on modern frameworks and tools that prioritize performance, maintainability, and developer experience.
+  - paragraph: Modular architecture allows teams to adopt components incrementally while maintaining consistency across different projects and platforms.
+  - figure "Early frontpage and information architecture wireframes":
+    - img "System wireframes"
+    - paragraph: Early frontpage and information architecture wireframes

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--wide-layout.light.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--wide-layout.light.yaml
@@ -1,0 +1,8 @@
+- region "System Infrastructure":
+  - paragraph: Technical Architecture
+  - heading "System Infrastructure" [level=4]
+  - paragraph: The technical foundation was built on modern frameworks and tools that prioritize performance, maintainability, and developer experience.
+  - paragraph: Modular architecture allows teams to adopt components incrementally while maintaining consistency across different projects and platforms.
+  - figure "Early frontpage and information architecture wireframes":
+    - img "System wireframes"
+    - paragraph: Early frontpage and information architecture wireframes

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--with-image-grid.dark.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--with-image-grid.dark.yaml
@@ -1,0 +1,11 @@
+- region "Ideation and Prototyping":
+  - paragraph: Design Process
+  - heading "Ideation and Prototyping" [level=4]
+  - paragraph: Collaborative workshops brought together designers, developers, and stakeholders to explore different approaches and validate assumptions early in the process.
+  - paragraph: Multiple concepts were prototyped and tested with real users to identify the most effective solutions before committing to full development.
+  - figure "Post-it findings from research sessions":
+    - img "Research findings and insights"
+    - paragraph: Post-it findings from research sessions
+  - figure "Benchmarking and goal-setting workshop":
+    - img "Goal setting workshop"
+    - paragraph: Benchmarking and goal-setting workshop

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--with-image-grid.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--with-image-grid.forced-colors.yaml
@@ -1,0 +1,11 @@
+- region "Ideation and Prototyping":
+  - paragraph: Design Process
+  - heading "Ideation and Prototyping" [level=4]
+  - paragraph: Collaborative workshops brought together designers, developers, and stakeholders to explore different approaches and validate assumptions early in the process.
+  - paragraph: Multiple concepts were prototyped and tested with real users to identify the most effective solutions before committing to full development.
+  - figure "Post-it findings from research sessions":
+    - img "Research findings and insights"
+    - paragraph: Post-it findings from research sessions
+  - figure "Benchmarking and goal-setting workshop":
+    - img "Goal setting workshop"
+    - paragraph: Benchmarking and goal-setting workshop

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--with-image-grid.light.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--with-image-grid.light.yaml
@@ -1,0 +1,11 @@
+- region "Ideation and Prototyping":
+  - paragraph: Design Process
+  - heading "Ideation and Prototyping" [level=4]
+  - paragraph: Collaborative workshops brought together designers, developers, and stakeholders to explore different approaches and validate assumptions early in the process.
+  - paragraph: Multiple concepts were prototyped and tested with real users to identify the most effective solutions before committing to full development.
+  - figure "Post-it findings from research sessions":
+    - img "Research findings and insights"
+    - paragraph: Post-it findings from research sessions
+  - figure "Benchmarking and goal-setting workshop":
+    - img "Goal setting workshop"
+    - paragraph: Benchmarking and goal-setting workshop

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--with-light-background.dark.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--with-light-background.dark.yaml
@@ -1,0 +1,11 @@
+- region "Validation and Refinement":
+  - paragraph: User Testing
+  - heading "Validation and Refinement" [level=4]
+  - paragraph: User testing sessions revealed critical insights about navigation patterns, content hierarchy, and interaction preferences that shaped the final design.
+  - paragraph: Iterative refinements based on real user feedback ensured the system met actual user needs rather than assumptions.
+  - figure "Persona creation illustration":
+    - img "User journey mapping"
+    - paragraph: Persona creation illustration
+  - figure "Journey mapping at a design workshop":
+    - img "Prototype detail view"
+    - paragraph: Journey mapping at a design workshop

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--with-light-background.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--with-light-background.forced-colors.yaml
@@ -1,0 +1,11 @@
+- region "Validation and Refinement":
+  - paragraph: User Testing
+  - heading "Validation and Refinement" [level=4]
+  - paragraph: User testing sessions revealed critical insights about navigation patterns, content hierarchy, and interaction preferences that shaped the final design.
+  - paragraph: Iterative refinements based on real user feedback ensured the system met actual user needs rather than assumptions.
+  - figure "Persona creation illustration":
+    - img "User journey mapping"
+    - paragraph: Persona creation illustration
+  - figure "Journey mapping at a design workshop":
+    - img "Prototype detail view"
+    - paragraph: Journey mapping at a design workshop

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--with-light-background.light.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--with-light-background.light.yaml
@@ -1,0 +1,11 @@
+- region "Validation and Refinement":
+  - paragraph: User Testing
+  - heading "Validation and Refinement" [level=4]
+  - paragraph: User testing sessions revealed critical insights about navigation patterns, content hierarchy, and interaction preferences that shaped the final design.
+  - paragraph: Iterative refinements based on real user feedback ensured the system met actual user needs rather than assumptions.
+  - figure "Persona creation illustration":
+    - img "User journey mapping"
+    - paragraph: Persona creation illustration
+  - figure "Journey mapping at a design workshop":
+    - img "Prototype detail view"
+    - paragraph: Journey mapping at a design workshop

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--with-single-image.dark.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--with-single-image.dark.yaml
@@ -1,0 +1,8 @@
+- region "Research and Analysis":
+  - paragraph: Discovery Process
+  - heading "Research and Analysis" [level=4]
+  - paragraph: The initial phase focused on understanding the current state through stakeholder interviews, user research, and competitive analysis.
+  - paragraph: Insights gathered during this phase informed the strategic direction and helped prioritize features for the minimum viable product.
+  - figure "Component structure and contribution workflow":
+    - img "System architecture diagram"
+    - paragraph: Component structure and contribution workflow

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--with-single-image.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--with-single-image.forced-colors.yaml
@@ -1,0 +1,8 @@
+- region "Research and Analysis":
+  - paragraph: Discovery Process
+  - heading "Research and Analysis" [level=4]
+  - paragraph: The initial phase focused on understanding the current state through stakeholder interviews, user research, and competitive analysis.
+  - paragraph: Insights gathered during this phase informed the strategic direction and helped prioritize features for the minimum viable product.
+  - figure "Component structure and contribution workflow":
+    - img "System architecture diagram"
+    - paragraph: Component structure and contribution workflow

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--with-single-image.light.yaml
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-snapshots__/patterns-storyblock--with-single-image.light.yaml
@@ -1,0 +1,8 @@
+- region "Research and Analysis":
+  - paragraph: Discovery Process
+  - heading "Research and Analysis" [level=4]
+  - paragraph: The initial phase focused on understanding the current state through stakeholder interviews, user research, and competitive analysis.
+  - paragraph: Insights gathered during this phase informed the strategic direction and helped prioritize features for the minimum viable product.
+  - figure "Component structure and contribution workflow":
+    - img "System architecture diagram"
+    - paragraph: Component structure and contribution workflow


### PR DESCRIPTION
Eyebrow subtitles rendered as a second h4 at title-xs size (20-28px since the title ladder gained real xs values; accidentally small before that). Now a non-heading Text kicker at ~16px, keeping each section's real title as its only heading.

- AT snapshots: heading level=4 → paragraph across StoryBlock stories (the point of the change)
- Evidence recaptured light/dark/forced-colors; doc-semantics 0/0
- Full local gate: typecheck, lint:all, 2842 tests, build — all exit 0
- Browser-verified on /work/project-spine: kicker 15.6px p, title h4 33px

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved StoryBlock subtitle semantics so kicker text no longer affects the document heading outline or assistive technology navigation.
  * Added and refreshed accessibility evidence across StoryBlock variants, themes, and display modes.
  * Accessibility snapshots now reflect updated content structure, headings, paragraphs, figures, and image descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->