### PR TITLE
feat(ds): contact form consumes Combobox for single-selects; submit lg; Combobox highlight robustness fix

### DIFF
--- a/nextjs-app/shared/components/Combobox/Combobox.test.tsx
+++ b/nextjs-app/shared/components/Combobox/Combobox.test.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import Combobox from "@dt/Combobox";
@@ -159,6 +160,43 @@ describe("Combobox", () => {
     expect(screen.getByText("Choose a timeline")).toHaveAttribute(
       "id",
       "timeline-helper",
+    );
+  });
+
+  it("keeps keyboard navigation working when options are rebuilt every render", () => {
+    // Consumers idiomatically build options inline (new array identity each
+    // render). The highlight must survive those re-renders: a regression
+    // here resets it to the selected option on every arrow key.
+    function InlineOptionsHarness() {
+      const [, force] = React.useState(0);
+      React.useEffect(() => {
+        const bump = () => force((n) => n + 1);
+        window.addEventListener("keydown", bump);
+        return () => window.removeEventListener("keydown", bump);
+      }, []);
+      return (
+        <Combobox
+          label="Timeline"
+          id="inline-timeline"
+          options={[
+            { value: "", label: "Select..." },
+            { value: "asap", label: "ASAP" },
+            { value: "flexible", label: "Flexible" },
+          ]}
+          value=""
+          onValueChange={() => {}}
+        />
+      );
+    }
+    render(<InlineOptionsHarness />);
+
+    const trigger = screen.getByRole("combobox");
+    fireEvent.keyDown(trigger, { key: "ArrowDown" }); // opens
+    fireEvent.keyDown(trigger, { key: "ArrowDown" }); // -> index 1 (asap)
+    fireEvent.keyDown(trigger, { key: "ArrowDown" }); // -> index 2 (flexible)
+    expect(trigger).toHaveAttribute(
+      "aria-activedescendant",
+      "inline-timeline-option-flexible",
     );
   });
 });

--- a/nextjs-app/shared/components/Combobox/Combobox.tsx
+++ b/nextjs-app/shared/components/Combobox/Combobox.tsx
@@ -92,15 +92,29 @@ export const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(
       setHighlightedIndex(0);
     }, []);
 
