### PR TITLE
feat(bench): publish corrected A/B distributions to the agent page (Astryx-gap Phase 3, increment 2)

### DIFF
--- a/app/design-system/agent/AgentBenchSection.tsx
+++ b/app/design-system/agent/AgentBenchSection.tsx
@@ -1,0 +1,148 @@
+import { Table } from "@dt/Table";
+import { TableRow } from "@dt/TableRow";
+import { TableHeaderCell } from "@dt/TableHeaderCell";
+import { TableCell } from "@dt/TableCell";
+
+type ArmSummary = {
+  runs: number;
+  firstTryPass: number;
+  finalPass: number;
+  passViaRepairLoop: number;
+  costUsdPerRun: { mean: number; min: number; max: number } | null;
+  dsReuse: { hits: number; eligible: number };
+};
+
+export type AgentBenchArtifact = {
+  generatedAt: string;
+  methodology: string;
+  runtime: string[];
+  totalRuns: number;
+  totalCostUsd: number;
+  notes: string[];
+  arms: { with: ArmSummary; without: ArmSummary };
+  tasks: {
+    id: string;
+    category: string;
+    with: ArmSummary;
+    without: ArmSummary;
+  }[];
+};
+
+const passRate = (arm: ArmSummary) => `${arm.finalPass}/${arm.runs}`;
+const reuse = (arm: ArmSummary) =>
+  arm.dsReuse.eligible > 0
+    ? `${arm.dsReuse.hits}/${arm.dsReuse.eligible}`
+    : "—";
+const repairNote = (arm: ArmSummary) =>
+  arm.passViaRepairLoop > 0 ? ` (${arm.passViaRepairLoop} via repair)` : "";
+
+/**
+ * Measured A/B benchmark distributions, rendered verbatim from the
+ * generated public/ds-health/agent-bench.json artifact — numbers on this
+ * page are never hand-written.
+ */
+export function AgentBenchSection({
+  artifact,
+}: {
+  artifact: AgentBenchArtifact;
+}) {
+  const { arms, tasks } = artifact;
+  return (
+    <section className="mt-12">
+      <h2 className="font-display text-xl font-semibold">
+        Agent benchmark (A/B)
+      </h2>
+      <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+        The same coding agent, twice per task: WITH the design-system
+        affordances documented in its workspace vs WITHOUT (identical
+        repository access). {artifact.totalRuns} runs, {artifact.runtime[0]},{" "}
+        total spend ${artifact.totalCostUsd.toFixed(2)}. Acceptance tests
+        semantics, not implementation — reuse of <code className="text-xs">@dt/*</code>{" "}
+        is reported separately. Methodology:{" "}
+        <code className="text-xs">{artifact.methodology}</code>.
+      </p>
+
+      <div className="mt-4 overflow-x-auto">
+        <Table caption="Agent benchmark arm summary" size="sm">
+          <thead>
+            <TableRow>
+              <TableHeaderCell>Arm</TableHeaderCell>
+              <TableHeaderCell>First-try pass</TableHeaderCell>
+              <TableHeaderCell>Final pass (repair loop)</TableHeaderCell>
+              <TableHeaderCell>Mean cost / run</TableHeaderCell>
+              <TableHeaderCell>DS reuse (build tasks)</TableHeaderCell>
+            </TableRow>
+          </thead>
+          <tbody>
+            {(["with", "without"] as const).map((arm) => (
+              <TableRow key={arm}>
+                <TableCell>{arm === "with" ? "WITH" : "WITHOUT"}</TableCell>
+                <TableCell>
+                  {arms[arm].firstTryPass}/{arms[arm].runs}
+                </TableCell>
+                <TableCell>
+                  {passRate(arms[arm])}
+                  {repairNote(arms[arm])}
+                </TableCell>
+                <TableCell>
+                  {arms[arm].costUsdPerRun
+                    ? `$${arms[arm].costUsdPerRun.mean.toFixed(2)}`
+                    : "—"}
+                </TableCell>
+                <TableCell>{reuse(arms[arm])}</TableCell>
+              </TableRow>
+            ))}
+          </tbody>
+        </Table>
+      </div>
+
+      <div className="mt-4 overflow-x-auto">
+        <Table caption="Agent benchmark per task" size="sm">
+          <thead>
+            <TableRow>
+              <TableHeaderCell>Task</TableHeaderCell>
+              <TableHeaderCell>WITH</TableHeaderCell>
+              <TableHeaderCell>WITHOUT</TableHeaderCell>
+              <TableHeaderCell>DS reuse (with / without)</TableHeaderCell>
+            </TableRow>
+          </thead>
+          <tbody>
+            {tasks.map((task) => (
+              <TableRow key={task.id}>
+                <TableCell>{task.category}</TableCell>
+                <TableCell>
+                  {passRate(task.with)}
+                  {repairNote(task.with)}
+                </TableCell>
+                <TableCell>
+                  {passRate(task.without)}
+                  {repairNote(task.without)}
+                </TableCell>
+                <TableCell>
+                  {reuse(task.with)} / {reuse(task.without)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </tbody>
+        </Table>
+      </div>
+
+      <ul className="mt-4 list-disc space-y-1 pl-5 text-xs leading-relaxed text-muted-foreground">
+        {artifact.notes.map((note) => (
+          <li key={note.slice(0, 40)}>{note}</li>
+        ))}
+      </ul>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Raw artifact:{" "}
+        <a
+          href="/ds-health/agent-bench.json"
+          className="underline underline-offset-2"
+        >
+          /ds-health/agent-bench.json
+        </a>{" "}
+        · n=3 per arm per task; runs are nondeterministic, so treat single
+        deltas as noise and distributions as the signal.
+      </p>
+    </section>
+  );
+}

--- a/app/design-system/agent/page.tsx
+++ b/app/design-system/agent/page.tsx
@@ -12,6 +12,11 @@ import {
   ComponentTaxonomyTree,
   type TaxonomyEntry,
 } from "./ComponentTaxonomyTree";
+import agentBenchJson from "../../../public/ds-health/agent-bench.json";
+import {
+  AgentBenchSection,
+  type AgentBenchArtifact,
+} from "./AgentBenchSection";
 
 export const metadata: Metadata = {
   title: "Design System Agent Demo | Digitaltableteur",
@@ -124,6 +129,10 @@ export default function DesignSystemAgentPage() {
           <ComponentTaxonomyTree entries={taxonomy} />
         </div>
       </section>
+
+      <AgentBenchSection
+        artifact={agentBenchJson as unknown as AgentBenchArtifact}
+      />
 
       <section className="mt-12">
         <h2 className="font-display text-xl font-semibold">Pattern recipes</h2>

--- a/public/ds-health/agent-bench.json
+++ b/public/ds-health/agent-bench.json
@@ -1,0 +1,291 @@
+{
+  "generatedAt": "2026-08-04T21:26:12.416Z",
+  "generator": {
+    "name": "agent-bench/aggregate.mjs",
+    "sourceCommit": "d7637e715d01649ff3817e4dd40bfada61f52af8"
+  },
+  "methodology": "docs/AGENT_BENCH_METHODOLOGY.md",
+  "runtime": [
+    "claude-sonnet-5 maxTurns=30 repairLoop=true"
+  ],
+  "resultFiles": [
+    "2026-08-04T15-05-04-claude.json",
+    "2026-08-04T15-06-36-claude.json",
+    "2026-08-04T15-07-35-claude.json",
+    "2026-08-04T15-26-06-claude.json",
+    "2026-08-04T21-25-31-claude.json"
+  ],
+  "totalRuns": 30,
+  "totalCostUsd": 25.72,
+  "notes": [
+    "Arms are identical except the workspace guidance file: WITH documents the dt CLI affordances; WITHOUT is generic with the same repository access. The control can discover the affordances on its own, so measured lift under-claims.",
+    "Acceptance is affordance-neutral (semantics, not implementation); design-system reuse is reported separately and never gates a pass.",
+    "The migration category is from a re-run after a task-spec fix (#1406): the original brief enumerated 4 files while acceptance swept wider. The corrected brief demands all consumers and acceptance matches; the confounded original migration results are excluded.",
+    "On the corrected migration task both arms passed 3/3; the affordance effect there is efficiency (WITH mean ~$1.18 and ~25 turns vs WITHOUT ~$1.73 and ~34 turns), with one WITHOUT run needing the repair loop.",
+    "num_turns counts top-level turns only; runs that delegate to subagents can show few turns at normal cost."
+  ],
+  "arms": {
+    "with": {
+      "runs": 15,
+      "firstTryPass": 15,
+      "finalPass": 15,
+      "passViaRepairLoop": 0,
+      "costUsdPerRun": {
+        "mean": 0.7949,
+        "min": 0.5086,
+        "max": 1.3702
+      },
+      "initialTurns": {
+        "mean": 16.7333,
+        "min": 9,
+        "max": 31
+      },
+      "dsReuse": {
+        "hits": 5,
+        "eligible": 9
+      }
+    },
+    "without": {
+      "runs": 15,
+      "firstTryPass": 14,
+      "finalPass": 15,
+      "passViaRepairLoop": 1,
+      "costUsdPerRun": {
+        "mean": 0.9196,
+        "min": 0.4794,
+        "max": 2.0977
+      },
+      "initialTurns": {
+        "mean": 15.4667,
+        "min": 1,
+        "max": 41
+      },
+      "dsReuse": {
+        "hits": 1,
+        "eligible": 9
+      }
+    }
+  },
+  "tasks": [
+    {
+      "id": "forced-colors-chip",
+      "category": "forced-colors",
+      "with": {
+        "runs": 3,
+        "firstTryPass": 3,
+        "finalPass": 3,
+        "passViaRepairLoop": 0,
+        "costUsdPerRun": {
+          "mean": 0.7464,
+          "min": 0.6926,
+          "max": 0.7838
+        },
+        "initialTurns": {
+          "mean": 15.3333,
+          "min": 13,
+          "max": 17
+        },
+        "dsReuse": {
+          "hits": 0,
+          "eligible": 3
+        }
+      },
+      "without": {
+        "runs": 3,
+        "firstTryPass": 3,
+        "finalPass": 3,
+        "passViaRepairLoop": 0,
+        "costUsdPerRun": {
+          "mean": 1.2011,
+          "min": 0.7265,
+          "max": 2.0977
+        },
+        "initialTurns": {
+          "mean": 12,
+          "min": 1,
+          "max": 19
+        },
+        "dsReuse": {
+          "hits": 1,
+          "eligible": 3
+        }
+      }
+    },
+    {
+      "id": "migration-badge-rename",
+      "category": "migration",
+      "with": {
+        "runs": 3,
+        "firstTryPass": 3,
+        "finalPass": 3,
+        "passViaRepairLoop": 0,
+        "costUsdPerRun": {
+          "mean": 1.1818,
+          "min": 0.9848,
+          "max": 1.3702
+        },
+        "initialTurns": {
+          "mean": 25.3333,
+          "min": 22,
+          "max": 31
+        },
+        "dsReuse": {
+          "hits": 0,
+          "eligible": 0
+        }
+      },
+      "without": {
+        "runs": 3,
+        "firstTryPass": 2,
+        "finalPass": 3,
+        "passViaRepairLoop": 1,
+        "costUsdPerRun": {
+          "mean": 1.7271,
+          "min": 1.3352,
+          "max": 1.9806
+        },
+        "initialTurns": {
+          "mean": 34.3333,
+          "min": 31,
+          "max": 41
+        },
+        "dsReuse": {
+          "hits": 0,
+          "eligible": 0
+        }
+      }
+    },
+    {
+      "id": "repair-status-panel",
+      "category": "repair",
+      "with": {
+        "runs": 3,
+        "firstTryPass": 3,
+        "finalPass": 3,
+        "passViaRepairLoop": 0,
+        "costUsdPerRun": {
+          "mean": 0.5712,
+          "min": 0.5086,
+          "max": 0.662
+        },
+        "initialTurns": {
+          "mean": 10.6667,
+          "min": 9,
+          "max": 12
+        },
+        "dsReuse": {
+          "hits": 0,
+          "eligible": 0
+        }
+      },
+      "without": {
+        "runs": 3,
+        "firstTryPass": 3,
+        "finalPass": 3,
+        "passViaRepairLoop": 0,
+        "costUsdPerRun": {
+          "mean": 0.6091,
+          "min": 0.4895,
+          "max": 0.712
+        },
+        "initialTurns": {
+          "mean": 11.3333,
+          "min": 8,
+          "max": 13
+        },
+        "dsReuse": {
+          "hits": 0,
+          "eligible": 0
+        }
+      }
+    },
+    {
+      "id": "table-species",
+      "category": "table",
+      "with": {
+        "runs": 3,
+        "firstTryPass": 3,
+        "finalPass": 3,
+        "passViaRepairLoop": 0,
+        "costUsdPerRun": {
+          "mean": 0.7389,
+          "min": 0.695,
+          "max": 0.7741
+        },
+        "initialTurns": {
+          "mean": 17,
+          "min": 16,
+          "max": 18
+        },
+        "dsReuse": {
+          "hits": 3,
+          "eligible": 3
+        }
+      },
+      "without": {
+        "runs": 3,
+        "firstTryPass": 3,
+        "finalPass": 3,
+        "passViaRepairLoop": 0,
+        "costUsdPerRun": {
+          "mean": 0.5058,
+          "min": 0.4817,
+          "max": 0.5278
+        },
+        "initialTurns": {
+          "mean": 9,
+          "min": 8,
+          "max": 10
+        },
+        "dsReuse": {
+          "hits": 0,
+          "eligible": 3
+        }
+      }
+    },
+    {
+      "id": "tree-taxonomy",
+      "category": "tree",
+      "with": {
+        "runs": 3,
+        "firstTryPass": 3,
+        "finalPass": 3,
+        "passViaRepairLoop": 0,
+        "costUsdPerRun": {
+          "mean": 0.7362,
+          "min": 0.6683,
+          "max": 0.791
+        },
+        "initialTurns": {
+          "mean": 15.3333,
+          "min": 11,
+          "max": 19
+        },
+        "dsReuse": {
+          "hits": 2,
+          "eligible": 3
+        }
+      },
+      "without": {
+        "runs": 3,
+        "firstTryPass": 3,
+        "finalPass": 3,
+        "passViaRepairLoop": 0,
+        "costUsdPerRun": {
+          "mean": 0.5551,
+          "min": 0.4794,
+          "max": 0.5974
+        },
+        "initialTurns": {
+          "mean": 10.6667,
+          "min": 9,
+          "max": 12
+        },
+        "dsReuse": {
+          "hits": 0,
+          "eligible": 3
+        }
+      }
+    }
+  ]
+}

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -121,8 +121,11 @@
 - `npm run agent:bench -- --task all --arm both --agent claude --reps 3`
   — a real benchmark run (spends tokens; pinned model + turn budget).
 - Methodology and fairness design: `docs/AGENT_BENCH_METHODOLOGY.md`.
-- Results land in `scripts/design-system/agent-bench/results/` (gitignored);
-  publishing to `public/ds-health` is manual once multi-rep numbers exist.
+- Results land in `scripts/design-system/agent-bench/results/` (gitignored).
+  Publish with `aggregate.mjs --out public/ds-health/agent-bench.json
+  [--note ...] <result files>` — the agent page renders that artifact
+  verbatim (numbers are generated, never hand-written); commit the
+  regenerated artifact with the run's caveats as notes.
 
 ---
 

--- a/scripts/design-system/agent-bench/aggregate.mjs
+++ b/scripts/design-system/agent-bench/aggregate.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * Aggregate benchmark result files into the published artifact.
+ *
+ *   node scripts/design-system/agent-bench/aggregate.mjs \
+ *     --out public/ds-health/agent-bench.json \
+ *     results/2026-08-04T15-05-04-claude.json [...]
+ *
+ * The artifact is the ONLY thing the agent page renders — numbers stay
+ * generated from named raw result files (recorded in provenance), never
+ * hand-written. Notes passed via repeated --note flags are carried
+ * verbatim so methodology caveats live next to the numbers.
+ */
+import { execFile } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+function parseArgs(argv) {
+  const files = [];
+  const notes = [];
+  let out = null;
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === "--out") out = argv[++index];
+    else if (value === "--note") notes.push(argv[++index]);
+    else files.push(value);
+  }
+  if (!out || files.length === 0) {
+    console.error(
+      "Usage: aggregate.mjs --out <artifact.json> [--note <text>]... <result.json>...",
+    );
+    process.exit(1);
+  }
+  return { out, notes, files };
+}
+
+function stats(values) {
+  const clean = values.filter((value) => value != null);
+  if (clean.length === 0) return null;
+  const mean = clean.reduce((a, b) => a + b, 0) / clean.length;
+  return {
+    mean: Number(mean.toFixed(4)),
+    min: Number(Math.min(...clean).toFixed(4)),
+    max: Number(Math.max(...clean).toFixed(4)),
+  };
+}
+
+function runCost(run) {
+  const base = run.metering.costUsd ?? 0;
+  return (
+    base +
+    run.repairRounds.reduce(
+      (total, round) => total + (round.metering.costUsd ?? 0),
+      0,
+    )
+  );
+}
+
+function armSummary(runs) {
+  return {
+    runs: runs.length,
+    firstTryPass: runs.filter((run) => run.pass && run.repairRounds.length === 0)
+      .length,
+    finalPass: runs.filter((run) => run.pass).length,
+    passViaRepairLoop: runs.filter(
+      (run) => run.pass && run.repairRounds.length > 0,
+    ).length,
+    costUsdPerRun: stats(runs.map(runCost)),
+    initialTurns: stats(runs.map((run) => run.metering.turns)),
+    dsReuse: {
+      hits: runs.filter((run) =>
+        run.metrics.some((metric) => metric.id === "ds-reuse" && metric.value),
+      ).length,
+      eligible: runs.filter((run) =>
+        run.metrics.some((metric) => metric.id === "ds-reuse"),
+      ).length,
+    },
+  };
+}
+
+const { out, notes, files } = parseArgs(process.argv.slice(2));
+
+const runs = [];
+const runtimes = new Set();
+for (const file of files) {
+  const data = JSON.parse(await readFile(file, "utf8"));
+  runtimes.add(
+    `${data.options.model} maxTurns=${data.options.maxTurns} repairLoop=${data.options.repairLoop}`,
+  );
+  runs.push(...data.runs);
+}
+
+const taskIds = [...new Set(runs.map((run) => run.task))].sort();
+const tasks = taskIds.map((task) => {
+  const scoped = runs.filter((run) => run.task === task);
+  return {
+    id: task,
+    category: scoped[0].category,
+    with: armSummary(scoped.filter((run) => run.arm === "with")),
+    without: armSummary(scoped.filter((run) => run.arm === "without")),
+  };
+});
+
+const sourceCommit = (
+  await execFileAsync("git", ["rev-parse", "HEAD"]).then(
+    ({ stdout }) => stdout,
+    () => "unknown",
+  )
+).trim();
+
+const artifact = {
+  generatedAt: new Date().toISOString(),
+  generator: { name: "agent-bench/aggregate.mjs", sourceCommit },
+  methodology: "docs/AGENT_BENCH_METHODOLOGY.md",
+  runtime: [...runtimes],
+  resultFiles: files.map((file) => basename(file)),
+  totalRuns: runs.length,
+  totalCostUsd: Number(
+    runs.reduce((total, run) => total + runCost(run), 0).toFixed(2),
+  ),
+  notes,
+  arms: {
+    with: armSummary(runs.filter((run) => run.arm === "with")),
+    without: armSummary(runs.filter((run) => run.arm === "without")),
+  },
+  tasks,
+};
+
+await writeFile(out, `${JSON.stringify(artifact, null, 2)}\n`);
+console.log(
+  `Wrote ${out}: ${artifact.totalRuns} runs, $${artifact.totalCostUsd}, ` +
+    `WITH ${artifact.arms.with.finalPass}/${artifact.arms.with.runs} vs ` +
+    `WITHOUT ${artifact.arms.without.finalPass}/${artifact.arms.without.runs}`,
+);


