### PR TITLE
feat(bench): agent benchmark harness — A/B arms, 5 task categories, null/oracle gate (Astryx-gap Phase 3, increment 1)

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -20,3 +20,7 @@ packages/react/_ds-sync-globals.css
 
 # Any minified stylesheet
 **/*.min.css
+
+# Agent-benchmark task fixtures: seeded with INTENTIONAL violations
+# (hardcoded hex, forced-colors bugs) that the benchmarked agent must fix.
+scripts/design-system/agent-bench/fixtures/**

--- a/docs/AGENT_BENCH_METHODOLOGY.md
+++ b/docs/AGENT_BENCH_METHODOLOGY.md
@@ -1,0 +1,103 @@
+# Agent benchmark methodology (Astryx-gap Phase 3)
+
+> Measures whether the design system's agent affordances (contracts, the
+> `dt` CLI, the generated registry) change what a coding agent builds — in
+> correctness, cost, and design-system reuse — under conditions a skeptic
+> can reproduce.
+
+## What is measured
+
+Five task categories, chosen to cover the system's claims: **table**,
+**tree**, **migration**, **repair**, **forced-colors**. Each task is a
+realistic brief with machine-checkable acceptance
+(`scripts/design-system/agent-bench/tasks.mjs`). Per run we record:
+
+- **pass/fail** per acceptance check (the primary outcome)
+- **token cost and turns** from the runtime's JSON envelope
+- **wall-clock duration**
+- **design-system reuse** as a reported metric — never a gate (see
+  Fairness)
+- **repair-loop convergence**: rounds needed to reach acceptance when the
+  automatic validate → guidance → revalidate loop is enabled
+
+## The A/B arms
+
+Both arms get an identical disposable git worktree, the identical TASK.md
+brief, the same pinned model, the same turn budget, and the same
+permissions. Exactly one thing differs — the workspace `CLAUDE.md`:
+
+- **WITH**: documents the `dt` CLI (search / component / example / validate
+  / upgrade / diff), the `@dt/<Name>` import convention, and the guidance to
+  reuse and validate.
+- **WITHOUT**: generic task rules only.
+
+### The control-condition decision
+
+The control keeps full repository access, including the contract files and
+generated registry on disk. We deliberately do **not** delete those
+artifacts in the control arm:
+
+1. Deleting them would change the codebase under test — imports break,
+   scripts fail, and the arm stops being "the same repo without guidance"
+   and becomes a different, broken repo.
+2. The claim under test is that the *affordance layer* (discoverability +
+   tooling) produces the lift, not that the files' mere existence does. An
+   agent in the control arm that finds and exploits the contracts on its own
+   is legitimate signal, not contamination.
+
+This is the same framing as the roadmap's Track C ("WITHOUT the `@dt`
+discovery affordance, same repo access"). It biases the measured lift
+*downward* (the control can stumble into the affordances), so a positive
+result under-claims rather than over-claims.
+
+## Fairness rules for acceptance
+
+- Acceptance is **affordance-neutral**: every check tests user-visible
+  semantics (roles, aria attributes, rendered content, absence of hardcoded
+  hex) or contract conformance of whatever the agent actually used. A
+  hand-rolled table with correct `aria-sort` semantics passes the table task
+  exactly like a `DataTable` solution.
+- Design-system reuse is recorded as a separate **metric**, so "did the
+  affordance change what the agent reached for?" is answered without
+  contaminating pass/fail.
+- Assertion tests are pre-written and shipped to both arms unmodified; the
+  brief states they must pass as-is.
+
+## Harness integrity: null and oracle agents
+
+Before any paid run, `npm run agent:bench:selftest` proves every grader
+discriminates:
+
+- the **null** agent (does nothing) must FAIL every task
+- the **oracle** agent (applies a committed reference solution) must PASS
+  every task
+
+A benchmark number from a grader that cannot tell "did nothing" from
+"reference solution" is meaningless; this gate runs with zero model spend.
+
+## Runtime, pinning, and metering
+
+The paid arm drives headless Claude Code (`claude -p --output-format json`)
+with a pinned `--model` and `--max-turns`, inside the worktree, with
+permissions skipped (the worktree is disposable and never merged). Token
+usage, turn count, and cost come from the runtime's JSON result envelope.
+
+## Variance and honesty
+
+- LLM runs are nondeterministic: report **distributions over `--reps`**,
+  never single figures.
+- Results are written to `scripts/design-system/agent-bench/results/` and
+  are **not** published to `public/ds-health/` until real multi-rep numbers
+  exist. Until then, every number on the public surface stays generated or
+  test-backed, per the honesty guardrail.
+- The repair loop is part of the system under test: report pass rates both
+  before and after repair rounds.
+
+## Running
+
+```bash
+npm run agent:bench:selftest                 # graders discriminate, no spend
+npm run agent:bench -- --task all --agent oracle          # ceiling check
+npm run agent:bench -- --task repair-status-panel \
+  --arm both --agent claude --reps 3 --repair-loop        # a real A/B slice
+```

--- a/package.json
+++ b/package.json
@@ -210,7 +210,9 @@
     "check:doc-semantics:json": "node scripts/design-system/check-doc-semantics.mjs --json",
     "project:dsds": "node scripts/design-system/project-dsds.mjs",
     "check:relationship-graph": "node scripts/design-system/check-relationship-graph.mjs",
-    "check:keyboard-delegation": "node scripts/design-system/check-keyboard-delegation.mjs"
+    "check:keyboard-delegation": "node scripts/design-system/check-keyboard-delegation.mjs",
+    "agent:bench": "node scripts/design-system/agent-bench/run.mjs",
+    "agent:bench:selftest": "node --test scripts/design-system/agent-bench/selftest.mjs"
   },
   "dependencies": {
     "@ai-sdk/mcp": "^2.0.15",

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -109,6 +109,21 @@
 - Run: `npm run cache-bust`
 - Adds version metadata and `.nojekyll`
 
+### Agent Benchmark (design-system, Astryx-gap Phase 3)
+
+**`scripts/design-system/agent-bench/`**
+
+- A/B benchmark: does the DS affordance layer (dt CLI + contracts) change
+  what a coding agent builds? Five task categories (table, tree, migration,
+  repair, forced-colors) with affordance-neutral machine acceptance.
+- `npm run agent:bench:selftest` — null/oracle grader integrity, no model
+  spend. Run before any paid run.
+- `npm run agent:bench -- --task all --arm both --agent claude --reps 3`
+  — a real benchmark run (spends tokens; pinned model + turn budget).
+- Methodology and fairness design: `docs/AGENT_BENCH_METHODOLOGY.md`.
+- Results land in `scripts/design-system/agent-bench/results/` (gitignored);
+  publishing to `public/ds-health` is manual once multi-rep numbers exist.
+
 ---
 
 ## Key Patterns

--- a/scripts/design-system/agent-bench/.gitignore
+++ b/scripts/design-system/agent-bench/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/scripts/design-system/agent-bench/fixtures/forced-colors/LegacyChip.assert.test-template.tsx
+++ b/scripts/design-system/agent-bench/fixtures/forced-colors/LegacyChip.assert.test-template.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import LegacyChip from "./LegacyChip";
+
+describe("bench: forced-colors acceptance", () => {
+  it("renders every status with its label", () => {
+    render(
+      <>
+        <LegacyChip status="operational" />
+        <LegacyChip status="degraded" />
+        <LegacyChip status="down" />
+      </>,
+    );
+    expect(screen.getByText("Operational")).toBeInTheDocument();
+    expect(screen.getByText("Degraded")).toBeInTheDocument();
+    expect(screen.getByText("Down")).toBeInTheDocument();
+  });
+});

--- a/scripts/design-system/agent-bench/fixtures/forced-colors/LegacyChip.module.css
+++ b/scripts/design-system/agent-bench/fixtures/forced-colors/LegacyChip.module.css
@@ -1,0 +1,19 @@
+.chip {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  color: #ffffff;
+}
+
+.operational {
+  background-color: #1a7f37;
+}
+
+.degraded {
+  background-color: #b58a00;
+}
+
+.down {
+  background-color: #c0272d;
+}

--- a/scripts/design-system/agent-bench/fixtures/forced-colors/LegacyChip.tsx
+++ b/scripts/design-system/agent-bench/fixtures/forced-colors/LegacyChip.tsx
@@ -1,0 +1,20 @@
+import styles from "./LegacyChip.module.css";
+
+export type LegacyChipStatus = "operational" | "degraded" | "down";
+
+const LABELS: Record<LegacyChipStatus, string> = {
+  operational: "Operational",
+  degraded: "Degraded",
+  down: "Down",
+};
+
+/**
+ * Service status chip. Each status renders with its own background colour.
+ */
+export default function LegacyChip({ status }: { status: LegacyChipStatus }) {
+  return (
+    <span className={`${styles.chip} ${styles[status]}`}>
+      {LABELS[status]}
+    </span>
+  );
+}

