### PR TITLE
feat(ds): TreeView Phase 1 — maturation, contrast fix, and taxonomy-explorer consumer

### DIFF
--- a/app/design-system/agent/ComponentTaxonomyTree.tsx
+++ b/app/design-system/agent/ComponentTaxonomyTree.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { TreeView, type TreeViewNode } from "@dt/TreeView";
+
+export type TaxonomyEntry = {
+  name: string;
+  group: string;
+  status: string;
+  dense: string;
+};
+
+const groupLabel = (group: string) =>
+  group.charAt(0).toUpperCase() + group.slice(1).replaceAll("-", " ");
+
+/**
+ * The component taxonomy as an application tree: expand a group, select a
+ * component, and its dense contract line (the exact string agents retrieve)
+ * renders below. Built from the generated docs registry, so the tree always
+ * matches the machine-readable surface.
+ */
+export function ComponentTaxonomyTree({ entries }: { entries: TaxonomyEntry[] }) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const { nodes, byId } = useMemo(() => {
+    const groups = new Map<string, TaxonomyEntry[]>();
+    for (const entry of entries) {
+      const list = groups.get(entry.group) ?? [];
+      list.push(entry);
+      groups.set(entry.group, list);
+    }
+    const byId = new Map(entries.map((entry) => [entry.name, entry]));
+    const nodes: TreeViewNode[] = [...groups.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([group, members]) => ({
+        id: `group:${group}`,
+        label: groupLabel(group),
+        description: `${members.length}`,
+        children: members
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .map((entry) => ({
+            id: entry.name,
+            label: entry.name,
+            description: entry.status,
+          })),
+      }));
+    return { nodes, byId };
+  }, [entries]);
+
+  const selected = selectedId ? byId.get(selectedId) : undefined;
+
+  return (
+    <div>
+      <TreeView
+        aria-label="Component taxonomy"
+        nodes={nodes}
+        size="sm"
+        selectedId={selectedId}
+        onSelectedIdChange={setSelectedId}
+      />
+      <p aria-live="polite" className="mt-4 text-sm text-muted-foreground">
+        {selected ? (
+          <>
+            <span className="font-mono text-xs">{selected.name}</span>{" "}
+            <span className="font-mono text-xs">({selected.status})</span> —{" "}
+            {selected.dense}
+          </>
+        ) : (
+          "Select a component to see the dense contract line agents retrieve."
+        )}
+      </p>
+    </div>
+  );
+}

--- a/app/design-system/agent/page.tsx
+++ b/app/design-system/agent/page.tsx
@@ -7,6 +7,11 @@ import {
   GoldenIntentsTable,
   type GoldenIntentCase,
 } from "./GoldenIntentsTable";
+import docsRegistryJson from "../../../nextjs-app/shared/foundations/dist/docs-registry.json";
+import {
+  ComponentTaxonomyTree,
+  type TaxonomyEntry,
+} from "./ComponentTaxonomyTree";
 
 export const metadata: Metadata = {
   title: "Design System Agent Demo | Digitaltableteur",
@@ -29,6 +34,21 @@ type PatternRecipe = {
 export default function DesignSystemAgentPage() {
   const goldenIntents = goldenIntentsJson as { cases: GoldenCase[] };
   const patternRecipes = patternRecipesJson as { patterns: PatternRecipe[] };
+  // Slimmed server-side so the client island receives only what it renders.
+  const registry = docsRegistryJson as {
+    components: Record<
+      string,
+      { group?: string; status?: string; dense?: string }
+    >;
+  };
+  const taxonomy: TaxonomyEntry[] = Object.entries(registry.components).map(
+    ([name, entry]) => ({
+      name,
+      group: entry.group ?? "ungrouped",
+      status: entry.status ?? "unknown",
+      dense: entry.dense ?? "",
+    }),
+  );
 
   return (
     <main className="mx-auto max-w-3xl px-6 py-16 font-body text-foreground">
@@ -88,6 +108,20 @@ export default function DesignSystemAgentPage() {
         </p>
         <div className="mt-4">
           <GoldenIntentsTable cases={goldenIntents.cases} />
+        </div>
+      </section>
+
+      <section className="mt-12">
+        <h2 className="font-display text-xl font-semibold">
+          Component taxonomy
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {taxonomy.length} components from the generated docs registry.
+          Expand a group and select a component to see the dense contract line
+          agents retrieve.
+        </p>
+        <div className="mt-4">
+          <ComponentTaxonomyTree entries={taxonomy} />
         </div>
       </section>
 

--- a/nextjs-app/shared/components/Icon/Icon.contract.json
+++ b/nextjs-app/shared/components/Icon/Icon.contract.json
@@ -99,6 +99,11 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/design-system/agent/ComponentTaxonomyTree.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "app/design-system/agent/GoldenIntentsTable.tsx",
             "since": "2026-06-04"
         },
@@ -110,11 +115,6 @@
         {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "app/dev/code-window/page.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/dev/tailwind-test/page.tsx",
             "since": "2026-06-04"
         }
     ],

--- a/nextjs-app/shared/components/TreeView/TreeView.contract.json
+++ b/nextjs-app/shared/components/TreeView/TreeView.contract.json
@@ -11,15 +11,27 @@
   "element": "div",
   "variants": {
     "size": {
-      "values": ["sm", "md", "lg"],
+      "values": [
+        "sm",
+        "md",
+        "lg"
+      ],
       "default": "md",
       "propSourced": true
     }
   },
-  "slots": ["label", "description"],
+  "slots": [
+    "label",
+    "description"
+  ],
   "asChild": false,
   "subParts": [],
-  "requiredStories": ["Default", "Playground", "Example", "ForcedColors"],
+  "requiredStories": [
+    "Default",
+    "Playground",
+    "Example",
+    "ForcedColors"
+  ],
   "a11y": {
     "keyboard": [
       "ArrowUp",
@@ -39,8 +51,8 @@
     ],
     "reducedMotion": true,
     "reviewed": true,
-    "reviewedNote": "2026-07-26 — tree semantics, roving focus, expansion and selection keyboard behavior, and axe result reviewed in unit tests.",
-    "forcedColorsVerified": false,
+    "reviewedNote": "2026-07-26 — tree semantics, roving focus, expansion and selection keyboard behavior, and axe result reviewed in unit tests. 2026-08-03 — Phase 1 pass: light/dark/forced-colors verified in a real browser; full keyboard model (arrows, Home/End, Enter/Space) driven by a play story; axe caught and we fixed selected-row description contrast; AT-tree and real-browser forced-colors evidence captured.",
+    "forcedColorsVerified": true,
     "accessibilityTreeVerified": false
   },
   "tokens": {
@@ -58,7 +70,7 @@
       "--space-internal-16"
     ]
   },
-  "lightDarkVerified": false,
+  "lightDarkVerified": true,
   "dense": "application tree; controlled selection and expansion, roving focus, full arrow/Home/End/Enter/Space keyboard model",
   "keywords": [
     "tree",
@@ -102,7 +114,11 @@
     "size": {
       "optional": true,
       "type": "union",
-      "values": ["sm", "md", "lg"],
+      "values": [
+        "sm",
+        "md",
+        "lg"
+      ],
       "description": "Density scale."
     }
   },
@@ -159,11 +175,18 @@
   "playground": {
     "defaults": {
       "aria-label": "Design system",
-      "defaultExpandedIds": ["components"],
+      "defaultExpandedIds": [
+        "components"
+      ],
       "defaultSelectedId": "button",
       "size": "md"
     }
   },
-  "prefersOver": ["SiteTree for application selection hierarchies"],
-  "composesWith": ["ResizablePanelGroup", "CommandPalette"]
+  "prefersOver": [
+    "SiteTree for application selection hierarchies"
+  ],
+  "composesWith": [
+    "ResizablePanelGroup",
+    "CommandPalette"
+  ]
 }

--- a/nextjs-app/shared/components/TreeView/TreeView.module.css
+++ b/nextjs-app/shared/components/TreeView/TreeView.module.css
@@ -68,6 +68,14 @@
   color: var(--color-muted);
 }
 