+    // Highlight follows the selected value at the moment the dropdown
+    // opens. This must NOT live in an effect keyed on `options`: consumers
+    // idiomatically build the options array inline, so its identity changes
+    // every render and an options-keyed effect resets the highlight on each
+    // arrow-key re-render, breaking keyboard navigation entirely.
+    const syncHighlightToValue = useCallback(() => {
+      const selectedIndex = options.findIndex(
+        (option) => option.value === value,
+      );
+      setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : 0);
+    }, [options, value]);
+
     const openDropdown = useCallback(() => {
       if (disabled) return;
+      syncHighlightToValue();
       setOpen(true);
-    }, [disabled]);
+    }, [disabled, syncHighlightToValue]);
 
     const toggleDropdown = useCallback(() => {
       if (disabled) return;
+      if (!open) syncHighlightToValue();
       setOpen((current) => !current);
-    }, [disabled]);
+    }, [disabled, open, syncHighlightToValue]);
 
     const selectOption = useCallback(
       (optionValue: string) => {
@@ -117,12 +131,6 @@ export const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(
       listRef,
       containerRef,
     } = useComboboxDropdown(open, options.length, closeDropdown);
-
-    useEffect(() => {
-      if (!open) return;
-      const selectedIndex = options.findIndex((option) => option.value === value);
-      setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : 0);
-    }, [open, options, value]);
 
     useEffect(() => {
       if (!open || !listRef.current) return;

--- a/nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css
+++ b/nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.module.css
@@ -30,9 +30,9 @@
  * components' own md sizing is untouched elsewhere.
  */
 
-.fields select {
-  padding-block: var(--space-internal-12);
-}
+/* (Native selects left the form when Budget/Timeline/Hear-about moved to
+ * Combobox; the only remaining <select> is react-phone-number-input's
+ * internal country picker, which keeps its own metrics.) */
 
 /* PhoneInput pads its composite wrapper (0.5rem); the inner input makes up
  * the remaining quarter rem so the wrapper rests at the same 56px. */

--- a/nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx
+++ b/nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx
@@ -10,10 +10,10 @@ import { FormFieldEditorial } from "../FormFieldEditorial";
 import { ExpandableSection } from "../ExpandableSection";
 import { useToast } from "../../lib/toast";
 import FileUpload from "@dt/FileUpload";
+import Combobox from "@dt/Combobox";
 import MultiCombobox from "@dt/MultiCombobox";
 import CheckboxGroup from "@dt/CheckboxGroup";
 import PhoneInput from "@dt/PhoneInput";
-import Select from "@dt/Select";
 import styles from "./ContactFormEditorial.module.css";
 import {
   CONTACT_ACCEPTED_ATTACHMENT_TYPES,
@@ -518,35 +518,35 @@ export function ContactFormEditorial({
         className={styles.expandable}
       >
         <div className={styles.fields}>
-          <Select
+          <Combobox
+            className={styles.alignedCombobox}
             label={t("contactBudgetLabel", "Budget range")}
+            placeholder={t("contactSelectPlaceholder", "Select...")}
             value={formData.budget}
             onValueChange={updateSelectField("budget")}
-          >
-            <option value="">
-              {t("contactSelectPlaceholder", "Select...")}
-            </option>
-            {BUDGET_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {t(opt.labelKey)}
-              </option>
-            ))}
-          </Select>
+            options={[
+              { value: "", label: t("contactSelectPlaceholder", "Select...") },
+              ...BUDGET_OPTIONS.map((opt) => ({
+                value: opt.value,
+                label: t(opt.labelKey),
+              })),
+            ]}
+          />
 
-          <Select
+          <Combobox
+            className={styles.alignedCombobox}
             label={t("contactTimelineLabel", "Timeline")}
+            placeholder={t("contactSelectPlaceholder", "Select...")}
             value={formData.timeline}
             onValueChange={updateSelectField("timeline")}
-          >
-            <option value="">
-              {t("contactSelectPlaceholder", "Select...")}
-            </option>
-            {TIMELINE_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {t(opt.labelKey)}
-              </option>
-            ))}
-          </Select>
+            options={[
+              { value: "", label: t("contactSelectPlaceholder", "Select...") },
+              ...TIMELINE_OPTIONS.map((opt) => ({
+                value: opt.value,
+                label: t(opt.labelKey),
+              })),
+            ]}
+          />
 
           <MultiCombobox
             className={styles.alignedCombobox}
@@ -599,20 +599,23 @@ export function ContactFormEditorial({
               }
             />
 
-            <Select
+            <Combobox
+              className={styles.alignedCombobox}
               label={t("contactHearAbout")}
+              placeholder={t("contactSelectPlaceholder", "Select...")}
               value={formData.hearAbout}
               onValueChange={updateSelectField("hearAbout")}
-            >
-              <option value="">
-                {t("contactSelectPlaceholder", "Select...")}
-              </option>
-              {HEAR_ABOUT_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {t(opt.labelKey)}
-                </option>
-              ))}
-            </Select>
+              options={[
+                {
+                  value: "",
+                  label: t("contactSelectPlaceholder", "Select..."),
+                },
+                ...HEAR_ABOUT_OPTIONS.map((opt) => ({
+                  value: opt.value,
+                  label: t(opt.labelKey),
+                })),
+              ]}
+            />
 
             <div className={styles.fileUploadWrapper}>
               <FileUpload
@@ -674,6 +677,7 @@ export function ContactFormEditorial({
       <Button
         submits
         variant="primary"
+        size="lg"
         loading={isSubmitting}
         disabled={!isFormValid}
         className={styles.submitButton}

--- a/nextjs-app/shared/components/Icon/Icon.contract.json
+++ b/nextjs-app/shared/components/Icon/Icon.contract.json
@@ -99,6 +99,11 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/design-system/agent/AgentBenchSection.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "app/design-system/agent/ComponentTaxonomyTree.tsx",
             "since": "2026-06-04"
         },
@@ -110,11 +115,6 @@
         {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "app/design-system/agent/page.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/dev/code-window/page.tsx",
             "since": "2026-06-04"
         }
     ],

--- a/nextjs-app/shared/components/Select/Select.contract.json
+++ b/nextjs-app/shared/components/Select/Select.contract.json
@@ -69,26 +69,6 @@
             "repo": "digitaltableteur/digitaltableteur",
             "path": "app/layout.tsx",
             "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/ContactPage/index.ts",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts",
-            "since": "2026-06-04"
         }
     ],
     "schemaVersion": 2,

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-08-04T12:26:40.893Z",
+  "generatedAt": "2026-08-05T08:09:32.289Z",
   "summary": {
     "componentCount": 177,
     "statusCounts": {
@@ -13,7 +13,7 @@
     "catalogCompletenessPercent": 90.8,
     "codebaseComponentCount": 195,
     "usageCoveragePercent": 93.2,
-    "componentsWithProductionUsage": 38,
+    "componentsWithProductionUsage": 42,
     "notReadyForStablePromotion": false
   },
   "exportPolicy": {
@@ -79,19 +79,19 @@
     "description": "Auto-detected import evidence from app/** and nextjs-app/**. Separate from contract.consumers[], which remains the stable-promotion gate for shipping-product proof.",
     "catalogedComponents": 177,
     "withAnyUsage": 165,
-    "withProductionUsage": 38,
+    "withProductionUsage": 42,
     "uniqueImportedComponents": 165,
-    "totalEvidenceRows": 828,
-    "aliasImportFiles": 431,
+    "totalEvidenceRows": 832,
+    "aliasImportFiles": 435,
     "relativeImportFiles": 430,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
   },
   "relationshipGraph": {
     "description": "Merged static composesWith policy + co-import evidence (see generate-relationship-graph.mjs).",
-    "generatedAt": "2026-07-27T05:57:59.042Z",
+    "generatedAt": "2026-08-05T08:09:22.131Z",
     "coImportMinFiles": 3,
-    "nodesWithComposesWith": 90,
+    "nodesWithComposesWith": 91,
     "regenerate": "npm run build:relationship-graph or npm run build:tokens",
     "path": "nextjs-app/shared/foundations/dist/relationship-graph.json"
   },
@@ -11054,9 +11054,9 @@
           "Button",
           "TextInput",
           "Text",
-          "Select",
           "FileUpload",
-          "PhoneInput"
+          "PhoneInput",
+          "TextArea"
         ],
         "prefersOver": [],
         "declaredPropCount": 8,
