### PR TITLE
fix(work): Home Remote copy tweaks: terser palette caption, equipment over displays

### DIFF
--- a/nextjs-app/shared/components/pages/Work/HomeRemote/HomeRemotePage.tsx
+++ b/nextjs-app/shared/components/pages/Work/HomeRemote/HomeRemotePage.tsx
@@ -82,7 +82,7 @@ export function HomeRemotePage({ nav }: { nav?: React.ReactNode }) {
             </Title>
             <p className={styles.metaOverview}>
               <strong>Home Remote</strong> is a native macOS menu-bar remote
-              for TVs, monitors, and other audio/video displays. A local
+              for TVs, monitors, and other audio/video equipment. A local
               daemon manages independently paired connections for each
               supported device. The macOS app, CLI, and MCP server use the
               same restricted local API, while device-control traffic remains
@@ -560,8 +560,7 @@ flowchart LR
           />
         </div>
         <Text size="xs" className={styles.installerCaption}>
-          The disk image: installer, icon, and app share one palette rather
-          than three.
+          The disk image: installer, icon, and app share one palette.
         </Text>
       </div>
     </ProjectDetailLayout>


### PR DESCRIPTION
Two copy tweaks to the Home Remote case study overview and disk-image caption:

- Caption: "installer, icon, and app share one palette." (drops "rather than three")
- Overview: "audio/video equipment" instead of "audio/video displays", matching the page metadata phrasing

Local gate: typecheck, lint, test, build all exit 0. Verified live on the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Clarified portfolio descriptions for audio/video equipment.
  * Shortened the installer caption to highlight its shared visual palette with the icon and app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->