### PR TITLE
fix(bench): grade max-turns agent outcomes instead of crashing the stream

### DIFF
--- a/scripts/design-system/agent-bench/harness.mjs
+++ b/scripts/design-system/agent-bench/harness.mjs
@@ -111,11 +111,20 @@ export async function runAgent(worktree, task, agent, options = {}) {
     "--dangerously-skip-permissions",
   ];
   const startedAt = Date.now();
-  const { stdout } = await execFileAsync("claude", args, {
-    cwd: worktree,
-    maxBuffer: 64 * 1024 * 1024,
-    timeout: options.timeoutMs ?? 20 * 60 * 1000,
-  });
+  // The runtime exits non-zero on outcomes that are still valid benchmark
+  // data (error_max_turns ships a full result envelope on stdout). Never
+  // crash the run: capture stdout either way and grade whatever state the
+  // agent left behind.
+  let stdout = "";
+  try {
+    ({ stdout } = await execFileAsync("claude", args, {
+      cwd: worktree,
+      maxBuffer: 64 * 1024 * 1024,
+      timeout: options.timeoutMs ?? 20 * 60 * 1000,
+    }));
+  } catch (error) {
+    stdout = error.stdout ?? "";
+  }
   let parsed = null;
   try {
     parsed = JSON.parse(stdout);
@@ -130,6 +139,7 @@ export async function runAgent(worktree, task, agent, options = {}) {
     usage: parsed?.usage ?? null,
     durationMs: Date.now() - startedAt,
     isError: parsed?.is_error ?? false,
+    terminalReason: parsed?.terminal_reason ?? null,
     resultTail:
       typeof parsed?.result === "string" ? parsed.result.slice(-400) : null,
   };


### PR DESCRIPTION
Found during the first full sonnet A/B run (30 runs): the runtime exits 1 on error_max_turns while shipping a complete JSON result envelope on stdout. The old harness crashed the whole stream and lost its results (they only write at the end). Now the harness captures error.stdout, records terminal_reason, and grades whatever state the agent left behind.

Local gate: typecheck, lint, 2862/2862 tests, build — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)