### PR DESCRIPTION
## Summary
- Astryx-gap **Phase 3, increment 2**: the corrected A/B benchmark distributions go public on `/design-system/agent`, per the roadmap's Track C ("live scored numbers … backed by a `public/ds-health/agent-bench.json` artifact").
- **Artifact**: `public/ds-health/agent-bench.json`, generated by the new `agent-bench/aggregate.mjs` from named raw result files. Carries provenance (generator, sourceCommit, pinned runtime, result file names, total spend) and the methodology caveats verbatim as notes. Numbers are never hand-written; the page renders the artifact as-is.
- **Page section**: `AgentBenchSection` (server component composing the `@dt` Table primitives — more dogfooding): arm summary (first-try pass, final pass with repair-loop attribution, mean cost/run, DS reuse on build tasks), per-task rows, fairness notes, and a link to the raw JSON at `/ds-health/agent-bench.json`.

## Published numbers (30 sonnet runs, $25.72, corrected migration spec)
| | WITH | WITHOUT |
|---|---|---|
| First-try pass | 15/15 | 14/15 |
| Final pass | 15/15 | 15/15 (1 via repair loop) |
| Mean cost/run | $0.79 | $0.92 |
| DS reuse (build tasks) | 5/9 | 1/9 |

- Reuse is the clean effect: table 3/3 vs 0/3, tree 2/3 vs 0/3 — the affordance changes what gets built even when affordance-neutral acceptance ties.
- Migration (corrected spec #1406, category re-run): both arms 3/3, but WITH ~\$1.18 / ~25 turns vs WITHOUT ~\$1.73 / ~34 turns — an efficiency lift, honestly reported instead of the confounded pass-rate delta.
- The confounded original migration results are excluded, and the exclusion is disclosed in the artifact notes.

## Verification
- Browser-verified on the dev server: section renders the artifact's 30-run numbers, both tables, notes, and raw-JSON link.
- Full local gate: typecheck, lint, full `npm test`, `next build` — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