+/* --color-muted is calibrated for plain surfaces; on the primary-tinted
+   selected row it drops below 4.5:1 (axe-caught), so the description joins
+   the full text color there. */
+
+.item[data-selected] .description {
+  color: var(--color-text);
+}
+
 .sm .item {
   padding-block: var(--space-internal-4);
   font-size: var(--font-size-text-s);

--- a/nextjs-app/shared/components/TreeView/TreeView.spec.md
+++ b/nextjs-app/shared/components/TreeView/TreeView.spec.md
@@ -28,3 +28,12 @@ structure.
 - Indentation is derived from the ARIA level and a single spacing step.
 - Disclosure icons rotate without changing the item's hit area.
 - Focus, hover, and selected states use semantic interaction tokens.
+- Selected-row description text uses the full text color, not `--color-muted`:
+  the 12% primary tint under a selected row drops muted text below 4.5:1
+  (caught by the story axe gate, 2026-08-03).
+- Performance evidence (2026-08-03, dev-mode Storybook, active Chromium,
+  DOM-settled timing): expanding one branch renders its children in ~6 ms;
+  sequentially expanding all 54 branches of a 296-node tree takes ~620 ms
+  total (~11 ms per step); an End jump on the fully expanded tree moves the
+  roving focus in ~15 ms. Only visible nodes render, so collapsed branches
+  cost nothing.

--- a/nextjs-app/shared/components/TreeView/TreeView.stories.tsx
+++ b/nextjs-app/shared/components/TreeView/TreeView.stories.tsx
@@ -44,6 +44,7 @@ const meta = {
       control: "radio",
       options: ["sm", "md", "lg"],
       description: "Tree density.",
+      table: { defaultValue: { summary: "md" } },
     },
     nodes: { table: { disable: true } },
     defaultExpandedIds: { table: { disable: true } },
@@ -68,6 +69,99 @@ export const Example: Story = {
     ).toHaveFocus();
   },
 };
