### PR TITLE
fix(ds): FormFieldEditorial labels join the unified label treatment

### DIFF
--- a/nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.module.css
+++ b/nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.module.css
@@ -8,10 +8,14 @@
 
 .label {
   display: block;
-  font-family: var(--font-body);
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--primary-text-color);
+
+  /* Typography matches the Label primitive exactly — the editorial fields
+   * share the one unified label treatment (2026-08-05; was 13px/600, the
+   * same hand-rolled style ComboboxField retired in #1409). */
+  font-family: var(--font-text);
+  font-size: 1rem;
+  font-weight: 400;
+  color: var(--color-primary);
 }
 
 .required {

--- a/scripts/design-system/stylelint-baseline.json
+++ b/scripts/design-system/stylelint-baseline.json
@@ -1,6 +1,6 @@
 {
   "generatedBy": "npm run lint:css:update",
-  "warningCount": 2339,
+  "warningCount": 2338,
   "warnings": [
     {
       "file": ".storybook/blocks/A11ySection.module.css",
@@ -6538,7 +6538,7 @@
     },
     {
       "file": "nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.module.css",
-      "line": 167,
+      "line": 171,
       "column": 27,
       "rule": "rhythmguard/prefer-token",
       "severity": "warning",
@@ -6547,16 +6547,7 @@
     },
     {
       "file": "nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.module.css",
-      "line": 12,
-      "column": 14,
-      "rule": "rhythmguard/use-scale",
-      "severity": "warning",
-      "text": "Unexpected off-scale value \"13px\". Use scale values (nearest: 12px or 16px). (rhythmguard/use-scale)",
-      "id": "nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.module.css::rhythmguard/use-scale::Unexpected off-scale value \"13px\". Use scale values (nearest: 12px or 16px). (rhythmguard/use-scale)::1"
-    },
-    {
-      "file": "nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.module.css",
-      "line": 59,
+      "line": 63,
       "column": 19,
       "rule": "rhythmguard/use-scale",
       "severity": "warning",


### PR DESCRIPTION
Follow-up to #1409, which missed FormFieldEditorial: the editorial contact fields (Full Name, Email, Your Message, Inspiration/References) kept the hand-rolled 13px/600 label style, leaving the form MORE inconsistent. FormFieldEditorial labels now match the Label primitive exactly.

Acceptance measured exhaustively: every visible label/legend in the rendered contact form (14 elements, both expanders open) resolves to exactly ONE computed style — zero outliers. Stylelint baseline shrinks 2339 → 2338 with the retired off-scale 13px.

Local gate: typecheck, lint, 2862/2862 tests, build — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated editorial form field labels with improved typography, including font, size, weight, and color adjustments.

* **Chores**
  * Updated style quality tracking to reflect the latest validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->