@@ -12628,11 +12628,17 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Combobox",
-        "importCount": 1,
+        "importCount": 2,
         "productionImportCount": 0,
         "patternImportCount": 0,
-        "componentImportCount": 1,
+        "componentImportCount": 2,
         "evidence": [
+          {
+            "path": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Combobox",
+            "context": "component"
+          },
           {
             "path": "nextjs-app/shared/components/FormFieldEditorial/FormFieldEditorial.tsx",
             "importKind": "alias",
@@ -12740,7 +12746,13 @@
         "forbiddenUse": [
           "nest inside containers with `overflow: hidden` without portaling (dropdown renders on `document.body`)."
         ],
-        "composesWith": [],
+        "composesWith": [
+          "Button",
+          "FileUpload",
+          "MultiCombobox",
+          "CheckboxGroup",
+          "PhoneInput"
+        ],
         "prefersOver": [],
         "declaredPropCount": 11,
         "guidelines": [
@@ -12770,20 +12782,20 @@
           {
             "id": "axe-no-violations",
             "statement": "Required stories produce no axe violations at the configured severity.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:matrix:ci"
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
           },
           {
             "id": "accessibility-tree",
             "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:matrix:ci"
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
           },
           {
             "id": "forced-colors-real-browser",
             "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:hc"
+            "verificationMode": "manual",
+            "note": "Storybook forced-colors addon (simulated, not real browser HC)."
           },
           {
             "id": "keyboard-contract",
@@ -12794,8 +12806,8 @@
           {
             "id": "aria-requirements",
             "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:matrix:ci"
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
           },
           {
             "id": "human-a11y-review",
@@ -14107,14 +14119,14 @@
           {
             "id": "axe-no-violations",
             "statement": "Required stories produce no axe violations at the configured severity.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:matrix:ci"
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
           },
           {
             "id": "accessibility-tree",
             "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:matrix:ci"
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
           },
           {
             "id": "forced-colors-real-browser",
@@ -19548,10 +19560,10 @@
         "composesWith": [
           "Button",
           "CheckboxGroup",
-          "Select",
           "PhoneInput",
           "TextInput",
-          "Modal"
+          "Modal",
+          "Toast"
         ],
         "prefersOver": [],
         "declaredPropCount": 15,
@@ -21386,20 +21398,20 @@
           {
             "id": "axe-no-violations",
             "statement": "Required stories produce no axe violations at the configured severity.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:matrix:ci"
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
           },
           {
             "id": "accessibility-tree",
             "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:matrix:ci"
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
           },
           {
             "id": "forced-colors-real-browser",
             "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:hc"
+            "verificationMode": "manual",
+            "note": "Storybook forced-colors addon (simulated, not real browser HC)."
           },
           {
             "id": "human-a11y-review",
@@ -32258,9 +32270,9 @@
         "composesWith": [
           "Button",
           "FileUpload",
+          "Combobox",
           "CheckboxGroup",
-          "PhoneInput",
-          "Select"
+          "PhoneInput"
         ],
         "prefersOver": [],
         "declaredPropCount": 11,
@@ -35679,10 +35691,10 @@
         "composesWith": [
           "Button",
           "CheckboxGroup",
-          "Select",
           "FileUpload",
           "TextInput",
-          "Modal"
+          "Modal",
+          "Toast"
         ],
         "prefersOver": [],
         "declaredPropCount": 10,
@@ -41700,19 +41712,13 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Select",
-        "importCount": 4,
+        "importCount": 3,
         "productionImportCount": 0,
         "patternImportCount": 0,
-        "componentImportCount": 3,
+        "componentImportCount": 2,
         "evidence": [
           {
             "path": "nextjs-app/shared/components/ContactForm/ContactForm.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/Select",
-            "context": "component"
-          },
-          {
-            "path": "nextjs-app/shared/components/ContactFormEditorial/ContactFormEditorial.tsx",
             "importKind": "alias",
             "importPath": "@dt/Select",
             "context": "component"
@@ -41832,12 +41838,12 @@
           "wrap the native chevron with a button overlay. The native click target is the entire control already; an overlay breaks forced-colors and mobile sheets."
         ],
         "composesWith": [
+          "TextInput",
+          "Text",
           "Button",
           "CheckboxGroup",
-          "FileUpload",
-          "PhoneInput",
-          "TextInput",
-          "Text"
+          "Modal",
+          "Toast"
         ],
         "prefersOver": [],
         "declaredPropCount": 8,
@@ -49065,11 +49071,17 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Table",
-        "importCount": 8,
-        "productionImportCount": 0,
+        "importCount": 9,
+        "productionImportCount": 1,
         "patternImportCount": 0,
         "componentImportCount": 4,
         "evidence": [
+          {
+            "path": "app/design-system/agent/AgentBenchSection.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Table",
+            "context": "production"
+          },
           {
             "path": "nextjs-app/shared/components/DataTable/DataTable.tsx",
             "importKind": "alias",
@@ -49491,11 +49503,17 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/TableCell",
-        "importCount": 6,
-        "productionImportCount": 0,
+        "importCount": 7,
+        "productionImportCount": 1,
         "patternImportCount": 0,
         "componentImportCount": 2,
         "evidence": [
+          {
+            "path": "app/design-system/agent/AgentBenchSection.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TableCell",
+            "context": "production"
+          },
           {
             "path": "nextjs-app/shared/components/DataTable/DataTable.tsx",
             "importKind": "alias",
@@ -49897,11 +49915,17 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/TableHeaderCell",
-        "importCount": 6,
-        "productionImportCount": 0,
+        "importCount": 7,
+        "productionImportCount": 1,
         "patternImportCount": 0,
         "componentImportCount": 2,
         "evidence": [
+          {
+            "path": "app/design-system/agent/AgentBenchSection.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TableHeaderCell",
+            "context": "production"
+          },
           {
             "path": "nextjs-app/shared/components/DataTable/DataTable.tsx",
             "importKind": "alias",
@@ -50623,11 +50647,17 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/TableRow",
-        "importCount": 6,
-        "productionImportCount": 0,
+        "importCount": 7,
+        "productionImportCount": 1,
         "patternImportCount": 0,
         "componentImportCount": 2,
         "evidence": [
+          {
+            "path": "app/design-system/agent/AgentBenchSection.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/TableRow",
+            "context": "production"
+          },
           {
             "path": "nextjs-app/shared/components/DataTable/DataTable.tsx",
             "importKind": "alias",

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-04T07:33:23.518Z",
+  "generatedAt": "2026-08-05T08:09:32.025Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -5741,9 +5741,9 @@
         "Button",
         "TextInput",
         "Text",
-        "Select",
         "FileUpload",
-        "PhoneInput"
+        "PhoneInput",
+        "TextArea"
       ],
       "prefersOver": [],
       "declaredPropCount": 8,
@@ -6594,7 +6594,13 @@
       "forbiddenUse": [
         "nest inside containers with `overflow: hidden` without portaling (dropdown renders on `document.body`)."
       ],
-      "composesWith": [],
+      "composesWith": [
+        "Button",
+        "FileUpload",
+        "MultiCombobox",
+        "CheckboxGroup",
+        "PhoneInput"
+      ],
       "prefersOver": [],
       "declaredPropCount": 11,
       "guidelines": [
@@ -6624,20 +6630,20 @@
         {
           "id": "axe-no-violations",
           "statement": "Required stories produce no axe violations at the configured severity.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:matrix:ci"
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
         },
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:matrix:ci"
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
         },
         {
           "id": "forced-colors-real-browser",
           "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:hc"
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
         },
         {
           "id": "keyboard-contract",
@@ -6648,8 +6654,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:matrix:ci"
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
         },
         {
           "id": "human-a11y-review",
@@ -7433,14 +7439,14 @@
         {
           "id": "axe-no-violations",
           "statement": "Required stories produce no axe violations at the configured severity.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:matrix:ci"
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
         },
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:matrix:ci"
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
         },
         {
           "id": "forced-colors-real-browser",
@@ -10282,10 +10288,10 @@
       "composesWith": [
         "Button",
         "CheckboxGroup",
-        "Select",
         "PhoneInput",
         "TextInput",
-        "Modal"
+        "Modal",
+        "Toast"
       ],
       "prefersOver": [],
       "declaredPropCount": 15,
@@ -11328,20 +11334,20 @@
         {
           "id": "axe-no-violations",
           "statement": "Required stories produce no axe violations at the configured severity.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:matrix:ci"
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
         },
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:matrix:ci"
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
         },
         {
           "id": "forced-colors-real-browser",
           "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:hc"
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
         },
         {
           "id": "human-a11y-review",
@@ -16932,9 +16938,9 @@
       "composesWith": [
         "Button",
         "FileUpload",
+        "Combobox",
         "CheckboxGroup",
-        "PhoneInput",
-        "Select"
+        "PhoneInput"
       ],
       "prefersOver": [],
       "declaredPropCount": 11,
@@ -18892,10 +18898,10 @@
       "composesWith": [
         "Button",
         "CheckboxGroup",
-        "Select",
         "FileUpload",
         "TextInput",
-        "Modal"
+        "Modal",
+        "Toast"
       ],
       "prefersOver": [],
       "declaredPropCount": 10,
@@ -22194,12 +22200,12 @@
         "wrap the native chevron with a button overlay. The native click target is the entire control already; an overlay breaks forced-colors and mobile sheets."
       ],
       "composesWith": [
+        "TextInput",
+        "Text",
         "Button",
         "CheckboxGroup",
-        "FileUpload",
-        "PhoneInput",
-        "TextInput",
-        "Text"
+        "Modal",
+        "Toast"
       ],
       "prefersOver": [],
       "declaredPropCount": 8,


### PR DESCRIPTION
Three contact-form control refinements plus a DS fix the swap surfaced:

1. **Native selects → Combobox**: Budget range, Timeline, and How-did-you-hear move from the native <select> to the stable Combobox — the same ComboboxField dropdown chrome the Project-type MultiCombobox uses, ending the mixed native/custom look. Clearable "Select..." semantics preserved via a leading empty-value option; 56px editorial height parity via the shared shim. The only remaining native select is react-phone-number-input's internal country picker.

2. **Submit button size="lg"** (the two-class .button.lg rule cleanly outranks the local padding; full-width preserved).

3. **Combobox robustness fix**: the highlight-sync effect was keyed on options IDENTITY, so consumers building options inline get their keyboard highlight reset whenever the parent re-renders mid-navigation. Highlight now syncs at dropdown open; regression test added whose harness rebuilds options every keydown — fails on the old code (verified via stash), passes on the fix. Stories never caught it because they pass module-constant arrays.

Browser-verified end to end: custom dropdowns at 56px, ArrowDown/Enter selection persists into form state, outside-click closes, labels stay unified, submit renders lg. dt validate on the form scope: 8 usages, 0 errors. Consumer arrays synced (audit:consumers), check:contract-props + check:consumers green.

Local gate: typecheck, lint, 2863/2863 tests, build — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated contact form dropdowns with searchable combobox controls for budget, timeline, and referral source.
  * Added a larger submit button presentation.

* **Bug Fixes**
  * Improved combobox highlighting when opening the menu or when options update.
  * Preserved keyboard navigation when options are recreated during rendering.
  * Corrected contact form field styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->