### PR TITLE
fix(bench): align migration brief with acceptance scope

### DIFF
--- a/scripts/design-system/agent-bench/tasks.mjs
+++ b/scripts/design-system/agent-bench/tasks.mjs
@@ -46,17 +46,16 @@ export const TASKS = [
     brief: `The Badge component's \`variant\` prop has been renamed to \`emphasis\`.
 The component, its stories, and its contract are already updated.
 
-Migrate the remaining consumer usages so they match the new contract. The
-consumers in scope are:
+Migrate ALL remaining consumer usages of Badge across the repository
+(app/ and nextjs-app/shared/, including story files) so they match the new
+contract. Finding the consumers is part of the task — Badge is imported
+both as \`@dt/Badge\` and as a named import from
+\`@digitaltableteur/react\`.
 
-- app/dev/tailwind-test/TailwindTest.tsx
-- nextjs-app/shared/components/CookieConsent/CookieConsent.tsx
-- nextjs-app/shared/components/MultiCombobox/MultiCombobox.tsx
-- nextjs-app/shared/components/OpenHours/OpenHours.tsx
-
-Do not modify the Badge component itself. Preserve every existing prop
-value. Only the Badge usages in the files above are in scope; leave other
-components (for example Button) untouched.`,
+Do not modify the Badge component itself
+(nextjs-app/shared/components/Badge/). Preserve every existing prop value.
+Only Badge usages are in scope; leave other components (for example
+Button, which also has a variant prop) untouched.`,
     async prep(worktree) {
       await renameInFile(
         join(worktree, "nextjs-app/shared/components/Badge/Badge.tsx"),
@@ -93,18 +92,32 @@ components (for example Button) untouched.`,
         component: "Badge",
         forbidProp: "variant",
         requireProp: "emphasis",
+        // Every repo file with a formerly-variant Badge usage; acceptance
+        // scope now matches the brief's "all consumers" exactly.
         files: [
           "app/dev/tailwind-test/TailwindTest.tsx",
           "nextjs-app/shared/components/CookieConsent/CookieConsent.tsx",
           "nextjs-app/shared/components/MultiCombobox/MultiCombobox.tsx",
           "nextjs-app/shared/components/OpenHours/OpenHours.tsx",
+          "nextjs-app/shared/components/pages/Pseo/PseoClusterBadges.tsx",
+          "nextjs-app/shared/components/pages/Pseo/PseoPillarMetaBadgeLinks.tsx",
+          "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+          "nextjs-app/shared/stories/Docs/ComponentUsage.stories.tsx",
+          "nextjs-app/shared/stories/TestHealth.stories.tsx",
         ],
       },
       {
-        id: "no-stale-variant-findings",
+        id: "no-stale-variant-findings-shared",
         kind: "validate-no-finding",
         components: ["Badge"],
-        path: "nextjs-app/shared/components",
+        path: "nextjs-app/shared",
+        prop: "variant",
+      },
+      {
+        id: "no-stale-variant-findings-app",
+        kind: "validate-no-finding",
+        components: ["Badge"],
+        path: "app",
         prop: "variant",
       },
       {


### PR DESCRIPTION
The first sonnet A/B round exposed a task-spec confound: the brief enumerated 4 consumer files while the acceptance swept all of shared/components, failing WITHOUT-arm agents on a file the brief never mentioned. The brief now demands migrating ALL Badge consumers (discovery is part of the task), and acceptance matches exactly: 9-file usage scan (incl. stories and package-consumer pages) plus validate-no-finding sweeps over nextjs-app/shared and app.

Migration null/oracle selftest re-proven 2/2. Full local gate: typecheck, lint, 2862/2862 tests, build — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the Badge migration task guidance to cover all repository consumers, including shared components and stories.
  * Clarified that unrelated `variant` properties must remain unchanged.
  * Added acceptance checks for all identified consumer files and stale `variant` usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->