### PR TITLE
feat(cli): dt upgrade — diff-coupled idempotent codemods (Astryx-gap Phase 2, increment 3)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,6 +13,7 @@ npx @digitaltableteur/cli diff --from v-prev-ref --to HEAD
 npx @digitaltableteur/cli diff DataTable --from HEAD~5
 npx @digitaltableteur/cli affected DataTable TreeView
 npx @digitaltableteur/cli validate --path src
+npx @digitaltableteur/cli upgrade --from v-prev-ref --path src --write
 npx @digitaltableteur/cli manifest --json
 npx @digitaltableteur/cli --help
 ```
@@ -48,4 +49,20 @@ error is found, so it works as a CI gate:
 ```bash
 npx @digitaltableteur/cli validate --path src
 npx @digitaltableteur/cli validate DataTable TreeView --path app --json
+```
+
+`upgrade` couples codemods to the contract diff: it classifies changes
+between `--from` and `--to` (default `HEAD` → the working tree) and rewrites
+consumer sources under `--path` for the mechanically safe cases — a prop
+rename (exactly one removed and one added prop with an identical declared
+type), a removed prop (the dead attribute is deleted), and a changed default
+(usages that omitted the prop get the previous default pinned explicitly so
+rendered behavior is preserved). Everything requiring judgment — a removed
+enum value in use, a newly required prop, a removed or deprecated
+component — is reported as a `manual` item instead of guessed. Dry-run by
+default; `--write` applies. Re-running is a no-op (idempotent).
+
+```bash
+npx @digitaltableteur/cli upgrade --from HEAD~1 --path src        # dry run
+npx @digitaltableteur/cli upgrade Badge --from HEAD~1 --path src --write
 ```

--- a/packages/cli/index.d.ts
+++ b/packages/cli/index.d.ts
@@ -163,3 +163,41 @@ export function validate(
     }
   >
 >;
+export type UpgradeEdit = {
+  kind: "prop-renamed" | "prop-removed" | "default-pinned";
+  file: string;
+  line: number;
+  component: string;
+  prop: string;
+  detail: string;
+  applied: boolean;
+};
+export type UpgradeManualItem = {
+  kind: string;
+  file?: string;
+  line?: number;
+  component: string;
+  prop?: string;
+  message: string;
+};
+export function upgrade(
+  names?: string[],
+  options?: CliOptions & { write?: boolean },
+): Promise<
+  DtCliResponse<
+    "upgrade.report",
+    {
+      from: string;
+      to: string;
+      path: string;
+      dryRun: boolean;
+      componentsWithChanges: string[];
+      componentsPlanned: string[];
+      filesScanned: number;
+      changedFiles: number;
+      edits: UpgradeEdit[];
+      manual: UpgradeManualItem[];
+      summary: { edits: number; manual: number; applied: number };
+    }
+  >
+>;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": false,
   "description": "Typed CLI and programmatic API for the Digitaltableteur design system registry.",
   "type": "module",

--- a/packages/cli/src/api.mjs
+++ b/packages/cli/src/api.mjs
@@ -6,6 +6,12 @@ export { DtCliError, ERROR_CODES } from "./errors.mjs";
 export { diff, classifyContractDiff } from "./diff.mjs";
 export { affected } from "./affected.mjs";
 export { validate } from "./validate.mjs";
+export {
+  upgrade,
+  planComponentUpgrade,
+  applyUpgradeToSource,
+  attributeSpan,
+} from "./upgrade.mjs";
 
 const GET_SECTIONS = ["all", "usage", "props", "examples", "theming"];
 

--- a/packages/cli/src/cli.mjs
+++ b/packages/cli/src/cli.mjs
@@ -8,6 +8,7 @@ import {
   example,
   manifest,
   search,
+  upgrade,
   validate,
 } from "./api.mjs";
 import { DtCliError, ERROR_CODES, errorEnvelope } from "./errors.mjs";
@@ -26,6 +27,8 @@ function parseArgs(argv) {
     else if (value === "--from") options.from = argv[++index];
     else if (value === "--to") options.to = argv[++index];
     else if (value === "--path") options.path = argv[++index];
+    else if (value === "--write") options.write = true;
+    else if (value === "--dry-run") options.write = false;
     else if (value.startsWith("--")) {
       throw new DtCliError(
         `Unknown option "${value}".`,
@@ -66,6 +69,8 @@ async function run(argv) {
       return affected(positional, options);
     case "validate":
       return validate(positional, options);
+    case "upgrade":
+      return upgrade(positional, options);
     case undefined:
       return manifest();
     default:

--- a/packages/cli/src/diff.mjs
+++ b/packages/cli/src/diff.mjs
@@ -139,13 +139,16 @@ export function classifyContractDiff(name, before, after) {
           required ? "major" : "minor",
           "prop-added",
           `prop \`${prop}\` added${required ? " as required" : ""}.`,