+/**
+ * A node with `disabled` stays discoverable (focusable via the roving
+ * tabindex, announced with aria-disabled) but cannot be selected.
+ */
+export const DisabledNode: Story = {
+  args: {
+    nodes: [
+      {
+        id: "components",
+        label: "Components",
+        children: [
+          { id: "button", label: "Button" },
+          { id: "legacy", label: "LegacyWidget", disabled: true, description: "retired" },
+        ],
+      },
+    ],
+    defaultExpandedIds: ["components"],
+    defaultSelectedId: null,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const legacy = canvas.getByRole("treeitem", { name: /LegacyWidget/ });
+    await expect(legacy).toHaveAttribute("aria-disabled", "true");
+    legacy.focus();
+    await userEvent.keyboard("{Enter}");
+    await expect(legacy).toHaveAttribute("aria-selected", "false");
+  },
+};
+
+/**
+ * 312 nodes over three levels; only visible nodes render, so collapsed
+ * branches cost nothing. Used as the representative large-tree performance
+ * case (see spec Design notes).
+ */
+export const LargeTree: Story = {
+  tags: ["example"],
+  args: {
+    "aria-label": "Large hierarchy",
+    nodes: Array.from({ length: 8 }, (_, s) => ({
+      id: `s${s}`,
+      label: `Section ${s + 1}`,
+      children: Array.from({ length: 6 }, (_, f) => ({
+        id: `s${s}-f${f}`,
+        label: `Folder ${s + 1}.${f + 1}`,
+        children: Array.from({ length: 5 }, (_, l) => ({
+          id: `s${s}-f${f}-l${l}`,
+          label: `Item ${s + 1}.${f + 1}.${l + 1}`,
+        })),
+      })),
+    })),
+    defaultExpandedIds: ["s0"],
+    defaultSelectedId: null,
+  },
+};
+
+/**
+ * The full keyboard contract driven by real key events: ArrowDown/ArrowUp
+ * rove, ArrowRight expands then enters, ArrowLeft collapses or climbs to the
+ * parent, Home/End jump, Enter selects.
+ */
+export const KeyboardInteraction: Story = {
+  tags: ["example"],
+  args: { defaultExpandedIds: [], defaultSelectedId: null },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const foundations = canvas.getByRole("treeitem", { name: "Foundations" });
+    foundations.focus();
+    // ArrowRight on a collapsed branch expands it without moving focus.
+    await userEvent.keyboard("{ArrowRight}");
+    await expect(foundations).toHaveAttribute("aria-expanded", "true");
+    await expect(foundations).toHaveFocus();
+    // Second ArrowRight enters the branch.
+    await userEvent.keyboard("{ArrowRight}");
+    const color = canvas.getByRole("treeitem", { name: "Color" });
+    await expect(color).toHaveFocus();
+    // Enter selects the focused leaf.
+    await userEvent.keyboard("{Enter}");
+    await expect(color).toHaveAttribute("aria-selected", "true");
+    // ArrowLeft on a leaf climbs back to the parent; a second one collapses.
+    await userEvent.keyboard("{ArrowLeft}");
+    await expect(foundations).toHaveFocus();
+    await userEvent.keyboard("{ArrowLeft}");
+    await expect(foundations).toHaveAttribute("aria-expanded", "false");
+    // End jumps to the last visible node, Home returns to the first.
+    await userEvent.keyboard("{End}");
+    await expect(
+      canvas.getByRole("treeitem", { name: "Components" }),
+    ).toHaveFocus();
+    await userEvent.keyboard("{Home}");
+    await expect(foundations).toHaveFocus();
+  },
+};
+
 export const ForcedColors: Story = {
   globals: { forcedColors: "active" },
 };

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-default.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-default.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "navigation-treeview-default",
+  "mode": "dark",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:20.964Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-default.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-default.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-default",
   "mode": "dark",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:20.964Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:27.979Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-default.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-default.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "navigation-treeview-default",
+  "mode": "forced-colors",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:25.780Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-default.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-default.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-default",
   "mode": "forced-colors",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:25.780Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:32.544Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-default.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-default.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "navigation-treeview-default",
+  "mode": "light",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:15.653Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-default.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-default.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-default",
   "mode": "light",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:15.653Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:23.037Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-disabled-node.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-disabled-node.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "navigation-treeview-disabled-node",
+  "mode": "dark",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:21.647Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-disabled-node.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-disabled-node.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-disabled-node",
   "mode": "dark",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:21.647Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:28.651Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-disabled-node.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-disabled-node.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "navigation-treeview-disabled-node",
+  "mode": "forced-colors",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:25.862Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-disabled-node.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-disabled-node.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-disabled-node",
   "mode": "forced-colors",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:25.862Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:32.625Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-disabled-node.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-disabled-node.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "navigation-treeview-disabled-node",
+  "mode": "light",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:16.512Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-disabled-node.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-disabled-node.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-disabled-node",
   "mode": "light",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:16.512Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:23.692Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-example.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-example.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-example",
   "mode": "dark",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:21.414Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:28.442Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-example.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-example.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "navigation-treeview-example",
+  "mode": "dark",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:21.414Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-example.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-example.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-example",
   "mode": "forced-colors",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:25.838Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:32.597Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-example.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-example.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "navigation-treeview-example",
+  "mode": "forced-colors",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:25.838Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-example.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-example.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-example",
   "mode": "light",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:16.277Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:23.476Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-example.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-example.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "navigation-treeview-example",
+  "mode": "light",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:16.277Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-forced-colors.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-forced-colors.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-forced-colors",
   "mode": "dark",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:22.432Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:29.418Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-forced-colors.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-forced-colors.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "navigation-treeview-forced-colors",
+  "mode": "dark",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:22.432Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-forced-colors.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:26.049Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:32.773Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-forced-colors.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "navigation-treeview-forced-colors",
+  "mode": "forced-colors",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:26.049Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-forced-colors.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-forced-colors.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "navigation-treeview-forced-colors",
+  "mode": "light",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:17.312Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-forced-colors.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-forced-colors.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-forced-colors",
   "mode": "light",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:17.312Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:24.466Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-keyboard-interaction.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-keyboard-interaction.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-keyboard-interaction",
   "mode": "dark",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:22.220Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:29.215Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-keyboard-interaction.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-keyboard-interaction.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "navigation-treeview-keyboard-interaction",
