### PR TITLE
fix(ds): unify field label typography + align contact form control heights

### DIFF
--- a/nextjs-app/shared/components/Combobox/ComboboxField.module.css
+++ b/nextjs-app/shared/components/Combobox/ComboboxField.module.css
@@ -6,10 +6,14 @@
 
 .label {
   display: block;
-  font-family: var(--font-body);
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--primary-text-color);
+
+  /* Typography matches the Label primitive exactly — Combobox,
+   * MultiCombobox and FileUpload labels read like every other field label
+   * (unified 2026-08-05; was 13px/600/--primary-text-color). */
+  font-family: var(--font-text);
+  font-size: 1rem;
+  font-weight: 400;
+  color: var(--color-primary);
 }
 
 .required {

--- a/nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css
+++ b/nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css
@@ -8,9 +8,9 @@
 
 .honeypot {
   position: absolute;
-  inset-inline-start: -10000px;
-  inline-size: 1px;
   block-size: 1px;
+  inline-size: 1px;
+  inset-inline-start: -10000px;
   overflow: hidden;
 }
 
@@ -20,6 +20,33 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-layout-24);
+}
+
+/*
+ * The editorial name/email/message fields set the form's resting control
+ * height (0.75rem block padding -> 56px at the 18px root). The embedded DS
+ * controls ship md metrics (0.5rem -> 47px), so these class+element
+ * selectors lift them to the editorial scale. Scoped to .fields only; the
+ * components' own md sizing is untouched elsewhere.
+ */
+
+.fields select {
+  padding-block: var(--space-internal-12);
+}
+
+/* PhoneInput pads its composite wrapper (0.5rem); the inner input makes up
+ * the remaining quarter rem so the wrapper rests at the same 56px. */
+
+.fields input[type="tel"] {
+  padding-block: var(--space-internal-4);
+}
+
+/* MultiCombobox rests 2px shy of the editorial height; pin its control
+ * (field > wrapper > control in the DS markup) to the same formula the
+ * editorial inputs resolve to: 2x0.75rem padding + 1.5rem line + borders. */
+
+.fields .alignedCombobox > div > div {
+  min-block-size: calc(2 * var(--space-internal-24) + 2px);
 }
 
 .checkboxField {
@@ -99,16 +126,16 @@
 }
 
 .submitButton:disabled {
-  cursor: not-allowed;
   background-color: var(--color-disabled-bg);
   color: color-mix(in srgb, var(--inverted-text-color) 60%, transparent);
+  cursor: not-allowed;
 }
 
 /* Loading spinner */
 
 .spinner {
-  inline-size: 16px;
   block-size: 16px;
+  inline-size: 16px;
   animation: spin 1s linear infinite;
 }
 

