### PR TITLE
feat(cli): dt verify — scoped verification + Phase 2 exit-gate demo (Astryx-gap Phase 2, increment 4)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,6 +14,7 @@ npx @digitaltableteur/cli diff DataTable --from HEAD~5
 npx @digitaltableteur/cli affected DataTable TreeView
 npx @digitaltableteur/cli validate --path src
 npx @digitaltableteur/cli upgrade --from v-prev-ref --path src --write
+npx @digitaltableteur/cli verify DataTable --path app
 npx @digitaltableteur/cli manifest --json
 npx @digitaltableteur/cli --help
 ```
@@ -65,4 +66,17 @@ default; `--write` applies. Re-running is a no-op (idempotent).
 ```bash
 npx @digitaltableteur/cli upgrade --from HEAD~1 --path src        # dry run
 npx @digitaltableteur/cli upgrade Badge --from HEAD~1 --path src --write
+```
+
+`verify` runs scoped checks for one or more components and exits 2 on any
+failure: `contract` (the contract file exists and parses), `usage` (a scoped
+`dt validate` over `--path`), `tests` (a scoped vitest run over the
+component directories — the rendered proof), and `types` (the repository
+typecheck — the compiled proof). Skip individual checks with
+`--skip tests,types`. Runs inside the repository
+(`ERR_GIT_CONTEXT_UNAVAILABLE` elsewhere).
+
+```bash
+npx @digitaltableteur/cli verify Badge --path app
+npx @digitaltableteur/cli verify DataTable TreeView --skip types --json
 ```

--- a/packages/cli/index.d.ts
+++ b/packages/cli/index.d.ts
@@ -201,3 +201,25 @@ export function upgrade(
     }
   >
 >;
+export type VerifyCheck = {
+  id: "contract" | "usage" | "tests" | "types";
+  component?: string;
+  status: "pass" | "fail";
+  detail: string;
+  durationMs: number;
+};
+export function verify(
+  names: string[],
+  options?: CliOptions & { skip?: string },
+): Promise<
+  DtCliResponse<
+    "verify.report",
+    {
+      components: string[];
+      skipped: string[];
+      checks: VerifyCheck[];
+      verified: boolean;
+      summary: { pass: number; fail: number; durationMs: number };
+    }
+  >
+>;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": false,
   "description": "Typed CLI and programmatic API for the Digitaltableteur design system registry.",
   "type": "module",

--- a/packages/cli/src/api.mjs
+++ b/packages/cli/src/api.mjs
@@ -12,6 +12,7 @@ export {
   applyUpgradeToSource,
   attributeSpan,
 } from "./upgrade.mjs";
+export { verify, VERIFY_CHECKS } from "./verify.mjs";
 
 const GET_SECTIONS = ["all", "usage", "props", "examples", "theming"];
 

--- a/packages/cli/src/cli.mjs
+++ b/packages/cli/src/cli.mjs
@@ -10,6 +10,7 @@ import {
   search,
   upgrade,
   validate,
+  verify,
 } from "./api.mjs";
 import { DtCliError, ERROR_CODES, errorEnvelope } from "./errors.mjs";
 import { formatHuman } from "./format.mjs";
@@ -29,6 +30,7 @@ function parseArgs(argv) {
     else if (value === "--path") options.path = argv[++index];
     else if (value === "--write") options.write = true;
     else if (value === "--dry-run") options.write = false;
+    else if (value === "--skip") options.skip = argv[++index];
     else if (value.startsWith("--")) {
       throw new DtCliError(
         `Unknown option "${value}".`,
@@ -71,6 +73,8 @@ async function run(argv) {
       return validate(positional, options);
     case "upgrade":
       return upgrade(positional, options);
+    case "verify":
+      return verify(positional, options);
     case undefined:
       return manifest();
     default:
@@ -87,9 +91,12 @@ try {
   process.stdout.write(
     `${parsed.options.json ? JSON.stringify(result) : formatHuman(result, parsed.options)}\n`,
   );
-  // validate is a gate: contract violations exit non-zero even though the
-  // report itself renders normally.
-  if (result.type === "validate.report" && !result.data.clean) {
+  // validate and verify are gates: violations and failed checks exit
+  // non-zero even though the report itself renders normally.
+  if (
+    (result.type === "validate.report" && !result.data.clean) ||
+    (result.type === "verify.report" && !result.data.verified)
+  ) {
     process.exitCode = 2;
   }
 } catch (error) {

--- a/packages/cli/src/data.mjs
+++ b/packages/cli/src/data.mjs
@@ -16,9 +16,13 @@ async function readable(path) {
 }
 
 export function candidateDataDirectories(cwd = process.cwd()) {
+  // Inside the repository the freshly generated dist wins over the snapshot
+  // packaged at publish time — otherwise stale packaged data shadows a
+  // just-rebuilt registry. Published consumers have no repo dist, so they
+  // still resolve the packaged data.
   return [
-    join(PACKAGE_ROOT, "data"),
     join(cwd, "nextjs-app", "shared", "foundations", "dist"),
+    join(PACKAGE_ROOT, "data"),
   ];
 }
 

--- a/packages/cli/src/format.mjs
+++ b/packages/cli/src/format.mjs
@@ -111,6 +111,15 @@ export function formatHuman(result, options = {}) {
       );
       return [head, ...editRows, ...manualRows].join("\n");
     }
+    case "verify.report": {
+      const { checks, verified, summary, skipped } = result.data;
+      const head = `${verified ? "Verified" : "Verification FAILED"}: ${summary.pass} pass / ${summary.fail} fail in ${Math.round(summary.durationMs / 1000)}s${skipped.length ? ` (skipped: ${skipped.join(", ")})` : ""}.`;
+      const rows = checks.map(
+        (check) =>
+          `- ${check.status.toUpperCase()} ${check.id}${check.component ? ` ${check.component}` : ""} (${Math.round(check.durationMs / 1000)}s)\n  ${check.detail}`,
+      );
+      return [head, ...rows].join("\n");
+    }
     case "manifest":
       return [
         `${result.data.name} ${result.data.version}`,

--- a/packages/cli/src/manifest.mjs
+++ b/packages/cli/src/manifest.mjs
@@ -1,6 +1,6 @@
 import { ERROR_CODES } from "./errors.mjs";
 
-export const CLI_VERSION = "0.4.0";
+export const CLI_VERSION = "0.5.0";
 export const API_VERSION = 1;
 
 export const CAPABILITY_MANIFEST = Object.freeze({
@@ -8,7 +8,7 @@ export const CAPABILITY_MANIFEST = Object.freeze({
   name: "dt",
   version: CLI_VERSION,
   description:
-    "Digitaltableteur design-system CLI — registry search, component docs, examples, composition, diagnostics, contract diffing, impact analysis, consumer usage validation, and diff-coupled upgrade codemods.",
+    "Digitaltableteur design-system CLI — registry search, component docs, examples, composition, diagnostics, contract diffing, impact analysis, consumer usage validation, diff-coupled upgrade codemods, and scoped verification.",
   globalOptions: [
     {
       flag: "--json",
@@ -135,6 +135,25 @@ export const CAPABILITY_MANIFEST = Object.freeze({
         },
       ],
       responseTypes: ["upgrade.report"],
+    },
+    {
+      name: "verify",
+      arguments: [{ name: "components", required: true, variadic: true }],
+      options: [
+        {
+          flag: "--path <directory>",
+          type: "string",
+          default: ".",
+          description: "Consumer source root for the usage check.",
+        },
+        {
+          flag: "--skip <checks>",
+          type: "string",
+          description:
+            "Comma-separated checks to skip: contract, usage, tests, types.",
+        },
+      ],
+      responseTypes: ["verify.report"],
     },
   ],
   errorCodes: Object.values(ERROR_CODES),

--- a/packages/cli/src/verify.mjs
+++ b/packages/cli/src/verify.mjs
@@ -1,0 +1,274 @@
+import { execFile } from "node:child_process";
+import { access, readFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { loadRegistry } from "./data.mjs";
+import { DtCliError, ERROR_CODES } from "./errors.mjs";
+import { validate } from "./validate.mjs";
+
+const execFileAsync = promisify(execFile);
+
+const COMPONENT_ROOTS = [
+  "nextjs-app/shared/components",
+  "nextjs-app/shared/components/animations",
+  "nextjs-app/shared/patterns",
+  "nextjs-app/shared/templates",
+];
+
+export const VERIFY_CHECKS = ["contract", "usage", "tests", "types"];
+
+async function repoRootFor(cwd) {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["rev-parse", "--show-toplevel"],
+      { cwd },
+    );
+    return stdout.trim();
+  } catch {
+    throw new DtCliError(
+      "dt verify runs scoped repository checks and needs to run inside the design-system repository.",
+      ERROR_CODES.GIT_CONTEXT_UNAVAILABLE,
+    );
+  }
+}
+
+async function componentDir(repoRoot, name) {
+  for (const root of COMPONENT_ROOTS) {
+    const dir = join(repoRoot, root, name);
+    try {
+      await access(join(dir, `${name}.contract.json`), constants.R_OK);
+      return { dir, relative: `${root}/${name}` };
+    } catch {
+      // try the next root
+    }
+  }
+  return null;
+}
+
+function tail(text, lines = 12) {
+  return String(text ?? "")
+    .trim()
+    .split("\n")
+    .slice(-lines)
+    .join("\n");
+}
+
+async function timed(run) {
+  const startedAt = Date.now();
+  const result = await run();
+  return { ...result, durationMs: Date.now() - startedAt };
+}
+
+/**
+ * Scoped verification for one or more components: the contract exists and
+ * parses, consumer usage passes `dt validate`, the component's own tests
+ * pass (rendered proof), and the repository typechecks (compiled proof).
+ * Every check reports pass/fail with evidence; `verified` is true only when
+ * nothing failed. Individual checks can be skipped with --skip.
+ */
+export async function verify(names = [], options = {}) {
+  if (!names || names.length === 0) {
+    throw new DtCliError(
+      "Provide at least one component name, e.g. `dt verify Badge`.",
+      ERROR_CODES.MISSING_ARGUMENT,
+    );
+  }
+  const skip = new Set(
+    String(options.skip ?? "")
+      .split(",")
+      .map((token) => token.trim())
+      .filter(Boolean),
+  );
+  for (const token of skip) {
+    if (!VERIFY_CHECKS.includes(token)) {
+      throw new DtCliError(
+        `Unknown check "${token}". Valid checks: ${VERIFY_CHECKS.join(", ")}.`,
+        ERROR_CODES.INVALID_ARGUMENT,
+      );
+    }
+  }
+  const repoRoot = await repoRootFor(options.cwd ?? process.cwd());
+  const { docsRegistry } = await loadRegistry(options);
+  const registry = docsRegistry.components ?? {};
+
+  const components = [];
+  for (const raw of names) {
+    const canonical = Object.keys(registry).find(
+      (candidate) => candidate.toLocaleLowerCase() === raw.toLocaleLowerCase(),
+    );
+    if (!canonical) {
+      throw new DtCliError(
+        `Unknown component "${raw}".`,
+        ERROR_CODES.UNKNOWN_COMPONENT,
+        Object.keys(registry)
+          .filter((candidate) =>
+            candidate.toLocaleLowerCase().includes(raw.toLocaleLowerCase()),
+          )
+          .slice(0, 5)
+          .map((name) => ({ name, reason: "partial name match" })),
+      );
+    }
+    components.push(canonical);
+  }
+
+  const checks = [];
+
+  if (!skip.has("contract")) {
+    for (const name of components) {
+      checks.push(
+        await timed(async () => {
+          const located = await componentDir(repoRoot, name);
+          if (!located) {
+            return {
+              id: "contract",
+              component: name,
+              status: "fail",
+              detail: `No ${name}.contract.json found under the component roots.`,
+            };
+          }
+          try {
+            const contract = JSON.parse(
+              await readFile(
+                join(located.dir, `${name}.contract.json`),
+                "utf8",
+              ),
+            );
+            return {
+              id: "contract",
+              component: name,
+              status: "pass",
+              detail: `${located.relative} [${contract.status}] group=${contract.group}`,
+            };
+          } catch (error) {
+            return {
+              id: "contract",
+              component: name,
+              status: "fail",
+              detail: `Contract does not parse: ${error.message}`,
+            };
+          }
+        }),
+      );
+    }
+  }
+
+  if (!skip.has("usage")) {
+    checks.push(
+      await timed(async () => {
+        try {
+          const report = await validate(components, {
+            cwd: options.cwd,
+            path: options.path,
+            dataDirectory: options.dataDirectory,
+          });
+          const { errors, warnings } = report.data.summary;
+          return {
+            id: "usage",
+            status: errors === 0 ? "pass" : "fail",
+            detail: `${report.data.usages} usage(s), ${errors} error(s), ${warnings} warning(s)${
+              errors > 0
+                ? `: ${report.data.findings
+                    .filter(({ severity }) => severity === "error")
+                    .slice(0, 3)
+                    .map(
+                      ({ file, line, message }) => `${file}:${line} ${message}`,
+                    )
+                    .join(" | ")}`
+                : ""
+            }`,
+          };
+        } catch (error) {
+          return {
+            id: "usage",
+            status: "fail",
+            detail: `dt validate errored: ${error.message}`,
+          };
+        }
+      }),
+    );
+  }
+
+  if (!skip.has("tests")) {
+    checks.push(
+      await timed(async () => {
+        const dirs = [];
+        for (const name of components) {
+          const located = await componentDir(repoRoot, name);
+          if (located) dirs.push(located.relative);
+        }
+        if (dirs.length === 0) {
+          return {
+            id: "tests",
+            status: "fail",
+            detail: "No component directories resolved for a scoped test run.",
+          };
+        }
+        try {
+          const { stdout } = await execFileAsync(
+            "npx",
+            ["vitest", "run", ...dirs],
+            { cwd: repoRoot, maxBuffer: 32 * 1024 * 1024 },
+          );
+          const summary =
+            stdout.split("\n").find((line) => line.includes("Tests ")) ?? "";
+          return {
+            id: "tests",
+            status: "pass",
+            detail: summary.trim() || `vitest run ${dirs.join(" ")} passed`,
+          };
+        } catch (error) {
+          return {
+            id: "tests",
+            status: "fail",
+            detail: tail(`${error.stdout ?? ""}\n${error.stderr ?? ""}`),
+          };
+        }
+      }),
+    );
+  }
+
+  if (!skip.has("types")) {
+    checks.push(
+      await timed(async () => {
+        try {
+          await execFileAsync("npm", ["run", "-s", "typecheck"], {
+            cwd: repoRoot,
+            maxBuffer: 32 * 1024 * 1024,
+          });
+          return {
+            id: "types",
+            status: "pass",
+            detail: "Repository typecheck (next typegen + tsc --noEmit) clean.",
+          };
+        } catch (error) {
+          return {
+            id: "types",
+            status: "fail",
+            detail: tail(`${error.stdout ?? ""}\n${error.stderr ?? ""}`),
+          };
+        }
+      }),
+    );
+  }
+
+  const failed = checks.filter(({ status }) => status === "fail");
+  return {
+    type: "verify.report",
+    data: {
+      components,
+      skipped: [...skip].sort(),
+      checks,
+      verified: failed.length === 0,
+      summary: {
+        pass: checks.length - failed.length,
+        fail: failed.length,
+        durationMs: checks.reduce(
+          (total, check) => total + check.durationMs,
+          0,
+        ),
+      },
+    },
+  };
+}

--- a/scripts/design-system/dt-cli.test.mjs
+++ b/scripts/design-system/dt-cli.test.mjs
@@ -20,6 +20,7 @@ import {
   search,
   upgrade,
   validate,
+  verify,
 } from "../../packages/cli/src/api.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -67,6 +68,7 @@ describe("@digitaltableteur/cli API", () => {
       "affected",
       "validate",
       "upgrade",
+      "verify",
     ]);
   });
 
@@ -360,6 +362,82 @@ describe("@digitaltableteur/cli API", () => {
       expect(result.data.dryRun).toBe(true);
       expect(result.data.summary.edits).toBe(0);
       expect(result.data.componentsPlanned).toEqual([]);
+    });
+  });
+
+  describe("verify", () => {
+    let cleanDir;
+    let brokenDir;
+
+    beforeAll(async () => {
+      cleanDir = await mkdtemp(join(tmpdir(), "dt-verify-clean-"));
+      brokenDir = await mkdtemp(join(tmpdir(), "dt-verify-broken-"));
+      await writeFile(
+        join(cleanDir, "Ok.tsx"),
+        `import Badge from "@dt/Badge";\nexport const Ok = () => <Badge variant="primary">ok</Badge>;\n`,
+      );
+      await writeFile(
+        join(brokenDir, "Broken.tsx"),
+        `import Badge from "@dt/Badge";\nexport const Broken = () => <Badge variant="nope">bad</Badge>;\n`,
+      );
+    });
+
+    afterAll(async () => {
+      await rm(cleanDir, { recursive: true, force: true });
+      await rm(brokenDir, { recursive: true, force: true });
+    });
+
+    it("passes contract and usage checks for a clean scope", async () => {
+      const result = await verify(["badge"], {
+        path: cleanDir,
+        skip: "tests,types",
+      });
+      expect(result.type).toBe("verify.report");
+      expect(result.data.components).toEqual(["Badge"]);
+      expect(result.data.skipped).toEqual(["tests", "types"]);
+      expect(result.data.verified).toBe(true);
+      const contract = result.data.checks.find(({ id }) => id === "contract");
+      expect(contract.status).toBe("pass");
+      expect(contract.detail).toContain("Badge");
+      const usage = result.data.checks.find(({ id }) => id === "usage");
+      expect(usage.status).toBe("pass");
+    });
+
+    it("fails verification when scoped usage has contract violations", async () => {
+      const result = await verify(["Badge"], {
+        path: brokenDir,
+        skip: "tests,types",
+      });
+      expect(result.data.verified).toBe(false);
+      const usage = result.data.checks.find(({ id }) => id === "usage");
+      expect(usage.status).toBe("fail");
+      expect(usage.detail).toContain("nope");
+    });
+
+    it("exits non-zero from the CLI when a check fails", async () => {
+      await expect(
+        execFileAsync(process.execPath, [
+          "packages/cli/src/cli.mjs",
+          "verify",
+          "Badge",
+          "--path",
+          brokenDir,
+          "--skip",
+          "tests,types",
+        ]),
+      ).rejects.toMatchObject({ code: 2 });
+    });
+
+    it("rejects unknown components, checks, and empty scope", async () => {
+      await expect(verify([], {})).rejects.toMatchObject({
+        code: "ERR_MISSING_ARGUMENT",
+      });
+      await expect(verify(["Buttn"], {})).rejects.toMatchObject({
+        code: "ERR_UNKNOWN_COMPONENT",
+      });
+      await expect(
+        verify(["Badge"], { skip: "tests,frobnicate" }),
+      ).rejects.toMatchObject({ code: "ERR_INVALID_ARGUMENT" });
     });
   });
 


### PR DESCRIPTION
## Summary
- Astryx-gap Phase 2, increment 4: `dt verify` (CLI 0.5.0) — the confirmation leg of the retrieval→repair loop.
- `dt verify <components...> [--path <dir>] [--skip <checks>]` runs four scoped checks and exits 2 on any failure:
  - **contract** — the component's contract file exists under the component roots and parses
  - **usage** — a scoped `dt validate` over `--path` (errors fail)
  - **tests** — a scoped vitest run over the component directories (the *rendered* proof)
  - **types** — the repository typecheck (the *compiled* proof)
- Runs inside the repository like `dt diff` (`ERR_GIT_CONTEXT_UNAVAILABLE` elsewhere); every check reports pass/fail with evidence and duration.
- Also fixes a data-resolution bug found during the demo: inside the repo, the freshly built `foundations/dist` now wins over the packaged data snapshot (previously a just-rebuilt registry was shadowed by stale publish-time data). Published consumers are unaffected.

## Phase 2 exit-gate demo (executed live in the worktree, then reverted)
Breaking change: Badge `variant` → `emphasis`, author-side (component, stories, contract).
1. **Detected + classified**: `dt diff Badge` → major (prop removed + prop added), 9 affected consumer files listed.
2. **Impact**: `dt affected Badge` → direct importers, 8 composing components, ~40 production-page files.
3. **Migrated**: `dt upgrade Badge --path . --write` → 16 edits across 9 files (including two shared story files the usage graph hadn't surfaced), 0 manual items.
4. **Validated**: registry rebuilt, `dt validate Badge` → 61 usages, 0 errors 0 warnings, exit 0.
5. **Confirmed**: `dt verify Badge` → contract PASS, usage PASS, tests PASS (10/10 rendered), **types FAIL, exit 2** — and that failure is the demo's key result: the three failing files consume Badge from the *published npm package*, whose `BadgeProps` still exposes `variant`. Verify correctly refused to confirm a half-landed migration; the loop closes only after the package republishes. In-repo `@dt` alias consumers compiled, rendered, and validated green end to end.

## Verification
- 4 new vitest cases in `dt-cli.test.mjs` (24/24): clean-scope pass, usage-failure fail, CLI exit 2, argument/skip validation.
- Live full run: `dt verify Badge --path app` on main state → 4/4 PASS in 9s.
- Full local gate: typecheck, lint, full `npm test`, `next build` — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
