### PR TITLE
fix(ds): TailwindTest imports Kbd from the registry package

### DIFF
--- a/app/dev/tailwind-test/TailwindTest.tsx
+++ b/app/dev/tailwind-test/TailwindTest.tsx
@@ -43,12 +43,12 @@ import {
   Divider,
   FormField,
   IconButton,
+  Kbd,
   Link,
   NavLink,
   Stack,
   useToast,
 } from "@digitaltableteur/react";
-import { Kbd } from "@dt/Kbd";
 import { Prose } from "@/nextjs-app/shared/components/ui";
 import { Lightbox } from "@/nextjs-app/shared/components/Lightbox";
 import { ArrowRight, Heart, Share, Star, Image as ImageIcon } from "@phosphor-icons/react";


### PR DESCRIPTION
check-package-registry-resolution fails on a clean origin/main worktree: TailwindTest.tsx kept a local @dt/Kbd import from before Kbd was published. Any push touching app/** is blocked until this lands. Swap verified: guard exit 0, audit:consumers zero changes, check:consumers green, full local gate all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the Tailwind test page to use the shared keyboard shortcut display component.
  * No visible changes to the component’s behavior or appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->