--- a/nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx
+++ b/nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx
@@ -549,6 +549,7 @@ export function ContactFormEditorial({
           </Select>
 
           <MultiCombobox
+            className={styles.alignedCombobox}
             label={t("contactProjectTypeLabel", "Project type")}
             options={PROJECT_TYPE_OPTIONS.map((opt) => ({
               value: opt.value,

--- a/nextjs-app/shared/components/GroupLabel/GroupLabel.module.css
+++ b/nextjs-app/shared/components/GroupLabel/GroupLabel.module.css
@@ -2,8 +2,11 @@
   display: flex;
   align-items: center;
   gap: 0.5rem; /* 8px */
-  font-family: var(--font-body, sans-serif);
+
+  /* Typography matches the Label primitive exactly — one label treatment
+   * across single fields and group legends (unified 2026-08-05). */
+  font-family: var(--font-text);
   font-size: 1rem;
-  font-weight: 500;
+  font-weight: 400;
   color: var(--color-primary);
 }

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -1,6 +1,6 @@
 {
   "generatedBy": "npm run lint:css:update",
-  "warningCount": 2344,
+  "warningCount": 2339,
   "warnings": [
     {
       "file": ".storybook/blocks/A11ySection.module.css",
@@ -3991,7 +3991,7 @@
     },
     {
       "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 166,
+      "line": 170,
       "column": 3,
       "rule": "order/properties-order",
       "severity": "warning",
@@ -4000,7 +4000,7 @@
     },
     {
       "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 197,
+      "line": 201,
       "column": 19,
       "rule": "rhythmguard/prefer-token",
       "severity": "warning",
@@ -4009,16 +4009,7 @@
     },
     {
       "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 10,
-      "column": 14,
-      "rule": "rhythmguard/use-scale",
-      "severity": "warning",
-      "text": "Unexpected off-scale value \"13px\". Use scale values (nearest: 12px or 16px). (rhythmguard/use-scale)",
-      "id": "nextjs-app/shared/components/Combobox/ComboboxField.module.css::rhythmguard/use-scale::Unexpected off-scale value \"13px\". Use scale values (nearest: 12px or 16px). (rhythmguard/use-scale)::1"
-    },
-    {
-      "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 155,
+      "line": 159,
       "column": 19,
       "rule": "rhythmguard/use-scale",
       "severity": "warning",
@@ -4027,7 +4018,7 @@
     },
     {
       "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 176,
+      "line": 180,
       "column": 19,
       "rule": "rhythmguard/use-scale",
       "severity": "warning",
@@ -4036,7 +4027,7 @@
     },
     {
       "file": "nextjs-app/shared/components/Combobox/ComboboxField.module.css",
-      "line": 222,
+      "line": 226,
       "column": 19,
       "rule": "rhythmguard/use-scale",
       "severity": "warning",
@@ -4522,61 +4513,25 @@
     },
     {
       "file": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css",
-      "line": 101,
+      "line": 128,
       "column": 1,
       "rule": "no-descending-specificity",
       "severity": "warning",
-      "text": "Expected selector \".submitButton:disabled\" to come before selector \".submitButton:hover:not(:disabled)\", at line 92 (no-descending-specificity)",
+      "text": "Expected selector \".submitButton:disabled\" to come before selector \".submitButton:hover:not(:disabled)\", at line 119 (no-descending-specificity)",
       "id": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css::no-descending-specificity::Expected selector \".submitButton:disabled\" to come before selector \".submitButton:hover:not(:disabled)\" (no-descending-specificity)::1"
     },
     {
       "file": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css",
-      "line": 96,
+      "line": 123,
       "column": 1,
       "rule": "no-descending-specificity",
       "severity": "warning",
-      "text": "Expected selector \".submitButton:focus-visible\" to come before selector \".submitButton:hover:not(:disabled)\", at line 92 (no-descending-specificity)",
+      "text": "Expected selector \".submitButton:focus-visible\" to come before selector \".submitButton:hover:not(:disabled)\", at line 119 (no-descending-specificity)",
       "id": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css::no-descending-specificity::Expected selector \".submitButton:focus-visible\" to come before selector \".submitButton:hover:not(:disabled)\" (no-descending-specificity)::1"
     },
     {
       "file": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css",
-      "line": 103,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"background-color\" to come before \"cursor\" (order/properties-order)",
-      "id": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css::order/properties-order::Expected \"background-color\" to come before \"cursor\" (order/properties-order)::1"
-    },
-    {
-      "file": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css",
       "line": 13,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"block-size\" to come before \"inline-size\" (order/properties-order)",
-      "id": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css::order/properties-order::Expected \"block-size\" to come before \"inline-size\" (order/properties-order)::1"
-    },
-    {
-      "file": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css",
-      "line": 111,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"block-size\" to come before \"inline-size\" (order/properties-order)",
-      "id": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css::order/properties-order::Expected \"block-size\" to come before \"inline-size\" (order/properties-order)::2"
-    },
-    {
-      "file": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css",
-      "line": 12,
-      "column": 3,
-      "rule": "order/properties-order",
-      "severity": "warning",
-      "text": "Expected \"inline-size\" to come before \"inset-inline-start\" (order/properties-order)",
-      "id": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css::order/properties-order::Expected \"inline-size\" to come before \"inset-inline-start\" (order/properties-order)::1"
-    },
-    {
-      "file": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css",
-      "line": 11,
       "column": 23,
       "rule": "rhythmguard/prefer-token",
       "severity": "warning",
@@ -4585,7 +4540,7 @@
     },
     {
       "file": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css",
-      "line": 11,
+      "line": 13,
       "column": 23,
       "rule": "rhythmguard/use-scale",
       "severity": "warning",
@@ -4594,7 +4549,7 @@
     },
     {
       "file": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css",
-      "line": 55,
+      "line": 82,
       "column": 14,
       "rule": "rhythmguard/use-scale",
       "severity": "warning",
@@ -4603,7 +4558,7 @@
     },
     {
       "file": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css",
-      "line": 83,
+      "line": 110,
       "column": 14,
       "rule": "rhythmguard/use-scale",
       "severity": "warning",
@@ -4612,8 +4567,8 @@
     },
     {
       "file": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css",
-      "line": 12,
-      "column": 16,
+      "line": 11,
+      "column": 15,
       "rule": "rhythmguard/use-scale",
       "severity": "warning",
       "text": "Unexpected off-scale value \"1px\". Use scale values (nearest: 0px or 2px). (rhythmguard/use-scale)",
@@ -4621,8 +4576,8 @@
     },
     {
       "file": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css",
-      "line": 13,
-      "column": 15,
+      "line": 12,
+      "column": 16,
       "rule": "rhythmguard/use-scale",
       "severity": "warning",
       "text": "Unexpected off-scale value \"1px\". Use scale values (nearest: 0px or 2px). (rhythmguard/use-scale)",


### PR DESCRIPTION
The contact form mixed three label treatments (Label 1rem/400, GroupLabel 1rem/500, ComboboxField 13px/600 off-token color) and two control heights (editorial fields 56px vs DS md controls 47-54px).

**Labels (DS-level):** GroupLabel and the ComboboxField label (Combobox/MultiCombobox/FileUpload) now match the Label primitive exactly: --font-text, 1rem, 400, --color-primary. Retiring the off-scale 13px also shrank the stylelint baseline 2344 -> 2339.

**Heights (scoped to the form's .fields class):** selects gain editorial block padding (--space-internal-12), PhoneInput's inner tel input contributes --space-internal-4 so the composite rests at 56px, MultiCombobox control pinned to the editorial formula via a scoped className. DS md sizing untouched elsewhere.

**Measured (browser, before/after):** selects 47→56, phone 47→56, multicombobox 54→56, matching the 56px reference inputs; label computed styles identical (18px/400) across all three former treatments, in EN and FI, dark and high-contrast-black.

Local gate: typecheck, lint (stylelint + rhythmguard green), 2862/2862 tests, build — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)