### PR TITLE
chore(deps): consume @digitaltableteur/react 0.1.21 + drop Rhythmguard interim override

### DIFF
--- a/nextjs-app/shared/components/pages/Work/Rhythmguard/rhythmguard.module.css
+++ b/nextjs-app/shared/components/pages/Work/Rhythmguard/rhythmguard.module.css
@@ -97,12 +97,3 @@
     gap: var(--space-layout-32);
   }
 }
-
-/* Interim HCB contrast fix: the npm-published CodeSnippet still ships
-   --code-token-comment: #928374, which is 4.01:1 on the gruvbox #282828
-   background. The component source now uses #a89984 (5.30:1); drop this
-   override once @digitaltableteur/react is republished and bumped. */
-
-:global(.themeHCB) .page pre {
-  --code-token-comment: #a89984;
-}

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.20
+  - definition: 0.1.21
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.forced-colors.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.20
+  - definition: 0.1.21
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.20
+  - definition: 0.1.21
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.20
+  - definition: 0.1.21
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.20
+  - definition: 0.1.21
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.forced-colors.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.20
+  - definition: 0.1.21
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.20
+  - definition: 0.1.21
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.20
+  - definition: 0.1.21
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.20
+  - definition: 0.1.21
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.forced-colors.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.20
+  - definition: 0.1.21
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.20
+  - definition: 0.1.21
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.20
+  - definition: 0.1.21
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.20
+  - definition: 0.1.21
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.forced-colors.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.20
+  - definition: 0.1.21
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.20
+  - definition: 0.1.21
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.20
+  - definition: 0.1.21
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ai-sdk/openai": "^4.0.16",
         "@ai-sdk/react": "^4.0.35",
         "@calcom/embed-react": "^1.5.3",
-        "@digitaltableteur/react": "^0.1.20",
+        "@digitaltableteur/react": "^0.1.21",
         "@digitaltableteur/tokens": "^0.1.4",
         "@digitaltableteur/tokens-css": "^0.1.5",
         "@digitaltableteur/web-components": "^0.10.0",
@@ -3421,9 +3421,9 @@
       "license": "MIT"
     },
     "node_modules/@digitaltableteur/react": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.20.tgz",
-      "integrity": "sha512-k83W00sRVJkT7PnqYH5shu0ed8MaMJNnxu8NTj15CMtWx9MCq58X81JIe/grrE10gcUz5O+KahzfhR5j/+QFLw==",
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.21.tgz",
+      "integrity": "sha512-3u+/otDDq5qH/rBiandfl8QsT1nrTJc1zv4PqGVmvg2tN23kZYxz6CKxuchMOZejIDd2Klv0UMCGdCwbo/yF4A==",
       "license": "UNLICENSED",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
     "@ai-sdk/openai": "^4.0.16",
     "@ai-sdk/react": "^4.0.35",
     "@calcom/embed-react": "^1.5.3",
-    "@digitaltableteur/react": "^0.1.20",
+    "@digitaltableteur/react": "^0.1.21",
     "@digitaltableteur/tokens": "^0.1.4",
     "@digitaltableteur/tokens-css": "^0.1.5",
     "@digitaltableteur/web-components": "^0.10.0",

--- a/tests/a11y/page-reports/work-projects/work-projects-report.md
+++ b/tests/a11y/page-reports/work-projects/work-projects-report.md
@@ -1,6 +1,6 @@
 # Work Project Pages Verification Report
 
-**Generated:** 2026-08-03T16:53:12.147Z
+**Generated:** 2026-08-03T18:36:44.827Z
 **Overall Status:** PASS
 **Pages Audited:** 16
 **Theme Combinations:** 64 (16 pages x 4 themes)


### PR DESCRIPTION
Consume side of the 0.1.21 release (publish run 30841315145, prep #1383).

- `@digitaltableteur/react` ^0.1.20 → ^0.1.21; installed dist verified to carry the CodeSnippet HCB comment token `#a89984` (old `#928374` absent).
- Rhythmguard interim HCB override removed; the page now gets AA comment contrast from the registry CSS alone. Work-pages audit: 16 pages x 4 themes = **0 violations**.
- AboutPageContent AT yamls: react definition line trued 0.1.20 → 0.1.21 (16 files, one line each, zero strays); /about browser-verified rendering react 0.1.21 · wc 0.10.0 · tokens 0.1.4 · tokens-css 0.1.5.
- Lockfile linux-optional count stable at 484 (Vercel install risk watched).
- Registry guards green: package-registry-resolution, storybook-registry-package, react-registry-install, published-tokens-freshness --strict.

Local gate: typecheck, lint, 2846 tests, build, build:tokens, check:contract-props, check:consumers all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)