--- a/scripts/design-system/agent-bench/fixtures/forced-colors/oracle/LegacyChip.tsx
+++ b/scripts/design-system/agent-bench/fixtures/forced-colors/oracle/LegacyChip.tsx
@@ -1,0 +1,28 @@
+import Badge from "@dt/Badge";
+
+export type LegacyChipStatus = "operational" | "degraded" | "down";
+
+const LABELS: Record<LegacyChipStatus, string> = {
+  operational: "Operational",
+  degraded: "Degraded",
+  down: "Down",
+};
+
+const TONES: Record<LegacyChipStatus, "success" | "warning" | "error"> = {
+  operational: "success",
+  degraded: "warning",
+  down: "error",
+};
+
+/**
+ * Service status chip. Delegates to the design-system Badge, whose tones
+ * come from the token system and carry forced-colors evidence: status stays
+ * distinguishable through text, not background colour alone.
+ */
+export default function LegacyChip({ status }: { status: LegacyChipStatus }) {
+  return (
+    <Badge size="sm" tone={TONES[status]}>
+      {LABELS[status]}
+    </Badge>
+  );
+}

--- a/scripts/design-system/agent-bench/fixtures/repair/StatusPanel.assert.test-template.tsx
+++ b/scripts/design-system/agent-bench/fixtures/repair/StatusPanel.assert.test-template.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import StatusPanel from "./StatusPanel";
+
+describe("bench: repair acceptance", () => {
+  it("renders the intended panel content", () => {
+    render(<StatusPanel />);
+    expect(
+      screen.getByRole("region", { name: "Deployment status" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Building")).toBeInTheDocument();
+    expect(screen.getByText("Stable")).toBeInTheDocument();
+    const kbd = document.querySelector("kbd");
+    expect(kbd).not.toBeNull();
+    expect(kbd?.textContent).toContain("L");
+  });
+});

--- a/scripts/design-system/agent-bench/fixtures/repair/StatusPanel.tsx
+++ b/scripts/design-system/agent-bench/fixtures/repair/StatusPanel.tsx
@@ -1,0 +1,23 @@
+import Badge from "@dt/Badge";
+import Kbd from "@dt/Kbd";
+
+/**
+ * Deployment status panel. Shows the pipeline stage, the release channel,
+ * and the shortcut that opens the full log view.
+ */
+export default function StatusPanel() {
+  return (
+    <section aria-label="Deployment status">
+      <h2>Deployment status</h2>
+      <p>
+        Pipeline: <Badge variant="tertiary">Building</Badge>
+      </p>
+      <p>
+        Channel: <Badge tone="stable" />
+      </p>
+      <p>
+        Logs: press <Kbd power="high">L</Kbd> to open the full view.
+      </p>
+    </section>
+  );
+}

--- a/scripts/design-system/agent-bench/fixtures/repair/oracle/StatusPanel.tsx
+++ b/scripts/design-system/agent-bench/fixtures/repair/oracle/StatusPanel.tsx
@@ -1,0 +1,23 @@
+import Badge from "@dt/Badge";
+import Kbd from "@dt/Kbd";
+
+/**
+ * Deployment status panel. Shows the pipeline stage, the release channel,
+ * and the shortcut that opens the full log view.
+ */
+export default function StatusPanel() {
+  return (
+    <section aria-label="Deployment status">
+      <h2>Deployment status</h2>
+      <p>
+        Pipeline: <Badge variant="secondary">Building</Badge>
+      </p>
+      <p>
+        Channel: <Badge tone="success">Stable</Badge>
+      </p>
+      <p>
+        Logs: press <Kbd>L</Kbd> to open the full view.
+      </p>
+    </section>
+  );
+}

--- a/scripts/design-system/agent-bench/fixtures/table/SpeciesTable.assert.test-template.tsx
+++ b/scripts/design-system/agent-bench/fixtures/table/SpeciesTable.assert.test-template.tsx
@@ -1,0 +1,47 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SpeciesTable from "./SpeciesTable";
+
+function headerFor(name: RegExp) {
+  return screen
+    .getAllByRole("columnheader")
+    .find((header) => name.test(header.textContent ?? ""));
+}
+
+describe("bench: table acceptance", () => {
+  it("renders an accessible captioned table of every species", () => {
+    render(<SpeciesTable />);
+    const table = screen.getByRole("table");
+    expect(table.querySelector("caption")?.textContent).toBeTruthy();
+    expect(screen.getByText("Common swift")).toBeInTheDocument();
+    expect(screen.getByText("Whooper swan")).toBeInTheDocument();
+    expect(screen.getByText("Corvidae")).toBeInTheDocument();
+  });
+
+  it("sorts by name via the column header with aria-sort semantics", async () => {
+    const user = userEvent.setup();
+    render(<SpeciesTable />);
+    const nameHeader = headerFor(/name/i);
+    expect(nameHeader).toBeTruthy();
+    const trigger = within(nameHeader as HTMLElement).queryByRole("button");
+    await user.click(trigger ?? (nameHeader as HTMLElement));
+    expect(headerFor(/name/i)).toHaveAttribute("aria-sort", "ascending");
+    await user.click(
+      within(headerFor(/name/i) as HTMLElement).queryByRole("button") ??
+        (headerFor(/name/i) as HTMLElement),
+    );
+    expect(headerFor(/name/i)).toHaveAttribute("aria-sort", "descending");
+  });
+
+  it("selects rows via accessibly named checkboxes", async () => {
+    const user = userEvent.setup();
+    render(<SpeciesTable />);
+    const checkboxes = screen.getAllByRole("checkbox", { name: /select/i });
+    // At least one checkbox per data row (a select-all is allowed on top).
+    expect(checkboxes.length).toBeGreaterThanOrEqual(6);
+    const rowBox = checkboxes[checkboxes.length - 1];
+    expect(rowBox).not.toBeChecked();
+    await user.click(rowBox);
+    expect(rowBox).toBeChecked();
+  });
+});

--- a/scripts/design-system/agent-bench/fixtures/table/oracle/SpeciesTable.tsx
+++ b/scripts/design-system/agent-bench/fixtures/table/oracle/SpeciesTable.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+import { DataTable, type DataTableColumn } from "@dt/DataTable";
+import { species, type Species } from "./species";
+
+const columns: DataTableColumn<Species>[] = [
+  { id: "name", header: "Name", accessor: (row) => row.name, sortable: true },
+  {
+    id: "family",
+    header: "Family",
+    accessor: (row) => row.family,
+    sortable: true,
+  },
+  {
+    id: "wingspanCm",
+    header: "Wingspan (cm)",
+    accessor: (row) => row.wingspanCm,
+    sortable: true,
+    align: "end",
+  },
+];
+
+export default function SpeciesTable() {
+  const [selected, setSelected] = useState<string[]>([]);
+  return (
+    <DataTable<Species>
+      data={species}
+      columns={columns}
+      getRowId={(row) => row.id}
+      caption="Bird species and wingspans"
+      selectedRowIds={selected}
+      onSelectionChange={setSelected}
+    />
+  );
+}

--- a/scripts/design-system/agent-bench/fixtures/table/species.ts
+++ b/scripts/design-system/agent-bench/fixtures/table/species.ts
@@ -1,0 +1,15 @@
+export type Species = {
+  id: string;
+  name: string;
+  family: string;
+  wingspanCm: number;
+};
+
+export const species: Species[] = [
+  { id: "apus-apus", name: "Common swift", family: "Apodidae", wingspanCm: 42 },
+  { id: "hirundo-rustica", name: "Barn swallow", family: "Hirundinidae", wingspanCm: 33 },
+  { id: "falco-peregrinus", name: "Peregrine falcon", family: "Falconidae", wingspanCm: 104 },
+  { id: "cygnus-cygnus", name: "Whooper swan", family: "Anatidae", wingspanCm: 225 },
+  { id: "parus-major", name: "Great tit", family: "Paridae", wingspanCm: 24 },
+  { id: "corvus-corax", name: "Common raven", family: "Corvidae", wingspanCm: 130 },
+];

--- a/scripts/design-system/agent-bench/fixtures/tree/TaxonomyTree.assert.test-template.tsx
+++ b/scripts/design-system/agent-bench/fixtures/tree/TaxonomyTree.assert.test-template.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TaxonomyTree from "./TaxonomyTree";
+
+describe("bench: tree acceptance", () => {
+  it("renders an accessible tree with collapsed branches", () => {
+    render(<TaxonomyTree />);
+    expect(screen.getByRole("tree")).toBeInTheDocument();
+    const items = screen.getAllByRole("treeitem");
+    expect(items.length).toBeGreaterThanOrEqual(3);
+    const branch = items.find(
+      (item) => item.getAttribute("aria-expanded") !== null,
+    );
+    expect(branch).toBeTruthy();
+    expect(branch).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Corvidae")).not.toBeInTheDocument();
+  });
+
+  it("expands a branch to reveal its children", async () => {
+    const user = userEvent.setup();
+    render(<TaxonomyTree />);
+    await user.click(screen.getByText("Passeriformes"));
+    expect(await screen.findByText("Corvidae")).toBeInTheDocument();
+    const branch = screen
+      .getAllByRole("treeitem")
+      .find((item) => item.textContent?.includes("Passeriformes"));
+    expect(branch).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("moves focus with ArrowDown per the tree keyboard model", async () => {
+    const user = userEvent.setup();
+    render(<TaxonomyTree />);
+    await user.tab();
+    const first = document.activeElement as HTMLElement;
+    expect(first).not.toBeNull();
+    await user.keyboard("{ArrowDown}");
+    expect(document.activeElement).not.toBe(first);
+  });
+});

--- a/scripts/design-system/agent-bench/fixtures/tree/oracle/TaxonomyTree.tsx
+++ b/scripts/design-system/agent-bench/fixtures/tree/oracle/TaxonomyTree.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { TreeView, type TreeViewNode } from "@dt/TreeView";
+import { taxonomy, type TaxonomyNode } from "./taxonomy";
+
+function toNodes(entries: TaxonomyNode[]): TreeViewNode[] {
+  return entries.map((entry) => ({
+    id: entry.id,
+    label: entry.label,
+    ...(entry.children ? { children: toNodes(entry.children) } : {}),
+  }));
+}
+
+const nodes = toNodes(taxonomy);
+
+export default function TaxonomyTree() {
+  return <TreeView aria-label="Bird taxonomy" nodes={nodes} />;
+}

--- a/scripts/design-system/agent-bench/fixtures/tree/taxonomy.ts
+++ b/scripts/design-system/agent-bench/fixtures/tree/taxonomy.ts
@@ -1,0 +1,23 @@
+export type TaxonomyNode = {
+  id: string;
+  label: string;
+  children?: TaxonomyNode[];
+};
+
+export const taxonomy: TaxonomyNode[] = [
+  {
+    id: "passeriformes",
+    label: "Passeriformes",
+    children: [
+      { id: "corvidae", label: "Corvidae" },
+      { id: "paridae", label: "Paridae" },
+      { id: "hirundinidae", label: "Hirundinidae" },
+    ],
+  },
+  {
+    id: "falconiformes",
+    label: "Falconiformes",
+    children: [{ id: "falconidae", label: "Falconidae" }],
+  },
+  { id: "apodiformes", label: "Apodiformes" },
+];

--- a/scripts/design-system/agent-bench/grade.mjs
+++ b/scripts/design-system/agent-bench/grade.mjs
@@ -1,0 +1,214 @@
+/**
+ * Acceptance executors for the agent benchmark. Every check returns
+ * { id, kind, pass, detail } and never throws — a grader crash is a fail
+ * with evidence, not an exception that hides the run.
+ */
+import { execFile } from "node:child_process";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { validate } from "../../../packages/cli/src/api.mjs";
+import {
+  extractImports,
+  extractUsages,
+} from "../../../packages/cli/src/validate.mjs";
+import { loadRegistry } from "../../../packages/cli/src/data.mjs";
+
+const execFileAsync = promisify(execFile);
+
+async function walkFiles(root) {
+  const files = [];
+  async function walk(directory) {
+    let entries;
+    try {
+      entries = await readdir(directory, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(directory, entry.name);
+      if (entry.isDirectory()) await walk(full);
+      else files.push(full);
+    }
+  }
+  await walk(root);
+  return files.sort();
+}
+
+async function usageScan(worktree, check) {
+  const { docsRegistry } = await loadRegistry({ cwd: worktree });
+  const registry = docsRegistry.components ?? {};
+  const problems = [];
+  for (const relativePath of check.files) {
+    let source;
+    try {
+      source = await readFile(join(worktree, relativePath), "utf8");
+    } catch {
+      problems.push(`${relativePath}: unreadable`);
+      continue;
+    }
+    const { locals } = extractImports(source, registry);
+    const relevant = new Map(
+      [...locals].filter(([, component]) => component === check.component),
+    );
+    const usages = extractUsages(source, new Set(relevant.keys()));
+    if (usages.length === 0) {
+      problems.push(`${relativePath}: no ${check.component} usage found`);
+      continue;
+    }
+    // forbidProp must hold for EVERY usage; requireProp is satisfied when
+    // AT LEAST ONE usage in the file passes it (files can legitimately mix
+    // usages that never carried the renamed prop).
+    let requireHit = !check.requireProp;
+    for (const usage of usages) {
+      const names = usage.attributes.map(({ name }) => name);
+      if (check.forbidProp && names.includes(check.forbidProp)) {
+        problems.push(
+          `${relativePath}:${usage.line} still passes ${check.forbidProp}`,
+        );
+      }
+      if (check.requireProp && names.includes(check.requireProp)) {
+        requireHit = true;
+      }
+    }
+    if (!requireHit) {
+      problems.push(
+        `${relativePath}: no usage passes ${check.requireProp}`,
+      );
+    }
+  }
+  return {
+    pass: problems.length === 0,
+    detail: problems.length ? problems.join(" | ") : "all scoped usages migrated",
+  };
+}
+
+async function validateCheck(worktree, check) {
+  const report = await validate(check.components ?? [], {
+    cwd: worktree,
+    path: check.path,
+  });
+  if (check.prop) {
+    const hits = report.data.findings.filter(
+      (finding) => finding.prop === check.prop,
+    );
+    return {
+      pass: hits.length === 0,
+      detail: hits.length
+        ? hits
+            .map((hit) => `${hit.file}:${hit.line ?? "?"} ${hit.kind}`)
+            .join(" | ")
+        : `no findings for prop "${check.prop}"`,
+    };
+  }
+  const { errors, warnings } = report.data.summary;
+  return {
+    pass: errors === 0,
+    detail: `${report.data.usages} usage(s), ${errors} error(s), ${warnings} warning(s)${
+      errors
+        ? `: ${report.data.findings
+            .filter(({ severity }) => severity === "error")
+            .slice(0, 3)
+            .map(({ file, line, message }) => `${file}:${line} ${message}`)
+            .join(" | ")}`
+        : ""
+    }`,
+  };
+}
+
+async function vitestCheck(worktree, check) {
+  try {
+    const { stdout } = await execFileAsync(
+      "npx",
+      ["vitest", "run", ...check.paths],
+      { cwd: worktree, maxBuffer: 32 * 1024 * 1024 },
+    );
+    const summary =
+      stdout.split("\n").find((line) => line.includes("Tests ")) ?? "passed";
+    return { pass: true, detail: summary.trim() };
+  } catch (error) {
+    const output = `${error.stdout ?? ""}\n${error.stderr ?? ""}`;
+    return {
+      pass: false,
+      detail: output.trim().split("\n").slice(-10).join("\n"),
+    };
+  }
+}
+
+async function sourceScan(worktree, check) {
+  const files = await walkFiles(join(worktree, check.dir));
+  if (files.length === 0) {
+    return { pass: false, detail: `${check.dir} is empty or missing` };
+  }
+  const problems = [];
+  let anyRequireHit = !check.requireAnyPattern;
+  for (const file of files) {
+    const source = await readFile(file, "utf8");
+    if (check.forbidPattern && new RegExp(check.forbidPattern).test(source)) {
+      problems.push(`${file.slice(worktree.length + 1)} matches forbidden ${check.forbidPattern}`);
+    }
+    if (
+      check.requireAnyPattern &&
+      check.requireAnyPattern.some((pattern) => source.includes(pattern))
+    ) {
+      anyRequireHit = true;
+    }
+  }
+  if (!anyRequireHit) {
+    problems.push(
+      `no file matches any of: ${check.requireAnyPattern.join(", ")}`,
+    );
+  }
+  return {
+    pass: problems.length === 0,
+    detail: problems.length ? problems.join(" | ") : "source scan clean",
+  };
+}
+
+export async function runCheck(worktree, check) {
+  try {
+    let outcome;
+    switch (check.kind) {
+      case "usage-scan":
+        outcome = await usageScan(worktree, check);
+        break;
+      case "validate-clean":
+      case "validate-no-finding":
+        outcome = await validateCheck(worktree, check);
+        break;
+      case "vitest":
+        outcome = await vitestCheck(worktree, check);
+        break;
+      case "source-scan":
+        outcome = await sourceScan(worktree, check);
+        break;
+      default:
+        outcome = { pass: false, detail: `unknown check kind ${check.kind}` };
+    }
+    return { id: check.id, kind: check.kind, ...outcome };
+  } catch (error) {
+    return {
+      id: check.id,
+      kind: check.kind,
+      pass: false,
+      detail: `grader error: ${error.message}`,
+    };
+  }
+}
+
+export async function gradeTask(worktree, task) {
+  const acceptance = [];
+  for (const check of task.acceptance) {
+    acceptance.push(await runCheck(worktree, check));
+  }
+  const metrics = [];
+  for (const metric of task.metrics ?? []) {
+    const outcome = await runCheck(worktree, metric);
+    metrics.push({ id: metric.id, value: outcome.pass, detail: outcome.detail });
+  }
+  return {
+    pass: acceptance.every(({ pass }) => pass),
+    acceptance,
+    metrics,
+  };
+}

--- a/scripts/design-system/agent-bench/harness.mjs
+++ b/scripts/design-system/agent-bench/harness.mjs
@@ -1,0 +1,136 @@
+/**
+ * Benchmark harness: disposable worktrees, arm setup, and agent drivers.
+ *
+ * Arms (the fairness design — see docs/AGENT_BENCH_METHODOLOGY.md):
+ * - "with":    the workspace CLAUDE.md points the agent at the design-system
+ *              affordances (dt CLI, contracts, agent registry).
+ * - "without": the workspace CLAUDE.md is generic. Same repository, same
+ *              task, same budget — only the affordance POINTER differs; the
+ *              artifacts themselves are not hidden, because deleting them
+ *              would change the codebase under test.
+ *
+ * Agents:
+ * - "null":   does nothing (graders must fail — discrimination floor)
+ * - "oracle": applies the reference solution (graders must pass — ceiling)
+ * - "claude": pinned headless Claude Code runtime with token metering
+ */
+import { execFile } from "node:child_process";
+import { mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const BASE_RULES = `# Benchmark workspace
+
+Complete the task described in TASK.md at the repository root.
+
+Rules:
+- Only modify the files the task puts in scope.
+- Do not run git commands that change history (commit, push, rebase).
+- Do not start dev servers or Storybook.
+`;
+
+const WITH_AFFORDANCES = `
+## Design-system affordances
+
+This repository ships a component design system with machine-readable
+contracts and a CLI:
+
+- \`node packages/cli/src/cli.mjs search "<intent>"\` — find components
+- \`node packages/cli/src/cli.mjs component <Name>\` — contract, props, usage
+- \`node packages/cli/src/cli.mjs example <Name>\` — runnable story sources
+- \`node packages/cli/src/cli.mjs validate [--path <dir>]\` — check usage
+  against contracts (exit 2 on violations)
+- \`node packages/cli/src/cli.mjs upgrade --from <ref> --path <dir> --write\`
+  — codemod consumers across contract changes
+- \`node packages/cli/src/cli.mjs diff [Component] --from <ref>\` — classify
+  contract changes
+
+Components are imported as \`import X from "@dt/<Name>"\` (see each
+component's contract for the exact import line). Prefer reusing design-system
+components over hand-rolling markup, and validate your work before finishing.
+`;
+
+export async function createWorktree(repoRoot) {
+  const dir = await mkdtemp(join(tmpdir(), "dt-bench-"));
+  const worktree = join(dir, "wt");
+  await execFileAsync(
+    "git",
+    ["worktree", "add", "--detach", worktree, "HEAD"],
+    { cwd: repoRoot },
+  );
+  await symlink(join(repoRoot, "node_modules"), join(worktree, "node_modules"));
+  return {
+    worktree,
+    async destroy() {
+      await execFileAsync(
+        "git",
+        ["worktree", "remove", "--force", worktree],
+        { cwd: repoRoot },
+      ).catch(() => {});
+    },
+  };
+}
+
+export async function prepareWorkspace(worktree, task, arm) {
+  await task.prep(worktree);
+  await writeFile(join(worktree, "TASK.md"), `# ${task.title}\n\n${task.brief}\n`);
+  await writeFile(
+    join(worktree, "CLAUDE.md"),
+    arm === "with" ? BASE_RULES + WITH_AFFORDANCES : BASE_RULES,
+  );
+}
+
+/** Drive one agent over a prepared workspace. Returns metering info. */
+export async function runAgent(worktree, task, agent, options = {}) {
+  if (agent === "null") {
+    return { agent, turns: 0, costUsd: 0, durationMs: 0 };
+  }
+  if (agent === "oracle") {
+    const startedAt = Date.now();
+    await task.oracle(worktree);
+    return { agent, turns: 0, costUsd: 0, durationMs: Date.now() - startedAt };
+  }
+  if (agent !== "claude") {
+    throw new Error(`Unknown agent "${agent}"`);
+  }
+  const prompt =
+    options.prompt ??
+    "Complete the task described in TASK.md at the repository root.";
+  const args = [
+    "-p",
+    prompt,
+    "--output-format",
+    "json",
+    "--max-turns",
+    String(options.maxTurns ?? 30),
+    "--model",
+    options.model ?? "claude-sonnet-5",
+    "--dangerously-skip-permissions",
+  ];
+  const startedAt = Date.now();
+  const { stdout } = await execFileAsync("claude", args, {
+    cwd: worktree,
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: options.timeoutMs ?? 20 * 60 * 1000,
+  });
+  let parsed = null;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    // fall through with raw output preserved
+  }
+  return {
+    agent,
+    model: options.model ?? "claude-sonnet-5",
+    turns: parsed?.num_turns ?? null,
+    costUsd: parsed?.total_cost_usd ?? null,
+    usage: parsed?.usage ?? null,
+    durationMs: Date.now() - startedAt,
+    isError: parsed?.is_error ?? false,
+    resultTail:
+      typeof parsed?.result === "string" ? parsed.result.slice(-400) : null,
+  };
+}

--- a/scripts/design-system/agent-bench/repair-loop.mjs
+++ b/scripts/design-system/agent-bench/repair-loop.mjs
@@ -1,0 +1,70 @@
+/**
+ * Automatic validate → repair-guidance → revalidate loop (Astryx-gap
+ * Phase 3). After an agent finishes, failing acceptance checks are turned
+ * into concrete guidance — validate findings plus the relevant contract
+ * lines — and the agent gets a bounded number of repair rounds. The loop is
+ * arm-neutral: guidance comes from the same machine findings both arms are
+ * graded with.
+ */
+import { component, validate } from "../../../packages/cli/src/api.mjs";
+import { gradeTask } from "./grade.mjs";
+import { runAgent } from "./harness.mjs";
+
+async function guidanceFor(worktree, task, grade) {
+  const lines = ["Your previous attempt does not meet acceptance yet."];
+  const componentsToExplain = new Set();
+
+  for (const check of grade.acceptance.filter(({ pass }) => !pass)) {
+    lines.push(`\nFailed check "${check.id}" (${check.kind}):`);
+    lines.push(check.detail);
+    if (check.kind === "validate-clean" || check.kind === "validate-no-finding") {
+      const scoped = task.acceptance.find((entry) => entry.id === check.id);
+      const report = await validate(scoped.components ?? [], {
+        cwd: worktree,
+        path: scoped.path,
+      }).catch(() => null);
+      for (const finding of report?.data.findings ?? []) {
+        lines.push(
+          `- ${finding.file}:${finding.line ?? "?"} [${finding.severity}] ${finding.message}`,
+        );
+        componentsToExplain.add(finding.component);
+      }
+    }
+  }
+
+  for (const name of componentsToExplain) {
+    const detail = await component(name, {
+      cwd: worktree,
+      section: "props",
+    }).catch(() => null);
+    if (detail) {
+      lines.push(`\nContract for ${name}:`);
+      lines.push(JSON.stringify(detail.data.props));
+    }
+  }
+
+  lines.push(
+    "\nFix the issues above, staying within the task's file scope, then finish.",
+  );
+  return lines.join("\n");
+}
+
+/**
+ * Run up to `maxRounds` repair rounds. Returns the final grade plus the
+ * per-round history so convergence is reportable.
+ */
+export async function repairLoop(worktree, task, initialGrade, options = {}) {
+  const maxRounds = options.maxRounds ?? 2;
+  const rounds = [];
+  let grade = initialGrade;
+  for (let round = 1; round <= maxRounds && !grade.pass; round += 1) {
+    const guidance = await guidanceFor(worktree, task, grade);
+    const metering = await runAgent(worktree, task, "claude", {
+      ...options,
+      prompt: guidance,
+    });
+    grade = await gradeTask(worktree, task);
+    rounds.push({ round, metering, pass: grade.pass });
+  }
+  return { grade, rounds };
+}

--- a/scripts/design-system/agent-bench/run.mjs
+++ b/scripts/design-system/agent-bench/run.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * Agent benchmark runner (Astryx-gap Phase 3).
+ *
+ *   node scripts/design-system/agent-bench/run.mjs \
+ *     --task all --arm both --agent claude --reps 3 \
+ *     --model claude-sonnet-5 --max-turns 30 --repair-loop
+ *
+ * Stub agents for harness integrity (no model spend):
+ *   --agent null    every task must FAIL acceptance
+ *   --agent oracle  every task must PASS acceptance
+ *
+ * Results land in scripts/design-system/agent-bench/results/<stamp>.json.
+ * Publishing to public/ds-health is deliberately manual until real
+ * multi-rep numbers exist (honesty guardrail).
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { TASKS, taskById } from "./tasks.mjs";
+import { createWorktree, prepareWorkspace, runAgent } from "./harness.mjs";
+import { gradeTask } from "./grade.mjs";
+import { repairLoop } from "./repair-loop.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "../../..");
+
+function parseArgs(argv) {
+  const options = {
+    task: "all",
+    arm: "both",
+    agent: "claude",
+    reps: 1,
+    model: "claude-sonnet-5",
+    maxTurns: 30,
+    repairLoop: false,
+    keep: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === "--task") options.task = argv[++index];
+    else if (value === "--arm") options.arm = argv[++index];
+    else if (value === "--agent") options.agent = argv[++index];
+    else if (value === "--reps") options.reps = Number(argv[++index]);
+    else if (value === "--model") options.model = argv[++index];
+    else if (value === "--max-turns") options.maxTurns = Number(argv[++index]);
+    else if (value === "--repair-loop") options.repairLoop = true;
+    else if (value === "--keep") options.keep = true;
+    else throw new Error(`Unknown option ${value}`);
+  }
+  return options;
+}
+
+export async function runOnce({ task, arm, agent, options }) {
+  const { worktree, destroy } = await createWorktree(REPO_ROOT);
+  try {
+    await prepareWorkspace(worktree, task, arm);
+    const metering = await runAgent(worktree, task, agent, options);
+    let grade = await gradeTask(worktree, task);
+    let repair = null;
+    if (options.repairLoop && agent === "claude" && !grade.pass) {
+      repair = await repairLoop(worktree, task, grade, options);
+      grade = repair.grade;
+    }
+    return {
+      task: task.id,
+      category: task.category,
+      arm,
+      agent,
+      pass: grade.pass,
+      acceptance: grade.acceptance,
+      metrics: grade.metrics,
+      metering,
+      repairRounds: repair?.rounds ?? [],
+    };
+  } finally {
+    if (!options.keep) await destroy();
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const tasks =
+    options.task === "all"
+      ? TASKS
+      : [taskById(options.task)].filter(Boolean);
+  if (tasks.length === 0) {
+    console.error(
+      `Unknown task "${options.task}". Known: ${TASKS.map(({ id }) => id).join(", ")}`,
+    );
+    process.exit(1);
+  }
+  const arms =
+    options.agent === "claude"
+      ? options.arm === "both"
+        ? ["with", "without"]
+        : [options.arm]
+      : ["with"]; // stub agents ignore affordances; one arm is enough
+
+  const runs = [];
+  for (const task of tasks) {
+    for (const arm of arms) {
+      for (let rep = 1; rep <= options.reps; rep += 1) {
+        const label = `${task.id} ${arm} ${options.agent} rep${rep}`;
+        process.stdout.write(`▶ ${label}\n`);
+        const run = await runOnce({ task, arm, agent: options.agent, options });
+        runs.push({ ...run, rep });
+        process.stdout.write(
+          `  ${run.pass ? "PASS" : "FAIL"}${
+            run.metering.costUsd != null
+              ? ` ($${run.metering.costUsd.toFixed(4)}, ${run.metering.turns} turns)`
+              : ""
+          }\n`,
+        );
+        for (const check of run.acceptance.filter(({ pass }) => !pass)) {
+          process.stdout.write(`    ✗ ${check.id}: ${check.detail.split("\n")[0]}\n`);
+        }
+      }
+    }
+  }
+
+  const stamp = new Date()
+    .toISOString()
+    .replace(/[:.]/g, "-")
+    .slice(0, 19);
+  const resultsDir = join(HERE, "results");
+  await mkdir(resultsDir, { recursive: true });
+  const outPath = join(resultsDir, `${stamp}-${options.agent}.json`);
+  await writeFile(
+    outPath,
+    `${JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        options,
+        runs,
+        summary: {
+          total: runs.length,
+          passed: runs.filter(({ pass }) => pass).length,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  process.stdout.write(
+    `\n${runs.filter(({ pass }) => pass).length}/${runs.length} runs passed → ${outPath}\n`,
+  );
+  process.exitCode = runs.every(({ pass }) => pass) ? 0 : 1;
+}
+
+const isDirectRun =
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isDirectRun) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/scripts/design-system/agent-bench/selftest.mjs
+++ b/scripts/design-system/agent-bench/selftest.mjs
@@ -1,0 +1,39 @@
+/**
+ * Harness integrity proof (no model spend): for every task the null agent
+ * must FAIL acceptance and the oracle agent must PASS it. A grader that
+ * cannot discriminate between "did nothing" and "reference solution" would
+ * make any benchmark number meaningless, so this runs before any paid run.
+ *
+ *   npm run agent:bench:selftest
+ *
+ * Heavy (worktrees, scoped vitest, one build:tokens per migration run);
+ * deliberately not part of `npm test`.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { TASKS } from "./tasks.mjs";
+import { runOnce } from "./run.mjs";
+
+const options = { repairLoop: false, keep: false };
+
+for (const task of TASKS) {
+  test(`${task.id}: null agent fails acceptance`, async () => {
+    const run = await runOnce({ task, arm: "with", agent: "null", options });
+    assert.equal(
+      run.pass,
+      false,
+      `null agent unexpectedly passed: ${JSON.stringify(run.acceptance)}`,
+    );
+  });
+
+  test(`${task.id}: oracle agent passes acceptance`, async () => {
+    const run = await runOnce({ task, arm: "with", agent: "oracle", options });
+    assert.equal(
+      run.pass,
+      true,
+      `oracle failed: ${JSON.stringify(
+        run.acceptance.filter(({ pass }) => !pass),
+      )}`,
+    );
+  });
+}

--- a/scripts/design-system/agent-bench/tasks.mjs
+++ b/scripts/design-system/agent-bench/tasks.mjs
@@ -1,0 +1,358 @@
+/**
+ * Agent benchmark task suite (Astryx-gap Phase 3). Each task is a realistic
+ * brief with a seeded workspace and machine-checkable acceptance. Acceptance
+ * must be affordance-neutral: a hand-rolled solution meeting the brief's
+ * semantics passes just like a design-system one. Design-system reuse is
+ * reported as a metric, never as a gate.
+ *
+ * Workspaces live under tests/bench-work/<task>/ inside a disposable
+ * worktree — the tests/ prefix keeps copied assertion tests inside the repo
+ * vitest include globs.
+ */
+import { copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const FIXTURES = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "fixtures",
+);
+
+async function copyFixture(task, names, workspace) {
+  await mkdir(workspace, { recursive: true });
+  for (const name of names) {
+    const target = name.replace(".test-template.", ".test.");
+    await copyFile(join(FIXTURES, task, name), join(workspace, target));
+  }
+}
+
+async function renameInFile(path, from, to) {
+  const source = await readFile(path, "utf8");
+  await writeFile(
+    path,
+    source.replace(new RegExp(`\\b${from}\\b`, "g"), to),
+  );
+}
+
+export const TASKS = [
+  {
+    id: "migration-badge-rename",
+    category: "migration",
+    title: "Migrate Badge consumers across a prop rename",
+    workspace: null, // operates on real consumer files inside the worktree
+    brief: `The Badge component's \`variant\` prop has been renamed to \`emphasis\`.
+The component, its stories, and its contract are already updated.
+
+Migrate the remaining consumer usages so they match the new contract. The
+consumers in scope are:
+
+- app/dev/tailwind-test/TailwindTest.tsx
+- nextjs-app/shared/components/CookieConsent/CookieConsent.tsx
+- nextjs-app/shared/components/MultiCombobox/MultiCombobox.tsx
+- nextjs-app/shared/components/OpenHours/OpenHours.tsx
+
+Do not modify the Badge component itself. Preserve every existing prop
+value. Only the Badge usages in the files above are in scope; leave other
+components (for example Button) untouched.`,
+    async prep(worktree) {
+      await renameInFile(
+        join(worktree, "nextjs-app/shared/components/Badge/Badge.tsx"),
+        "variant",
+        "emphasis",
+      );
+      await renameInFile(
+        join(worktree, "nextjs-app/shared/components/Badge/Badge.stories.tsx"),
+        "variant",
+        "emphasis",
+      );
+      const contractPath = join(
+        worktree,
+        "nextjs-app/shared/components/Badge/Badge.contract.json",
+      );
+      const contract = JSON.parse(await readFile(contractPath, "utf8"));
+      const props = {};
+      for (const [key, value] of Object.entries(contract.props)) {
+        props[key === "variant" ? "emphasis" : key] = value;
+      }
+      contract.props = props;
+      await writeFile(contractPath, `${JSON.stringify(contract, null, 2)}\n`);
+      // Regenerate the registry so scanners and dt commands inside the
+      // worktree see the renamed contract (both arms get the same state).
+      await execFileAsync("npm", ["run", "-s", "build:tokens"], {
+        cwd: worktree,
+        maxBuffer: 32 * 1024 * 1024,
+      });
+    },
+    acceptance: [
+      {
+        id: "consumers-migrated",
+        kind: "usage-scan",
+        component: "Badge",
+        forbidProp: "variant",
+        requireProp: "emphasis",
+        files: [
+          "app/dev/tailwind-test/TailwindTest.tsx",
+          "nextjs-app/shared/components/CookieConsent/CookieConsent.tsx",
+          "nextjs-app/shared/components/MultiCombobox/MultiCombobox.tsx",
+          "nextjs-app/shared/components/OpenHours/OpenHours.tsx",
+        ],
+      },
+      {
+        id: "no-stale-variant-findings",
+        kind: "validate-no-finding",
+        components: ["Badge"],
+        path: "nextjs-app/shared/components",
+        prop: "variant",
+      },
+      {
+        id: "consumer-tests-pass",
+        kind: "vitest",
+        paths: [
+          "nextjs-app/shared/components/CookieConsent",
+          "nextjs-app/shared/components/MultiCombobox",
+          "nextjs-app/shared/components/OpenHours",
+        ],
+      },
+    ],
+    metrics: [],
+    async oracle(worktree) {
+      await execFileAsync(
+        "node",
+        ["packages/cli/src/cli.mjs", "upgrade", "Badge", "--path", ".", "--write"],
+        { cwd: worktree, maxBuffer: 32 * 1024 * 1024 },
+      );
+    },
+  },
+
+  {
+    id: "repair-status-panel",
+    category: "repair",
+    title: "Repair contract violations in a status panel",
+    workspace: "tests/bench-work/repair",
+    brief: `tests/bench-work/repair/StatusPanel.tsx uses design-system components in
+ways that violate their contracts, and some intended content is missing.
+
+Repair the file so that:
+- every design-system component usage matches its contract (valid prop
+  values, required props supplied), and
+- the panel communicates: pipeline stage "Building", release channel
+  "Stable", and the L keyboard shortcut for logs.
+
+Only edit tests/bench-work/repair/StatusPanel.tsx.`,
+    async prep(worktree) {
+      await copyFixture(
+        "repair",
+        ["StatusPanel.tsx", "StatusPanel.assert.test-template.tsx"],
+        join(worktree, "tests/bench-work/repair"),
+      );
+    },
+    acceptance: [
+      {
+        id: "usage-clean",
+        kind: "validate-clean",
+        path: "tests/bench-work/repair",
+      },
+      {
+        id: "panel-renders-intended-content",
+        kind: "vitest",
+        paths: ["tests/bench-work/repair"],
+      },
+    ],
+    metrics: [],
+    async oracle(worktree) {
+      await copyFile(
+        join(FIXTURES, "repair/oracle/StatusPanel.tsx"),
+        join(worktree, "tests/bench-work/repair/StatusPanel.tsx"),
+      );
+    },
+  },
+
+  {
+    id: "table-species",
+    category: "table",
+    title: "Build a sortable, selectable species table",
+    workspace: "tests/bench-work/table",
+    brief: `Create tests/bench-work/table/SpeciesTable.tsx, default-exporting a React
+component that renders the dataset from ./species as an accessible data
+table.
+
+Requirements:
+- a table with a caption naming the dataset
+- one row per species showing name, family, and wingspan
+- sorting by column: activating a column header cycles the sort and the
+  header exposes the state via aria-sort ("ascending"/"descending")
+- row selection via checkboxes with accessible names starting "Select"
+
+The acceptance test at tests/bench-work/table/SpeciesTable.assert.test.tsx
+must pass unmodified. Only add files under tests/bench-work/table/.`,
+    async prep(worktree) {
+      await copyFixture(
+        "table",
+        ["species.ts", "SpeciesTable.assert.test-template.tsx"],
+        join(worktree, "tests/bench-work/table"),
+      );
+    },
+    acceptance: [
+      {
+        id: "table-semantics",
+        kind: "vitest",
+        paths: ["tests/bench-work/table"],
+      },
+      {
+        id: "usage-clean",
+        kind: "validate-clean",
+        path: "tests/bench-work/table",
+      },
+    ],
+    metrics: [
+      {
+        id: "ds-reuse",
+        kind: "source-scan",
+        dir: "tests/bench-work/table",
+        requireAnyPattern: ["@dt/DataTable", "@digitaltableteur/react"],
+      },
+    ],
+    async oracle(worktree) {
+      await copyFile(
+        join(FIXTURES, "table/oracle/SpeciesTable.tsx"),
+        join(worktree, "tests/bench-work/table/SpeciesTable.tsx"),
+      );
+    },
+  },
+
+  {
+    id: "tree-taxonomy",
+    category: "tree",
+    title: "Build a keyboard-navigable taxonomy tree",
+    workspace: "tests/bench-work/tree",
+    brief: `Create tests/bench-work/tree/TaxonomyTree.tsx, default-exporting a React
+component that renders the dataset from ./taxonomy as an accessible tree.
+
+Requirements:
+- role="tree" with treeitem semantics
+- branches start collapsed, expose aria-expanded, and expand on activation
+  to reveal their children
+- ArrowDown moves focus to the next visible item (roving focus)
+
+The acceptance test at tests/bench-work/tree/TaxonomyTree.assert.test.tsx
+must pass unmodified. Only add files under tests/bench-work/tree/.`,
+    async prep(worktree) {
+      await copyFixture(
+        "tree",
+        ["taxonomy.ts", "TaxonomyTree.assert.test-template.tsx"],
+        join(worktree, "tests/bench-work/tree"),
+      );
+    },
+    acceptance: [
+      {
+        id: "tree-semantics",
+        kind: "vitest",
+        paths: ["tests/bench-work/tree"],
+      },
+      {
+        id: "usage-clean",
+        kind: "validate-clean",
+        path: "tests/bench-work/tree",
+      },
+    ],
+    metrics: [
+      {
+        id: "ds-reuse",
+        kind: "source-scan",
+        dir: "tests/bench-work/tree",
+        requireAnyPattern: ["@dt/TreeView", "@digitaltableteur/react"],
+      },
+    ],
+    async oracle(worktree) {
+      await copyFile(
+        join(FIXTURES, "tree/oracle/TaxonomyTree.tsx"),
+        join(worktree, "tests/bench-work/tree/TaxonomyTree.tsx"),
+      );
+    },
+  },
+
+  {
+    id: "forced-colors-chip",
+    category: "forced-colors",
+    title: "Make a status chip survive forced-colors mode",
+    workspace: "tests/bench-work/forced-colors",
+    brief: `tests/bench-work/forced-colors/LegacyChip.tsx renders service status chips
+whose only status signal is a hardcoded background colour. In Windows High
+Contrast (forced-colors) mode backgrounds are stripped, so every status
+looks identical — and hardcoded hex values bypass the design token system.
+
+Fix the chip so that:
+- each status stays distinguishable in forced-colors mode (through text or
+  explicit forced-colors handling, not background colour alone)
+- no hardcoded hex colours remain anywhere under
+  tests/bench-work/forced-colors/
+- the component keeps its public API ({ status }) and renders the same
+  labels
+
+Only edit files under tests/bench-work/forced-colors/.`,
+    async prep(worktree) {
+      await copyFixture(
+        "forced-colors",
+        [
+          "LegacyChip.tsx",
+          "LegacyChip.module.css",
+          "LegacyChip.assert.test-template.tsx",
+        ],
+        join(worktree, "tests/bench-work/forced-colors"),
+      );
+    },
+    acceptance: [
+      {
+        id: "labels-render",
+        kind: "vitest",
+        paths: ["tests/bench-work/forced-colors"],
+      },
+      {
+        id: "no-hardcoded-hex",
+        kind: "source-scan",
+        dir: "tests/bench-work/forced-colors",
+        forbidPattern: "#[0-9a-fA-F]{3,8}\\b",
+      },
+      {
+        id: "forced-colors-strategy",
+        kind: "source-scan",
+        dir: "tests/bench-work/forced-colors",
+        requireAnyPattern: [
+          "forced-colors",
+          "@dt/Badge",
+          "@dt/StatusDot",
+          "@digitaltableteur/react",
+        ],
+      },
+      {
+        id: "usage-clean",
+        kind: "validate-clean",
+        path: "tests/bench-work/forced-colors",
+      },
+    ],
+    metrics: [
+      {
+        id: "ds-reuse",
+        kind: "source-scan",
+        dir: "tests/bench-work/forced-colors",
+        requireAnyPattern: ["@dt/Badge", "@dt/StatusDot"],
+      },
+    ],
+    async oracle(worktree) {
+      await copyFile(
+        join(FIXTURES, "forced-colors/oracle/LegacyChip.tsx"),
+        join(worktree, "tests/bench-work/forced-colors/LegacyChip.tsx"),
+      );
+      await rm(
+        join(worktree, "tests/bench-work/forced-colors/LegacyChip.module.css"),
+      );
+    },
+  },
+];
+
+export function taskById(id) {
+  return TASKS.find((task) => task.id === id) ?? null;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -62,6 +62,7 @@
     "shared_backup_20251123",
     "api-legacy-vercel-functions",
     "digitaltableteur-blog",
+    "scripts/design-system/agent-bench/fixtures",
     "**/*.test.ts",
     "**/*.test.tsx",
     "**/*.stories.ts",


### PR DESCRIPTION
## Summary
- Astryx-gap **Phase 3, increment 1**: the fair end-to-end agent benchmark scaffold. Methodology (including the control-condition decision, the crux) in [docs/AGENT_BENCH_METHODOLOGY.md](../blob/main/docs/AGENT_BENCH_METHODOLOGY.md).
- **Task suite** — the plan's five categories: table (sortable/selectable species table), tree (keyboard-navigable taxonomy), migration (Badge prop rename across real consumers), repair (seeded contract violations), forced-colors (hardcoded-hex chip). Acceptance is affordance-neutral machine checks: usage scans via the dt scanner, `dt validate` findings, scoped vitest of pre-written assertion tests, and source scans. Design-system reuse is a reported **metric**, never a gate — a hand-rolled table with honest `aria-sort` semantics passes like a DataTable one.
- **A/B harness** — disposable git worktrees off HEAD (symlinked node_modules); the arms differ only in the workspace `CLAUDE.md` (WITH documents the dt CLI affordances; WITHOUT is generic, same repo access). This biases measured lift downward, so results under-claim. Pinned headless runtime (`claude -p --output-format json`) with token/turn/cost metering.
- **Null/oracle integrity gate** (`npm run agent:bench:selftest`) — for every task, the null agent must FAIL and the committed oracle solution must PASS, proving graders discriminate with zero model spend.
- **Automatic repair loop** — failing checks become concrete guidance (`dt validate` findings + contract prop lines) for bounded repair rounds; convergence recorded per round.
- Runner: `npm run agent:bench -- --task all --arm both --agent claude --reps 3 --repair-loop`; results land in a gitignored `results/` dir. Publishing to `public/ds-health` stays manual until real multi-rep numbers exist (honesty guardrail).

## Verification
- Selftest 10/10: every task's null run fails, every oracle run passes — including the DataTable/TreeView oracles passing the semantic assertion tests (`aria-sort` cycling, tree roving focus).
- The integrity gate caught a real grader bug before any model spend: `requireProp` demanded the renamed prop on **every** usage, but files legitimately mix Badge usages that never carried `variant`.
- Fixtures with intentional violations excluded from `tsc` (tsconfig) and stylelint (`.stylelintignore`, commented); assertion templates named `.test-template.tsx` so the repo suite never collects them.
- **Paid-path smoke proven**: one real run (`repair-status-panel`, WITH arm, haiku, 14-turn budget) — the agent repaired the panel in 11 turns for $0.1511, acceptance passed, token/cost metering captured in the results JSON.
- Full local gate: typecheck, lint, full `npm test`, `next build` — all exit 0.
- `validate:agent-docs` passes with the new scripts/AGENTS.md section.

## Next (Phase 3 increments)
Paid A/B runs (pinned model, ≥3 reps per arm) once the owner picks the model/budget; variance reporting; then publishing to the agent page with distributions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a design-system agent benchmark covering component migration, status panels, sortable tables, keyboard-navigable trees, and forced-colors support.
  * Added acceptance checks for accessibility, keyboard interaction, sorting, selection, status labels, and visual-state behavior.
  * Added benchmark execution, grading, repair-loop, self-test, and result-reporting capabilities.

* **Documentation**
  * Added methodology and usage guidance covering evaluation criteria, controls, reporting, and safeguards.

* **Chores**
  * Added commands and configuration for running benchmarks and excluding generated results and fixture styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->