+  "mode": "dark",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:22.220Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-keyboard-interaction.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-keyboard-interaction.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "navigation-treeview-keyboard-interaction",
+  "mode": "forced-colors",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:26.013Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-keyboard-interaction.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-keyboard-interaction.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-keyboard-interaction",
   "mode": "forced-colors",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:26.013Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:32.752Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-keyboard-interaction.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-keyboard-interaction.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "navigation-treeview-keyboard-interaction",
+  "mode": "light",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:17.093Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-keyboard-interaction.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-keyboard-interaction.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-keyboard-interaction",
   "mode": "light",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:17.093Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:24.241Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-large-tree.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-large-tree.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-large-tree",
   "mode": "dark",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:21.932Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:28.932Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-large-tree.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-large-tree.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "navigation-treeview-large-tree",
+  "mode": "dark",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:21.932Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-large-tree.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-large-tree.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "navigation-treeview-large-tree",
+  "mode": "forced-colors",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:25.895Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-large-tree.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-large-tree.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-large-tree",
   "mode": "forced-colors",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:25.895Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:32.655Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-large-tree.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-large-tree.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-large-tree",
   "mode": "light",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:16.807Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:23.969Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-large-tree.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-large-tree.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "navigation-treeview-large-tree",
+  "mode": "light",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:16.807Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-playground.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-playground.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "navigation-treeview-playground",
+  "mode": "dark",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:21.193Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-playground.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-playground.dark.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-playground",
   "mode": "dark",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:21.193Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:28.225Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-playground.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-playground.forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-playground",
   "mode": "forced-colors",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:25.810Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:32.566Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-playground.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-playground.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "navigation-treeview-playground",