-          { prop },
+          { prop, propType: afterProps[prop]?.type, required },
         );
       }
     }
     for (const prop of Object.keys(beforeProps)) {
       if (!(prop in afterProps)) {
-        change("major", "prop-removed", `prop \`${prop}\` removed.`, { prop });
+        change("major", "prop-removed", `prop \`${prop}\` removed.`, {
+          prop,
+          propType: beforeProps[prop]?.type,
+        });
         continue;
       }
       const beforeSchema = beforeProps[prop];
@@ -210,7 +213,7 @@ export function classifyContractDiff(name, before, after) {
           "minor",
           "prop-default-changed",
           `prop \`${prop}\` default changed: ${JSON.stringify(beforeSchema.default)} -> ${JSON.stringify(afterSchema.default)} (behavioral).`,
-          { prop },
+          { prop, from: beforeSchema.default, to: afterSchema.default },
         );
       }
     }

--- a/packages/cli/src/format.mjs
+++ b/packages/cli/src/format.mjs
@@ -97,6 +97,20 @@ export function formatHuman(result, options = {}) {
       );
       return [head, ...rows, result.data.note ?? ""].filter(Boolean).join("\n");
     }
+    case "upgrade.report": {
+      const { summary, edits, manual, dryRun, changedFiles, filesScanned } =
+        result.data;
+      const head = `Upgrade ${result.data.from} -> ${result.data.to} (${dryRun ? "dry run" : "applied"}): ${summary.edits} edit(s) in ${changedFiles} of ${filesScanned} file(s), ${summary.manual} manual item(s).`;
+      const editRows = edits.map(
+        (edit) =>
+          `- [edit] ${edit.kind} ${edit.file}:${edit.line} ${edit.component} — ${edit.detail}${edit.applied ? "" : " (dry run)"}`,
+      );
+      const manualRows = manual.map(
+        (item) =>
+          `- [manual] ${item.kind} ${item.file ? `${item.file}${item.line ? `:${item.line}` : ""} ` : ""}${item.component}\n  ${item.message}`,
+      );
+      return [head, ...editRows, ...manualRows].join("\n");
+    }
     case "manifest":
       return [
         `${result.data.name} ${result.data.version}`,

--- a/packages/cli/src/manifest.mjs
+++ b/packages/cli/src/manifest.mjs
@@ -1,6 +1,6 @@
 import { ERROR_CODES } from "./errors.mjs";
 
-export const CLI_VERSION = "0.3.0";
+export const CLI_VERSION = "0.4.0";
 export const API_VERSION = 1;
 
 export const CAPABILITY_MANIFEST = Object.freeze({
@@ -8,7 +8,7 @@ export const CAPABILITY_MANIFEST = Object.freeze({
   name: "dt",
   version: CLI_VERSION,
   description:
-    "Digitaltableteur design-system CLI — registry search, component docs, examples, composition, diagnostics, contract diffing, impact analysis, and consumer usage validation.",
+    "Digitaltableteur design-system CLI — registry search, component docs, examples, composition, diagnostics, contract diffing, impact analysis, consumer usage validation, and diff-coupled upgrade codemods.",
   globalOptions: [
     {
       flag: "--json",
@@ -103,6 +103,38 @@ export const CAPABILITY_MANIFEST = Object.freeze({
         },
       ],
       responseTypes: ["validate.report"],
+    },
+    {
+      name: "upgrade",
+      arguments: [{ name: "components", required: false, variadic: true }],
+      options: [
+        {
+          flag: "--from <git-ref>",
+          type: "string",
+          default: "HEAD",
+          description: "Baseline ref for the contract diff driving codemods.",
+        },
+        {
+          flag: "--to <git-ref|worktree>",
+          type: "string",
+          default: "worktree",
+          description: "Target ref, or the working tree.",
+        },
+        {
+          flag: "--path <directory>",
+          type: "string",
+          default: ".",
+          description: "Consumer source root to rewrite.",
+        },
+        {
+          flag: "--write",
+          type: "boolean",
+          default: false,
+          description:
+            "Apply the codemods. Without it the report is a dry run.",
+        },
+      ],
+      responseTypes: ["upgrade.report"],
     },
   ],
   errorCodes: Object.values(ERROR_CODES),

--- a/packages/cli/src/upgrade.mjs
+++ b/packages/cli/src/upgrade.mjs
@@ -1,0 +1,384 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { relative, resolve } from "node:path";
+import { diff } from "./diff.mjs";
+import { loadRegistry } from "./data.mjs";
+import { DtCliError, ERROR_CODES } from "./errors.mjs";
+import {
+  collectSourceFiles,
+  extractImports,
+  extractUsages,
+} from "./validate.mjs";
+
+/**
+ * Locate one attribute inside a JSX attribute region. Walks the region at
+ * expression depth 0 (skipping quoted strings and balanced braces) so
+ * identifiers inside expression values are never mistaken for attribute
+ * names. Returns { start, end, nameStart, nameEnd } — `start` includes the
+ * leading whitespace so a removal leaves no double spaces — or null.
+ */
+export function attributeSpan(region, attrName) {
+  let index = 0;
+  while (index < region.length) {
+    const char = region[index];
+    if (/["'`]/.test(char)) {
+      const quote = char;
+      index += 1;
+      while (index < region.length) {
+        if (region[index] === "\\" && quote !== "`") index += 1;
+        else if (region[index] === quote) break;
+        index += 1;
+      }
+      index += 1;
+      continue;
+    }
+    if (char === "{") {
+      let depth = 1;
+      index += 1;
+      while (index < region.length && depth > 0) {
+        const inner = region[index];
+        if (/["'`]/.test(inner)) {
+          const quote = inner;
+          index += 1;
+          while (index < region.length) {
+            if (region[index] === "\\" && quote !== "`") index += 1;
+            else if (region[index] === quote) break;
+            index += 1;
+          }
+        } else if (inner === "{") depth += 1;
+        else if (inner === "}") depth -= 1;
+        index += 1;
+      }
+      continue;
+    }
+    if (/[A-Za-z_]/.test(char)) {
+      const nameStart = index;
+      while (index < region.length && /[\w-]/.test(region[index])) index += 1;
+      const name = region.slice(nameStart, index);
+      let cursor = index;
+      while (cursor < region.length && /\s/.test(region[cursor])) cursor += 1;
+      let valueEnd = index;
+      if (region[cursor] === "=") {
+        cursor += 1;
+        while (cursor < region.length && /\s/.test(region[cursor])) cursor += 1;
+        const valueChar = region[cursor];
+        if (/["']/.test(valueChar)) {
+          cursor += 1;
+          while (cursor < region.length && region[cursor] !== valueChar)
+            cursor += 1;
+          valueEnd = cursor + 1;
+        } else if (valueChar === "{") {
+          let depth = 1;
+          cursor += 1;
+          while (cursor < region.length && depth > 0) {
+            const inner = region[cursor];
+            if (/["'`]/.test(inner)) {
+              const quote = inner;
+              cursor += 1;
+              while (cursor < region.length) {
+                if (region[cursor] === "\\" && quote !== "`") cursor += 1;
+                else if (region[cursor] === quote) break;
+                cursor += 1;
+              }
+            } else if (inner === "{") depth += 1;
+            else if (inner === "}") depth -= 1;
+            cursor += 1;
+          }
+          valueEnd = cursor;
+        }
+      }
+      if (name === attrName) {
+        let start = nameStart;
+        while (start > 0 && /\s/.test(region[start - 1])) start -= 1;
+        return {
+          start,
+          end: valueEnd,
+          nameStart,
+          nameEnd: nameStart + name.length,
+        };
+      }
+      index = Math.max(valueEnd, index);
+      continue;
+    }
+    index += 1;
+  }
+  return null;
+}
+
+function renderDefaultAttribute(prop, value) {
+  if (typeof value === "string") return `${prop}="${value}"`;
+  if (value === true) return prop;
+  if (value === false) return `${prop}={false}`;
+  if (typeof value === "number") return `${prop}={${value}}`;
+  return null;
+}
+
+/**
+ * Turn one component's classified contract changes into a codemod plan.
+ * Only mechanically safe rewrites become actions; everything requiring
+ * judgment lands in `manual`. Rename pairing is deliberately conservative:
+ * exactly one removed and one added prop with an identical declared type.
+ */
+export function planComponentUpgrade(report) {
+  const actions = { renames: [], removals: [], defaults: [] };
+  const manual = [];
+  const conditional = { valuesRemoved: [], nowRequired: [] };
+
+  const removed = report.changes.filter(({ kind }) => kind === "prop-removed");
+  const added = report.changes.filter(({ kind }) => kind === "prop-added");
+  let renamePair = null;
+  if (
+    removed.length === 1 &&
+    added.length === 1 &&
+    removed[0].propType &&
+    removed[0].propType === added[0].propType
+  ) {
+    renamePair = { from: removed[0].prop, to: added[0].prop };
+    actions.renames.push(renamePair);
+  }
+
+  for (const change of report.changes) {
+    switch (change.kind) {
+      case "prop-removed":
+        if (renamePair?.from !== change.prop)
+          actions.removals.push(change.prop);
+        break;
+      case "prop-added":
+        if (change.required && renamePair?.to !== change.prop)
+          conditional.nowRequired.push(change.prop);
+        break;
+      case "prop-default-changed": {
+        const attribute = renderDefaultAttribute(change.prop, change.from);
+        if (attribute) actions.defaults.push({ prop: change.prop, attribute });
+        else
+          manual.push({
+            kind: change.kind,
+            prop: change.prop,
+            message: `${report.name} ${change.prop} default changed to a non-primitive; review usages that relied on the old default.`,
+          });
+        break;
+      }
+      case "prop-values-removed":
+        conditional.valuesRemoved.push({
+          prop: change.prop,
+          values: change.values ?? [],
+        });
+        break;
+      case "prop-now-required":
+        conditional.nowRequired.push(change.prop);
+        break;
+      case "component-removed":
+        manual.push({
+          kind: change.kind,
+          message: `${report.name} was removed; migrate every usage to a replacement component.`,
+        });
+        break;
+      case "status-changed":
+        if (change.detail.endsWith("-> deprecated"))
+          manual.push({
+            kind: "component-deprecated",
+            message: `${report.name} is now deprecated; plan a migration.`,
+          });
+        break;
+      default:
+        break;
+    }
+  }
+  return { actions, manual, conditional };
+}
+
+function editsForUsage(source, usage, plan, component) {
+  const region = source.slice(usage.regionStart, usage.regionEnd);
+  const edits = [];
+  const manual = [];
+  const present = new Set(usage.attributes.map(({ name }) => name));
+
+  for (const rename of plan.actions.renames) {
+    const span = attributeSpan(region, rename.from);
+    if (span) {
+      edits.push({
+        start: usage.regionStart + span.nameStart,
+        end: usage.regionStart + span.nameEnd,
+        replacement: rename.to,
+        kind: "prop-renamed",
+        prop: rename.from,
+        detail: `${rename.from} -> ${rename.to}`,
+      });
+    }
+  }
+  for (const prop of plan.actions.removals) {
+    const span = attributeSpan(region, prop);
+    if (span) {
+      edits.push({
+        start: usage.regionStart + span.start,
+        end: usage.regionStart + span.end,
+        replacement: "",
+        kind: "prop-removed",
+        prop,
+        detail: `removed dead prop ${prop}`,
+      });
+    }
+  }
+  for (const insert of plan.actions.defaults) {
+    if (present.has(insert.prop) || usage.hasSpread) continue;
+    edits.push({
+      start: usage.regionStart,
+      end: usage.regionStart,
+      replacement: ` ${insert.attribute}`,
+      kind: "default-pinned",
+      prop: insert.prop,
+      detail: `pinned previous default: ${insert.attribute}`,
+    });
+  }
+  for (const { prop, values } of plan.conditional.valuesRemoved) {
+    const attribute = usage.attributes.find(
+      (candidate) => candidate.name === prop && candidate.isLiteral,
+    );
+    if (attribute && values.includes(attribute.value)) {
+      manual.push({
+        kind: "prop-values-removed",
+        prop,
+        message: `${component} ${prop}="${attribute.value}" is no longer a contract value; pick a replacement.`,
+      });
+    }
+  }
+  for (const prop of plan.conditional.nowRequired) {
+    if (!present.has(prop) && !usage.hasSpread && prop !== "children") {
+      manual.push({
+        kind: "prop-now-required",
+        prop,
+        message: `${component} now requires "${prop}"; supply a value.`,
+      });
+    }
+  }
+  return { edits, manual };
+}
+
+/**
+ * Apply a set of upgrade plans to one source file. Returns the rewritten
+ * source plus the edit and manual records. Edits are applied back-to-front
+ * so earlier offsets stay valid; re-running on the output is a no-op.
+ */
+export function applyUpgradeToSource(source, locals, plansByComponent) {
+  const relevant = new Map(
+    [...locals].filter(([, component]) => plansByComponent.has(component)),
+  );
+  const edits = [];
+  const manual = [];
+  for (const usage of extractUsages(source, new Set(relevant.keys()))) {
+    const component = relevant.get(usage.local);
+    const plan = plansByComponent.get(component);
+    const result = editsForUsage(source, usage, plan, component);
+    for (const edit of result.edits)
+      edits.push({ ...edit, component, line: usage.line });
+    for (const item of result.manual)
+      manual.push({ ...item, component, line: usage.line });
+  }
+  let output = source;
+  const ordered = [...edits].sort((a, b) => b.start - a.start);
+  for (const edit of ordered) {
+    output =
+      output.slice(0, edit.start) + edit.replacement + output.slice(edit.end);
+  }
+  return { output, edits, manual };
+}
+
+/**
+ * Diff-coupled consumer codemod: classify contract changes between two refs
+ * (default HEAD -> worktree), derive mechanically safe rewrites, and apply
+ * them to the consumer sources under --path. Dry-run by default; --write
+ * persists. Judgment calls are reported as `manual` items instead of being
+ * guessed.
+ */
+export async function upgrade(names = [], options = {}) {
+  const write = options.write === true;
+  const diffReport = await diff(names.length === 1 ? names[0] : undefined, {
+    from: options.from,
+    to: options.to,
+    cwd: options.cwd,
+  });
+  let reports = diffReport.data.components;
+  if (names.length > 1) {
+    const wanted = new Set(names.map((name) => name.toLocaleLowerCase()));
+    reports = reports.filter((report) =>
+      wanted.has(report.name.toLocaleLowerCase()),
+    );
+  }
+
+  const plansByComponent = new Map();
+  const globalManual = [];
+  for (const report of reports) {
+    const plan = planComponentUpgrade(report);
+    for (const item of plan.manual)
+      globalManual.push({ ...item, component: report.name });
+    if (
+      plan.actions.renames.length ||
+      plan.actions.removals.length ||
+      plan.actions.defaults.length ||
+      plan.conditional.valuesRemoved.length ||
+      plan.conditional.nowRequired.length
+    ) {
+      plansByComponent.set(report.name, plan);
+    }
+  }
+
+  const root = resolve(options.cwd ?? process.cwd(), options.path ?? ".");
+  // Nothing planned means nothing to scan — identical refs stay cheap.
+  const files = plansByComponent.size > 0 ? await collectSourceFiles(root) : [];
+  if (files.length === 0 && plansByComponent.size > 0) {
+    throw new DtCliError(
+      `No .tsx/.jsx source files found under "${root}".`,
+      ERROR_CODES.INVALID_ARGUMENT,
+    );
+  }
+
+  const allEdits = [];
+  const allManual = [...globalManual];
+  let changedFiles = 0;
+  if (plansByComponent.size > 0) {
+    const { docsRegistry } = await loadRegistry(options);
+    const registry = docsRegistry.components ?? {};
+    // Components can be missing from the installed registry when the diff
+    // says they were removed; map imports for planned components regardless.
+    for (const name of plansByComponent.keys()) {
+      if (!registry[name]) registry[name] = { name };
+    }
+    for (const file of files) {
+      const source = await readFile(file, "utf8");
+      const fileLabel = relative(root, file) || file;
+      const { locals } = extractImports(source, registry);
+      const { output, edits, manual } = applyUpgradeToSource(
+        source,
+        locals,
+        plansByComponent,
+      );
+      for (const edit of edits)
+        allEdits.push({ ...edit, file: fileLabel, applied: write });
+      for (const item of manual) allManual.push({ ...item, file: fileLabel });
+      if (edits.length > 0) {
+        changedFiles += 1;
+        if (write) await writeFile(file, output);
+      }
+    }
+  }
+
+  return {
+    type: "upgrade.report",
+    data: {
+      from: diffReport.data.from,
+      to: diffReport.data.to,
+      path: root,
+      dryRun: !write,
+      componentsWithChanges: reports.map(({ name }) => name),
+      componentsPlanned: [...plansByComponent.keys()],
+      filesScanned: files.length,
+      changedFiles,
+      edits: allEdits.map(({ start, end, replacement, ...edit }) => edit),
+      manual: allManual,
+      summary: {
+        edits: allEdits.length,
+        manual: allManual.length,
+        applied: write ? allEdits.length : 0,
+      },
+    },
+  };
+}

--- a/packages/cli/src/validate.mjs
+++ b/packages/cli/src/validate.mjs
@@ -43,7 +43,7 @@ function isGlobalAttribute(name) {
   );
 }
 
-async function collectSourceFiles(root) {
+export async function collectSourceFiles(root) {
   const files = [];
   async function walk(directory) {
     let entries;
@@ -180,6 +180,10 @@ export function extractUsages(source, localNames) {
       selfClosing,
       hasSpread: /\{\s*\.\.\./.test(attrRegion),
       attributes: parseAttributes(attrRegion),
+      // Offsets of the attribute region in the original source, so
+      // `dt upgrade` can apply textual codemods precisely.
+      regionStart: start,
+      regionEnd: index,
     });
   }
   return usages;

--- a/scripts/design-system/dt-cli.test.mjs
+++ b/scripts/design-system/dt-cli.test.mjs
@@ -6,6 +6,8 @@ import { promisify } from "node:util";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   affected,
+  applyUpgradeToSource,
+  attributeSpan,
   classifyContractDiff,
   component,
   compose,
@@ -14,7 +16,9 @@ import {
   DtCliError,
   example,
   manifest,
+  planComponentUpgrade,
   search,
+  upgrade,
   validate,
 } from "../../packages/cli/src/api.mjs";
 
@@ -62,6 +66,7 @@ describe("@digitaltableteur/cli API", () => {
       "diff",
       "affected",
       "validate",
+      "upgrade",
     ]);
   });
 
@@ -249,6 +254,112 @@ describe("@digitaltableteur/cli API", () => {
           fixtureDir,
         ]),
       ).rejects.toMatchObject({ code: 2 });
+    });
+  });
+
+  describe("upgrade", () => {
+    const beforeContract = {
+      status: "beta",
+      props: {
+        tone: { optional: true, type: '"info" | "error"' },
+        size: { optional: true, type: '"sm" | "md" | "lg"', default: "md" },
+        dense: { optional: true, type: "boolean" },
+      },
+    };
+    const afterContract = {
+      status: "beta",
+      props: {
+        intent: { optional: true, type: '"info" | "error"' },
+        size: { optional: true, type: '"sm" | "md" | "lg"', default: "sm" },
+        dense: { optional: true, type: "boolean" },
+      },
+    };
+
+    it("finds attribute spans at expression depth 0 only", () => {
+      const region = ` label={render({ size: "x" })} size="md" onClick={() => size()}`;
+      const span = attributeSpan(region, "size");
+      expect(region.slice(span.nameStart, span.nameEnd)).toBe("size");
+      expect(region.slice(span.start, span.end)).toBe(` size="md"`);
+      expect(attributeSpan(region, "missing")).toBeNull();
+    });
+
+    it("plans renames conservatively and pins changed defaults", () => {
+      const report = classifyContractDiff(
+        "Widget",
+        beforeContract,
+        afterContract,
+      );
+      const plan = planComponentUpgrade(report);
+      expect(plan.actions.renames).toEqual([{ from: "tone", to: "intent" }]);
+      expect(plan.actions.removals).toEqual([]);
+      expect(plan.actions.defaults).toEqual([
+        { prop: "size", attribute: `size="md"` },
+      ]);
+    });
+
+    it("rewrites usages idempotently", () => {
+      const report = classifyContractDiff(
+        "Widget",
+        beforeContract,
+        afterContract,
+      );
+      const plans = new Map([["Widget", planComponentUpgrade(report)]]);
+      const locals = new Map([["Widget", "Widget"]]);
+      const source = [
+        `const a = <Widget tone="error" size="lg" />;`,
+        `const b = <Widget dense />;`,
+        `const c = <Widget {...rest} />;`,
+      ].join("\n");
+      const first = applyUpgradeToSource(source, locals, plans);
+      expect(first.output).toContain(`<Widget intent="error" size="lg" />`);
+      // The omitted-size usage gets the previous default pinned; the
+      // spread usage is left alone.
+      expect(first.output).toContain(`<Widget size="md" dense />`);
+      expect(first.output).toContain(`<Widget {...rest} />`);
+      const second = applyUpgradeToSource(first.output, locals, plans);
+      expect(second.edits).toHaveLength(0);
+      expect(second.output).toBe(first.output);
+    });
+
+    it("routes judgment calls to manual items instead of guessing", () => {
+      const report = classifyContractDiff(
+        "Widget",
+        {
+          status: "beta",
+          props: {
+            size: { optional: true, type: '"sm" | "md" | "lg"' },
+            label: { optional: true, type: "string" },
+          },
+        },
+        {
+          status: "beta",
+          props: {
+            size: { optional: true, type: '"sm" | "md"' },
+            label: { optional: false, type: "string" },
+          },
+        },
+      );
+      const plan = planComponentUpgrade(report);
+      const plans = new Map([["Widget", plan]]);
+      const locals = new Map([["Widget", "Widget"]]);
+      const source = [
+        `const a = <Widget size="lg" label="ok" />;`,
+        `const b = <Widget size="sm" />;`,
+      ].join("\n");
+      const result = applyUpgradeToSource(source, locals, plans);
+      expect(result.edits).toHaveLength(0);
+      const kinds = result.manual.map((item) => item.kind);
+      expect(kinds).toContain("prop-values-removed"); // size="lg" in use
+      expect(kinds).toContain("prop-now-required"); // label missing on b
+      expect(result.manual).toHaveLength(2);
+    });
+
+    it("reports an empty upgrade for identical refs", { timeout: 30000 }, async () => {
+      const result = await upgrade([], { from: "HEAD", to: "HEAD" });
+      expect(result.type).toBe("upgrade.report");
+      expect(result.data.dryRun).toBe(true);
+      expect(result.data.summary.edits).toBe(0);
+      expect(result.data.componentsPlanned).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Summary
- Astryx-gap Phase 2, increment 3: `dt upgrade` (CLI 0.4.0) — codemods coupled to contract diffs, closing the diff → affected → **upgrade** → validate chain.
- `dt upgrade [components...] --from <ref> [--to <ref>] --path <dir> [--write]` classifies contract changes via the existing `classifyContractDiff` (now enriched with machine-readable extras: `propType` on prop-removed/prop-added, `from`/`to` on prop-default-changed — additive) and rewrites consumer `.tsx`/`.jsx`:
  - **Rename**: exactly one removed + one added prop with an identical declared type → attribute renamed. Deliberately conservative; ambiguous pairings fall through to removal + manual.
  - **Removal**: unpaired `prop-removed` → dead attribute deleted, including expression values (balanced-brace scanning at depth 0) and leading whitespace.
  - **Default pin**: `prop-default-changed` → usages that omitted the prop (and carry no JSX spread) get the previous default written explicitly, preserving rendered behavior.
- **Never guesses**: removed enum values actually in use, newly required props, removed/deprecated components become `manual` items with file:line.
- Dry-run by default, `--write` applies, re-running is a no-op (idempotent, tested).
- Reuses the `dt validate` scanner (now exporting `collectSourceFiles` and usage region offsets); `attributeSpan` walks attribute regions at expression depth 0 so identifiers inside expression values are never touched.

## Verification
- 5 new vitest cases in `dt-cli.test.mjs` (20/20): depth-0 span finding, conservative rename planning + default pinning, idempotent rewrites with spread bailout, manual-item routing, empty upgrade on identical refs.
- **Live demo on real files**: worktree rename of Badge `variant`→`emphasis` → `dt diff Badge` classified it major and listed 9 affected consumers; `dt upgrade Badge --path <copies> --write` rewrote CookieConsent/OpenHours copies exactly (`variant="secondary"` → `emphasis="secondary"`, the adjacent `tone` prop untouched); re-run reported 0 edits. Contract edit reverted after the demo.
- Full local gate: typecheck, lint, full `npm test`, `next build` — all exit 0.

## Remaining Phase 2
`dt verify` (scoped checks), then the exit-gate demo: breaking change detected → classified → migrated → compiled → rendered → validated → confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
