### PR TITLE
chore(ds): re-emit StoryBlock evidence at post-merge SHA

### DIFF
--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-compact-spacing.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-compact-spacing.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-compact-spacing",
   "mode": "dark",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:39.735Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:06.555Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-compact-spacing.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-compact-spacing.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-compact-spacing",
   "mode": "forced-colors",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:44.971Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:11.637Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-compact-spacing.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-compact-spacing.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-compact-spacing",
   "mode": "light",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:32.973Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:04:59.915Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-default.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-default.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-default",
   "mode": "dark",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:38.369Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:05.188Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-default.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-default.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-default",
   "mode": "forced-colors",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:44.786Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:11.467Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-default.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-default.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-default",
   "mode": "light",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:31.563Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:04:58.518Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-example.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-example.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-example",
   "mode": "dark",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:40.819Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:07.688Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-example.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-example.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-example",
   "mode": "forced-colors",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:45.091Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:11.757Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-example.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-example.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-example",
   "mode": "light",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:34.047Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:00.989Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-forced-colors.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-forced-colors.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-forced-colors",
   "mode": "dark",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:41.058Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:07.903Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-forced-colors.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:45.119Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:11.782Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-forced-colors.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-forced-colors.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-forced-colors",
   "mode": "light",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:34.270Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:01.222Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-full-width.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-full-width.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-full-width",
   "mode": "dark",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:39.961Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:06.774Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-full-width.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-full-width.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-full-width",
   "mode": "forced-colors",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:44.995Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:11.660Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-full-width.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-full-width.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-full-width",
   "mode": "light",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:33.193Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:00.125Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-multiple-images-single-layout.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-multiple-images-single-layout.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-multiple-images-single-layout",
   "mode": "dark",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:40.185Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:07.003Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-multiple-images-single-layout.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-multiple-images-single-layout.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-multiple-images-single-layout",
   "mode": "forced-colors",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:45.019Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:11.684Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-multiple-images-single-layout.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-multiple-images-single-layout.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-multiple-images-single-layout",
   "mode": "light",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:33.419Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:00.350Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-playground.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-playground.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-playground",
   "mode": "dark",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:40.607Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:07.471Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-playground.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-playground.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-playground",
   "mode": "forced-colors",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:45.067Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:11.732Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-playground.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-playground.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-playground",
   "mode": "light",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:33.845Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:00.778Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-rich-content.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-rich-content.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-rich-content",
   "mode": "dark",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:40.396Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:07.234Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-rich-content.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-rich-content.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-rich-content",
   "mode": "forced-colors",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:45.042Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:11.708Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-rich-content.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-rich-content.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-rich-content",
   "mode": "light",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:33.626Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:00.561Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-text-only.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-text-only.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-text-only",
   "mode": "dark",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:39.071Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:05.888Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-text-only.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-text-only.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-text-only",
   "mode": "forced-colors",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:44.901Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:11.565Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-text-only.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-text-only.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-text-only",
   "mode": "light",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:32.309Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:04:59.239Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-wide-layout.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-wide-layout.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-wide-layout",
   "mode": "dark",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:39.516Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:06.334Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-wide-layout.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-wide-layout.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-wide-layout",
   "mode": "forced-colors",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:44.950Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:11.615Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-wide-layout.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-wide-layout.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-wide-layout",
   "mode": "light",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:32.759Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:04:59.704Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-image-grid.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-image-grid.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-with-image-grid",
   "mode": "dark",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:38.854Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:05.667Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-image-grid.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-image-grid.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-with-image-grid",
   "mode": "forced-colors",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:44.846Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:11.540Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-image-grid.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-image-grid.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-with-image-grid",
   "mode": "light",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:32.062Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:04:58.995Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-light-background.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-light-background.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-with-light-background",
   "mode": "dark",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:39.295Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:06.112Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-light-background.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-light-background.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-with-light-background",
   "mode": "forced-colors",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:44.926Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:11.590Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-light-background.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-light-background.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-with-light-background",
   "mode": "light",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:32.530Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:04:59.489Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-single-image.dark.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-single-image.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-with-single-image",
   "mode": "dark",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:38.618Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:05.438Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-single-image.forced-colors.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-single-image.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-with-single-image",
   "mode": "forced-colors",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:44.816Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:05:11.501Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-single-image.light.json
+++ b/nextjs-app/shared/patterns/StoryBlock/__a11y-evidence__/patterns-storyblock-with-single-image.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "patterns-storyblock-with-single-image",
   "mode": "light",
-  "sourceSHA": "ebe8a0af82395aaa66b2e973785555913e50dd50",
-  "capturedAt": "2026-07-30T09:59:31.836Z",
+  "sourceSHA": "391961976ecb60a638899c1b4ecfd804b7c2342e",
+  "capturedAt": "2026-07-30T10:04:58.773Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {


### PR DESCRIPTION
Follow-up to #1370: its evidence was captured before the source commit existed, so the squash staled it (doc-semantics 2 > 0 on main). Recaptured at the merged tip; gate 0/0 locally with these records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)