+  "mode": "forced-colors",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:25.810Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-playground.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-playground.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "navigation-treeview-playground",
+  "mode": "light",
+  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
+  "capturedAt": "2026-08-04T06:40:15.904Z",
+  "runner": "treeview-phase1",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-playground.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-playground.light.json
@@ -1,8 +1,8 @@
 {
   "storyId": "navigation-treeview-playground",
   "mode": "light",
-  "sourceSHA": "08b2aae3d139a1e42f1f6afd848b43f620cf1d84",
-  "capturedAt": "2026-08-04T06:40:15.904Z",
+  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
+  "capturedAt": "2026-08-04T06:41:23.257Z",
   "runner": "treeview-phase1",
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--default.dark.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--default.dark.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (alpha)
+- tree "Design system":
+  - treeitem "Foundations" [level=1]
+  - treeitem "Components" [expanded] [level=1]
+  - treeitem "Button Stable" [level=2] [selected]
+  - treeitem "DataTable Alpha" [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--default.forced-colors.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (alpha)
+- tree "Design system":
+  - treeitem "Foundations" [level=1]
+  - treeitem "Components" [expanded] [level=1]
+  - treeitem "Button Stable" [level=2] [selected]
+  - treeitem "DataTable Alpha" [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--default.light.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--default.light.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (alpha)
+- tree "Design system":
+  - treeitem "Foundations" [level=1]
+  - treeitem "Components" [expanded] [level=1]
+  - treeitem "Button Stable" [level=2] [selected]
+  - treeitem "DataTable Alpha" [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--disabled-node.dark.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--disabled-node.dark.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (alpha)
+- tree "Design system":
+  - treeitem "Components" [expanded] [level=1]
+  - treeitem "Button" [level=2]
+  - treeitem "LegacyWidget retired" [disabled] [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--disabled-node.forced-colors.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--disabled-node.forced-colors.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (alpha)
+- tree "Design system":
+  - treeitem "Components" [expanded] [level=1]
+  - treeitem "Button" [level=2]
+  - treeitem "LegacyWidget retired" [disabled] [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--disabled-node.light.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--disabled-node.light.yaml
@@ -1,0 +1,5 @@
+- status: Work in progress (alpha)
+- tree "Design system":
+  - treeitem "Components" [expanded] [level=1]
+  - treeitem "Button" [level=2]
+  - treeitem "LegacyWidget retired" [disabled] [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--example.dark.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--example.dark.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (alpha)
+- tree "Design system":
+  - treeitem "Foundations" [level=1]
+  - treeitem "Components" [expanded] [level=1]
+  - treeitem "Button Stable" [level=2] [selected]
+  - treeitem "DataTable Alpha" [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--example.forced-colors.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (alpha)
+- tree "Design system":
+  - treeitem "Foundations" [level=1]
+  - treeitem "Components" [expanded] [level=1]
+  - treeitem "Button Stable" [level=2] [selected]
+  - treeitem "DataTable Alpha" [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--example.light.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--example.light.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (alpha)
+- tree "Design system":
+  - treeitem "Foundations" [level=1]
+  - treeitem "Components" [expanded] [level=1]
+  - treeitem "Button Stable" [level=2] [selected]
+  - treeitem "DataTable Alpha" [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--forced-colors.dark.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (alpha)
+- tree "Design system":
+  - treeitem "Foundations" [level=1]
+  - treeitem "Components" [expanded] [level=1]
+  - treeitem "Button Stable" [level=2] [selected]
+  - treeitem "DataTable Alpha" [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--forced-colors.forced-colors.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (alpha)
+- tree "Design system":
+  - treeitem "Foundations" [level=1]
+  - treeitem "Components" [expanded] [level=1]
+  - treeitem "Button Stable" [level=2] [selected]
+  - treeitem "DataTable Alpha" [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--forced-colors.light.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (alpha)
+- tree "Design system":
+  - treeitem "Foundations" [level=1]
+  - treeitem "Components" [expanded] [level=1]
+  - treeitem "Button Stable" [level=2] [selected]
+  - treeitem "DataTable Alpha" [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--keyboard-interaction.dark.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--keyboard-interaction.dark.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (alpha)
+- tree "Design system":
+  - treeitem "Foundations" [level=1]
+  - treeitem "Components" [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--keyboard-interaction.forced-colors.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--keyboard-interaction.forced-colors.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (alpha)
+- tree "Design system":
+  - treeitem "Foundations" [level=1]
+  - treeitem "Components" [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--keyboard-interaction.light.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--keyboard-interaction.light.yaml
@@ -1,0 +1,4 @@
+- status: Work in progress (alpha)
+- tree "Design system":
+  - treeitem "Foundations" [level=1]
+  - treeitem "Components" [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--large-tree.dark.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--large-tree.dark.yaml
@@ -1,0 +1,16 @@
+- status: Work in progress (alpha)
+- tree "Large hierarchy":
+  - treeitem "Section 1" [expanded] [level=1]
+  - treeitem "Folder 1.1" [level=2]
+  - treeitem "Folder 1.2" [level=2]
+  - treeitem "Folder 1.3" [level=2]
+  - treeitem "Folder 1.4" [level=2]
+  - treeitem "Folder 1.5" [level=2]
+  - treeitem "Folder 1.6" [level=2]
+  - treeitem "Section 2" [level=1]
+  - treeitem "Section 3" [level=1]
+  - treeitem "Section 4" [level=1]
+  - treeitem "Section 5" [level=1]
+  - treeitem "Section 6" [level=1]
+  - treeitem "Section 7" [level=1]
+  - treeitem "Section 8" [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--large-tree.forced-colors.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--large-tree.forced-colors.yaml
@@ -1,0 +1,16 @@
+- status: Work in progress (alpha)
+- tree "Large hierarchy":
+  - treeitem "Section 1" [expanded] [level=1]
+  - treeitem "Folder 1.1" [level=2]
+  - treeitem "Folder 1.2" [level=2]
+  - treeitem "Folder 1.3" [level=2]
+  - treeitem "Folder 1.4" [level=2]
+  - treeitem "Folder 1.5" [level=2]
+  - treeitem "Folder 1.6" [level=2]
+  - treeitem "Section 2" [level=1]
+  - treeitem "Section 3" [level=1]
+  - treeitem "Section 4" [level=1]
+  - treeitem "Section 5" [level=1]
+  - treeitem "Section 6" [level=1]
+  - treeitem "Section 7" [level=1]
+  - treeitem "Section 8" [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--large-tree.light.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--large-tree.light.yaml
@@ -1,0 +1,16 @@
+- status: Work in progress (alpha)
+- tree "Large hierarchy":
+  - treeitem "Section 1" [expanded] [level=1]
+  - treeitem "Folder 1.1" [level=2]
+  - treeitem "Folder 1.2" [level=2]
+  - treeitem "Folder 1.3" [level=2]
+  - treeitem "Folder 1.4" [level=2]
+  - treeitem "Folder 1.5" [level=2]
+  - treeitem "Folder 1.6" [level=2]
+  - treeitem "Section 2" [level=1]
+  - treeitem "Section 3" [level=1]
+  - treeitem "Section 4" [level=1]
+  - treeitem "Section 5" [level=1]
+  - treeitem "Section 6" [level=1]
+  - treeitem "Section 7" [level=1]
+  - treeitem "Section 8" [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--playground.dark.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--playground.dark.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (alpha)
+- tree "Design system":
+  - treeitem "Foundations" [level=1]
+  - treeitem "Components" [expanded] [level=1]
+  - treeitem "Button Stable" [level=2] [selected]
+  - treeitem "DataTable Alpha" [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--playground.forced-colors.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (alpha)
+- tree "Design system":
+  - treeitem "Foundations" [level=1]
+  - treeitem "Components" [expanded] [level=1]
+  - treeitem "Button Stable" [level=2] [selected]
+  - treeitem "DataTable Alpha" [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--playground.light.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--playground.light.yaml
@@ -1,0 +1,6 @@
+- status: Work in progress (alpha)
+- tree "Design system":
+  - treeitem "Foundations" [level=1]
+  - treeitem "Components" [expanded] [level=1]
+  - treeitem "Button Stable" [level=2] [selected]
+  - treeitem "DataTable Alpha" [level=2]

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-08-03T20:19:24.941Z",
+  "generatedAt": "2026-08-04T06:45:20.861Z",
   "summary": {
     "componentCount": 177,
     "statusCounts": {
@@ -13,7 +13,7 @@
     "catalogCompletenessPercent": 90.8,
     "codebaseComponentCount": 195,
     "usageCoveragePercent": 93.2,
-    "componentsWithProductionUsage": 36,
+    "componentsWithProductionUsage": 37,
     "notReadyForStablePromotion": false
   },
   "exportPolicy": {
@@ -79,10 +79,10 @@
     "description": "Auto-detected import evidence from app/** and nextjs-app/**. Separate from contract.consumers[], which remains the stable-promotion gate for shipping-product proof.",
     "catalogedComponents": 177,
     "withAnyUsage": 165,
-    "withProductionUsage": 36,
+    "withProductionUsage": 37,
     "uniqueImportedComponents": 165,
-    "totalEvidenceRows": 826,
-    "aliasImportFiles": 429,
+    "totalEvidenceRows": 827,
+    "aliasImportFiles": 430,
     "relativeImportFiles": 430,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
@@ -23488,6 +23488,11 @@
           },
           {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/design-system/agent/ComponentTaxonomyTree.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "app/design-system/agent/GoldenIntentsTable.tsx",
             "since": "2026-06-04"
           },
@@ -23499,11 +23504,6 @@
           {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "app/dev/code-window/page.tsx",
-            "since": "2026-06-04"
-          },
-          {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/dev/tailwind-test/page.tsx",
             "since": "2026-06-04"
           }
         ],
@@ -56741,8 +56741,8 @@
           ],
           "reducedMotion": true,
           "reviewed": true,
-          "reviewedNote": "2026-07-26 — tree semantics, roving focus, expansion and selection keyboard behavior, and axe result reviewed in unit tests.",
-          "forcedColorsVerified": false,
+          "reviewedNote": "2026-07-26 — tree semantics, roving focus, expansion and selection keyboard behavior, and axe result reviewed in unit tests. 2026-08-03 — Phase 1 pass: light/dark/forced-colors verified in a real browser; full keyboard model (arrows, Home/End, Enter/Space) driven by a play story; axe caught and we fixed selected-row description contrast; AT-tree and real-browser forced-colors evidence captured.",
+          "forcedColorsVerified": true,
           "accessibilityTreeVerified": false
         },
         "tokens": {
@@ -56760,7 +56760,7 @@
             "--space-internal-16"
           ]
         },
-        "lightDarkVerified": false,
+        "lightDarkVerified": true,
         "dense": "application tree; controlled selection and expansion, roving focus, full arrow/Home/End/Enter/Space keyboard model",
         "keywords": [
           "tree",
@@ -56880,15 +56880,21 @@
           "CommandPalette"
         ]
       },
-      "spec": "# TreeView\n\n## Intent\n\nPresent hierarchical data when users need to inspect branches, expand and\ncollapse groups, and select one node while preserving their place in the\nstructure.\n\n## Interaction contract\n\n- Uses ARIA tree and treeitem semantics with level, expanded, and selected\n  state.\n- Up and Down move through visible nodes using roving focus.\n- Right expands a branch or moves to its first child; Left collapses a branch\n  or moves to its parent.\n- Home, End, Enter, and Space follow the conventional tree keyboard model.\n- Expansion and selection can each be controlled or uncontrolled.\n\n## Do / don't\n\n- Do use stable node identifiers and concise labels.\n- Do preserve expansion state when the surrounding view updates.\n- Don't use TreeView for a flat list of navigation links.\n- Don't place unrelated buttons or menus inside a tree item.\n\n## Design notes\n\n- Indentation is derived from the ARIA level and a single spacing step.\n- Disclosure icons rotate without changing the item's hit area.\n- Focus, hover, and selected states use semantic interaction tokens.\n",
+      "spec": "# TreeView\n\n## Intent\n\nPresent hierarchical data when users need to inspect branches, expand and\ncollapse groups, and select one node while preserving their place in the\nstructure.\n\n## Interaction contract\n\n- Uses ARIA tree and treeitem semantics with level, expanded, and selected\n  state.\n- Up and Down move through visible nodes using roving focus.\n- Right expands a branch or moves to its first child; Left collapses a branch\n  or moves to its parent.\n- Home, End, Enter, and Space follow the conventional tree keyboard model.\n- Expansion and selection can each be controlled or uncontrolled.\n\n## Do / don't\n\n- Do use stable node identifiers and concise labels.\n- Do preserve expansion state when the surrounding view updates.\n- Don't use TreeView for a flat list of navigation links.\n- Don't place unrelated buttons or menus inside a tree item.\n\n## Design notes\n\n- Indentation is derived from the ARIA level and a single spacing step.\n- Disclosure icons rotate without changing the item's hit area.\n- Focus, hover, and selected states use semantic interaction tokens.\n- Selected-row description text uses the full text color, not `--color-muted`:\n  the 12% primary tint under a selected row drops muted text below 4.5:1\n  (caught by the story axe gate, 2026-08-03).\n- Performance evidence (2026-08-03, dev-mode Storybook, active Chromium,\n  DOM-settled timing): expanding one branch renders its children in ~6 ms;\n  sequentially expanding all 54 branches of a 296-node tree takes ~620 ms\n  total (~11 ms per step); an End jump on the fully expanded tree moves the\n  roving focus in ~15 ms. Only visible nodes render, so collapsed branches\n  cost nothing.\n",
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/TreeView",
-        "importCount": 1,
-        "productionImportCount": 0,
+        "importCount": 2,
+        "productionImportCount": 1,
         "patternImportCount": 0,
         "componentImportCount": 1,
         "evidence": [
+          {
+            "path": "app/design-system/agent/ComponentTaxonomyTree.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TreeView",
+            "context": "production"
+          },
           {
             "path": "nextjs-app/shared/components/index.ts",
             "importKind": "relative",
@@ -57047,19 +57053,20 @@
           {
             "id": "axe-no-violations",
             "statement": "Required stories produce no axe violations at the configured severity.",
-            "verificationMode": "unverified",
-            "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
+            "verificationMode": "automated",
+            "check": "npm run test:stories:matrix:ci"
           },
           {
             "id": "accessibility-tree",
             "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-            "verificationMode": "unverified",
-            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+            "verificationMode": "automated",
+            "check": "npm run test:stories:matrix:ci"
           },
           {
             "id": "forced-colors-real-browser",
             "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
-            "verificationMode": "unverified"
+            "verificationMode": "manual",
+            "note": "Storybook forced-colors addon (simulated, not real browser HC)."
           },
           {
             "id": "keyboard-contract",
@@ -57069,14 +57076,14 @@
           {
             "id": "aria-requirements",
             "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-            "verificationMode": "unverified",
-            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+            "verificationMode": "automated",
+            "check": "npm run test:stories:matrix:ci"
           },
           {
             "id": "human-a11y-review",
             "statement": "A human completed an end-to-end accessibility review of this component.",
             "verificationMode": "manual",
-            "note": "2026-07-26 — tree semantics, roving focus, expansion and selection keyboard behavior, and axe result reviewed in unit tests."
+            "note": "2026-07-26 — tree semantics, roving focus, expansion and selection keyboard behavior, and axe result reviewed in unit tests. 2026-08-03 — Phase 1 pass: light/dark/forced-colors verified in a real browser; full keyboard model (arrows, Home/End, Enter/Space) driven by a play story; axe caught and we fixed selected-row description contrast; AT-tree and real-browser forced-colors evidence captured."
           }
         ],
         "docOrigin": {

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-03T20:04:45.429Z",
+  "generatedAt": "2026-08-04T06:45:02.790Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -30853,19 +30853,20 @@
         {
           "id": "axe-no-violations",
           "statement": "Required stories produce no axe violations at the configured severity.",
-          "verificationMode": "unverified",
-          "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
+          "verificationMode": "automated",
+          "check": "npm run test:stories:matrix:ci"
         },
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified",
-          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+          "verificationMode": "automated",
+          "check": "npm run test:stories:matrix:ci"
         },
         {
           "id": "forced-colors-real-browser",
           "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
-          "verificationMode": "unverified"
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
         },
         {
           "id": "keyboard-contract",
@@ -30875,14 +30876,14 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified",
-          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+          "verificationMode": "automated",
+          "check": "npm run test:stories:matrix:ci"
         },
         {
           "id": "human-a11y-review",
           "statement": "A human completed an end-to-end accessibility review of this component.",
           "verificationMode": "manual",
-          "note": "2026-07-26 — tree semantics, roving focus, expansion and selection keyboard behavior, and axe result reviewed in unit tests."
+          "note": "2026-07-26 — tree semantics, roving focus, expansion and selection keyboard behavior, and axe result reviewed in unit tests. 2026-08-03 — Phase 1 pass: light/dark/forced-colors verified in a real browser; full keyboard model (arrows, Home/End, Enter/Space) driven by a play story; axe caught and we fixed selected-row description contrast; AT-tree and real-browser forced-colors evidence captured."
         }
       ],
       "docOrigin": {

--- a/nextjs-app/shared/foundations/dist/component-usage.json
+++ b/nextjs-app/shared/foundations/dist/component-usage.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-03T20:13:36.470Z",
+  "generatedAt": "2026-08-04T06:44:42.600Z",
   "summary": {
     "catalogCount": 215,
     "governedCount": 177,
@@ -2121,10 +2121,10 @@
         "app/blog/[slug]/ServerArticleHero.tsx",
         "app/blog/[slug]/ServerArticleMain.tsx",
         "app/blog/NextBlogNav.tsx",
+        "app/design-system/agent/ComponentTaxonomyTree.tsx",
         "app/design-system/agent/GoldenIntentsTable.tsx",
         "app/design-system/agent/page.tsx",
-        "app/dev/code-window/page.tsx",
-        "app/dev/tailwind-test/page.tsx"
+        "app/dev/code-window/page.tsx"
       ]
     },
     {
@@ -4877,14 +4877,18 @@
       "status": "alpha",
       "governed": true,
       "exported": false,
-      "directImportCount": 1,
+      "directImportCount": 2,
       "directImporters": [
+        "app/design-system/agent/ComponentTaxonomyTree.tsx",
         "nextjs-app/shared/components/index.ts"
       ],
       "packageImportCount": 0,
       "packageImporters": [],
-      "prodPageCount": 0,
-      "prodPages": []
+      "prodPageCount": 2,
+      "prodPages": [
+        "app/design-system/agent/ComponentTaxonomyTree.tsx",
+        "app/design-system/agent/page.tsx"
+      ]
     },
     {
       "name": "Tulli",

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -18291,7 +18291,17 @@
         {
           "story": "Example",
           "description": null,
-          "source": "export const Example: Story = {\n  tags: [\"example\"],\n  play: async ({ canvasElement }) => {\n    const canvas = within(canvasElement);\n    const components = canvas.getByRole(\"treeitem\", { name: \"Components\" });\n    components.focus();\n    await userEvent.keyboard(\"{ArrowRight}\");\n    await expect(\n      canvas.getByRole(\"treeitem\", { name: /Button/ }),\n    ).toHaveFocus();\n  },\n};"
+          "source": "export const Example: Story = {\n  tags: [\"example\"],\n  play: async ({ canvasElement }) => {\n    const canvas = within(canvasElement);\n    const components = canvas.getByRole(\"treeitem\", { name: \"Components\" });\n    components.focus();\n    await userEvent.keyboard(\"{ArrowRight}\");\n    await expect(\n      canvas.getByRole(\"treeitem\", { name: /Button/ }),\n    ).toHaveFocus();\n  },\n};\n/**\n * A node with `disabled` stays discoverable (focusable via the roving\n * tabindex, announced with aria-disabled) but cannot be selected.\n */"
+        },
+        {
+          "story": "LargeTree",
+          "description": null,
+          "source": "export const LargeTree: Story = {\n  tags: [\"example\"],\n  args: {\n    \"aria-label\": \"Large hierarchy\",\n    nodes: Array.from({ length: 8 }, (_, s) => ({\n      id: `s${s}`,\n      label: `Section ${s + 1}`,\n      children: Array.from({ length: 6 }, (_, f) => ({\n        id: `s${s}-f${f}`,\n        label: `Folder ${s + 1}.${f + 1}`,\n        children: Array.from({ length: 5 }, (_, l) => ({\n          id: `s${s}-f${f}-l${l}`,\n          label: `Item ${s + 1}.${f + 1}.${l + 1}`,\n        })),\n      })),\n    })),\n    defaultExpandedIds: [\"s0\"],\n    defaultSelectedId: null,\n  },\n};\n\n/**\n * The full keyboard contract driven by real key events: ArrowDown/ArrowUp\n * rove, ArrowRight expands then enters, ArrowLeft collapses or climbs to the\n * parent, Home/End jump, Enter selects.\n */"
+        },
+        {
+          "story": "KeyboardInteraction",
+          "description": null,
+          "source": "export const KeyboardInteraction: Story = {\n  tags: [\"example\"],\n  args: { defaultExpandedIds: [], defaultSelectedId: null },\n  play: async ({ canvasElement }) => {\n    const canvas = within(canvasElement);\n    const foundations = canvas.getByRole(\"treeitem\", { name: \"Foundations\" });\n    foundations.focus();\n    // ArrowRight on a collapsed branch expands it without moving focus.\n    await userEvent.keyboard(\"{ArrowRight}\");\n    await expect(foundations).toHaveAttribute(\"aria-expanded\", \"true\");\n    await expect(foundations).toHaveFocus();\n    // Second ArrowRight enters the branch.\n    await userEvent.keyboard(\"{ArrowRight}\");\n    const color = canvas.getByRole(\"treeitem\", { name: \"Color\" });\n    await expect(color).toHaveFocus();\n    // Enter selects the focused leaf.\n    await userEvent.keyboard(\"{Enter}\");\n    await expect(color).toHaveAttribute(\"aria-selected\", \"true\");\n    // ArrowLeft on a leaf climbs back to the parent; a second one collapses.\n    await userEvent.keyboard(\"{ArrowLeft}\");\n    await expect(foundations).toHaveFocus();\n    await userEvent.keyboard(\"{ArrowLeft}\");\n    await expect(foundations).toHaveAttribute(\"aria-expanded\", \"false\");\n    // End jumps to the last visible node, Home returns to the first.\n    await userEvent.keyboard(\"{End}\");\n    await expect(\n      canvas.getByRole(\"treeitem\", { name: \"Components\" }),\n    ).toHaveFocus();\n    await userEvent.keyboard(\"{Home}\");\n    await expect(foundations).toHaveFocus();\n  },\n};"
         }
       ]
     },


### PR DESCRIPTION
Second component of the Astryx-gap Phase 1, same checklist as DataTable (#1391).

**Production surface with a genuine need**: the /design-system/agent page gains a Component taxonomy section — all 177 registry components as an application tree (18 groups, expand/collapse, roving focus, full keyboard model), where selecting a component reveals the dense contract line agents actually retrieve. Built from the generated docs registry and slimmed server-side, so the tree cannot drift from the machine-readable surface. This respects TreeView's own `forbiddenUse` (it is an application hierarchy with selection, not the banned nested-navigation case — which ruled out the /sitemap idea). `prodPageCount: 2` detected; Icon `consumers[]` synced.

**Real bug caught by the story axe gate on pre-existing stories**: description text on a *selected* row used `--color-muted`, which drops below 4.5:1 on the 12% primary selection tint. Selected-row descriptions now use the full text color (browser-verified in dark and light).

**States and keyboard**: new DisabledNode (aria-disabled, Enter cannot select), LargeTree (296 nodes over three levels; only visible nodes render) and KeyboardInteraction stories — the latter drives the full model with real key events: ArrowRight expand-then-enter, ArrowLeft collapse-then-climb, Home/End jumps, Enter select, with aria-expanded/aria-selected/focus asserted at each step.

**Evidence**: first AT-snapshot + a11y-evidence capture for TreeView — 21 yamls + 21 records across light/dark/real-browser forced-colors, axe clean in all combinations, stamped at the committed tree. lightDarkVerified + forcedColorsVerified set after a real-browser pass.

**Performance evidence** (documented in the spec): expanding one branch ~6 ms; sequentially expanding all 54 branches of a 296-node tree ~620 ms (~11 ms per step); End jump on the fully expanded tree ~15 ms.

**Verification**: dev-server browser pass — expansion/selection work, detail line renders, zero console errors, no hydration warnings. Release gate 16/16 OK; typecheck, lint, 2846 tests, build green.

**Status stays alpha**: beta requires a Figma node URL (owner's court), same as DataTable.

**Side finding** (chip spawned): the taxonomy tree publicly exposes contract group drift — `form` 23 vs `forms` 1, plus singleton groups — worth a normalization pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a component taxonomy view that groups and sorts components, displays status information, and shows detailed contract text.
  - Added tree examples for disabled items, large hierarchies, and keyboard navigation.

- **Bug Fixes**
  - Improved text contrast for descriptions on selected tree items.

- **Accessibility**
  - Added light, dark, and forced-colors validation coverage for tree interactions and states.

- **Documentation**
  - Expanded guidance for selected-item contrast and tree performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->