### PR TITLE
feat(ds): data primitives go beta with real Figma nodes (Astryx-gap re-export unblock)

### DIFF
--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-async-options.dark.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-async-options.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "forms-combobox-async-options",
+  "mode": "dark",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:52.674Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-async-options.forced-colors.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-async-options.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "forms-combobox-async-options",
+  "mode": "forced-colors",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:39:01.458Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-async-options.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-async-options.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "forms-combobox-async-options",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:32.428Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-async-options.light.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-async-options.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "forms-combobox-async-options",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:42.209Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-default.dark.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-default.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "forms-combobox-default",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:35:13.409Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:51.403Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-default.forced-colors.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-default.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "forms-combobox-default",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:40:48.185Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:39:01.309Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-default.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-default.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "forms-combobox-default",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:31.143Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-default.light.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-default.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "forms-combobox-default",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:25:20.531Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:40.943Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-disabled.dark.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-disabled.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "forms-combobox-disabled",
+  "mode": "dark",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:52.454Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-disabled.forced-colors.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-disabled.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "forms-combobox-disabled",
+  "mode": "forced-colors",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:39:01.429Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-disabled.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-disabled.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "forms-combobox-disabled",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:32.194Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-disabled.light.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-disabled.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "forms-combobox-disabled",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:41.969Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-example.dark.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-example.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "forms-combobox-example",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:35:13.979Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:51.925Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-example.forced-colors.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-example.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "forms-combobox-example",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:40:48.606Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:39:01.379Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-example.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-example.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "forms-combobox-example",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:31.676Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-example.light.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-example.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "forms-combobox-example",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:25:20.981Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:41.456Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-forced-colors.dark.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-forced-colors.dark.json
@@ -1,14 +1,10 @@
 {
   "storyId": "forms-combobox-forced-colors",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:35:14.511Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:52.977Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
       "passed": true
     }

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-forced-colors.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "forms-combobox-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:40:49.004Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:39:01.524Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-forced-colors.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "forms-combobox-forced-colors",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:32.712Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-forced-colors.light.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-forced-colors.light.json
@@ -1,14 +1,10 @@
 {
   "storyId": "forms-combobox-forced-colors",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:25:21.400Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:42.502Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
       "passed": true
     }

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-keyboard-selection.dark.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-keyboard-selection.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "forms-combobox-keyboard-selection",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:35:14.266Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:52.946Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-keyboard-selection.forced-colors.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-keyboard-selection.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "forms-combobox-keyboard-selection",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:40:48.812Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:39:01.499Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-keyboard-selection.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-keyboard-selection.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "forms-combobox-keyboard-selection",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:32.690Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-keyboard-selection.light.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-keyboard-selection.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "forms-combobox-keyboard-selection",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:25:21.204Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:42.477Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-playground.dark.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-playground.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "forms-combobox-playground",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:35:13.682Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:51.670Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-playground.forced-colors.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-playground.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "forms-combobox-playground",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:40:48.390Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:39:01.337Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-playground.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-playground.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "forms-combobox-playground",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:31.390Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-playground.light.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-playground.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "forms-combobox-playground",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:25:20.753Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:41.200Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-with-error.dark.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-with-error.dark.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "forms-combobox-with-error",
+  "mode": "dark",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:52.204Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-with-error.forced-colors.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-with-error.forced-colors.json
@@ -1,0 +1,12 @@
+{
+  "storyId": "forms-combobox-with-error",
+  "mode": "forced-colors",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:39:01.406Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    }
+  }
+}

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-with-error.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-with-error.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "forms-combobox-with-error",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:31.956Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-with-error.light.json
+++ b/nextjs-app/shared/components/Combobox/__a11y-evidence__/forms-combobox-with-error.light.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "forms-combobox-with-error",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:41.732Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-default.dark.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-default.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-contactformeditorial-default",
   "mode": "dark",
-  "sourceSHA": "cce5144a9dae8fcf8f1eb964313e89021569fc5b",
-  "capturedAt": "2026-08-03T16:18:59.395Z",
-  "runner": "fix-contact-error-toast",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:56.071Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-default.forced-colors.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-default.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-contactformeditorial-default",
   "mode": "forced-colors",
-  "sourceSHA": "cce5144a9dae8fcf8f1eb964313e89021569fc5b",
-  "capturedAt": "2026-08-03T16:19:03.565Z",
-  "runner": "fix-contact-error-toast",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:39:03.994Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-default.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-default.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-contactformeditorial-default",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:35.620Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-default.light.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-default.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-contactformeditorial-default",
   "mode": "light",
-  "sourceSHA": "cce5144a9dae8fcf8f1eb964313e89021569fc5b",
-  "capturedAt": "2026-08-03T16:18:54.831Z",
-  "runner": "fix-contact-error-toast",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:45.599Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-example.dark.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-example.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-contactformeditorial-example",
   "mode": "dark",
-  "sourceSHA": "cce5144a9dae8fcf8f1eb964313e89021569fc5b",
-  "capturedAt": "2026-08-03T16:18:59.840Z",
-  "runner": "fix-contact-error-toast",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:56.637Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-example.forced-colors.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-example.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-contactformeditorial-example",
   "mode": "forced-colors",
-  "sourceSHA": "cce5144a9dae8fcf8f1eb964313e89021569fc5b",
-  "capturedAt": "2026-08-03T16:19:03.622Z",
-  "runner": "fix-contact-error-toast",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:39:04.060Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-example.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-example.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-contactformeditorial-example",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:36.084Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-example.light.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-example.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-contactformeditorial-example",
   "mode": "light",
-  "sourceSHA": "cce5144a9dae8fcf8f1eb964313e89021569fc5b",
-  "capturedAt": "2026-08-03T16:18:55.293Z",
-  "runner": "fix-contact-error-toast",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:46.132Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-forced-colors.dark.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-forced-colors.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-contactformeditorial-forced-colors",
   "mode": "dark",
-  "sourceSHA": "cce5144a9dae8fcf8f1eb964313e89021569fc5b",
-  "capturedAt": "2026-08-03T16:19:00.075Z",
-  "runner": "fix-contact-error-toast",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:56.891Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-forced-colors.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-contactformeditorial-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "cce5144a9dae8fcf8f1eb964313e89021569fc5b",
-  "capturedAt": "2026-08-03T16:19:03.672Z",
-  "runner": "fix-contact-error-toast",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:39:04.085Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-forced-colors.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-forced-colors.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-contactformeditorial-forced-colors",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:36.306Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-forced-colors.light.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-forced-colors.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-contactformeditorial-forced-colors",
   "mode": "light",
-  "sourceSHA": "cce5144a9dae8fcf8f1eb964313e89021569fc5b",
-  "capturedAt": "2026-08-03T16:18:55.519Z",
-  "runner": "fix-contact-error-toast",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:46.399Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-playground.dark.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-playground.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-contactformeditorial-playground",
   "mode": "dark",
-  "sourceSHA": "cce5144a9dae8fcf8f1eb964313e89021569fc5b",
-  "capturedAt": "2026-08-03T16:18:59.626Z",
-  "runner": "fix-contact-error-toast",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:56.347Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-playground.forced-colors.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-playground.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-contactformeditorial-playground",
   "mode": "forced-colors",
-  "sourceSHA": "cce5144a9dae8fcf8f1eb964313e89021569fc5b",
-  "capturedAt": "2026-08-03T16:19:03.591Z",
-  "runner": "fix-contact-error-toast",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:39:04.035Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-playground.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-playground.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-contactformeditorial-playground",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:35.860Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-playground.light.json
+++ b/nextjs-app/shared/components/ContactFormEditorial/__a11y-evidence__/site-contactformeditorial-playground.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-contactformeditorial-playground",
   "mode": "light",
-  "sourceSHA": "cce5144a9dae8fcf8f1eb964313e89021569fc5b",
-  "capturedAt": "2026-08-03T16:18:55.075Z",
-  "runner": "fix-contact-error-toast",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:45.877Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/DataTable.contract.json
+++ b/nextjs-app/shared/components/DataTable/DataTable.contract.json
@@ -4,9 +4,9 @@
   "name": "DataTable",
   "tier": "organism",
   "group": "data-display",
-  "status": "alpha",
+  "status": "beta",
   "description": "Accessible data table with typed columns, three-state sortable headings, optional row selection and pagination, and density variants. Composes the Table primitives and the useTable* hooks.",
-  "figma": null,
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1719-3254",
   "radixPrimitive": null,
   "element": "table",
   "variants": {
@@ -29,9 +29,6 @@
     }
   },
   "slots": [
-    "caption",
-    "header",
-    "cell",
     "emptyState"
   ],
   "asChild": false,

--- a/nextjs-app/shared/components/DataTable/DataTable.contract.json
+++ b/nextjs-app/shared/components/DataTable/DataTable.contract.json
@@ -1,231 +1,255 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-  "schemaVersion": 2,
-  "name": "DataTable",
-  "tier": "organism",
-  "group": "data-display",
-  "status": "beta",
-  "description": "Accessible data table with typed columns, three-state sortable headings, optional row selection and pagination, and density variants. Composes the Table primitives and the useTable* hooks.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1719-3254",
-  "radixPrimitive": null,
-  "element": "table",
-  "variants": {
-    "size": {
-      "values": [
-        "sm",
-        "md",
-        "lg"
-      ],
-      "default": "md",
-      "propSourced": true
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "schemaVersion": 2,
+    "name": "DataTable",
+    "tier": "organism",
+    "group": "data-display",
+    "status": "beta",
+    "description": "Accessible data table with typed columns, three-state sortable headings, optional row selection and pagination, and density variants. Composes the Table primitives and the useTable* hooks.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1719-3254",
+    "radixPrimitive": null,
+    "element": "table",
+    "variants": {
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "default": "md",
+            "propSourced": true
+        },
+        "striped": {
+            "values": [
+                "true",
+                "false"
+            ],
+            "default": "false",
+            "propSourced": true
+        }
     },
-    "striped": {
-      "values": [
-        "true",
-        "false"
-      ],
-      "default": "false",
-      "propSourced": true
-    }
-  },
-  "slots": [
-    "emptyState"
-  ],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [
-      "Tab",
-      "Space",
-      "Enter"
+    "slots": [
+        "emptyState"
     ],
-    "ariaRequirements": [
-      "native table, thead, tbody, th and td semantics",
-      "caption supplies the accessible table name",
-      "sortable headings expose aria-sort",
-      "selection uses labelled native checkboxes"
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "2026-07-26 — native table, caption, sorting, selection labels, keyboard behavior, and axe result reviewed in unit tests. 2026-08-03 — Phase 1 pass: light/dark/forced-colors verified in a real browser; keyboard contract (Tab/Space/Enter) driven by a play story; axe clean across 9 stories x 3 modes; AT-tree and real-browser forced-colors evidence captured.",
-    "forcedColorsVerified": true,
-    "accessibilityTreeVerified": false
-  },
-  "tokens": {
-    "colors": [
-      "--color-text",
-      "--color-muted",
-      "--color-primary",
-      "--color-border-light",
-      "--color-light-bg",
-      "--color-neutral-bg"
+    "a11y": {
+        "keyboard": [
+            "Tab",
+            "Space",
+            "Enter"
+        ],
+        "ariaRequirements": [
+            "native table, thead, tbody, th and td semantics",
+            "caption supplies the accessible table name",
+            "sortable headings expose aria-sort",
+            "selection uses labelled native checkboxes"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-07-26 — native table, caption, sorting, selection labels, keyboard behavior, and axe result reviewed in unit tests. 2026-08-03 — Phase 1 pass: light/dark/forced-colors verified in a real browser; keyboard contract (Tab/Space/Enter) driven by a play story; axe clean across 9 stories x 3 modes; AT-tree and real-browser forced-colors evidence captured.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": false
+    },
+    "tokens": {
+        "colors": [
+            "--color-text",
+            "--color-muted",
+            "--color-primary",
+            "--color-border-light",
+            "--color-light-bg",
+            "--color-neutral-bg"
+        ],
+        "spacing": [
+            "--space-internal-4",
+            "--space-internal-8",
+            "--space-internal-12",
+            "--space-internal-16",
+            "--space-layout-24",
+            "--space-layout-32"
+        ]
+    },
+    "lightDarkVerified": true,
+    "dense": "typed native data table; sortable columns, optional row selection, accessible caption, empty state, sm/md/lg density",
+    "keywords": [
+        "table",
+        "data",
+        "rows",
+        "columns",
+        "sort",
+        "selection",
+        "grid"
     ],
-    "spacing": [
-      "--space-internal-4",
-      "--space-internal-8",
-      "--space-internal-12",
-      "--space-internal-16",
-      "--space-layout-24",
-      "--space-layout-32"
+    "props": {
+        "data": {
+            "optional": false,
+            "type": "Row[]",
+            "description": "Table rows."
+        },
+        "columns": {
+            "optional": false,
+            "type": "DataTableColumn<Row>[]",
+            "description": "Ordered column definitions."
+        },
+        "getRowId": {
+            "optional": false,
+            "type": "(row: Row) => string",
+            "description": "Stable row identifier."
+        },
+        "caption": {
+            "optional": false,
+            "type": "string",
+            "description": "Accessible table name rendered as a caption."
+        },
+        "hideCaption": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Visually hides the caption while retaining the accessible name."
+        },
+        "sort": {
+            "optional": true,
+            "type": "DataTableSort | null",
+            "description": "Controlled sort state."
+        },
+        "defaultSort": {
+            "optional": true,
+            "type": "DataTableSort | null",
+            "description": "Initial uncontrolled sort state."
+        },
+        "onSortChange": {
+            "optional": true,
+            "type": "(sort: DataTableSort | null) => void",
+            "description": "Receives sort changes."
+        },
+        "selectedRowIds": {
+            "optional": true,
+            "type": "string[]",
+            "description": "Controlled selected row identifiers; enables selection."
+        },
+        "defaultSelectedRowIds": {
+            "optional": true,
+            "type": "string[]",
+            "description": "Initial uncontrolled selection; also enables selection."
+        },
+        "onSelectionChange": {
+            "optional": true,
+            "type": "(rowIds: string[]) => void",
+            "description": "Receives selected row identifiers; also enables selection."
+        },
+        "getRowLabel": {
+            "optional": true,
+            "type": "(row: Row) => string",
+            "description": "Accessible row label used by selection checkboxes."
+        },
+        "pageSize": {
+            "optional": true,
+            "type": "number",
+            "description": "Rows per page; enables pagination when set."
+        },
+        "emptyState": {
+            "optional": true,
+            "type": "React.ReactNode",
+            "description": "Empty-state cell content."
+        },
+        "striped": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Alternating row surfaces."
+        },
+        "stickyHeader": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Pin the header row while the body scrolls."
+        },
+        "size": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "description": "Density scale."
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "use it for page layout",
+        "omit a meaningful caption",
+        "use unstable row indexes as identifiers"
+    ],
+    "usage": {
+        "description": "Use DataTable for structured records that users need to compare, sort, or select. Provide stable row identifiers and a meaningful caption.",
+        "bestPractices": [
+            {
+                "guidance": true,
+                "description": "Give every table a concise caption that explains what its rows represent."
+            },
+            {
+                "guidance": true,
+                "description": "Use stable domain identifiers so selection survives sorting and data refreshes."
+            },
+            {
+                "guidance": true,
+                "description": "Make a column sortable only when its values have an understandable order."
+            },
+            {
+                "guidance": true,
+                "description": "Keep cell content concise and move detailed content into a dedicated view."
+            },
+            {
+                "guidance": false,
+                "description": "Do not use DataTable as a page-layout grid or a visual card collection."
+            },
+            {
+                "guidance": false,
+                "description": "Do not hide row actions until pointer hover; keyboard users must find them too."
+            }
+        ],
+        "anatomy": [
+            {
+                "name": "Caption",
+                "required": true,
+                "description": "Accessible name that explains the table's record set."
+            },
+            {
+                "name": "Header",
+                "required": true,
+                "description": "Column labels and optional sort controls."
+            },
+            {
+                "name": "Rows",
+                "required": true,
+                "description": "Typed records rendered as native table rows and cells."
+            },
+            {
+                "name": "Selection",
+                "required": false,
+                "description": "Native checkboxes for selecting individual or all visible rows."
+            }
+        ]
+    },
+    "playground": {
+        "defaults": {
+            "caption": "Project contributors",
+            "hideCaption": false,
+            "size": "md",
+            "striped": false
+        }
+    },
+    "composesWith": [
+        "Table",
+        "Checkbox",
+        "IconButton",
+        "EmptyState"
     ]
-  },
-  "lightDarkVerified": true,
-  "dense": "typed native data table; sortable columns, optional row selection, accessible caption, empty state, sm/md/lg density",
-  "keywords": [
-    "table",
-    "data",
-    "rows",
-    "columns",
-    "sort",
-    "selection",
-    "grid"
-  ],
-  "props": {
-    "data": {
-      "optional": false,
-      "type": "Row[]",
-      "description": "Table rows."
-    },
-    "columns": {
-      "optional": false,
-      "type": "DataTableColumn<Row>[]",
-      "description": "Ordered typed column definitions."
-    },
-    "getRowId": {
-      "optional": false,
-      "type": "(row: Row) => string",
-      "description": "Stable row identifier."
-    },
-    "caption": {
-      "optional": false,
-      "type": "string",
-      "description": "Accessible table name."
-    },
-    "hideCaption": {
-      "optional": true,
-      "type": "boolean",
-      "description": "Visually hides the caption."
-    },
-    "sort": {
-      "optional": true,
-      "type": "DataTableSort | null",
-      "description": "Controlled sort state."
-    },
-    "onSortChange": {
-      "optional": true,
-      "type": "(sort: DataTableSort | null) => void",
-      "description": "Receives sort changes."
-    },
-    "selectedRowIds": {
-      "optional": true,
-      "type": "string[]",
-      "description": "Controlled selected row identifiers."
-    },
-    "onSelectionChange": {
-      "optional": true,
-      "type": "(rowIds: string[]) => void",
-      "description": "Receives selection changes."
-    },
-    "pageSize": {
-      "optional": true,
-      "type": "number",
-      "description": "Rows per page; enables pagination when set."
-    },
-    "size": {
-      "optional": true,
-      "type": "union",
-      "values": [
-        "sm",
-        "md",
-        "lg"
-      ],
-      "description": "Density scale."
-    },
-    "striped": {
-      "optional": true,
-      "type": "boolean",
-      "description": "Alternates row surfaces."
-    },
-    "stickyHeader": {
-      "optional": true,
-      "type": "boolean",
-      "description": "Pin the header row while the body scrolls."
-    }
-  },
-  "forbiddenUse": [
-    "use it for page layout",
-    "omit a meaningful caption",
-    "use unstable row indexes as identifiers"
-  ],
-  "usage": {
-    "description": "Use DataTable for structured records that users need to compare, sort, or select. Provide stable row identifiers and a meaningful caption.",
-    "bestPractices": [
-      {
-        "guidance": true,
-        "description": "Give every table a concise caption that explains what its rows represent."
-      },
-      {
-        "guidance": true,
-        "description": "Use stable domain identifiers so selection survives sorting and data refreshes."
-      },
-      {
-        "guidance": true,
-        "description": "Make a column sortable only when its values have an understandable order."
-      },
-      {
-        "guidance": true,
-        "description": "Keep cell content concise and move detailed content into a dedicated view."
-      },
-      {
-        "guidance": false,
-        "description": "Do not use DataTable as a page-layout grid or a visual card collection."
-      },
-      {
-        "guidance": false,
-        "description": "Do not hide row actions until pointer hover; keyboard users must find them too."
-      }
-    ],
-    "anatomy": [
-      {
-        "name": "Caption",
-        "required": true,
-        "description": "Accessible name that explains the table's record set."
-      },
-      {
-        "name": "Header",
-        "required": true,
-        "description": "Column labels and optional sort controls."
-      },
-      {
-        "name": "Rows",
-        "required": true,
-        "description": "Typed records rendered as native table rows and cells."
-      },
-      {
-        "name": "Selection",
-        "required": false,
-        "description": "Native checkboxes for selecting individual or all visible rows."
-      }
-    ]
-  },
-  "playground": {
-    "defaults": {
-      "caption": "Project contributors",
-      "hideCaption": false,
-      "size": "md",
-      "striped": false
-    }
-  },
-  "composesWith": [
-    "Table",
-    "Checkbox",
-    "IconButton",
-    "EmptyState"
-  ]
 }

--- a/nextjs-app/shared/components/DataTable/DataTable.stories.tsx
+++ b/nextjs-app/shared/components/DataTable/DataTable.stories.tsx
@@ -49,7 +49,7 @@ const meta = {
     contractStatus: contract.status,
     docs: { description: { component: contract.description } },
   },
-  tags: ["alpha", "autodocs"],
+  tags: ["beta", "autodocs"],
   args: {
     caption: "Project contributors",
     columns,
@@ -95,16 +95,21 @@ const meta = {
     getRowId: { table: { disable: true } },
     getRowLabel: { table: { disable: true } },
     onSelectionChange: { table: { disable: true } },
+    sort: { table: { disable: true } },
+    defaultSort: { table: { disable: true } },
+    selectedRowIds: { table: { disable: true } },
+    defaultSelectedRowIds: { table: { disable: true } },
+    emptyState: { table: { disable: true } },
   },
 } satisfies Meta<typeof DataTable<Person>>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-export const Playground: Story = {};
+export const Default: Story = { tags: ["beta-matrix"] };
+export const Playground: Story = { tags: ["beta-matrix"] };
 export const Example: Story = {
-  tags: ["example"],
+  tags: ["beta-matrix", "example"],
   args: { striped: true },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -224,5 +229,6 @@ export const KeyboardInteraction: Story = {
 };
 
 export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
 };

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-default.dark.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-default.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-default",
   "mode": "dark",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:09.038Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:44.888Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-default.forced-colors.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-default.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-default",
   "mode": "forced-colors",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:15.293Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:07.743Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-default.light.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-default.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-default",
   "mode": "light",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:01.872Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:11.334Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-empty.dark.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-empty.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-empty",
   "mode": "dark",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:10.067Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:46.062Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-empty.forced-colors.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-empty.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-empty",
   "mode": "forced-colors",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:15.413Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:07.917Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-empty.light.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-empty.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-empty",
   "mode": "light",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:02.915Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:12.510Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-example.dark.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-example.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-example",
   "mode": "dark",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:09.577Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:45.440Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-example.forced-colors.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-example.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-example",
   "mode": "forced-colors",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:15.360Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:07.824Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-example.light.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-example.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-example",
   "mode": "light",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:02.403Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:11.917Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-forced-colors.dark.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-forced-colors.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-forced-colors",
   "mode": "dark",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:11.523Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:47.611Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-forced-colors.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:15.672Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:08.342Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-forced-colors.light.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-forced-colors.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-forced-colors",
   "mode": "light",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:04.400Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:14.009Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-keyboard-interaction.dark.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-keyboard-interaction.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-keyboard-interaction",
   "mode": "dark",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:11.276Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:47.352Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-keyboard-interaction.forced-colors.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-keyboard-interaction.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-keyboard-interaction",
   "mode": "forced-colors",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:15.640Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:08.307Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-keyboard-interaction.light.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-keyboard-interaction.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-keyboard-interaction",
   "mode": "light",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:04.129Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:13.758Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-large-dataset.dark.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-large-dataset.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-large-dataset",
   "mode": "dark",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:10.705Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:46.749Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-large-dataset.forced-colors.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-large-dataset.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-large-dataset",
   "mode": "forced-colors",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:15.510Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:08.105Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-large-dataset.light.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-large-dataset.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-large-dataset",
   "mode": "light",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:03.541Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:13.171Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-overflow.dark.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-overflow.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-overflow",
   "mode": "dark",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:10.986Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:47.048Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-overflow.forced-colors.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-overflow.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-overflow",
   "mode": "forced-colors",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:15.542Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:08.218Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-overflow.light.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-overflow.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-overflow",
   "mode": "light",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:03.835Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:13.471Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-paginated.dark.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-paginated.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-paginated",
   "mode": "dark",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:09.834Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:45.789Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-paginated.forced-colors.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-paginated.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-paginated",
   "mode": "forced-colors",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:15.389Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:07.886Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-paginated.light.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-paginated.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-paginated",
   "mode": "light",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:02.686Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:12.266Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-playground.dark.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-playground.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-playground",
   "mode": "dark",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:09.319Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:45.153Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-playground.forced-colors.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-playground.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-playground",
   "mode": "forced-colors",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:15.321Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:07.780Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-playground.light.json
+++ b/nextjs-app/shared/components/DataTable/__a11y-evidence__/data-display-datatable-playground.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-datatable-playground",
   "mode": "light",
-  "sourceSHA": "767b28187b761a33d54329feed37e3e0081c1e00",
-  "capturedAt": "2026-08-03T20:13:02.135Z",
-  "runner": "datatable-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:11.636Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--default.dark.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--default.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--default.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--default.light.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--default.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--empty.dark.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--empty.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--empty.forced-colors.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--empty.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--empty.light.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--empty.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--example.dark.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--example.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--example.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--example.light.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--example.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--forced-colors.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--forced-colors.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--forced-colors.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--keyboard-interaction.dark.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--keyboard-interaction.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--keyboard-interaction.forced-colors.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--keyboard-interaction.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--keyboard-interaction.light.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--keyboard-interaction.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--large-dataset.dark.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--large-dataset.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "1,000 contributors":
   - caption: 1,000 contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--large-dataset.forced-colors.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--large-dataset.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "1,000 contributors":
   - caption: 1,000 contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--large-dataset.light.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--large-dataset.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "1,000 contributors":
   - caption: 1,000 contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--overflow.dark.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--overflow.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Wide result set":
   - caption: Wide result set
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--overflow.forced-colors.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--overflow.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Wide result set":
   - caption: Wide result set
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--overflow.light.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--overflow.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Wide result set":
   - caption: Wide result set
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--paginated.dark.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--paginated.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--paginated.forced-colors.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--paginated.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--paginated.light.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--paginated.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--playground.dark.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--playground.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--playground.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--playground.light.yaml
+++ b/nextjs-app/shared/components/DataTable/__a11y-snapshots__/data-display-datatable--playground.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-default.dark.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-default.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-formfieldeditorial-default",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:39:16.477Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:56.045Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-default.forced-colors.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-default.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-formfieldeditorial-default",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:43:57.473Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:39:03.986Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-default.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-default.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-formfieldeditorial-default",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:34.845Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-default.light.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-default.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-formfieldeditorial-default",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:31:17.325Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:45.544Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-example.dark.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-example.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-formfieldeditorial-example",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:39:17.004Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:56.543Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-example.forced-colors.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-example.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-formfieldeditorial-example",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:43:57.929Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:39:04.057Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-example.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-example.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-formfieldeditorial-example",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:35.302Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-example.light.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-example.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-formfieldeditorial-example",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:31:17.829Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:46.013Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-forced-colors.dark.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-forced-colors.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-formfieldeditorial-forced-colors",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:39:17.245Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:56.794Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-forced-colors.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-formfieldeditorial-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:43:58.145Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:39:04.077Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-forced-colors.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-forced-colors.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-formfieldeditorial-forced-colors",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:35.525Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-forced-colors.light.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-forced-colors.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-formfieldeditorial-forced-colors",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:31:18.072Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:46.242Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-playground.dark.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-playground.dark.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-formfieldeditorial-playground",
   "mode": "dark",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:39:16.741Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:56.304Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-playground.forced-colors.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-playground.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "site-formfieldeditorial-playground",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:43:57.712Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:39:04.027Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-playground.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-playground.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-formfieldeditorial-playground",
+  "mode": "light",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:35.081Z",
+  "runner": "beta-flip-dt1412",
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-playground.light.json
+++ b/nextjs-app/shared/components/FormFieldEditorial/__a11y-evidence__/site-formfieldeditorial-playground.light.json
@@ -1,16 +1,16 @@
 {
   "storyId": "site-formfieldeditorial-playground",
   "mode": "light",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:31:17.584Z",
-  "runner": "backfill",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:45.789Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
     "axe-no-violations": {
       "passed": true,
       "axeViolations": 0
-    },
-    "accessibility-tree": {
-      "passed": true
     }
   }
 }

--- a/nextjs-app/shared/components/ResizablePanelGroup/ResizablePanelGroup.contract.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/ResizablePanelGroup.contract.json
@@ -1,160 +1,164 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-  "schemaVersion": 2,
-  "name": "ResizablePanelGroup",
-  "tier": "organism",
-  "group": "layout",
-  "status": "beta",
-  "description": "Two-or-more-panel layout with pointer and keyboard-accessible resize separators.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1722-2833",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {
-    "orientation": {
-      "values": [
-        "horizontal",
-        "vertical"
-      ],
-      "default": "horizontal",
-      "propSourced": true
-    }
-  },
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [
-      "ArrowLeft",
-      "ArrowRight",
-      "ArrowUp",
-      "ArrowDown",
-      "Home",
-      "End"
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "schemaVersion": 2,
+    "name": "ResizablePanelGroup",
+    "tier": "organism",
+    "group": "layout",
+    "status": "beta",
+    "description": "Two-or-more-panel layout with pointer and keyboard-accessible resize separators.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1722-2833",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "orientation": {
+            "values": [
+                "horizontal",
+                "vertical"
+            ],
+            "default": "horizontal",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "ariaRequirements": [
-      "each panel is a named region",
-      "handles use role=separator",
-      "separator exposes aria-orientation, aria-valuemin, aria-valuemax and aria-valuenow"
+    "a11y": {
+        "keyboard": [
+            "ArrowLeft",
+            "ArrowRight",
+            "ArrowUp",
+            "ArrowDown",
+            "Home",
+            "End"
+        ],
+        "ariaRequirements": [
+            "each panel is a named region",
+            "handles use role=separator",
+            "separator exposes aria-orientation, aria-valuemin, aria-valuemax and aria-valuenow"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-07-26 — named regions, separator value semantics, keyboard resize behavior, and axe result reviewed in unit tests. 2026-08-04 — Phase 1 pass: light/dark/forced-colors verified in a real browser; clamped keyboard model (arrows/Home/End, min-size limits, aria-valuenow) driven by a play story; drag-resize latency measured; AT-tree and real-browser forced-colors evidence captured.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": false
+    },
+    "tokens": {
+        "colors": [
+            "--color-border-light",
+            "--color-neutral-bg",
+            "--color-primary",
+            "--color-muted"
+        ],
+        "spacing": [
+            "--space-internal-8",
+            "--space-layout-24"
+        ]
+    },
+    "lightDarkVerified": true,
+    "dense": "horizontal or vertical resizable panel layout; pointer drag, arrow/Home/End keyboard resize, separator value semantics",
+    "keywords": [
+        "resizable",
+        "panels",
+        "split",
+        "layout",
+        "workbench",
+        "sidebar"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "2026-07-26 — named regions, separator value semantics, keyboard resize behavior, and axe result reviewed in unit tests. 2026-08-04 — Phase 1 pass: light/dark/forced-colors verified in a real browser; clamped keyboard model (arrows/Home/End, min-size limits, aria-valuenow) driven by a play story; drag-resize latency measured; AT-tree and real-browser forced-colors evidence captured.",
-    "forcedColorsVerified": true,
-    "accessibilityTreeVerified": false
-  },
-  "tokens": {
-    "colors": [
-      "--color-border-light",
-      "--color-neutral-bg",
-      "--color-primary",
-      "--color-muted"
+    "props": {
+        "panels": {
+            "optional": false,
+            "type": "ResizablePanel[]",
+            "description": "Two or more ordered panels."
+        },
+        "orientation": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "horizontal",
+                "vertical"
+            ],
+            "description": "Resize axis."
+        },
+        "keyboardStep": {
+            "optional": true,
+            "type": "number",
+            "description": "Keyboard resize increment in percentage points."
+        },
+        "onSizesChange": {
+            "optional": true,
+            "type": "(sizes: Record<string, number>) => void",
+            "description": "Receives the current percentage per panel id."
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "replace a fixed responsive page grid",
+        "allow panels to shrink below usable content minimums"
     ],
-    "spacing": [
-      "--space-internal-8",
-      "--space-layout-24"
+    "usage": {
+        "description": "Use ResizablePanelGroup for adjacent work areas whose relative space users need to control. Set realistic minimum sizes for every panel.",
+        "bestPractices": [
+            {
+                "guidance": true,
+                "description": "Name every panel region so assistive technology communicates its purpose."
+            },
+            {
+                "guidance": true,
+                "description": "Choose minimum sizes that keep each panel's essential controls usable."
+            },
+            {
+                "guidance": true,
+                "description": "Persist sizes only when restoring the user's workspace is genuinely valuable."
+            },
+            {
+                "guidance": true,
+                "description": "Use a keyboard step that changes layout perceptibly without large jumps."
+            },
+            {
+                "guidance": false,
+                "description": "Do not replace an ordinary responsive page grid with draggable panels."
+            },
+            {
+                "guidance": false,
+                "description": "Do not allow a panel to collapse past the minimum needed by its content."
+            }
+        ],
+        "anatomy": [
+            {
+                "name": "Panel",
+                "required": true,
+                "description": "Named region containing one adjacent workspace."
+            },
+            {
+                "name": "Separator",
+                "required": true,
+                "description": "Focusable resize control between a pair of panels."
+            },
+            {
+                "name": "Handle",
+                "required": true,
+                "description": "Visible affordance that communicates the separator's drag axis."
+            }
+        ]
+    },
+    "playground": {
+        "defaults": {
+            "orientation": "horizontal",
+            "keyboardStep": 5
+        }
+    },
+    "composesWith": [
+        "TreeView",
+        "DataTable",
+        "CodeBlockWindow"
     ]
-  },
-  "lightDarkVerified": true,
-  "dense": "horizontal or vertical resizable panel layout; pointer drag, arrow/Home/End keyboard resize, separator value semantics",
-  "keywords": [
-    "resizable",
-    "panels",
-    "split",
-    "layout",
-    "workbench",
-    "sidebar"
-  ],
-  "props": {
-    "panels": {
-      "optional": false,
-      "type": "ResizablePanel[]",
-      "description": "Two or more ordered panels."
-    },
-    "orientation": {
-      "optional": true,
-      "type": "union",
-      "values": [
-        "horizontal",
-        "vertical"
-      ],
-      "description": "Resize axis."
-    },
-    "keyboardStep": {
-      "optional": true,
-      "type": "number",
-      "description": "Keyboard resize increment in percentage points."
-    },
-    "onSizesChange": {
-      "optional": true,
-      "type": "(sizes: Record<string, number>) => void",
-      "description": "Receives current panel percentages."
-    }
-  },
-  "forbiddenUse": [
-    "replace a fixed responsive page grid",
-    "allow panels to shrink below usable content minimums"
-  ],
-  "usage": {
-    "description": "Use ResizablePanelGroup for adjacent work areas whose relative space users need to control. Set realistic minimum sizes for every panel.",
-    "bestPractices": [
-      {
-        "guidance": true,
-        "description": "Name every panel region so assistive technology communicates its purpose."
-      },
-      {
-        "guidance": true,
-        "description": "Choose minimum sizes that keep each panel's essential controls usable."
-      },
-      {
-        "guidance": true,
-        "description": "Persist sizes only when restoring the user's workspace is genuinely valuable."
-      },
-      {
-        "guidance": true,
-        "description": "Use a keyboard step that changes layout perceptibly without large jumps."
-      },
-      {
-        "guidance": false,
-        "description": "Do not replace an ordinary responsive page grid with draggable panels."
-      },
-      {
-        "guidance": false,
-        "description": "Do not allow a panel to collapse past the minimum needed by its content."
-      }
-    ],
-    "anatomy": [
-      {
-        "name": "Panel",
-        "required": true,
-        "description": "Named region containing one adjacent workspace."
-      },
-      {
-        "name": "Separator",
-        "required": true,
-        "description": "Focusable resize control between a pair of panels."
-      },
-      {
-        "name": "Handle",
-        "required": true,
-        "description": "Visible affordance that communicates the separator's drag axis."
-      }
-    ]
-  },
-  "playground": {
-    "defaults": {
-      "orientation": "horizontal",
-      "keyboardStep": 5
-    }
-  },
-  "composesWith": [
-    "TreeView",
-    "DataTable",
-    "CodeBlockWindow"
-  ]
 }

--- a/nextjs-app/shared/components/ResizablePanelGroup/ResizablePanelGroup.contract.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/ResizablePanelGroup.contract.json
@@ -4,9 +4,9 @@
   "name": "ResizablePanelGroup",
   "tier": "organism",
   "group": "layout",
-  "status": "alpha",
+  "status": "beta",
   "description": "Two-or-more-panel layout with pointer and keyboard-accessible resize separators.",
-  "figma": null,
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1722-2833",
   "radixPrimitive": null,
   "element": "div",
   "variants": {
@@ -19,10 +19,7 @@
       "propSourced": true
     }
   },
-  "slots": [
-    "panel",
-    "separator"
-  ],
+  "slots": [],
   "asChild": false,
   "subParts": [],
   "requiredStories": [

--- a/nextjs-app/shared/components/ResizablePanelGroup/ResizablePanelGroup.stories.tsx
+++ b/nextjs-app/shared/components/ResizablePanelGroup/ResizablePanelGroup.stories.tsx
@@ -48,7 +48,7 @@ const meta = {
     contractStatus: contract.status,
     docs: { description: { component: contract.description } },
   },
-  tags: ["alpha", "autodocs"],
+  tags: ["beta", "autodocs"],
   args: {
     orientation: "horizontal",
     keyboardStep: 5,
@@ -73,10 +73,10 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-export const Playground: Story = {};
+export const Default: Story = { tags: ["beta-matrix"] };
+export const Playground: Story = { tags: ["beta-matrix"] };
 export const Example: Story = {
-  tags: ["example"],
+  tags: ["beta-matrix", "example"],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const separator = canvas.getByRole("separator");
@@ -154,5 +154,6 @@ export const ThreePanels: Story = {
   },
 };
 export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
 };

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-default.dark.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-default.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-default",
   "mode": "dark",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:47.156Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:54.771Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-default.forced-colors.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-default.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-default",
   "mode": "forced-colors",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:51.485Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:10.548Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-default.light.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-default.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-default",
   "mode": "light",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:42.387Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:24.595Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-example.dark.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-example.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-example",
   "mode": "dark",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:47.574Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:55.267Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-example.forced-colors.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-example.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-example",
   "mode": "forced-colors",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:51.537Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:10.600Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-example.light.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-example.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-example",
   "mode": "light",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:42.804Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:25.081Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-forced-colors.dark.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-forced-colors.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-forced-colors",
   "mode": "dark",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:48.430Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:56.290Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-forced-colors.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:51.670Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:10.742Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-forced-colors.light.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-forced-colors.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-forced-colors",
   "mode": "light",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:43.652Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:26.064Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-keyboard-resize.dark.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-keyboard-resize.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-keyboard-resize",
   "mode": "dark",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:48.026Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:55.803Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-keyboard-resize.forced-colors.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-keyboard-resize.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-keyboard-resize",
   "mode": "forced-colors",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:51.626Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:10.694Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-keyboard-resize.light.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-keyboard-resize.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-keyboard-resize",
   "mode": "light",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:43.248Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:25.572Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-playground.dark.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-playground.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-playground",
   "mode": "dark",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:47.370Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:55.014Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-playground.forced-colors.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-playground.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-playground",
   "mode": "forced-colors",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:51.513Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:10.573Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-playground.light.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-playground.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-playground",
   "mode": "light",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:42.602Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:24.835Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-three-panels.dark.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-three-panels.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-three-panels",
   "mode": "dark",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:48.231Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:56.055Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-three-panels.forced-colors.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-three-panels.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-three-panels",
   "mode": "forced-colors",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:51.648Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:10.720Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-three-panels.light.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-three-panels.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-three-panels",
   "mode": "light",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:43.449Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:25.830Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-vertical.dark.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-vertical.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-vertical",
   "mode": "dark",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:47.780Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:55.520Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-vertical.forced-colors.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-vertical.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-vertical",
   "mode": "forced-colors",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:51.558Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:10.623Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-vertical.light.json
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-evidence__/layout-resizablepanelgroup-vertical.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "layout-resizablepanelgroup-vertical",
   "mode": "light",
-  "sourceSHA": "85f6b3e77978b8938a3861a07a1e50c1a7b836ae",
-  "capturedAt": "2026-08-04T07:20:43.008Z",
-  "runner": "rpg-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:25.303Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--default.dark.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--default.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Navigation":
   - heading "Navigation" [level=3]
   - paragraph: Browse system foundations and components.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--default.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Navigation":
   - heading "Navigation" [level=3]
   - paragraph: Browse system foundations and components.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--default.light.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--default.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Navigation":
   - heading "Navigation" [level=3]
   - paragraph: Browse system foundations and components.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--example.dark.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--example.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Navigation":
   - heading "Navigation" [level=3]
   - paragraph: Browse system foundations and components.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--example.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Navigation":
   - heading "Navigation" [level=3]
   - paragraph: Browse system foundations and components.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--example.light.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--example.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Navigation":
   - heading "Navigation" [level=3]
   - paragraph: Browse system foundations and components.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--forced-colors.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Navigation":
   - heading "Navigation" [level=3]
   - paragraph: Browse system foundations and components.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--forced-colors.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Navigation":
   - heading "Navigation" [level=3]
   - paragraph: Browse system foundations and components.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--forced-colors.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Navigation":
   - heading "Navigation" [level=3]
   - paragraph: Browse system foundations and components.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--keyboard-resize.dark.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--keyboard-resize.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Navigation":
   - heading "Navigation" [level=3]
   - paragraph: Browse system foundations and components.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--keyboard-resize.forced-colors.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--keyboard-resize.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Navigation":
   - heading "Navigation" [level=3]
   - paragraph: Browse system foundations and components.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--keyboard-resize.light.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--keyboard-resize.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Navigation":
   - heading "Navigation" [level=3]
   - paragraph: Browse system foundations and components.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--playground.dark.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--playground.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Navigation":
   - heading "Navigation" [level=3]
   - paragraph: Browse system foundations and components.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--playground.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Navigation":
   - heading "Navigation" [level=3]
   - paragraph: Browse system foundations and components.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--playground.light.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--playground.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Navigation":
   - heading "Navigation" [level=3]
   - paragraph: Browse system foundations and components.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--three-panels.dark.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--three-panels.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Tree":
   - heading "Tree" [level=3]
   - paragraph: Hierarchy.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--three-panels.forced-colors.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--three-panels.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Tree":
   - heading "Tree" [level=3]
   - paragraph: Hierarchy.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--three-panels.light.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--three-panels.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Tree":
   - heading "Tree" [level=3]
   - paragraph: Hierarchy.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--vertical.dark.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--vertical.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Navigation":
   - heading "Navigation" [level=3]
   - paragraph: Browse system foundations and components.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--vertical.forced-colors.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--vertical.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Navigation":
   - heading "Navigation" [level=3]
   - paragraph: Browse system foundations and components.

--- a/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--vertical.light.yaml
+++ b/nextjs-app/shared/components/ResizablePanelGroup/__a11y-snapshots__/layout-resizablepanelgroup--vertical.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - region "Navigation":
   - heading "Navigation" [level=3]
   - paragraph: Browse system foundations and components.

--- a/nextjs-app/shared/components/Table/Table.contract.json
+++ b/nextjs-app/shared/components/Table/Table.contract.json
@@ -4,12 +4,12 @@
   "name": "Table",
   "tier": "molecule",
   "group": "data-display",
-  "status": "alpha",
+  "status": "beta",
   "description": "The composable table root: a scroll wrapper around a semantic table with density, striping, and a sticky header. Compose with the sibling TableRow, TableHeaderCell, and TableCell components. The presentational layer beneath DataTable; pair with the useTable* hooks for behavior.",
   "usage": {
     "description": "Table renders semantic tabular data: a caption-led <table> whose rows and cells come from TableRow, TableHeaderCell and TableCell, with sorting and selection driven by the useTable* hooks rather than cell-local state. Use it when the content really is a data grid; DataTable wraps it for the batteries-included workflow."
   },
-  "figma": null,
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1716-2986",
   "radixPrimitive": null,
   "element": "table",
   "variants": {

--- a/nextjs-app/shared/components/Table/Table.contract.json
+++ b/nextjs-app/shared/components/Table/Table.contract.json
@@ -1,152 +1,152 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-  "schemaVersion": 2,
-  "name": "Table",
-  "tier": "molecule",
-  "group": "data-display",
-  "status": "beta",
-  "description": "The composable table root: a scroll wrapper around a semantic table with density, striping, and a sticky header. Compose with the sibling TableRow, TableHeaderCell, and TableCell components. The presentational layer beneath DataTable; pair with the useTable* hooks for behavior.",
-  "usage": {
-    "description": "Table renders semantic tabular data: a caption-led <table> whose rows and cells come from TableRow, TableHeaderCell and TableCell, with sorting and selection driven by the useTable* hooks rather than cell-local state. Use it when the content really is a data grid; DataTable wraps it for the batteries-included workflow."
-  },
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1716-2986",
-  "radixPrimitive": null,
-  "element": "table",
-  "variants": {
-    "size": {
-      "values": [
-        "sm",
-        "md",
-        "lg"
-      ],
-      "default": "md",
-      "propSourced": true
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "schemaVersion": 2,
+    "name": "Table",
+    "tier": "molecule",
+    "group": "data-display",
+    "status": "beta",
+    "description": "The composable table root: a scroll wrapper around a semantic table with density, striping, and a sticky header. Compose with the sibling TableRow, TableHeaderCell, and TableCell components. The presentational layer beneath DataTable; pair with the useTable* hooks for behavior.",
+    "usage": {
+        "description": "Table renders semantic tabular data: a caption-led <table> whose rows and cells come from TableRow, TableHeaderCell and TableCell, with sorting and selection driven by the useTable* hooks rather than cell-local state. Use it when the content really is a data grid; DataTable wraps it for the batteries-included workflow."
     },
-    "striped": {
-      "values": [
-        "true",
-        "false"
-      ],
-      "default": "false",
-      "propSourced": true
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1716-2986",
+    "radixPrimitive": null,
+    "element": "table",
+    "variants": {
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "default": "md",
+            "propSourced": true
+        },
+        "striped": {
+            "values": [
+                "true",
+                "false"
+            ],
+            "default": "false",
+            "propSourced": true
+        },
+        "stickyHeader": {
+            "values": [
+                "true",
+                "false"
+            ],
+            "default": "false",
+            "propSourced": true
+        }
     },
-    "stickyHeader": {
-      "values": [
-        "true",
-        "false"
-      ],
-      "default": "false",
-      "propSourced": true
-    }
-  },
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [
-      "Tab",
-      "Space",
-      "Enter"
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "ariaRequirements": [
-      "native table, thead, tbody, th and td semantics",
-      "caption supplies the accessible table name",
-      "sortable headers expose aria-sort and toggle via an inner button",
-      "sort caret is decorative (aria-hidden); state is carried by aria-sort"
+    "a11y": {
+        "keyboard": [
+            "Tab",
+            "Space",
+            "Enter"
+        ],
+        "ariaRequirements": [
+            "native table, thead, tbody, th and td semantics",
+            "caption supplies the accessible table name",
+            "sortable headers expose aria-sort and toggle via an inner button",
+            "sort caret is decorative (aria-hidden); state is carried by aria-sort"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-07-27 — native table semantics, caption naming, aria-sort on sortable headers, decorative sort caret, and axe result reviewed in unit tests. 2026-08-04 — Phase 1 pass: light/dark/forced-colors verified in a real browser; axe clean across all stories x 3 modes; AT-tree and real-browser forced-colors evidence captured; keyboard sort cycle and selection driven by play stories at the Table composition level.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": false
+    },
+    "tokens": {
+        "colors": [
+            "--color-text",
+            "--color-muted",
+            "--color-primary",
+            "--color-surface",
+            "--color-border",
+            "--color-border-light",
+            "--color-light-bg",
+            "--color-neutral-bg"
+        ],
+        "spacing": [
+            "--space-internal-4",
+            "--space-internal-6",
+            "--space-internal-8",
+            "--space-internal-12",
+            "--space-internal-16",
+            "--space-layout-24"
+        ],
+        "radii": [
+            "--radius-sm",
+            "--radius-md"
+        ]
+    },
+    "lightDarkVerified": true,
+    "dense": "composable native table primitives; density, striping, sticky header, three-state DS-Icon sort caret; pairs with useTable* hooks",
+    "keywords": [
+        "table",
+        "grid",
+        "rows",
+        "columns",
+        "cell",
+        "sort",
+        "header"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "2026-07-27 — native table semantics, caption naming, aria-sort on sortable headers, decorative sort caret, and axe result reviewed in unit tests. 2026-08-04 — Phase 1 pass: light/dark/forced-colors verified in a real browser; axe clean across all stories x 3 modes; AT-tree and real-browser forced-colors evidence captured; keyboard sort cycle and selection driven by play stories at the Table composition level.",
-    "forcedColorsVerified": true,
-    "accessibilityTreeVerified": false
-  },
-  "tokens": {
-    "colors": [
-      "--color-text",
-      "--color-muted",
-      "--color-primary",
-      "--color-surface",
-      "--color-border",
-      "--color-border-light",
-      "--color-light-bg",
-      "--color-neutral-bg"
+    "props": {
+        "caption": {
+            "optional": false,
+            "type": "string",
+            "description": "Accessible table name, rendered as a `<caption>`."
+        },
+        "hideCaption": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Visually hide the caption while keeping the accessible name."
+        },
+        "size": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "description": "Density scale."
+        },
+        "striped": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Alternating row surfaces."
+        },
+        "stickyHeader": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Pin the header row while the table body scrolls."
+        },
+        "wrapperClassName": {
+            "optional": true,
+            "type": "string",
+            "description": "Class applied to the scroll wrapper."
+        }
+    },
+    "forbiddenUse": [
+        "use it for page layout",
+        "omit a meaningful caption",
+        "put interactive sort logic in the cell instead of the useTable* hooks"
     ],
-    "spacing": [
-      "--space-internal-4",
-      "--space-internal-6",
-      "--space-internal-8",
-      "--space-internal-12",
-      "--space-internal-16",
-      "--space-layout-24"
-    ],
-    "radii": [
-      "--radius-sm",
-      "--radius-md"
+    "composesWith": [
+        "TableRow",
+        "TableHeaderCell",
+        "TableCell",
+        "DataTable"
     ]
-  },
-  "lightDarkVerified": true,
-  "dense": "composable native table primitives; density, striping, sticky header, three-state DS-Icon sort caret; pairs with useTable* hooks",
-  "keywords": [
-    "table",
-    "grid",
-    "rows",
-    "columns",
-    "cell",
-    "sort",
-    "header"
-  ],
-  "props": {
-    "caption": {
-      "optional": false,
-      "type": "string",
-      "description": "Accessible table name rendered as a caption."
-    },
-    "hideCaption": {
-      "optional": true,
-      "type": "boolean",
-      "description": "Visually hide the caption while keeping the accessible name."
-    },
-    "size": {
-      "optional": true,
-      "type": "union",
-      "values": [
-        "sm",
-        "md",
-        "lg"
-      ],
-      "description": "Density scale."
-    },
-    "striped": {
-      "optional": true,
-      "type": "boolean",
-      "description": "Alternating row surfaces."
-    },
-    "stickyHeader": {
-      "optional": true,
-      "type": "boolean",
-      "description": "Pin the header row while the body scrolls."
-    },
-    "wrapperClassName": {
-      "optional": true,
-      "type": "string",
-      "description": "Class applied to the scroll wrapper."
-    }
-  },
-  "forbiddenUse": [
-    "use it for page layout",
-    "omit a meaningful caption",
-    "put interactive sort logic in the cell instead of the useTable* hooks"
-  ],
-  "composesWith": [
-    "TableRow",
-    "TableHeaderCell",
-    "TableCell",
-    "DataTable"
-  ]
 }

--- a/nextjs-app/shared/components/Table/Table.stories.tsx
+++ b/nextjs-app/shared/components/Table/Table.stories.tsx
@@ -24,7 +24,7 @@ const meta = {
     contractStatus: contract.status,
     docs: { description: { component: contract.description } },
   },
-  tags: ["alpha", "autodocs"],
+  tags: ["beta", "autodocs"],
   args: {
     caption: "Project contributors",
     size: "md",
@@ -36,12 +36,19 @@ const meta = {
       control: "radio",
       options: ["sm", "md", "lg"],
       description: "Density scale.",
+      table: { defaultValue: { summary: "md" } },
     },
-    striped: { control: "boolean", description: "Alternating row surfaces." },
+    striped: {
+      control: "boolean",
+      description: "Alternating row surfaces.",
+      table: { defaultValue: { summary: "false" } },
+    },
     stickyHeader: {
       control: "boolean",
       description: "Pin the header row while the body scrolls.",
+      table: { defaultValue: { summary: "false" } },
     },
+    wrapperClassName: { table: { disable: true } },
     hideCaption: {
       control: "boolean",
       description: "Visually hide the caption (kept for assistive tech).",
@@ -77,6 +84,7 @@ function Body() {
 }
 
 export const Default: Story = {
+  tags: ["beta-matrix"],
   render: (args) => (
     <Table {...args}>
       <Body />
@@ -84,7 +92,8 @@ export const Default: Story = {
   ),
 };
 
-export const Playground: Story = { ...Default };
+export const Playground: Story = {
+  tags: ["beta-matrix"], ...Default };
 
 export const Sortable: Story = {
   tags: ["example"],
@@ -199,7 +208,7 @@ export const Selectable: Story = {
 };
 
 export const Example: Story = {
-  tags: ["example"],
+  tags: ["beta-matrix", "example"],
   args: { striped: true },
   render: (args) => (
     <Table {...args} caption="Contributors (striped)">
@@ -264,6 +273,7 @@ export const KeyboardInteraction: Story = {
 };
 
 export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
   render: (args) => (
     <Table {...args}>

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-default.dark.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-default.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-default",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:41.600Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:50.129Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-default.forced-colors.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-default.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-default",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:46.378Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:10.577Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-default.light.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-default.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-default",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:36.343Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:16.670Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-example.dark.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-example.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-example",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:42.490Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:51.173Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-example.forced-colors.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-example.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-example",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:46.487Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:10.678Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-example.light.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-example.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-example",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:37.259Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:17.684Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-forced-colors.dark.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-forced-colors.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-forced-colors",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:42.964Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:51.693Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-forced-colors.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:46.569Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:10.766Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-forced-colors.light.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-forced-colors.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-forced-colors",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:37.717Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:18.174Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-keyboard-interaction.dark.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-keyboard-interaction.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-keyboard-interaction",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:42.742Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:51.448Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-keyboard-interaction.forced-colors.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-keyboard-interaction.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-keyboard-interaction",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:46.544Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:10.735Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-keyboard-interaction.light.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-keyboard-interaction.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-keyboard-interaction",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:37.509Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:17.945Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-playground.dark.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-playground.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-playground",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:41.825Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:50.368Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-playground.forced-colors.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-playground.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-playground",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:46.410Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:10.600Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-playground.light.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-playground.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-playground",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:36.572Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:16.923Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-selectable.dark.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-selectable.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-selectable",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:42.281Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:50.891Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-selectable.forced-colors.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-selectable.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-selectable",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:46.466Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:10.656Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-selectable.light.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-selectable.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-selectable",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:37.052Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:17.438Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-sortable.dark.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-sortable.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-sortable",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:42.048Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:50.642Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-sortable.forced-colors.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-sortable.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-sortable",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:46.436Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:10.626Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-sortable.light.json
+++ b/nextjs-app/shared/components/Table/__a11y-evidence__/data-display-table-sortable.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-table-sortable",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:36.807Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:17.188Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--default.dark.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--default.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--default.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--default.light.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--default.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--example.dark.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--example.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors (striped)":
   - caption: Contributors (striped)
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--example.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors (striped)":
   - caption: Contributors (striped)
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--example.light.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--example.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors (striped)":
   - caption: Contributors (striped)
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--forced-colors.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--forced-colors.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--forced-colors.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--keyboard-interaction.dark.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--keyboard-interaction.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Keyboard sort":
   - caption: Keyboard sort
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--keyboard-interaction.forced-colors.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--keyboard-interaction.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Keyboard sort":
   - caption: Keyboard sort
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--keyboard-interaction.light.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--keyboard-interaction.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Keyboard sort":
   - caption: Keyboard sort
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--playground.dark.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--playground.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--playground.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--playground.light.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--playground.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Project contributors":
   - caption: Project contributors
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--selectable.dark.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--selectable.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Selectable rows":
   - caption: Selectable rows
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--selectable.forced-colors.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--selectable.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Selectable rows":
   - caption: Selectable rows
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--selectable.light.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--selectable.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Selectable rows":
   - caption: Selectable rows
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--sortable.dark.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--sortable.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Sortable columns":
   - caption: Sortable columns
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--sortable.forced-colors.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--sortable.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Sortable columns":
   - caption: Sortable columns
   - rowgroup:

--- a/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--sortable.light.yaml
+++ b/nextjs-app/shared/components/Table/__a11y-snapshots__/data-display-table--sortable.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Sortable columns":
   - caption: Sortable columns
   - rowgroup:

--- a/nextjs-app/shared/components/TableCell/TableCell.contract.json
+++ b/nextjs-app/shared/components/TableCell/TableCell.contract.json
@@ -4,12 +4,12 @@
   "name": "TableCell",
   "tier": "atom",
   "group": "data-display",
-  "status": "alpha",
+  "status": "beta",
   "description": "A table data cell (<td>) for the Table family. align controls text alignment; numeric right-aligns with tabular figures so columns line up on the decimal.",
   "usage": {
     "description": "TableCell is the body cell of the Table family: plain tabular data with an optional numeric mode that aligns figures on the decimal. Header semantics belong to TableHeaderCell; TableCell never announces scope."
   },
-  "figma": null,
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1715-2814",
   "radixPrimitive": null,
   "element": "td",
   "variants": {

--- a/nextjs-app/shared/components/TableCell/TableCell.contract.json
+++ b/nextjs-app/shared/components/TableCell/TableCell.contract.json
@@ -1,100 +1,100 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-  "schemaVersion": 2,
-  "name": "TableCell",
-  "tier": "atom",
-  "group": "data-display",
-  "status": "beta",
-  "description": "A table data cell (<td>) for the Table family. align controls text alignment; numeric right-aligns with tabular figures so columns line up on the decimal.",
-  "usage": {
-    "description": "TableCell is the body cell of the Table family: plain tabular data with an optional numeric mode that aligns figures on the decimal. Header semantics belong to TableHeaderCell; TableCell never announces scope."
-  },
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1715-2814",
-  "radixPrimitive": null,
-  "element": "td",
-  "variants": {
-    "align": {
-      "values": [
-        "start",
-        "center",
-        "end"
-      ],
-      "default": "start",
-      "propSourced": true
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "schemaVersion": 2,
+    "name": "TableCell",
+    "tier": "atom",
+    "group": "data-display",
+    "status": "beta",
+    "description": "A table data cell (<td>) for the Table family. align controls text alignment; numeric right-aligns with tabular figures so columns line up on the decimal.",
+    "usage": {
+        "description": "TableCell is the body cell of the Table family: plain tabular data with an optional numeric mode that aligns figures on the decimal. Header semantics belong to TableHeaderCell; TableCell never announces scope."
     },
-    "numeric": {
-      "values": [
-        "true",
-        "false"
-      ],
-      "default": "false",
-      "propSourced": true
-    }
-  },
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [
-      "native <td> semantics; no ARIA of its own",
-      "pairs with TableHeaderCell scope=col/row so cells inherit column and row context"
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1715-2814",
+    "radixPrimitive": null,
+    "element": "td",
+    "variants": {
+        "align": {
+            "values": [
+                "start",
+                "center",
+                "end"
+            ],
+            "default": "start",
+            "propSourced": true
+        },
+        "numeric": {
+            "values": [
+                "true",
+                "false"
+            ],
+            "default": "false",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "2026-07-27 — native td; alignment and numeric tabular figures verified; axe asserted inside a table in the unit test. 2026-08-04 — Phase 1 pass: light/dark/forced-colors verified in a real browser; axe clean across all stories x 3 modes; AT-tree and real-browser forced-colors evidence captured; keyboard sort cycle and selection driven by play stories at the Table composition level.",
-    "forcedColorsVerified": true,
-    "accessibilityTreeVerified": false
-  },
-  "tokens": {
-    "colors": [
-      "--color-border-light"
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [
+            "native <td> semantics; no ARIA of its own",
+            "pairs with TableHeaderCell scope=col/row so cells inherit column and row context"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-07-27 — native td; alignment and numeric tabular figures verified; axe asserted inside a table in the unit test. 2026-08-04 — Phase 1 pass: light/dark/forced-colors verified in a real browser; axe clean across all stories x 3 modes; AT-tree and real-browser forced-colors evidence captured; keyboard sort cycle and selection driven by play stories at the Table composition level.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": false
+    },
+    "tokens": {
+        "colors": [
+            "--color-border-light"
+        ],
+        "spacing": [
+            "--space-internal-8",
+            "--space-internal-12",
+            "--space-internal-16",
+            "--space-layout-24"
+        ]
+    },
+    "lightDarkVerified": true,
+    "dense": "table td; align start/center/end, numeric = tabular figures right-aligned",
+    "keywords": [
+        "table",
+        "cell",
+        "td",
+        "numeric"
     ],
-    "spacing": [
-      "--space-internal-8",
-      "--space-internal-12",
-      "--space-internal-16",
-      "--space-layout-24"
+    "props": {
+        "align": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "center",
+                "end",
+                "start"
+            ],
+            "description": "Cell content alignment."
+        },
+        "numeric": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Right-align and tabular-figure numeric values."
+        }
+    },
+    "forbiddenUse": [
+        "render it outside a table row",
+        "use it for a header — use TableHeaderCell so column/row context is announced"
+    ],
+    "composesWith": [
+        "Table",
+        "TableRow",
+        "TableHeaderCell"
     ]
-  },
-  "lightDarkVerified": true,
-  "dense": "table td; align start/center/end, numeric = tabular figures right-aligned",
-  "keywords": [
-    "table",
-    "cell",
-    "td",
-    "numeric"
-  ],
-  "props": {
-    "align": {
-      "optional": true,
-      "type": "union",
-      "values": [
-        "start",
-        "center",
-        "end"
-      ],
-      "description": "Cell content alignment."
-    },
-    "numeric": {
-      "optional": true,
-      "type": "boolean",
-      "description": "Right-align with tabular figures for numeric values."
-    }
-  },
-  "forbiddenUse": [
-    "render it outside a table row",
-    "use it for a header — use TableHeaderCell so column/row context is announced"
-  ],
-  "composesWith": [
-    "Table",
-    "TableRow",
-    "TableHeaderCell"
-  ]
 }

--- a/nextjs-app/shared/components/TableCell/TableCell.stories.tsx
+++ b/nextjs-app/shared/components/TableCell/TableCell.stories.tsx
@@ -14,11 +14,20 @@ const meta = {
     contractStatus: contract.status,
     docs: { description: { component: contract.description } },
   },
-  tags: ["alpha", "autodocs"],
+  tags: ["beta", "autodocs"],
   args: { children: "Ada Lovelace", numeric: false },
   argTypes: {
-    align: { control: "inline-radio", options: ["start", "center", "end"] },
-    numeric: { control: "boolean", description: "Tabular figures, end-aligned." },
+    align: {
+      control: "inline-radio",
+      options: ["start", "center", "end"],
+      description: "Text alignment inside the cell.",
+      table: { defaultValue: { summary: "start" } },
+    },
+    numeric: {
+      control: "boolean",
+      description: "Tabular figures, end-aligned.",
+      table: { defaultValue: { summary: "false" } },
+    },
   },
   render: (args) => (
     <Table caption="Contributors">
@@ -41,11 +50,11 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-export const Playground: Story = {};
+export const Default: Story = { tags: ["beta-matrix"] };
+export const Playground: Story = { tags: ["beta-matrix"] };
 
 export const Example: Story = {
-  tags: ["example"],
+  tags: ["beta-matrix", "example"],
   parameters: {
     docs: {
       description: {
@@ -79,4 +88,5 @@ export const Example: Story = {
   ),
 };
 
-export const ForcedColors: Story = { globals: { forcedColors: "active" } };
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"], globals: { forcedColors: "active" } };

--- a/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-default.dark.json
+++ b/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-default.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablecell-default",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:21.061Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:02.390Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-default.forced-colors.json
+++ b/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-default.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablecell-default",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:25.102Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:17.899Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-default.light.json
+++ b/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-default.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablecell-default",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:16.703Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:16.653Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-example.dark.json
+++ b/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-example.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablecell-example",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:21.486Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:02.810Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-example.forced-colors.json
+++ b/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-example.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablecell-example",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:25.157Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:17.949Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-example.light.json
+++ b/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-example.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablecell-example",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:17.130Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:17.119Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-forced-colors.dark.json
+++ b/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-forced-colors.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablecell-forced-colors",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:21.685Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:03.012Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-forced-colors.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablecell-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:25.178Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:17.990Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-forced-colors.light.json
+++ b/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-forced-colors.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablecell-forced-colors",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:17.330Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:17.336Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-playground.dark.json
+++ b/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-playground.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablecell-playground",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:21.272Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:02.600Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-playground.forced-colors.json
+++ b/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-playground.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablecell-playground",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:25.129Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:17.928Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-playground.light.json
+++ b/nextjs-app/shared/components/TableCell/__a11y-evidence__/data-display-tablecell-playground.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablecell-playground",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:16.915Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:16.895Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--default.dark.yaml
+++ b/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--default.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--default.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--default.light.yaml
+++ b/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--default.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--example.dark.yaml
+++ b/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--example.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Numbers":
   - caption: Numbers
   - rowgroup:

--- a/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--example.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Numbers":
   - caption: Numbers
   - rowgroup:

--- a/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--example.light.yaml
+++ b/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--example.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Numbers":
   - caption: Numbers
   - rowgroup:

--- a/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--forced-colors.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--forced-colors.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--forced-colors.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--playground.dark.yaml
+++ b/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--playground.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--playground.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--playground.light.yaml
+++ b/nextjs-app/shared/components/TableCell/__a11y-snapshots__/data-display-tablecell--playground.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.contract.json
+++ b/nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.contract.json
@@ -1,142 +1,142 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-  "schemaVersion": 2,
-  "name": "TableHeaderCell",
-  "tier": "atom",
-  "group": "data-display",
-  "status": "beta",
-  "description": "A table header cell (<th>). scope=col (default) carries an optional three-state DS-Icon sort control and aria-sort; scope=row marks the identifying cell of a body row so screen readers announce the row context with every other cell.",
-  "usage": {
-    "description": "TableHeaderCell names a column or row with correct scope semantics, and hosts sortable column headers driven by useTableSortable; sort state is announced via aria-sort, never by caret colour alone."
-  },
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1715-2794",
-  "radixPrimitive": null,
-  "element": "th",
-  "variants": {
-    "align": {
-      "values": [
-        "start",
-        "center",
-        "end"
-      ],
-      "default": "start",
-      "propSourced": true
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "schemaVersion": 2,
+    "name": "TableHeaderCell",
+    "tier": "atom",
+    "group": "data-display",
+    "status": "beta",
+    "description": "A table header cell (<th>). scope=col (default) carries an optional three-state DS-Icon sort control and aria-sort; scope=row marks the identifying cell of a body row so screen readers announce the row context with every other cell.",
+    "usage": {
+        "description": "TableHeaderCell names a column or row with correct scope semantics, and hosts sortable column headers driven by useTableSortable; sort state is announced via aria-sort, never by caret colour alone."
     },
-    "scope": {
-      "values": [
-        "col",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1715-2794",
+    "radixPrimitive": null,
+    "element": "th",
+    "variants": {
+        "align": {
+            "values": [
+                "start",
+                "center",
+                "end"
+            ],
+            "default": "start",
+            "propSourced": true
+        },
+        "scope": {
+            "values": [
+                "col",
+                "row"
+            ],
+            "default": "col",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
+    ],
+    "a11y": {
+        "keyboard": [
+            "Tab",
+            "Enter",
+            "Space"
+        ],
+        "ariaRequirements": [
+            "native <th> with an explicit scope (col or row)",
+            "sortable column headers expose aria-sort and toggle via an inner button",
+            "the sort caret is decorative (aria-hidden); state is carried by aria-sort, never the icon alone"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-07-27 — th with explicit scope; aria-sort on active column headers; decorative caret; row-header (scope=row) verified to name its row; axe asserted inside a table in the unit test. 2026-08-04 — Phase 1 pass: light/dark/forced-colors verified in a real browser; axe clean across all stories x 3 modes; AT-tree and real-browser forced-colors evidence captured; keyboard sort cycle and selection driven by play stories at the Table composition level.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": false
+    },
+    "tokens": {
+        "colors": [
+            "--color-muted",
+            "--color-primary",
+            "--color-border",
+            "--color-light-bg",
+            "--color-neutral-bg"
+        ],
+        "spacing": [
+            "--space-internal-6",
+            "--space-internal-8",
+            "--space-internal-12",
+            "--space-internal-16",
+            "--space-layout-24"
+        ],
+        "radii": [
+            "--radius-sm"
+        ]
+    },
+    "lightDarkVerified": true,
+    "dense": "th with scope col/row; col carries the three-state sort caret + aria-sort, row names its data row",
+    "keywords": [
+        "table",
+        "header",
+        "th",
+        "sort",
+        "scope",
+        "column",
         "row"
-      ],
-      "default": "col",
-      "propSourced": true
-    }
-  },
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [
-      "Tab",
-      "Enter",
-      "Space"
     ],
-    "ariaRequirements": [
-      "native <th> with an explicit scope (col or row)",
-      "sortable column headers expose aria-sort and toggle via an inner button",
-      "the sort caret is decorative (aria-hidden); state is carried by aria-sort, never the icon alone"
+    "props": {
+        "align": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "center",
+                "end",
+                "start"
+            ],
+            "description": "Cell content alignment."
+        },
+        "scope": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "row",
+                "col"
+            ],
+            "description": "Header scope. `col` (default) labels a column; `row` makes the cell the\naccessible name for its row — use it on the identifying cell of each body\nrow so screen readers announce the row context with every other cell."
+        },
+        "sortable": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Renders the sort affordance and toggles on click. Only for column headers."
+        },
+        "sortDirection": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "none",
+                "ascending",
+                "descending"
+            ],
+            "description": "Current sort state; drives `aria-sort` and the caret icon."
+        },
+        "onSort": {
+            "optional": true,
+            "type": "() => void",
+            "description": "Called when a sortable header is activated."
+        }
+    },
+    "forbiddenUse": [
+        "render it outside a table",
+        "make a scope=row header sortable — row headers are not sort controls",
+        "convey sort state with the caret colour alone"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "2026-07-27 — th with explicit scope; aria-sort on active column headers; decorative caret; row-header (scope=row) verified to name its row; axe asserted inside a table in the unit test. 2026-08-04 — Phase 1 pass: light/dark/forced-colors verified in a real browser; axe clean across all stories x 3 modes; AT-tree and real-browser forced-colors evidence captured; keyboard sort cycle and selection driven by play stories at the Table composition level.",
-    "forcedColorsVerified": true,
-    "accessibilityTreeVerified": false
-  },
-  "tokens": {
-    "colors": [
-      "--color-muted",
-      "--color-primary",
-      "--color-border",
-      "--color-light-bg",
-      "--color-neutral-bg"
-    ],
-    "spacing": [
-      "--space-internal-6",
-      "--space-internal-8",
-      "--space-internal-12",
-      "--space-internal-16",
-      "--space-layout-24"
-    ],
-    "radii": [
-      "--radius-sm"
+    "composesWith": [
+        "Table",
+        "TableRow",
+        "TableCell",
+        "Icon"
     ]
-  },
-  "lightDarkVerified": true,
-  "dense": "th with scope col/row; col carries the three-state sort caret + aria-sort, row names its data row",
-  "keywords": [
-    "table",
-    "header",
-    "th",
-    "sort",
-    "scope",
-    "column",
-    "row"
-  ],
-  "props": {
-    "align": {
-      "optional": true,
-      "type": "union",
-      "values": [
-        "start",
-        "center",
-        "end"
-      ],
-      "description": "Cell content alignment."
-    },
-    "scope": {
-      "optional": true,
-      "type": "union",
-      "values": [
-        "col",
-        "row"
-      ],
-      "description": "Header scope; row names the identifying cell of a body row."
-    },
-    "sortable": {
-      "optional": true,
-      "type": "boolean",
-      "description": "Renders the sort control (column headers only)."
-    },
-    "sortDirection": {
-      "optional": true,
-      "type": "union",
-      "values": [
-        "ascending",
-        "descending",
-        "none"
-      ],
-      "description": "Current sort state; drives aria-sort and the caret."
-    },
-    "onSort": {
-      "optional": true,
-      "type": "() => void",
-      "description": "Called when a sortable header is activated."
-    }
-  },
-  "forbiddenUse": [
-    "render it outside a table",
-    "make a scope=row header sortable — row headers are not sort controls",
-    "convey sort state with the caret colour alone"
-  ],
-  "composesWith": [
-    "Table",
-    "TableRow",
-    "TableCell",
-    "Icon"
-  ]
 }

--- a/nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.contract.json
+++ b/nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.contract.json
@@ -4,12 +4,12 @@
   "name": "TableHeaderCell",
   "tier": "atom",
   "group": "data-display",
-  "status": "alpha",
+  "status": "beta",
   "description": "A table header cell (<th>). scope=col (default) carries an optional three-state DS-Icon sort control and aria-sort; scope=row marks the identifying cell of a body row so screen readers announce the row context with every other cell.",
   "usage": {
     "description": "TableHeaderCell names a column or row with correct scope semantics, and hosts sortable column headers driven by useTableSortable; sort state is announced via aria-sort, never by caret colour alone."
   },
-  "figma": null,
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1715-2794",
   "radixPrimitive": null,
   "element": "th",
   "variants": {

--- a/nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.stories.tsx
+++ b/nextjs-app/shared/components/TableHeaderCell/TableHeaderCell.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
     contractStatus: contract.status,
     docs: { description: { component: contract.description } },
   },
-  tags: ["alpha", "autodocs"],
+  tags: ["beta", "autodocs"],
   args: {
     children: "Name",
     align: "start",
@@ -25,12 +25,27 @@ const meta = {
     sortDirection: "ascending",
   },
   argTypes: {
-    align: { control: "inline-radio", options: ["start", "center", "end"] },
-    scope: { control: "inline-radio", options: ["col", "row"] },
-    sortable: { control: "boolean" },
+    align: {
+      control: "inline-radio",
+      options: ["start", "center", "end"],
+      description: "Text alignment inside the header cell.",
+      table: { defaultValue: { summary: "start" } },
+    },
+    scope: {
+      control: "inline-radio",
+      options: ["col", "row"],
+      description:
+        "col names a column (quiet uppercase header); row names a row and renders like an emphasised body cell.",
+      table: { defaultValue: { summary: "col" } },
+    },
+    sortable: {
+      control: "boolean",
+      description: "Wraps the label in a sort button with a caret.",
+    },
     sortDirection: {
       control: "radio",
       options: ["ascending", "descending", "none"],
+      description: "Current sort state; drives aria-sort and the caret icon.",
     },
   },
   render: (args) => (
@@ -54,11 +69,11 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-export const Playground: Story = {};
+export const Default: Story = { tags: ["beta-matrix"] };
+export const Playground: Story = { tags: ["beta-matrix"] };
 
 export const Example: Story = {
-  tags: ["example"],
+  tags: ["beta-matrix", "example"],
   parameters: {
     docs: {
       description: {
@@ -174,4 +189,5 @@ export const SortCycle: Story = {
   },
 };
 
-export const ForcedColors: Story = { globals: { forcedColors: "active" } };
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"], globals: { forcedColors: "active" } };

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-default.dark.json
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-default.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tableheadercell-default",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:08.320Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:54.771Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-default.forced-colors.json
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-default.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tableheadercell-default",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:12.761Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:13.148Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-default.light.json
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-default.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tableheadercell-default",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:03.364Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:20.695Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-example.dark.json
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-example.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tableheadercell-example",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:08.763Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:55.280Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-example.forced-colors.json
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-example.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tableheadercell-example",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:12.818Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:13.201Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-example.light.json
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-example.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tableheadercell-example",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:03.807Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:21.199Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-forced-colors.dark.json
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-forced-colors.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tableheadercell-forced-colors",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:09.421Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:56.037Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-forced-colors.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tableheadercell-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:12.926Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:13.294Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-forced-colors.light.json
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-forced-colors.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tableheadercell-forced-colors",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:04.457Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:21.924Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-playground.dark.json
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-playground.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tableheadercell-playground",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:08.543Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:55.013Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-playground.forced-colors.json
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-playground.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tableheadercell-playground",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:12.794Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:13.179Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-playground.light.json
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-playground.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tableheadercell-playground",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:03.582Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:20.929Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-row-header.dark.json
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-row-header.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tableheadercell-row-header",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:08.980Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:55.544Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-row-header.forced-colors.json
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-row-header.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tableheadercell-row-header",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:12.860Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:13.223Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-row-header.light.json
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-row-header.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tableheadercell-row-header",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:04.012Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:21.444Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-sort-cycle.dark.json
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-sort-cycle.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tableheadercell-sort-cycle",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:09.216Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:55.782Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-sort-cycle.forced-colors.json
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-sort-cycle.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tableheadercell-sort-cycle",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:12.902Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:13.271Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-sort-cycle.light.json
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-evidence__/data-display-tableheadercell-sort-cycle.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tableheadercell-sort-cycle",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:58:04.252Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:21.691Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--default.dark.yaml
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--default.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--default.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--default.light.yaml
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--default.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--example.dark.yaml
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--example.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Sort states":
   - caption: Sort states
   - rowgroup:

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--example.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Sort states":
   - caption: Sort states
   - rowgroup:

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--example.light.yaml
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--example.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Sort states":
   - caption: Sort states
   - rowgroup:

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--forced-colors.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--forced-colors.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--forced-colors.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--playground.dark.yaml
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--playground.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--playground.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--playground.light.yaml
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--playground.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--row-header.dark.yaml
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--row-header.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "People":
   - caption: People
   - rowgroup:

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--row-header.forced-colors.yaml
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--row-header.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "People":
   - caption: People
   - rowgroup:

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--row-header.light.yaml
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--row-header.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "People":
   - caption: People
   - rowgroup:

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--sort-cycle.dark.yaml
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--sort-cycle.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Sort cycle":
   - caption: Sort cycle
   - rowgroup:

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--sort-cycle.forced-colors.yaml
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--sort-cycle.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Sort cycle":
   - caption: Sort cycle
   - rowgroup:

--- a/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--sort-cycle.light.yaml
+++ b/nextjs-app/shared/components/TableHeaderCell/__a11y-snapshots__/data-display-tableheadercell--sort-cycle.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Sort cycle":
   - caption: Sort cycle
   - rowgroup:

--- a/nextjs-app/shared/components/TableRow/TableRow.contract.json
+++ b/nextjs-app/shared/components/TableRow/TableRow.contract.json
@@ -4,12 +4,12 @@
   "name": "TableRow",
   "tier": "atom",
   "group": "data-display",
-  "status": "alpha",
+  "status": "beta",
   "description": "A table row (<tr>) for the Table family. Works in <thead> and <tbody>; selected renders the selection surface. Presentational — semantics belong to the surrounding table.",
   "usage": {
     "description": "TableRow groups cells inside a Table's thead or tbody and carries the selected state visually while a real selection control (Checkbox) remains the source of truth."
   },
-  "figma": null,
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1715-2833",
   "radixPrimitive": null,
   "element": "tr",
   "variants": {

--- a/nextjs-app/shared/components/TableRow/TableRow.contract.json
+++ b/nextjs-app/shared/components/TableRow/TableRow.contract.json
@@ -1,78 +1,78 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-  "schemaVersion": 2,
-  "name": "TableRow",
-  "tier": "atom",
-  "group": "data-display",
-  "status": "beta",
-  "description": "A table row (<tr>) for the Table family. Works in <thead> and <tbody>; selected renders the selection surface. Presentational — semantics belong to the surrounding table.",
-  "usage": {
-    "description": "TableRow groups cells inside a Table's thead or tbody and carries the selected state visually while a real selection control (Checkbox) remains the source of truth."
-  },
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1715-2833",
-  "radixPrimitive": null,
-  "element": "tr",
-  "variants": {
-    "selected": {
-      "values": [
-        "true",
-        "false"
-      ],
-      "default": "false",
-      "propSourced": true
-    }
-  },
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [
-      "native <tr> semantics; no ARIA of its own",
-      "selection is visual only (data-selected); the row's selection state belongs to a checkbox or the consuming app"
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "schemaVersion": 2,
+    "name": "TableRow",
+    "tier": "atom",
+    "group": "data-display",
+    "status": "beta",
+    "description": "A table row (<tr>) for the Table family. Works in <thead> and <tbody>; selected renders the selection surface. Presentational — semantics belong to the surrounding table.",
+    "usage": {
+        "description": "TableRow groups cells inside a Table's thead or tbody and carries the selected state visually while a real selection control (Checkbox) remains the source of truth."
+    },
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1715-2833",
+    "radixPrimitive": null,
+    "element": "tr",
+    "variants": {
+        "selected": {
+            "values": [
+                "true",
+                "false"
+            ],
+            "default": "false",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "2026-07-27 — native tr; hover/zebra/selection tint are presentational; axe asserted inside a table in the unit test. 2026-08-04 — Phase 1 pass: light/dark/forced-colors verified in a real browser; axe clean across all stories x 3 modes; AT-tree and real-browser forced-colors evidence captured; keyboard sort cycle and selection driven by play stories at the Table composition level.",
-    "forcedColorsVerified": true,
-    "accessibilityTreeVerified": false
-  },
-  "tokens": {
-    "colors": [
-      "--color-border-light",
-      "--color-primary",
-      "--color-light-bg"
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [
+            "native <tr> semantics; no ARIA of its own",
+            "selection is visual only (data-selected); the row's selection state belongs to a checkbox or the consuming app"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-07-27 — native tr; hover/zebra/selection tint are presentational; axe asserted inside a table in the unit test. 2026-08-04 — Phase 1 pass: light/dark/forced-colors verified in a real browser; axe clean across all stories x 3 modes; AT-tree and real-browser forced-colors evidence captured; keyboard sort cycle and selection driven by play stories at the Table composition level.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": false
+    },
+    "tokens": {
+        "colors": [
+            "--color-border-light",
+            "--color-primary",
+            "--color-light-bg"
+        ],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "dense": "table row; works in thead/tbody, selected surface, hover + zebra via the Table root",
+    "keywords": [
+        "table",
+        "row",
+        "tr",
+        "selection"
     ],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "dense": "table row; works in thead/tbody, selected surface, hover + zebra via the Table root",
-  "keywords": [
-    "table",
-    "row",
-    "tr",
-    "selection"
-  ],
-  "props": {
-    "selected": {
-      "optional": true,
-      "type": "boolean",
-      "description": "Renders the selected surface and sets data-selected. Visual only."
-    }
-  },
-  "forbiddenUse": [
-    "render it outside a table",
-    "rely on selected for semantics — pair it with a checkbox or aria-selected on the consuming structure"
-  ],
-  "composesWith": [
-    "Table",
-    "TableCell",
-    "TableHeaderCell"
-  ]
+    "props": {
+        "selected": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Renders the selected surface and sets `data-selected`. Visual only."
+        }
+    },
+    "forbiddenUse": [
+        "render it outside a table",
+        "rely on selected for semantics — pair it with a checkbox or aria-selected on the consuming structure"
+    ],
+    "composesWith": [
+        "Table",
+        "TableCell",
+        "TableHeaderCell"
+    ]
 }

--- a/nextjs-app/shared/components/TableRow/TableRow.stories.tsx
+++ b/nextjs-app/shared/components/TableRow/TableRow.stories.tsx
@@ -20,10 +20,14 @@ const meta = {
     contractStatus: contract.status,
     docs: { description: { component: contract.description } },
   },
-  tags: ["alpha", "autodocs"],
+  tags: ["beta", "autodocs"],
   args: { selected: false },
   argTypes: {
-    selected: { control: "boolean", description: "Selected surface (visual only)." },
+    selected: {
+      control: "boolean",
+      description: "Selected surface (visual only).",
+      table: { defaultValue: { summary: "false" } },
+    },
   },
   render: (args) => (
     <Table caption="Contributors">
@@ -46,11 +50,11 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-export const Playground: Story = {};
+export const Default: Story = { tags: ["beta-matrix"] };
+export const Playground: Story = { tags: ["beta-matrix"] };
 
 export const Example: Story = {
-  tags: ["example"],
+  tags: ["beta-matrix", "example"],
   parameters: {
     docs: {
       description: {
@@ -79,4 +83,5 @@ export const Example: Story = {
   ),
 };
 
-export const ForcedColors: Story = { globals: { forcedColors: "active" } };
+export const ForcedColors: Story = {
+  tags: ["beta-matrix"], globals: { forcedColors: "active" } };

--- a/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-default.dark.json
+++ b/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-default.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablerow-default",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:55.243Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:58.995Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-default.forced-colors.json
+++ b/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-default.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablerow-default",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:59.290Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:15.764Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-default.light.json
+++ b/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-default.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablerow-default",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:50.496Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:20.779Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-example.dark.json
+++ b/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-example.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablerow-example",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:55.666Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:59.504Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-example.forced-colors.json
+++ b/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-example.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablerow-example",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:59.340Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:15.810Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-example.light.json
+++ b/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-example.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablerow-example",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:50.929Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:21.291Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-forced-colors.dark.json
+++ b/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-forced-colors.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablerow-forced-colors",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:55.869Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:59.760Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-forced-colors.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablerow-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:59.360Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:15.833Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-forced-colors.light.json
+++ b/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-forced-colors.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablerow-forced-colors",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:51.127Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:21.517Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-playground.dark.json
+++ b/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-playground.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablerow-playground",
   "mode": "dark",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:55.451Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:59.247Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-playground.forced-colors.json
+++ b/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-playground.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablerow-playground",
   "mode": "forced-colors",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:59.319Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:15.786Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-playground.light.json
+++ b/nextjs-app/shared/components/TableRow/__a11y-evidence__/data-display-tablerow-playground.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-tablerow-playground",
   "mode": "light",
-  "sourceSHA": "707d7917acb7fe832bfefa4c4314d79be17cd22a",
-  "capturedAt": "2026-08-04T06:57:50.711Z",
-  "runner": "table-family-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:21.032Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--default.dark.yaml
+++ b/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--default.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--default.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--default.light.yaml
+++ b/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--default.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--example.dark.yaml
+++ b/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--example.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--example.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--example.light.yaml
+++ b/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--example.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--forced-colors.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--forced-colors.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--forced-colors.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--playground.dark.yaml
+++ b/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--playground.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--playground.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--playground.light.yaml
+++ b/nextjs-app/shared/components/TableRow/__a11y-snapshots__/data-display-tablerow--playground.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - table "Contributors":
   - caption: Contributors
   - rowgroup:

--- a/nextjs-app/shared/components/TreeView/TreeView.contract.json
+++ b/nextjs-app/shared/components/TreeView/TreeView.contract.json
@@ -4,9 +4,9 @@
   "name": "TreeView",
   "tier": "organism",
   "group": "navigation",
-  "status": "alpha",
+  "status": "beta",
   "description": "Application tree with hierarchical selection, expansion, roving focus, and arrow-key navigation.",
-  "figma": null,
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1721-5507",
   "radixPrimitive": null,
   "element": "div",
   "variants": {
@@ -20,10 +20,7 @@
       "propSourced": true
     }
   },
-  "slots": [
-    "label",
-    "description"
-  ],
+  "slots": [],
   "asChild": false,
   "subParts": [],
   "requiredStories": [

--- a/nextjs-app/shared/components/TreeView/TreeView.contract.json
+++ b/nextjs-app/shared/components/TreeView/TreeView.contract.json
@@ -1,189 +1,203 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-  "schemaVersion": 2,
-  "name": "TreeView",
-  "tier": "organism",
-  "group": "navigation",
-  "status": "beta",
-  "description": "Application tree with hierarchical selection, expansion, roving focus, and arrow-key navigation.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1721-5507",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {
-    "size": {
-      "values": [
-        "sm",
-        "md",
-        "lg"
-      ],
-      "default": "md",
-      "propSourced": true
-    }
-  },
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [
-      "ArrowUp",
-      "ArrowDown",
-      "ArrowLeft",
-      "ArrowRight",
-      "Home",
-      "End",
-      "Enter",
-      "Space"
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "schemaVersion": 2,
+    "name": "TreeView",
+    "tier": "organism",
+    "group": "navigation",
+    "status": "beta",
+    "description": "Application tree with hierarchical selection, expansion, roving focus, and arrow-key navigation.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1721-5507",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "size": {
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "default": "md",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "ariaRequirements": [
-      "root has role=tree and an accessible name",
-      "nodes expose role=treeitem, aria-level and aria-selected",
-      "branch nodes expose aria-expanded",
-      "only the focused treeitem has tabIndex=0"
+    "a11y": {
+        "keyboard": [
+            "ArrowUp",
+            "ArrowDown",
+            "ArrowLeft",
+            "ArrowRight",
+            "Home",
+            "End",
+            "Enter",
+            "Space"
+        ],
+        "ariaRequirements": [
+            "root has role=tree and an accessible name",
+            "nodes expose role=treeitem, aria-level and aria-selected",
+            "branch nodes expose aria-expanded",
+            "only the focused treeitem has tabIndex=0"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-07-26 — tree semantics, roving focus, expansion and selection keyboard behavior, and axe result reviewed in unit tests. 2026-08-03 — Phase 1 pass: light/dark/forced-colors verified in a real browser; full keyboard model (arrows, Home/End, Enter/Space) driven by a play story; axe caught and we fixed selected-row description contrast; AT-tree and real-browser forced-colors evidence captured.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": false
+    },
+    "tokens": {
+        "colors": [
+            "--color-text",
+            "--color-muted",
+            "--color-primary",
+            "--color-neutral-bg",
+            "--color-border-light"
+        ],
+        "spacing": [
+            "--space-internal-4",
+            "--space-internal-8",
+            "--space-internal-12",
+            "--space-internal-16"
+        ]
+    },
+    "lightDarkVerified": true,
+    "dense": "application tree; controlled selection and expansion, roving focus, full arrow/Home/End/Enter/Space keyboard model",
+    "keywords": [
+        "tree",
+        "hierarchy",
+        "folders",
+        "navigation",
+        "outline",
+        "nested"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "2026-07-26 — tree semantics, roving focus, expansion and selection keyboard behavior, and axe result reviewed in unit tests. 2026-08-03 — Phase 1 pass: light/dark/forced-colors verified in a real browser; full keyboard model (arrows, Home/End, Enter/Space) driven by a play story; axe caught and we fixed selected-row description contrast; AT-tree and real-browser forced-colors evidence captured.",
-    "forcedColorsVerified": true,
-    "accessibilityTreeVerified": false
-  },
-  "tokens": {
-    "colors": [
-      "--color-text",
-      "--color-muted",
-      "--color-primary",
-      "--color-neutral-bg",
-      "--color-border-light"
+    "props": {
+        "nodes": {
+            "optional": false,
+            "type": "TreeViewNode[]",
+            "description": "Hierarchical nodes."
+        },
+        "aria-label": {
+            "optional": false,
+            "type": "string",
+            "description": "Accessible name for the tree."
+        },
+        "selectedId": {
+            "optional": true,
+            "type": "string | null",
+            "description": "Controlled selected node identifier."
+        },
+        "defaultSelectedId": {
+            "optional": true,
+            "type": "string | null",
+            "description": "Initial uncontrolled selected node identifier."
+        },
+        "onSelectedIdChange": {
+            "optional": true,
+            "type": "(id: string) => void",
+            "description": "Receives selection changes."
+        },
+        "expandedIds": {
+            "optional": true,
+            "type": "string[]",
+            "description": "Controlled expanded node identifiers."
+        },
+        "defaultExpandedIds": {
+            "optional": true,
+            "type": "string[]",
+            "description": "Initial uncontrolled expanded node identifiers."
+        },
+        "onExpandedIdsChange": {
+            "optional": true,
+            "type": "(ids: string[]) => void",
+            "description": "Receives expansion changes."
+        },
+        "size": {
+            "optional": true,
+            "type": "union",
+            "values": [
+                "sm",
+                "md",
+                "lg"
+            ],
+            "description": "Density scale."
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "replace a sitemap or ordinary nested navigation list",
+        "nest independently focusable controls inside node labels"
     ],
-    "spacing": [
-      "--space-internal-4",
-      "--space-internal-8",
-      "--space-internal-12",
-      "--space-internal-16"
+    "usage": {
+        "description": "Use TreeView for application hierarchies that users expand, collapse, navigate, and select. Use stable identifiers and concise node labels.",
+        "bestPractices": [
+            {
+                "guidance": true,
+                "description": "Give the tree an accessible label that identifies the hierarchy."
+            },
+            {
+                "guidance": true,
+                "description": "Use stable node identifiers across filtering, refreshes, and reordering."
+            },
+            {
+                "guidance": true,
+                "description": "Keep labels concise and place secondary status in the description."
+            },
+            {
+                "guidance": true,
+                "description": "Preserve expansion state when nearby application content changes."
+            },
+            {
+                "guidance": false,
+                "description": "Do not use TreeView for a flat set of links or ordinary site navigation."
+            },
+            {
+                "guidance": false,
+                "description": "Do not embed buttons, inputs, or menus inside a tree item's label."
+            }
+        ],
+        "anatomy": [
+            {
+                "name": "Tree",
+                "required": true,
+                "description": "Accessible root that owns the visible hierarchy."
+            },
+            {
+                "name": "Tree item",
+                "required": true,
+                "description": "Selectable node with its hierarchy level and expansion state."
+            },
+            {
+                "name": "Disclosure icon",
+                "required": false,
+                "description": "Visual expansion indicator shown only for branch nodes."
+            }
+        ]
+    },
+    "playground": {
+        "defaults": {
+            "aria-label": "Design system",
+            "defaultExpandedIds": [
+                "components"
+            ],
+            "defaultSelectedId": "button",
+            "size": "md"
+        }
+    },
+    "prefersOver": [
+        "SiteTree for application selection hierarchies"
+    ],
+    "composesWith": [
+        "ResizablePanelGroup",
+        "CommandPalette"
     ]
-  },
-  "lightDarkVerified": true,
-  "dense": "application tree; controlled selection and expansion, roving focus, full arrow/Home/End/Enter/Space keyboard model",
-  "keywords": [
-    "tree",
-    "hierarchy",
-    "folders",
-    "navigation",
-    "outline",
-    "nested"
-  ],
-  "props": {
-    "nodes": {
-      "optional": false,
-      "type": "TreeViewNode[]",
-      "description": "Hierarchical nodes."
-    },
-    "aria-label": {
-      "optional": false,
-      "type": "string",
-      "description": "Accessible name for the tree."
-    },
-    "selectedId": {
-      "optional": true,
-      "type": "string | null",
-      "description": "Controlled selected node identifier."
-    },
-    "onSelectedIdChange": {
-      "optional": true,
-      "type": "(id: string) => void",
-      "description": "Receives selection changes."
-    },
-    "expandedIds": {
-      "optional": true,
-      "type": "string[]",
-      "description": "Controlled expanded node identifiers."
-    },
-    "onExpandedIdsChange": {
-      "optional": true,
-      "type": "(ids: string[]) => void",
-      "description": "Receives expansion changes."
-    },
-    "size": {
-      "optional": true,
-      "type": "union",
-      "values": [
-        "sm",
-        "md",
-        "lg"
-      ],
-      "description": "Density scale."
-    }
-  },
-  "forbiddenUse": [
-    "replace a sitemap or ordinary nested navigation list",
-    "nest independently focusable controls inside node labels"
-  ],
-  "usage": {
-    "description": "Use TreeView for application hierarchies that users expand, collapse, navigate, and select. Use stable identifiers and concise node labels.",
-    "bestPractices": [
-      {
-        "guidance": true,
-        "description": "Give the tree an accessible label that identifies the hierarchy."
-      },
-      {
-        "guidance": true,
-        "description": "Use stable node identifiers across filtering, refreshes, and reordering."
-      },
-      {
-        "guidance": true,
-        "description": "Keep labels concise and place secondary status in the description."
-      },
-      {
-        "guidance": true,
-        "description": "Preserve expansion state when nearby application content changes."
-      },
-      {
-        "guidance": false,
-        "description": "Do not use TreeView for a flat set of links or ordinary site navigation."
-      },
-      {
-        "guidance": false,
-        "description": "Do not embed buttons, inputs, or menus inside a tree item's label."
-      }
-    ],
-    "anatomy": [
-      {
-        "name": "Tree",
-        "required": true,
-        "description": "Accessible root that owns the visible hierarchy."
-      },
-      {
-        "name": "Tree item",
-        "required": true,
-        "description": "Selectable node with its hierarchy level and expansion state."
-      },
-      {
-        "name": "Disclosure icon",
-        "required": false,
-        "description": "Visual expansion indicator shown only for branch nodes."
-      }
-    ]
-  },
-  "playground": {
-    "defaults": {
-      "aria-label": "Design system",
-      "defaultExpandedIds": [
-        "components"
-      ],
-      "defaultSelectedId": "button",
-      "size": "md"
-    }
-  },
-  "prefersOver": [
-    "SiteTree for application selection hierarchies"
-  ],
-  "composesWith": [
-    "ResizablePanelGroup",
-    "CommandPalette"
-  ]
 }

--- a/nextjs-app/shared/components/TreeView/TreeView.stories.tsx
+++ b/nextjs-app/shared/components/TreeView/TreeView.stories.tsx
@@ -31,7 +31,7 @@ const meta = {
     contractStatus: contract.status,
     docs: { description: { component: contract.description } },
   },
-  tags: ["alpha", "autodocs"],
+  tags: ["beta", "autodocs"],
   args: {
     "aria-label": "Design system",
     defaultExpandedIds: ["components"],
@@ -49,16 +49,22 @@ const meta = {
     nodes: { table: { disable: true } },
     defaultExpandedIds: { table: { disable: true } },
     defaultSelectedId: { table: { disable: true } },
+    selectedId: { table: { disable: true } },
+    expandedIds: { table: { disable: true } },
+    "aria-label": {
+      control: "text",
+      description: "Accessible name for the tree.",
+    },
   },
 } satisfies Meta<typeof TreeView>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-export const Playground: Story = {};
+export const Default: Story = { tags: ["beta-matrix"] };
+export const Playground: Story = { tags: ["beta-matrix"] };
 export const Example: Story = {
-  tags: ["example"],
+  tags: ["beta-matrix", "example"],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const components = canvas.getByRole("treeitem", { name: "Components" });
@@ -163,5 +169,6 @@ export const KeyboardInteraction: Story = {
 };
 
 export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
 };

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-default.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-default.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-default",
   "mode": "dark",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:27.979Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:50.262Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-default.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-default.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-default",
   "mode": "forced-colors",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:32.544Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:13.148Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-default.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-default.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-default",
   "mode": "light",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:23.037Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:24.611Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-disabled-node.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-disabled-node.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-disabled-node",
   "mode": "dark",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:28.651Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:51.038Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-disabled-node.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-disabled-node.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-disabled-node",
   "mode": "forced-colors",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:32.625Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:13.231Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-disabled-node.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-disabled-node.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-disabled-node",
   "mode": "light",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:23.692Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:25.347Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-example.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-example.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-example",
   "mode": "dark",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:28.442Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:50.777Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-example.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-example.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-example",
   "mode": "forced-colors",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:32.597Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:13.207Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-example.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-example.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-example",
   "mode": "light",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:23.476Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:25.113Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-forced-colors.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-forced-colors.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-forced-colors",
   "mode": "dark",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:29.418Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:51.922Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-forced-colors.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:32.773Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:13.398Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-forced-colors.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-forced-colors.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-forced-colors",
   "mode": "light",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:24.466Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:26.237Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-keyboard-interaction.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-keyboard-interaction.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-keyboard-interaction",
   "mode": "dark",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:29.215Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:51.680Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-keyboard-interaction.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-keyboard-interaction.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-keyboard-interaction",
   "mode": "forced-colors",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:32.752Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:13.373Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-keyboard-interaction.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-keyboard-interaction.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-keyboard-interaction",
   "mode": "light",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:24.241Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:26.006Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-large-tree.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-large-tree.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-large-tree",
   "mode": "dark",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:28.932Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:51.352Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-large-tree.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-large-tree.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-large-tree",
   "mode": "forced-colors",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:32.655Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:13.265Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-large-tree.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-large-tree.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-large-tree",
   "mode": "light",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:23.969Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:25.682Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-playground.dark.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-playground.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-playground",
   "mode": "dark",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:28.225Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:50.512Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-playground.forced-colors.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-playground.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-playground",
   "mode": "forced-colors",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:32.566Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:13.179Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-playground.light.json
+++ b/nextjs-app/shared/components/TreeView/__a11y-evidence__/navigation-treeview-playground.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "navigation-treeview-playground",
   "mode": "light",
-  "sourceSHA": "65f96d08b8f1caaabfced096ff1b2e68e744d88f",
-  "capturedAt": "2026-08-04T06:41:23.257Z",
-  "runner": "treeview-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:24.863Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--default.dark.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--default.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Design system":
   - treeitem "Foundations" [level=1]
   - treeitem "Components" [expanded] [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--default.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Design system":
   - treeitem "Foundations" [level=1]
   - treeitem "Components" [expanded] [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--default.light.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--default.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Design system":
   - treeitem "Foundations" [level=1]
   - treeitem "Components" [expanded] [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--disabled-node.dark.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--disabled-node.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Design system":
   - treeitem "Components" [expanded] [level=1]
   - treeitem "Button" [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--disabled-node.forced-colors.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--disabled-node.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Design system":
   - treeitem "Components" [expanded] [level=1]
   - treeitem "Button" [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--disabled-node.light.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--disabled-node.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Design system":
   - treeitem "Components" [expanded] [level=1]
   - treeitem "Button" [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--example.dark.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--example.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Design system":
   - treeitem "Foundations" [level=1]
   - treeitem "Components" [expanded] [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--example.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Design system":
   - treeitem "Foundations" [level=1]
   - treeitem "Components" [expanded] [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--example.light.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--example.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Design system":
   - treeitem "Foundations" [level=1]
   - treeitem "Components" [expanded] [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--forced-colors.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Design system":
   - treeitem "Foundations" [level=1]
   - treeitem "Components" [expanded] [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--forced-colors.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Design system":
   - treeitem "Foundations" [level=1]
   - treeitem "Components" [expanded] [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--forced-colors.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Design system":
   - treeitem "Foundations" [level=1]
   - treeitem "Components" [expanded] [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--keyboard-interaction.dark.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--keyboard-interaction.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Design system":
   - treeitem "Foundations" [level=1]
   - treeitem "Components" [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--keyboard-interaction.forced-colors.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--keyboard-interaction.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Design system":
   - treeitem "Foundations" [level=1]
   - treeitem "Components" [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--keyboard-interaction.light.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--keyboard-interaction.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Design system":
   - treeitem "Foundations" [level=1]
   - treeitem "Components" [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--large-tree.dark.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--large-tree.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Large hierarchy":
   - treeitem "Section 1" [expanded] [level=1]
   - treeitem "Folder 1.1" [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--large-tree.forced-colors.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--large-tree.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Large hierarchy":
   - treeitem "Section 1" [expanded] [level=1]
   - treeitem "Folder 1.1" [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--large-tree.light.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--large-tree.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Large hierarchy":
   - treeitem "Section 1" [expanded] [level=1]
   - treeitem "Folder 1.1" [level=2]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--playground.dark.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--playground.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Design system":
   - treeitem "Foundations" [level=1]
   - treeitem "Components" [expanded] [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--playground.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Design system":
   - treeitem "Foundations" [level=1]
   - treeitem "Components" [expanded] [level=1]

--- a/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--playground.light.yaml
+++ b/nextjs-app/shared/components/TreeView/__a11y-snapshots__/navigation-treeview--playground.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - tree "Design system":
   - treeitem "Foundations" [level=1]
   - treeitem "Components" [expanded] [level=1]

--- a/nextjs-app/shared/components/VirtualList/VirtualList.contract.json
+++ b/nextjs-app/shared/components/VirtualList/VirtualList.contract.json
@@ -1,165 +1,174 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-  "schemaVersion": 2,
-  "name": "VirtualList",
-  "tier": "organism",
-  "group": "data-display",
-  "status": "beta",
-  "description": "Fixed-height windowed list with overscan and explicit assistive-technology position metadata.",
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1719-3321",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {},
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [
-      "PageUp",
-      "PageDown",
-      "Home",
-      "End"
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "schemaVersion": 2,
+    "name": "VirtualList",
+    "tier": "organism",
+    "group": "data-display",
+    "status": "beta",
+    "description": "Fixed-height windowed list with overscan and explicit assistive-technology position metadata.",
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1719-3321",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {},
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "ariaRequirements": [
-      "viewport uses role=list and an accessible name",
-      "rendered rows use role=listitem",
-      "rows expose aria-posinset and aria-setsize"
+    "a11y": {
+        "keyboard": [
+            "PageUp",
+            "PageDown",
+            "Home",
+            "End"
+        ],
+        "ariaRequirements": [
+            "viewport uses role=list and an accessible name",
+            "rendered rows use role=listitem",
+            "rows expose aria-posinset and aria-setsize"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-07-26 — list semantics, item position metadata, rendered range behavior, and axe result reviewed in unit tests. 2026-08-04 — Phase 1 pass: light/dark/forced-colors verified in a real browser; windowing asserted at 10,000 rows (DOM capped at visible+overscan, true posinset/setsize); scroll-window focusability play; scroll-stability latency measured; AT-tree and real-browser forced-colors evidence captured.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": false
+    },
+    "tokens": {
+        "colors": [
+            "--color-border-light"
+        ],
+        "spacing": [
+            "--space-internal-16"
+        ]
+    },
+    "lightDarkVerified": true,
+    "dense": "fixed-height windowed collection; overscan, stable keys, rendered-range callback, aria position and set-size metadata",
+    "keywords": [
+        "virtual",
+        "virtualized",
+        "windowed",
+        "large list",
+        "performance",
+        "collection"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "2026-07-26 — list semantics, item position metadata, rendered range behavior, and axe result reviewed in unit tests. 2026-08-04 — Phase 1 pass: light/dark/forced-colors verified in a real browser; windowing asserted at 10,000 rows (DOM capped at visible+overscan, true posinset/setsize); scroll-window focusability play; scroll-stability latency measured; AT-tree and real-browser forced-colors evidence captured.",
-    "forcedColorsVerified": true,
-    "accessibilityTreeVerified": false
-  },
-  "tokens": {
-    "colors": [
-      "--color-border-light"
+    "props": {
+        "items": {
+            "optional": false,
+            "type": "Item[]",
+            "description": "Complete item collection."
+        },
+        "itemHeight": {
+            "optional": false,
+            "type": "number",
+            "description": "Fixed item height in pixels."
+        },
+        "height": {
+            "optional": false,
+            "type": "number",
+            "description": "Visible viewport height in pixels."
+        },
+        "getItemKey": {
+            "optional": false,
+            "type": "(item: Item, index: number) => React.Key",
+            "description": "Stable item key."
+        },
+        "getItemProps": {
+            "optional": false,
+            "type": "(item: Item, index: number) => VirtualListItemContent",
+            "description": "Maps an item to its VirtualListItem chrome (label via `children`, plus\noptional `icon`, `meta`, `trailingIcon`, `selected`, `tone`). VirtualList\ninjects the position (`posInSet`/`setSize`) and windowing style."
+        },
+        "aria-label": {
+            "optional": false,
+            "type": "string",
+            "description": "Accessible list name."
+        },
+        "overscan": {
+            "optional": true,
+            "type": "number",
+            "description": "Extra rows rendered before and after the viewport."
+        },
+        "initialScrollOffset": {
+            "optional": true,
+            "type": "number",
+            "description": "Initial scroll offset in pixels."
+        },
+        "onRangeChange": {
+            "optional": true,
+            "type": "(range: VirtualListRange) => void",
+            "description": "Receives the rendered index range."
+        },
+        "className": {
+            "optional": true,
+            "type": "string"
+        }
+    },
+    "forbiddenUse": [
+        "use it for short collections",
+        "use it for variable-height rows",
+        "use it when browser find-in-page must search every item"
     ],
-    "spacing": [
-      "--space-internal-16"
+    "usage": {
+        "description": "Use VirtualList for long, fixed-height collections when rendering every item would be wasteful. Keep item keys stable and row height accurate.",
+        "bestPractices": [
+            {
+                "guidance": true,
+                "description": "Measure and provide the exact fixed row height used by rendered items."
+            },
+            {
+                "guidance": true,
+                "description": "Use stable item keys that survive filtering, sorting, and refreshes."
+            },
+            {
+                "guidance": true,
+                "description": "Keep overscan small while preventing blank edges during normal scrolling."
+            },
+            {
+                "guidance": true,
+                "description": "Use range changes for prefetching without coupling them to visual state."
+            },
+            {
+                "guidance": false,
+                "description": "Do not virtualize a short collection that renders cheaply without it."
+            },
+            {
+                "guidance": false,
+                "description": "Do not use VirtualList for variable-height rows or full-page text search."
+            }
+        ],
+        "anatomy": [
+            {
+                "name": "Viewport",
+                "required": true,
+                "description": "Scrollable list region with the collection's accessible name."
+            },
+            {
+                "name": "Spacer",
+                "required": true,
+                "description": "Full-height internal surface that preserves the native scroll range."
+            },
+            {
+                "name": "Rendered item",
+                "required": true,
+                "description": "Visible fixed-height row with position and set-size metadata."
+            }
+        ]
+    },
+    "playground": {
+        "defaults": {
+            "aria-label": "Component results",
+            "height": 320,
+            "itemHeight": 48,
+            "overscan": 3
+        }
+    },
+    "composesWith": [
+        "VirtualListItem",
+        "ListItem",
+        "CommandPalette",
+        "TreeView"
     ]
-  },
-  "lightDarkVerified": true,
-  "dense": "fixed-height windowed collection; overscan, stable keys, rendered-range callback, aria position and set-size metadata",
-  "keywords": [
-    "virtual",
-    "virtualized",
-    "windowed",
-    "large list",
-    "performance",
-    "collection"
-  ],
-  "props": {
-    "items": {
-      "optional": false,
-      "type": "Item[]",
-      "description": "Complete item collection."
-    },
-    "itemHeight": {
-      "optional": false,
-      "type": "number",
-      "description": "Fixed item height in pixels."
-    },
-    "height": {
-      "optional": false,
-      "type": "number",
-      "description": "Visible viewport height in pixels."
-    },
-    "getItemKey": {
-      "optional": false,
-      "type": "(item: Item, index: number) => React.Key",
-      "description": "Stable item key."
-    },
-    "getItemProps": {
-      "optional": false,
-      "type": "(item: Item, index: number) => VirtualListItemContent",
-      "description": "Maps an item to its VirtualListItem chrome (label, icon, meta, selected, tone); VirtualList injects position + windowing style."
-    },
-    "aria-label": {
-      "optional": false,
-      "type": "string",
-      "description": "Accessible list name."
-    },
-    "overscan": {
-      "optional": true,
-      "type": "number",
-      "description": "Extra rows before and after the viewport."
-    },
-    "onRangeChange": {
-      "optional": true,
-      "type": "(range: VirtualListRange) => void",
-      "description": "Receives the rendered index range."
-    }
-  },
-  "forbiddenUse": [
-    "use it for short collections",
-    "use it for variable-height rows",
-    "use it when browser find-in-page must search every item"
-  ],
-  "usage": {
-    "description": "Use VirtualList for long, fixed-height collections when rendering every item would be wasteful. Keep item keys stable and row height accurate.",
-    "bestPractices": [
-      {
-        "guidance": true,
-        "description": "Measure and provide the exact fixed row height used by rendered items."
-      },
-      {
-        "guidance": true,
-        "description": "Use stable item keys that survive filtering, sorting, and refreshes."
-      },
-      {
-        "guidance": true,
-        "description": "Keep overscan small while preventing blank edges during normal scrolling."
-      },
-      {
-        "guidance": true,
-        "description": "Use range changes for prefetching without coupling them to visual state."
-      },
-      {
-        "guidance": false,
-        "description": "Do not virtualize a short collection that renders cheaply without it."
-      },
-      {
-        "guidance": false,
-        "description": "Do not use VirtualList for variable-height rows or full-page text search."
-      }
-    ],
-    "anatomy": [
-      {
-        "name": "Viewport",
-        "required": true,
-        "description": "Scrollable list region with the collection's accessible name."
-      },
-      {
-        "name": "Spacer",
-        "required": true,
-        "description": "Full-height internal surface that preserves the native scroll range."
-      },
-      {
-        "name": "Rendered item",
-        "required": true,
-        "description": "Visible fixed-height row with position and set-size metadata."
-      }
-    ]
-  },
-  "playground": {
-    "defaults": {
-      "aria-label": "Component results",
-      "height": 320,
-      "itemHeight": 48,
-      "overscan": 3
-    }
-  },
-  "composesWith": [
-    "VirtualListItem",
-    "ListItem",
-    "CommandPalette",
-    "TreeView"
-  ]
 }

--- a/nextjs-app/shared/components/VirtualList/VirtualList.contract.json
+++ b/nextjs-app/shared/components/VirtualList/VirtualList.contract.json
@@ -4,15 +4,13 @@
   "name": "VirtualList",
   "tier": "organism",
   "group": "data-display",
-  "status": "alpha",
+  "status": "beta",
   "description": "Fixed-height windowed list with overscan and explicit assistive-technology position metadata.",
-  "figma": null,
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1719-3321",
   "radixPrimitive": null,
   "element": "div",
   "variants": {},
-  "slots": [
-    "item"
-  ],
+  "slots": [],
   "asChild": false,
   "subParts": [],
   "requiredStories": [

--- a/nextjs-app/shared/components/VirtualList/VirtualList.stories.tsx
+++ b/nextjs-app/shared/components/VirtualList/VirtualList.stories.tsx
@@ -32,7 +32,7 @@ const meta = {
       </div>
     ),
   ],
-  tags: ["alpha", "autodocs"],
+  tags: ["beta", "autodocs"],
   args: {
     "aria-label": "Component results",
     getItemKey: (item) => item.id,
@@ -55,17 +55,25 @@ const meta = {
     items: { table: { disable: true } },
     getItemKey: { table: { disable: true } },
     getItemProps: { table: { disable: true } },
+    initialScrollOffset: {
+      control: "number",
+      description: "Scroll position in pixels applied on mount.",
+    },
+    "aria-label": {
+      control: "text",
+      description: "Accessible name for the listbox viewport.",
+    },
   },
 } satisfies Meta<typeof VirtualList<(typeof items)[number]>>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-export const Playground: Story = {};
+export const Default: Story = { tags: ["beta-matrix"] };
+export const Playground: Story = { tags: ["beta-matrix"] };
 
 export const Example: Story = {
-  tags: ["example"],
+  tags: ["beta-matrix", "example"],
   parameters: {
     docs: {
       description: {
@@ -152,5 +160,6 @@ export const KeyboardScroll: Story = {
 };
 
 export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
 };

--- a/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-default.dark.json
+++ b/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-default.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallist-default",
   "mode": "dark",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:38.122Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:44.904Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-default.forced-colors.json
+++ b/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-default.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallist-default",
   "mode": "forced-colors",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:42.720Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:07.741Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-default.light.json
+++ b/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-default.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallist-default",
   "mode": "light",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:32.985Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:11.346Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-example.dark.json
+++ b/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-example.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallist-example",
   "mode": "dark",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:38.668Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:45.569Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-example.forced-colors.json
+++ b/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-example.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallist-example",
   "mode": "forced-colors",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:42.826Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:07.886Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-example.light.json
+++ b/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-example.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallist-example",
   "mode": "light",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:33.526Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:12.016Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-forced-colors.dark.json
+++ b/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-forced-colors.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallist-forced-colors",
   "mode": "dark",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:39.613Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:46.752Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-forced-colors.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallist-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:43.192Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:08.327Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-forced-colors.light.json
+++ b/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-forced-colors.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallist-forced-colors",
   "mode": "light",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:34.479Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:13.147Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-keyboard-scroll.dark.json
+++ b/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-keyboard-scroll.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallist-keyboard-scroll",
   "mode": "dark",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:39.368Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:46.424Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-keyboard-scroll.forced-colors.json
+++ b/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-keyboard-scroll.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallist-keyboard-scroll",
   "mode": "forced-colors",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:43.148Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:08.278Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-keyboard-scroll.light.json
+++ b/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-keyboard-scroll.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallist-keyboard-scroll",
   "mode": "light",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:34.232Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:12.826Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-playground.dark.json
+++ b/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-playground.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallist-playground",
   "mode": "dark",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:38.389Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:45.219Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-playground.forced-colors.json
+++ b/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-playground.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallist-playground",
   "mode": "forced-colors",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:42.774Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:07.801Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-playground.light.json
+++ b/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-playground.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallist-playground",
   "mode": "light",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:33.248Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:11.672Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-ten-thousand-rows.dark.json
+++ b/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-ten-thousand-rows.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallist-ten-thousand-rows",
   "mode": "dark",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:39.111Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:46.120Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-ten-thousand-rows.forced-colors.json
+++ b/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-ten-thousand-rows.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallist-ten-thousand-rows",
   "mode": "forced-colors",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:43.081Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:08.207Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-ten-thousand-rows.light.json
+++ b/nextjs-app/shared/components/VirtualList/__a11y-evidence__/data-display-virtuallist-ten-thousand-rows.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallist-ten-thousand-rows",
   "mode": "light",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:33.974Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:12.539Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--default.dark.yaml
+++ b/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--default.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Component results":
   - listitem: Component result 1
   - listitem: Component result 2

--- a/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--default.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Component results":
   - listitem: Component result 1
   - listitem: Component result 2

--- a/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--default.light.yaml
+++ b/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--default.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Component results":
   - listitem: Component result 1
   - listitem: Component result 2

--- a/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--example.dark.yaml
+++ b/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--example.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Component results":
   - listitem: Component result 1 New
   - listitem: Component result 2 Offline

--- a/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--example.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Component results":
   - listitem: Component result 1 New
   - listitem: Component result 2 Offline

--- a/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--example.light.yaml
+++ b/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--example.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Component results":
   - listitem: Component result 1 New
   - listitem: Component result 2 Offline

--- a/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--forced-colors.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Component results":
   - listitem: Component result 1
   - listitem: Component result 2

--- a/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--forced-colors.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Component results":
   - listitem: Component result 1
   - listitem: Component result 2

--- a/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--forced-colors.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Component results":
   - listitem: Component result 1
   - listitem: Component result 2

--- a/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--keyboard-scroll.dark.yaml
+++ b/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--keyboard-scroll.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Component results":
   - listitem: Component result 991
   - listitem: Component result 992

--- a/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--keyboard-scroll.forced-colors.yaml
+++ b/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--keyboard-scroll.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Component results":
   - listitem: Component result 991
   - listitem: Component result 992

--- a/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--keyboard-scroll.light.yaml
+++ b/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--keyboard-scroll.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Component results":
   - listitem: Component result 991
   - listitem: Component result 992

--- a/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--playground.dark.yaml
+++ b/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--playground.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Component results":
   - listitem: Component result 1
   - listitem: Component result 2

--- a/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--playground.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Component results":
   - listitem: Component result 1
   - listitem: Component result 2

--- a/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--playground.light.yaml
+++ b/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--playground.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Component results":
   - listitem: Component result 1
   - listitem: Component result 2

--- a/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--ten-thousand-rows.dark.yaml
+++ b/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--ten-thousand-rows.dark.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Ten thousand rows":
   - listitem: Row 8998
   - listitem: Row 8999

--- a/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--ten-thousand-rows.forced-colors.yaml
+++ b/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--ten-thousand-rows.forced-colors.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Ten thousand rows":
   - listitem: Row 8998
   - listitem: Row 8999

--- a/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--ten-thousand-rows.light.yaml
+++ b/nextjs-app/shared/components/VirtualList/__a11y-snapshots__/data-display-virtuallist--ten-thousand-rows.light.yaml
@@ -1,4 +1,4 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Ten thousand rows":
   - listitem: Row 8998
   - listitem: Row 8999

--- a/nextjs-app/shared/components/VirtualListItem/VirtualListItem.contract.json
+++ b/nextjs-app/shared/components/VirtualListItem/VirtualListItem.contract.json
@@ -4,12 +4,12 @@
   "name": "VirtualListItem",
   "tier": "molecule",
   "group": "data-display",
-  "status": "alpha",
+  "status": "beta",
   "description": "A single windowed list row: owns the role=listitem semantics with aria-posinset/aria-setsize position metadata, and composes ListItem for its chrome (leading icon, truncating label, end meta, trailing icon, selected check, destructive tone). Rendered by VirtualList.",
   "usage": {
     "description": "VirtualListItem is the presentational row for VirtualList: ListItem chrome with an end-aligned meta slot, positioned by getItemProps inside a role=\"list\" container. It carries no interactive semantics of its own."
   },
-  "figma": null,
+  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1719-3278",
   "radixPrimitive": null,
   "element": "div",
   "variants": {

--- a/nextjs-app/shared/components/VirtualListItem/VirtualListItem.contract.json
+++ b/nextjs-app/shared/components/VirtualListItem/VirtualListItem.contract.json
@@ -1,126 +1,92 @@
 {
-  "$schema": "../../../scripts/design-system/contract.schema.v2.json",
-  "schemaVersion": 2,
-  "name": "VirtualListItem",
-  "tier": "molecule",
-  "group": "data-display",
-  "status": "beta",
-  "description": "A single windowed list row: owns the role=listitem semantics with aria-posinset/aria-setsize position metadata, and composes ListItem for its chrome (leading icon, truncating label, end meta, trailing icon, selected check, destructive tone). Rendered by VirtualList.",
-  "usage": {
-    "description": "VirtualListItem is the presentational row for VirtualList: ListItem chrome with an end-aligned meta slot, positioned by getItemProps inside a role=\"list\" container. It carries no interactive semantics of its own."
-  },
-  "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1719-3278",
-  "radixPrimitive": null,
-  "element": "div",
-  "variants": {
-    "tone": {
-      "values": [
-        "neutral",
-        "destructive"
-      ],
-      "default": "neutral",
-      "propSourced": true
-    }
-  },
-  "slots": [],
-  "asChild": false,
-  "subParts": [],
-  "requiredStories": [
-    "Default",
-    "Playground",
-    "Example",
-    "ForcedColors"
-  ],
-  "a11y": {
-    "keyboard": [],
-    "ariaRequirements": [
-      "role=listitem — must be rendered inside a role=list container (VirtualList's viewport)",
-      "aria-posinset/aria-setsize announce the true position within the full collection even though only the windowed rows are in the DOM",
-      "chrome is delegated to ListItem: icon/trailingIcon/check are decorative (aria-hidden), meta is exposed"
+    "$schema": "../../../scripts/design-system/contract.schema.v2.json",
+    "schemaVersion": 2,
+    "name": "VirtualListItem",
+    "tier": "molecule",
+    "group": "data-display",
+    "status": "beta",
+    "description": "A single windowed list row: owns the role=listitem semantics with aria-posinset/aria-setsize position metadata, and composes ListItem for its chrome (leading icon, truncating label, end meta, trailing icon, selected check, destructive tone). Rendered by VirtualList.",
+    "usage": {
+        "description": "VirtualListItem is the presentational row for VirtualList: ListItem chrome with an end-aligned meta slot, positioned by getItemProps inside a role=\"list\" container. It carries no interactive semantics of its own."
+    },
+    "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1719-3278",
+    "radixPrimitive": null,
+    "element": "div",
+    "variants": {
+        "tone": {
+            "values": [
+                "neutral",
+                "destructive"
+            ],
+            "default": "neutral",
+            "propSourced": true
+        }
+    },
+    "slots": [],
+    "asChild": false,
+    "subParts": [],
+    "requiredStories": [
+        "Default",
+        "Playground",
+        "Example",
+        "ForcedColors"
     ],
-    "reducedMotion": true,
-    "reviewed": true,
-    "reviewedNote": "2026-07-27 — role=listitem with aria-posinset/aria-setsize verified; composes ListItem so chrome a11y (decorative icons, exposed meta, selection is visual-only) is inherited; axe asserted in a list context in the unit test. 2026-08-04 — Phase 1 pass: light/dark/forced-colors verified in a real browser; axe clean across stories x 3 modes; AT-tree and real-browser forced-colors evidence captured; composed and position-stamped by VirtualList.",
-    "forcedColorsVerified": true,
-    "accessibilityTreeVerified": false
-  },
-  "tokens": {
-    "colors": [
-      "--color-border-light"
+    "a11y": {
+        "keyboard": [],
+        "ariaRequirements": [
+            "role=listitem — must be rendered inside a role=list container (VirtualList's viewport)",
+            "aria-posinset/aria-setsize announce the true position within the full collection even though only the windowed rows are in the DOM",
+            "chrome is delegated to ListItem: icon/trailingIcon/check are decorative (aria-hidden), meta is exposed"
+        ],
+        "reducedMotion": true,
+        "reviewed": true,
+        "reviewedNote": "2026-07-27 — role=listitem with aria-posinset/aria-setsize verified; composes ListItem so chrome a11y (decorative icons, exposed meta, selection is visual-only) is inherited; axe asserted in a list context in the unit test. 2026-08-04 — Phase 1 pass: light/dark/forced-colors verified in a real browser; axe clean across stories x 3 modes; AT-tree and real-browser forced-colors evidence captured; composed and position-stamped by VirtualList.",
+        "forcedColorsVerified": true,
+        "accessibilityTreeVerified": false
+    },
+    "tokens": {
+        "colors": [
+            "--color-border-light"
+        ],
+        "spacing": []
+    },
+    "lightDarkVerified": true,
+    "dense": "windowed list row; role=listitem + aria-posinset/aria-setsize, composes ListItem chrome; positioning arrives from VirtualList via style",
+    "keywords": [
+        "virtual",
+        "list",
+        "row",
+        "item",
+        "windowed",
+        "posinset"
     ],
-    "spacing": []
-  },
-  "lightDarkVerified": true,
-  "dense": "windowed list row; role=listitem + aria-posinset/aria-setsize, composes ListItem chrome; positioning arrives from VirtualList via style",
-  "keywords": [
-    "virtual",
-    "list",
-    "row",
-    "item",
-    "windowed",
-    "posinset"
-  ],
-  "props": {
-    "posInSet": {
-      "optional": false,
-      "type": "number",
-      "description": "1-based position within the full collection (aria-posinset)."
+    "props": {
+        "posInSet": {
+            "optional": false,
+            "type": "number",
+            "description": "1-based position within the full collection (`aria-posinset`)."
+        },
+        "setSize": {
+            "optional": false,
+            "type": "number",
+            "description": "Total item count in the full collection (`aria-setsize`)."
+        },
+        "style": {
+            "optional": true,
+            "type": "React.CSSProperties",
+            "description": "Positioning style supplied by VirtualList (transform + block-size)."
+        }
     },
-    "setSize": {
-      "optional": false,
-      "type": "number",
-      "description": "Total item count in the full collection (aria-setsize)."
-    },
-    "children": {
-      "optional": false,
-      "type": "React.ReactNode",
-      "description": "Primary label (delegated to ListItem; truncates)."
-    },
-    "icon": {
-      "optional": true,
-      "type": "React.ReactNode",
-      "description": "Leading icon node."
-    },
-    "meta": {
-      "optional": true,
-      "type": "React.ReactNode",
-      "description": "End-aligned secondary content (Badge, Kbd, StatusDot, value)."
-    },
-    "trailingIcon": {
-      "optional": true,
-      "type": "React.ReactNode",
-      "description": "Trailing icon after meta."
-    },
-    "selected": {
-      "optional": true,
-      "type": "boolean",
-      "description": "Renders the trailing check. Visual only."
-    },
-    "tone": {
-      "optional": true,
-      "type": "union",
-      "values": [
-        "neutral",
-        "destructive"
-      ],
-      "description": "Destructive rows use the error treatment."
-    },
-    "style": {
-      "optional": true,
-      "type": "React.CSSProperties",
-      "description": "Windowing position style injected by VirtualList (absolute + transform + block-size)."
-    }
-  },
-  "forbiddenUse": [
-    "render it outside a role=list container",
-    "duplicate ListItem chrome instead of composing it",
-    "put interactive semantics on the row — selection is visual only"
-  ],
-  "composesWith": [
-    "VirtualList",
-    "ListItem",
-    "Icon",
-    "Badge",
-    "StatusDot"
-  ]
+    "forbiddenUse": [
+        "render it outside a role=list container",
+        "duplicate ListItem chrome instead of composing it",
+        "put interactive semantics on the row — selection is visual only"
+    ],
+    "composesWith": [
+        "VirtualList",
+        "ListItem",
+        "Icon",
+        "Badge",
+        "StatusDot"
+    ]
 }

--- a/nextjs-app/shared/components/VirtualListItem/VirtualListItem.stories.tsx
+++ b/nextjs-app/shared/components/VirtualListItem/VirtualListItem.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
     contractStatus: contract.status,
     docs: { description: { component: contract.description } },
   },
-  tags: ["alpha", "autodocs"],
+  tags: ["beta", "autodocs"],
   // role="listitem" is only valid inside a list; wrap and give it width.
   decorators: [
     (Story) => (
@@ -36,6 +36,7 @@ const meta = {
       control: "inline-radio",
       options: ["neutral", "destructive"],
       description: "Destructive rows use the error treatment.",
+      table: { defaultValue: { summary: "neutral" } },
     },
     icon: { table: { disable: true } },
     meta: { table: { disable: true } },
@@ -47,11 +48,11 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
-export const Playground: Story = {};
+export const Default: Story = { tags: ["beta-matrix"] };
+export const Playground: Story = { tags: ["beta-matrix"] };
 
 export const Example: Story = {
-  tags: ["example"],
+  tags: ["beta-matrix", "example"],
   args: {
     icon: <Icon name="cube" ariaLabel="" />,
     meta: (
@@ -71,5 +72,6 @@ export const WithStatus: Story = {
 };
 
 export const ForcedColors: Story = {
+  tags: ["beta-matrix"],
   globals: { forcedColors: "active" },
 };

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-default.dark.json
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-default.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallistitem-default",
   "mode": "dark",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:50.935Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:58.963Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-default.forced-colors.json
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-default.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallistitem-default",
   "mode": "forced-colors",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:54.824Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:15.764Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-default.light.json
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-default.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallistitem-default",
   "mode": "light",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:46.671Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:28.671Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-example.dark.json
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-example.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallistitem-example",
   "mode": "dark",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:51.355Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:59.464Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-example.forced-colors.json
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-example.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallistitem-example",
   "mode": "forced-colors",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:54.875Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:15.815Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-example.light.json
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-example.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallistitem-example",
   "mode": "light",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:47.087Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:29.098Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-forced-colors.dark.json
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-forced-colors.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallistitem-forced-colors",
   "mode": "dark",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:51.743Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:59.929Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-forced-colors.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallistitem-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:54.919Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:15.895Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-forced-colors.light.json
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-forced-colors.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallistitem-forced-colors",
   "mode": "light",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:47.479Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:29.510Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-playground.dark.json
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-playground.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallistitem-playground",
   "mode": "dark",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:51.143Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:59.196Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-playground.forced-colors.json
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-playground.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallistitem-playground",
   "mode": "forced-colors",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:54.848Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:15.786Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-playground.light.json
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-playground.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallistitem-playground",
   "mode": "light",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:46.870Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:28.878Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-with-status.dark.json
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-with-status.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallistitem-with-status",
   "mode": "dark",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:51.553Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:59.705Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-with-status.forced-colors.json
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-with-status.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallistitem-with-status",
   "mode": "forced-colors",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:54.900Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:38:15.841Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-with-status.light.json
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-evidence__/data-display-virtuallistitem-with-status.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "data-display-virtuallistitem-with-status",
   "mode": "light",
-  "sourceSHA": "251ba60d7fe146f367cff4683a8ee324f84ee59c",
-  "capturedAt": "2026-08-04T07:32:47.283Z",
-  "runner": "virtuallist-phase1",
+  "sourceSHA": "fe396819e62c487b08704d773ddf396d6ef737da",
+  "capturedAt": "2026-08-05T09:37:29.312Z",
+  "runner": "beta-flip-dt1412",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--default.dark.yaml
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--default.dark.yaml
@@ -1,3 +1,3 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Example list":
   - listitem: Component result 3

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--default.forced-colors.yaml
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--default.forced-colors.yaml
@@ -1,3 +1,3 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Example list":
   - listitem: Component result 3

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--default.light.yaml
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--default.light.yaml
@@ -1,3 +1,3 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Example list":
   - listitem: Component result 3

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--example.dark.yaml
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--example.dark.yaml
@@ -1,3 +1,3 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Example list":
   - listitem: Component result 3 New

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--example.forced-colors.yaml
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--example.forced-colors.yaml
@@ -1,3 +1,3 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Example list":
   - listitem: Component result 3 New

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--example.light.yaml
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--example.light.yaml
@@ -1,3 +1,3 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Example list":
   - listitem: Component result 3 New

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--forced-colors.dark.yaml
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--forced-colors.dark.yaml
@@ -1,3 +1,3 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Example list":
   - listitem: Component result 3

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--forced-colors.forced-colors.yaml
@@ -1,3 +1,3 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Example list":
   - listitem: Component result 3

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--forced-colors.light.yaml
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--forced-colors.light.yaml
@@ -1,3 +1,3 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Example list":
   - listitem: Component result 3

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--playground.dark.yaml
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--playground.dark.yaml
@@ -1,3 +1,3 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Example list":
   - listitem: Component result 3

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--playground.forced-colors.yaml
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--playground.forced-colors.yaml
@@ -1,3 +1,3 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Example list":
   - listitem: Component result 3

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--playground.light.yaml
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--playground.light.yaml
@@ -1,3 +1,3 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Example list":
   - listitem: Component result 3

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--with-status.dark.yaml
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--with-status.dark.yaml
@@ -1,3 +1,3 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Example list":
   - listitem: Component result 3 Online

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--with-status.forced-colors.yaml
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--with-status.forced-colors.yaml
@@ -1,3 +1,3 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Example list":
   - listitem: Component result 3 Online

--- a/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--with-status.light.yaml
+++ b/nextjs-app/shared/components/VirtualListItem/__a11y-snapshots__/data-display-virtuallistitem--with-status.light.yaml
@@ -1,3 +1,3 @@
-- status: Work in progress (alpha)
+- status: Work in progress (beta)
 - list "Example list":
   - listitem: Component result 3 Online

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-08-05T08:09:32.289Z",
+  "generatedAt": "2026-08-05T09:33:54.170Z",
   "summary": {
     "componentCount": 177,
     "statusCounts": {
-      "beta": 40,
+      "beta": 49,
       "stable": 104,
-      "alpha": 32,
+      "alpha": 23,
       "deprecated": 1
     },
     "honestBetaDocDebt": 0,
@@ -107,9 +107,9 @@
     },
     "statusMix": {
       "digitaltableteur": {
-        "beta": 40,
+        "beta": 49,
         "stable": 104,
-        "alpha": 32,
+        "alpha": 23,
         "deprecated": 1
       },
       "dsharp": {
@@ -15339,9 +15339,9 @@
         "name": "DataTable",
         "tier": "organism",
         "group": "data-display",
-        "status": "alpha",
+        "status": "beta",
         "description": "Accessible data table with typed columns, three-state sortable headings, optional row selection and pagination, and density variants. Composes the Table primitives and the useTable* hooks.",
-        "figma": null,
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1719-3254",
         "radixPrimitive": null,
         "element": "table",
         "variants": {
@@ -15364,9 +15364,6 @@
           }
         },
         "slots": [
-          "caption",
-          "header",
-          "cell",
           "emptyState"
         ],
         "asChild": false,
@@ -15792,7 +15789,8 @@
           {
             "id": "keyboard-contract",
             "statement": "Every documented keyboard interaction works as specified.",
-            "verificationMode": "manual"
+            "verificationMode": "automated",
+            "check": "npm run test:stories:matrix:ci"
           },
           {
             "id": "aria-requirements",
@@ -23500,6 +23498,11 @@
           },
           {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "app/design-system/agent/AgentBenchSection.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "app/design-system/agent/ComponentTaxonomyTree.tsx",
             "since": "2026-06-04"
           },
@@ -23511,11 +23514,6 @@
           {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "app/design-system/agent/page.tsx",
-            "since": "2026-06-04"
-          },
-          {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/dev/code-window/page.tsx",
             "since": "2026-06-04"
           }
         ],
@@ -39201,9 +39199,9 @@
         "name": "ResizablePanelGroup",
         "tier": "organism",
         "group": "layout",
-        "status": "alpha",
+        "status": "beta",
         "description": "Two-or-more-panel layout with pointer and keyboard-accessible resize separators.",
-        "figma": null,
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1722-2833",
         "radixPrimitive": null,
         "element": "div",
         "variants": {
@@ -39216,10 +39214,7 @@
             "propSourced": true
           }
         },
-        "slots": [
-          "panel",
-          "separator"
-        ],
+        "slots": [],
         "asChild": false,
         "subParts": [],
         "requiredStories": [
@@ -39518,7 +39513,8 @@
           {
             "id": "keyboard-contract",
             "statement": "Every documented keyboard interaction works as specified.",
-            "verificationMode": "manual"
+            "verificationMode": "automated",
+            "check": "npm run test:stories:matrix:ci"
           },
           {
             "id": "aria-requirements",
@@ -41562,26 +41558,6 @@
           {
             "repo": "digitaltableteur/digitaltableteur",
             "path": "app/layout.tsx",
-            "since": "2026-06-04"
-          },
-          {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/ContactPage/ContactPage.tsx",
-            "since": "2026-06-04"
-          },
-          {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/ContactPage/index.ts",
-            "since": "2026-06-04"
-          },
-          {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
-            "since": "2026-06-04"
-          },
-          {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/index.ts",
             "since": "2026-06-04"
           }
         ],
@@ -48921,12 +48897,12 @@
         "name": "Table",
         "tier": "molecule",
         "group": "data-display",
-        "status": "alpha",
+        "status": "beta",
         "description": "The composable table root: a scroll wrapper around a semantic table with density, striping, and a sticky header. Compose with the sibling TableRow, TableHeaderCell, and TableCell components. The presentational layer beneath DataTable; pair with the useTable* hooks for behavior.",
         "usage": {
           "description": "Table renders semantic tabular data: a caption-led <table> whose rows and cells come from TableRow, TableHeaderCell and TableCell, with sorting and selection driven by the useTable* hooks rather than cell-local state. Use it when the content really is a data grid; DataTable wraps it for the batteries-included workflow."
         },
-        "figma": null,
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1716-2986",
         "radixPrimitive": null,
         "element": "table",
         "variants": {
@@ -49296,7 +49272,8 @@
           {
             "id": "keyboard-contract",
             "statement": "Every documented keyboard interaction works as specified.",
-            "verificationMode": "manual"
+            "verificationMode": "automated",
+            "check": "npm run test:stories:matrix:ci"
           },
           {
             "id": "aria-requirements",
@@ -49405,12 +49382,12 @@
         "name": "TableCell",
         "tier": "atom",
         "group": "data-display",
-        "status": "alpha",
+        "status": "beta",
         "description": "A table data cell (<td>) for the Table family. align controls text alignment; numeric right-aligns with tabular figures so columns line up on the decimal.",
         "usage": {
           "description": "TableCell is the body cell of the Table family: plain tabular data with an optional numeric mode that aligns figures on the decimal. Header semantics belong to TableHeaderCell; TableCell never announces scope."
         },
-        "figma": null,
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1715-2814",
         "radixPrimitive": null,
         "element": "td",
         "variants": {
@@ -49775,12 +49752,12 @@
         "name": "TableHeaderCell",
         "tier": "atom",
         "group": "data-display",
-        "status": "alpha",
+        "status": "beta",
         "description": "A table header cell (<th>). scope=col (default) carries an optional three-state DS-Icon sort control and aria-sort; scope=row marks the identifying cell of a body row so screen readers announce the row context with every other cell.",
         "usage": {
           "description": "TableHeaderCell names a column or row with correct scope semantics, and hosts sortable column headers driven by useTableSortable; sort state is announced via aria-sort, never by caret colour alone."
         },
-        "figma": null,
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1715-2794",
         "radixPrimitive": null,
         "element": "th",
         "variants": {
@@ -50121,7 +50098,8 @@
           {
             "id": "keyboard-contract",
             "statement": "Every documented keyboard interaction works as specified.",
-            "verificationMode": "manual"
+            "verificationMode": "automated",
+            "check": "npm run test:stories:matrix:ci"
           },
           {
             "id": "aria-requirements",
@@ -50571,12 +50549,12 @@
         "name": "TableRow",
         "tier": "atom",
         "group": "data-display",
-        "status": "alpha",
+        "status": "beta",
         "description": "A table row (<tr>) for the Table family. Works in <thead> and <tbody>; selected renders the selection surface. Presentational — semantics belong to the surrounding table.",
         "usage": {
           "description": "TableRow groups cells inside a Table's thead or tbody and carries the selected state visually while a real selection control (Checkbox) remains the source of truth."
         },
-        "figma": null,
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1715-2833",
         "radixPrimitive": null,
         "element": "tr",
         "variants": {
@@ -56748,9 +56726,9 @@
         "name": "TreeView",
         "tier": "organism",
         "group": "navigation",
-        "status": "alpha",
+        "status": "beta",
         "description": "Application tree with hierarchical selection, expansion, roving focus, and arrow-key navigation.",
-        "figma": null,
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1721-5507",
         "radixPrimitive": null,
         "element": "div",
         "variants": {
@@ -56764,10 +56742,7 @@
             "propSourced": true
           }
         },
-        "slots": [
-          "label",
-          "description"
-        ],
+        "slots": [],
         "asChild": false,
         "subParts": [],
         "requiredStories": [
@@ -57125,7 +57100,8 @@
           {
             "id": "keyboard-contract",
             "statement": "Every documented keyboard interaction works as specified.",
-            "verificationMode": "manual"
+            "verificationMode": "automated",
+            "check": "npm run test:stories:matrix:ci"
           },
           {
             "id": "aria-requirements",
@@ -57640,15 +57616,13 @@
         "name": "VirtualList",
         "tier": "organism",
         "group": "data-display",
-        "status": "alpha",
+        "status": "beta",
         "description": "Fixed-height windowed list with overscan and explicit assistive-technology position metadata.",
-        "figma": null,
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1719-3321",
         "radixPrimitive": null,
         "element": "div",
         "variants": {},
-        "slots": [
-          "item"
-        ],
+        "slots": [],
         "asChild": false,
         "subParts": [],
         "requiredStories": [
@@ -57966,7 +57940,8 @@
           {
             "id": "keyboard-contract",
             "statement": "Every documented keyboard interaction works as specified.",
-            "verificationMode": "manual"
+            "verificationMode": "automated",
+            "check": "npm run test:stories:matrix:ci"
           },
           {
             "id": "aria-requirements",
@@ -58075,12 +58050,12 @@
         "name": "VirtualListItem",
         "tier": "molecule",
         "group": "data-display",
-        "status": "alpha",
+        "status": "beta",
         "description": "A single windowed list row: owns the role=listitem semantics with aria-posinset/aria-setsize position metadata, and composes ListItem for its chrome (leading icon, truncating label, end meta, trailing icon, selected check, destructive tone). Rendered by VirtualList.",
         "usage": {
           "description": "VirtualListItem is the presentational row for VirtualList: ListItem chrome with an end-aligned meta slot, positioned by getItemProps inside a role=\"list\" container. It carries no interactive semantics of its own."
         },
-        "figma": null,
+        "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1719-3278",
         "radixPrimitive": null,
         "element": "div",
         "variants": {

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-08-05T09:33:54.170Z",
+  "generatedAt": "2026-08-05T09:43:13.196Z",
   "summary": {
     "componentCount": 177,
     "statusCounts": {
@@ -12782,14 +12782,14 @@
           {
             "id": "axe-no-violations",
             "statement": "Required stories produce no axe violations at the configured severity.",
-            "verificationMode": "unverified",
-            "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
+            "verificationMode": "automated",
+            "check": "npm run test:stories:matrix:ci"
           },
           {
             "id": "accessibility-tree",
             "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-            "verificationMode": "unverified",
-            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+            "verificationMode": "automated",
+            "check": "npm run test:stories:matrix:ci"
           },
           {
             "id": "forced-colors-real-browser",
@@ -12806,8 +12806,8 @@
           {
             "id": "aria-requirements",
             "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-            "verificationMode": "unverified",
-            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+            "verificationMode": "automated",
+            "check": "npm run test:stories:matrix:ci"
           },
           {
             "id": "human-a11y-review",
@@ -14119,14 +14119,14 @@
           {
             "id": "axe-no-violations",
             "statement": "Required stories produce no axe violations at the configured severity.",
-            "verificationMode": "unverified",
-            "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
+            "verificationMode": "automated",
+            "check": "npm run test:stories:matrix:ci"
           },
           {
             "id": "accessibility-tree",
             "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-            "verificationMode": "unverified",
-            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+            "verificationMode": "automated",
+            "check": "npm run test:stories:matrix:ci"
           },
           {
             "id": "forced-colors-real-browser",
@@ -15430,7 +15430,7 @@
           "columns": {
             "optional": false,
             "type": "DataTableColumn<Row>[]",
-            "description": "Ordered typed column definitions."
+            "description": "Ordered column definitions."
           },
           "getRowId": {
             "optional": false,
@@ -15440,17 +15440,22 @@
           "caption": {
             "optional": false,
             "type": "string",
-            "description": "Accessible table name."
+            "description": "Accessible table name rendered as a caption."
           },
           "hideCaption": {
             "optional": true,
             "type": "boolean",
-            "description": "Visually hides the caption."
+            "description": "Visually hides the caption while retaining the accessible name."
           },
           "sort": {
             "optional": true,
             "type": "DataTableSort | null",
             "description": "Controlled sort state."
+          },
+          "defaultSort": {
+            "optional": true,
+            "type": "DataTableSort | null",
+            "description": "Initial uncontrolled sort state."
           },
           "onSortChange": {
             "optional": true,
@@ -15460,17 +15465,42 @@
           "selectedRowIds": {
             "optional": true,
             "type": "string[]",
-            "description": "Controlled selected row identifiers."
+            "description": "Controlled selected row identifiers; enables selection."
+          },
+          "defaultSelectedRowIds": {
+            "optional": true,
+            "type": "string[]",
+            "description": "Initial uncontrolled selection; also enables selection."
           },
           "onSelectionChange": {
             "optional": true,
             "type": "(rowIds: string[]) => void",
-            "description": "Receives selection changes."
+            "description": "Receives selected row identifiers; also enables selection."
+          },
+          "getRowLabel": {
+            "optional": true,
+            "type": "(row: Row) => string",
+            "description": "Accessible row label used by selection checkboxes."
           },
           "pageSize": {
             "optional": true,
             "type": "number",
             "description": "Rows per page; enables pagination when set."
+          },
+          "emptyState": {
+            "optional": true,
+            "type": "React.ReactNode",
+            "description": "Empty-state cell content."
+          },
+          "striped": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Alternating row surfaces."
+          },
+          "stickyHeader": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Pin the header row while the body scrolls."
           },
           "size": {
             "optional": true,
@@ -15482,15 +15512,9 @@
             ],
             "description": "Density scale."
           },
-          "striped": {
+          "className": {
             "optional": true,
-            "type": "boolean",
-            "description": "Alternates row surfaces."
-          },
-          "stickyHeader": {
-            "optional": true,
-            "type": "boolean",
-            "description": "Pin the header row while the body scrolls."
+            "type": "string"
           }
         },
         "forbiddenUse": [
@@ -21396,14 +21420,14 @@
           {
             "id": "axe-no-violations",
             "statement": "Required stories produce no axe violations at the configured severity.",
-            "verificationMode": "unverified",
-            "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
+            "verificationMode": "automated",
+            "check": "npm run test:stories:matrix:ci"
           },
           {
             "id": "accessibility-tree",
             "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-            "verificationMode": "unverified",
-            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+            "verificationMode": "automated",
+            "check": "npm run test:stories:matrix:ci"
           },
           {
             "id": "forced-colors-real-browser",
@@ -39288,7 +39312,11 @@
           "onSizesChange": {
             "optional": true,
             "type": "(sizes: Record<string, number>) => void",
-            "description": "Receives current panel percentages."
+            "description": "Receives the current percentage per panel id."
+          },
+          "className": {
+            "optional": true,
+            "type": "string"
           }
         },
         "forbiddenUse": [
@@ -48998,7 +49026,7 @@
           "caption": {
             "optional": false,
             "type": "string",
-            "description": "Accessible table name rendered as a caption."
+            "description": "Accessible table name, rendered as a `<caption>`."
           },
           "hideCaption": {
             "optional": true,
@@ -49023,7 +49051,7 @@
           "stickyHeader": {
             "optional": true,
             "type": "boolean",
-            "description": "Pin the header row while the body scrolls."
+            "description": "Pin the header row while the table body scrolls."
           },
           "wrapperClassName": {
             "optional": true,
@@ -49454,16 +49482,16 @@
             "optional": true,
             "type": "union",
             "values": [
-              "start",
               "center",
-              "end"
+              "end",
+              "start"
             ],
             "description": "Cell content alignment."
           },
           "numeric": {
             "optional": true,
             "type": "boolean",
-            "description": "Right-align with tabular figures for numeric values."
+            "description": "Right-align and tabular-figure numeric values."
           }
         },
         "forbiddenUse": [
@@ -49840,9 +49868,9 @@
             "optional": true,
             "type": "union",
             "values": [
-              "start",
               "center",
-              "end"
+              "end",
+              "start"
             ],
             "description": "Cell content alignment."
           },
@@ -49850,25 +49878,25 @@
             "optional": true,
             "type": "union",
             "values": [
-              "col",
-              "row"
+              "row",
+              "col"
             ],
-            "description": "Header scope; row names the identifying cell of a body row."
+            "description": "Header scope. `col` (default) labels a column; `row` makes the cell the\naccessible name for its row — use it on the identifying cell of each body\nrow so screen readers announce the row context with every other cell."
           },
           "sortable": {
             "optional": true,
             "type": "boolean",
-            "description": "Renders the sort control (column headers only)."
+            "description": "Renders the sort affordance and toggles on click. Only for column headers."
           },
           "sortDirection": {
             "optional": true,
             "type": "union",
             "values": [
+              "none",
               "ascending",
-              "descending",
-              "none"
+              "descending"
             ],
-            "description": "Current sort state; drives aria-sort and the caret."
+            "description": "Current sort state; drives `aria-sort` and the caret icon."
           },
           "onSort": {
             "optional": true,
@@ -50608,7 +50636,7 @@
           "selected": {
             "optional": true,
             "type": "boolean",
-            "description": "Renders the selected surface and sets data-selected. Visual only."
+            "description": "Renders the selected surface and sets `data-selected`. Visual only."
           }
         },
         "forbiddenUse": [
@@ -56815,6 +56843,11 @@
             "type": "string | null",
             "description": "Controlled selected node identifier."
           },
+          "defaultSelectedId": {
+            "optional": true,
+            "type": "string | null",
+            "description": "Initial uncontrolled selected node identifier."
+          },
           "onSelectedIdChange": {
             "optional": true,
             "type": "(id: string) => void",
@@ -56824,6 +56857,11 @@
             "optional": true,
             "type": "string[]",
             "description": "Controlled expanded node identifiers."
+          },
+          "defaultExpandedIds": {
+            "optional": true,
+            "type": "string[]",
+            "description": "Initial uncontrolled expanded node identifiers."
           },
           "onExpandedIdsChange": {
             "optional": true,
@@ -56839,6 +56877,10 @@
               "lg"
             ],
             "description": "Density scale."
+          },
+          "className": {
+            "optional": true,
+            "type": "string"
           }
         },
         "forbiddenUse": [
@@ -57691,7 +57733,7 @@
           "getItemProps": {
             "optional": false,
             "type": "(item: Item, index: number) => VirtualListItemContent",
-            "description": "Maps an item to its VirtualListItem chrome (label, icon, meta, selected, tone); VirtualList injects position + windowing style."
+            "description": "Maps an item to its VirtualListItem chrome (label via `children`, plus\noptional `icon`, `meta`, `trailingIcon`, `selected`, `tone`). VirtualList\ninjects the position (`posInSet`/`setSize`) and windowing style."
           },
           "aria-label": {
             "optional": false,
@@ -57701,12 +57743,21 @@
           "overscan": {
             "optional": true,
             "type": "number",
-            "description": "Extra rows before and after the viewport."
+            "description": "Extra rows rendered before and after the viewport."
+          },
+          "initialScrollOffset": {
+            "optional": true,
+            "type": "number",
+            "description": "Initial scroll offset in pixels."
           },
           "onRangeChange": {
             "optional": true,
             "type": "(range: VirtualListRange) => void",
             "description": "Receives the rendered index range."
+          },
+          "className": {
+            "optional": true,
+            "type": "string"
           }
         },
         "forbiddenUse": [
@@ -58110,51 +58161,17 @@
           "posInSet": {
             "optional": false,
             "type": "number",
-            "description": "1-based position within the full collection (aria-posinset)."
+            "description": "1-based position within the full collection (`aria-posinset`)."
           },
           "setSize": {
             "optional": false,
             "type": "number",
-            "description": "Total item count in the full collection (aria-setsize)."
-          },
-          "children": {
-            "optional": false,
-            "type": "React.ReactNode",
-            "description": "Primary label (delegated to ListItem; truncates)."
-          },
-          "icon": {
-            "optional": true,
-            "type": "React.ReactNode",
-            "description": "Leading icon node."
-          },
-          "meta": {
-            "optional": true,
-            "type": "React.ReactNode",
-            "description": "End-aligned secondary content (Badge, Kbd, StatusDot, value)."
-          },
-          "trailingIcon": {
-            "optional": true,
-            "type": "React.ReactNode",
-            "description": "Trailing icon after meta."
-          },
-          "selected": {
-            "optional": true,
-            "type": "boolean",
-            "description": "Renders the trailing check. Visual only."
-          },
-          "tone": {
-            "optional": true,
-            "type": "union",
-            "values": [
-              "neutral",
-              "destructive"
-            ],
-            "description": "Destructive rows use the error treatment."
+            "description": "Total item count in the full collection (`aria-setsize`)."
           },
           "style": {
             "optional": true,
             "type": "React.CSSProperties",
-            "description": "Windowing position style injected by VirtualList (absolute + transform + block-size)."
+            "description": "Positioning style supplied by VirtualList (transform + block-size)."
           }
         },
         "forbiddenUse": [

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-05T08:09:32.025Z",
+  "generatedAt": "2026-08-05T09:28:52.913Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -8304,7 +8304,8 @@
         {
           "id": "keyboard-contract",
           "statement": "Every documented keyboard interaction works as specified.",
-          "verificationMode": "manual"
+          "verificationMode": "automated",
+          "check": "npm run test:stories:matrix:ci"
         },
         {
           "id": "aria-requirements",
@@ -21034,7 +21035,8 @@
         {
           "id": "keyboard-contract",
           "statement": "Every documented keyboard interaction works as specified.",
-          "verificationMode": "manual"
+          "verificationMode": "automated",
+          "check": "npm run test:stories:matrix:ci"
         },
         {
           "id": "aria-requirements",
@@ -26725,7 +26727,8 @@
         {
           "id": "keyboard-contract",
           "statement": "Every documented keyboard interaction works as specified.",
-          "verificationMode": "manual"
+          "verificationMode": "automated",
+          "check": "npm run test:stories:matrix:ci"
         },
         {
           "id": "aria-requirements",
@@ -27196,7 +27199,8 @@
         {
           "id": "keyboard-contract",
           "statement": "Every documented keyboard interaction works as specified.",
-          "verificationMode": "manual"
+          "verificationMode": "automated",
+          "check": "npm run test:stories:matrix:ci"
         },
         {
           "id": "aria-requirements",
@@ -30891,7 +30895,8 @@
         {
           "id": "keyboard-contract",
           "statement": "Every documented keyboard interaction works as specified.",
-          "verificationMode": "manual"
+          "verificationMode": "automated",
+          "check": "npm run test:stories:matrix:ci"
         },
         {
           "id": "aria-requirements",
@@ -31367,7 +31372,8 @@
         {
           "id": "keyboard-contract",
           "statement": "Every documented keyboard interaction works as specified.",
-          "verificationMode": "manual"
+          "verificationMode": "automated",
+          "check": "npm run test:stories:matrix:ci"
         },
         {
           "id": "aria-requirements",

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-05T09:28:52.913Z",
+  "generatedAt": "2026-08-05T09:43:12.914Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -6630,14 +6630,14 @@
         {
           "id": "axe-no-violations",
           "statement": "Required stories produce no axe violations at the configured severity.",
-          "verificationMode": "unverified",
-          "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
+          "verificationMode": "automated",
+          "check": "npm run test:stories:matrix:ci"
         },
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified",
-          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+          "verificationMode": "automated",
+          "check": "npm run test:stories:matrix:ci"
         },
         {
           "id": "forced-colors-real-browser",
@@ -6654,8 +6654,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "unverified",
-          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+          "verificationMode": "automated",
+          "check": "npm run test:stories:matrix:ci"
         },
         {
           "id": "human-a11y-review",
@@ -7439,14 +7439,14 @@
         {
           "id": "axe-no-violations",
           "statement": "Required stories produce no axe violations at the configured severity.",
-          "verificationMode": "unverified",
-          "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
+          "verificationMode": "automated",
+          "check": "npm run test:stories:matrix:ci"
         },
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified",
-          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+          "verificationMode": "automated",
+          "check": "npm run test:stories:matrix:ci"
         },
         {
           "id": "forced-colors-real-browser",
@@ -11335,14 +11335,14 @@
         {
           "id": "axe-no-violations",
           "statement": "Required stories produce no axe violations at the configured severity.",
-          "verificationMode": "unverified",
-          "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
+          "verificationMode": "automated",
+          "check": "npm run test:stories:matrix:ci"
         },
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "unverified",
-          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
+          "verificationMode": "automated",
+          "check": "npm run test:stories:matrix:ci"
         },
         {
           "id": "forced-colors-real-browser",

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -5030,7 +5030,7 @@
         "columns": {
           "optional": false,
           "type": "DataTableColumn<Row>[]",
-          "description": "Ordered typed column definitions."
+          "description": "Ordered column definitions."
         },
         "getRowId": {
           "optional": false,
@@ -5040,17 +5040,22 @@
         "caption": {
           "optional": false,
           "type": "string",
-          "description": "Accessible table name."
+          "description": "Accessible table name rendered as a caption."
         },
         "hideCaption": {
           "optional": true,
           "type": "boolean",
-          "description": "Visually hides the caption."
+          "description": "Visually hides the caption while retaining the accessible name."
         },
         "sort": {
           "optional": true,
           "type": "DataTableSort | null",
           "description": "Controlled sort state."
+        },
+        "defaultSort": {
+          "optional": true,
+          "type": "DataTableSort | null",
+          "description": "Initial uncontrolled sort state."
         },
         "onSortChange": {
           "optional": true,
@@ -5060,17 +5065,42 @@
         "selectedRowIds": {
           "optional": true,
           "type": "string[]",
-          "description": "Controlled selected row identifiers."
+          "description": "Controlled selected row identifiers; enables selection."
+        },
+        "defaultSelectedRowIds": {
+          "optional": true,
+          "type": "string[]",
+          "description": "Initial uncontrolled selection; also enables selection."
         },
         "onSelectionChange": {
           "optional": true,
           "type": "(rowIds: string[]) => void",
-          "description": "Receives selection changes."
+          "description": "Receives selected row identifiers; also enables selection."
+        },
+        "getRowLabel": {
+          "optional": true,
+          "type": "(row: Row) => string",
+          "description": "Accessible row label used by selection checkboxes."
         },
         "pageSize": {
           "optional": true,
           "type": "number",
           "description": "Rows per page; enables pagination when set."
+        },
+        "emptyState": {
+          "optional": true,
+          "type": "React.ReactNode",
+          "description": "Empty-state cell content."
+        },
+        "striped": {
+          "optional": true,
+          "type": "boolean",
+          "description": "Alternating row surfaces."
+        },
+        "stickyHeader": {
+          "optional": true,
+          "type": "boolean",
+          "description": "Pin the header row while the body scrolls."
         },
         "size": {
           "optional": true,
@@ -5082,15 +5112,9 @@
           ],
           "description": "Density scale."
         },
-        "striped": {
+        "className": {
           "optional": true,
-          "type": "boolean",
-          "description": "Alternates row surfaces."
-        },
-        "stickyHeader": {
-          "optional": true,
-          "type": "boolean",
-          "description": "Pin the header row while the body scrolls."
+          "type": "string"
         }
       },
       "composesWith": [
@@ -12771,6 +12795,11 @@
           "name": "keyboardStep",
           "type": "number",
           "required": false
+        },
+        {
+          "name": "className",
+          "type": "string",
+          "required": false
         }
       ],
       "props": {
@@ -12796,7 +12825,11 @@
         "onSizesChange": {
           "optional": true,
           "type": "(sizes: Record<string, number>) => void",
-          "description": "Receives current panel percentages."
+          "description": "Receives the current percentage per panel id."
+        },
+        "className": {
+          "optional": true,
+          "type": "string"
         }
       },
       "composesWith": [
@@ -15847,7 +15880,7 @@
         "caption": {
           "optional": false,
           "type": "string",
-          "description": "Accessible table name rendered as a caption."
+          "description": "Accessible table name, rendered as a `<caption>`."
         },
         "hideCaption": {
           "optional": true,
@@ -15872,7 +15905,7 @@
         "stickyHeader": {
           "optional": true,
           "type": "boolean",
-          "description": "Pin the header row while the body scrolls."
+          "description": "Pin the header row while the table body scrolls."
         },
         "wrapperClassName": {
           "optional": true,
@@ -15959,7 +15992,7 @@
       "keyProps": [
         {
           "name": "align",
-          "type": "start | center | end",
+          "type": "center | end | start",
           "required": false
         },
         {
@@ -15973,16 +16006,16 @@
           "optional": true,
           "type": "union",
           "values": [
-            "start",
             "center",
-            "end"
+            "end",
+            "start"
           ],
           "description": "Cell content alignment."
         },
         "numeric": {
           "optional": true,
           "type": "boolean",
-          "description": "Right-align with tabular figures for numeric values."
+          "description": "Right-align and tabular-figure numeric values."
         }
       },
       "composesWith": [
@@ -16037,17 +16070,17 @@
       "keyProps": [
         {
           "name": "align",
-          "type": "start | center | end",
+          "type": "center | end | start",
           "required": false
         },
         {
           "name": "scope",
-          "type": "col | row",
+          "type": "row | col",
           "required": false
         },
         {
           "name": "sortDirection",
-          "type": "ascending | descending | none",
+          "type": "none | ascending | descending",
           "required": false
         },
         {
@@ -16061,9 +16094,9 @@
           "optional": true,
           "type": "union",
           "values": [
-            "start",
             "center",
-            "end"
+            "end",
+            "start"
           ],
           "description": "Cell content alignment."
         },
@@ -16071,25 +16104,25 @@
           "optional": true,
           "type": "union",
           "values": [
-            "col",
-            "row"
+            "row",
+            "col"
           ],
-          "description": "Header scope; row names the identifying cell of a body row."
+          "description": "Header scope. `col` (default) labels a column; `row` makes the cell the\naccessible name for its row — use it on the identifying cell of each body\nrow so screen readers announce the row context with every other cell."
         },
         "sortable": {
           "optional": true,
           "type": "boolean",
-          "description": "Renders the sort control (column headers only)."
+          "description": "Renders the sort affordance and toggles on click. Only for column headers."
         },
         "sortDirection": {
           "optional": true,
           "type": "union",
           "values": [
+            "none",
             "ascending",
-            "descending",
-            "none"
+            "descending"
           ],
-          "description": "Current sort state; drives aria-sort and the caret."
+          "description": "Current sort state; drives `aria-sort` and the caret icon."
         },
         "onSort": {
           "optional": true,
@@ -16252,7 +16285,7 @@
         "selected": {
           "optional": true,
           "type": "boolean",
-          "description": "Renders the selected surface and sets data-selected. Visual only."
+          "description": "Renders the selected surface and sets `data-selected`. Visual only."
         }
       },
       "composesWith": [
@@ -18183,6 +18216,11 @@
           "required": false
         },
         {
+          "name": "defaultSelectedId",
+          "type": "string | null",
+          "required": false
+        },
+        {
           "name": "expandedIds",
           "type": "string[]",
           "required": false
@@ -18204,6 +18242,11 @@
           "type": "string | null",
           "description": "Controlled selected node identifier."
         },
+        "defaultSelectedId": {
+          "optional": true,
+          "type": "string | null",
+          "description": "Initial uncontrolled selected node identifier."
+        },
         "onSelectedIdChange": {
           "optional": true,
           "type": "(id: string) => void",
@@ -18213,6 +18256,11 @@
           "optional": true,
           "type": "string[]",
           "description": "Controlled expanded node identifiers."
+        },
+        "defaultExpandedIds": {
+          "optional": true,
+          "type": "string[]",
+          "description": "Initial uncontrolled expanded node identifiers."
         },
         "onExpandedIdsChange": {
           "optional": true,
@@ -18228,6 +18276,10 @@
             "lg"
           ],
           "description": "Density scale."
+        },
+        "className": {
+          "optional": true,
+          "type": "string"
         }
       },
       "composesWith": [
@@ -18501,7 +18553,7 @@
         "getItemProps": {
           "optional": false,
           "type": "(item: Item, index: number) => VirtualListItemContent",
-          "description": "Maps an item to its VirtualListItem chrome (label, icon, meta, selected, tone); VirtualList injects position + windowing style."
+          "description": "Maps an item to its VirtualListItem chrome (label via `children`, plus\noptional `icon`, `meta`, `trailingIcon`, `selected`, `tone`). VirtualList\ninjects the position (`posInSet`/`setSize`) and windowing style."
         },
         "aria-label": {
           "optional": false,
@@ -18511,12 +18563,21 @@
         "overscan": {
           "optional": true,
           "type": "number",
-          "description": "Extra rows before and after the viewport."
+          "description": "Extra rows rendered before and after the viewport."
+        },
+        "initialScrollOffset": {
+          "optional": true,
+          "type": "number",
+          "description": "Initial scroll offset in pixels."
         },
         "onRangeChange": {
           "optional": true,
           "type": "(range: VirtualListRange) => void",
           "description": "Receives the rendered index range."
+        },
+        "className": {
+          "optional": true,
+          "type": "string"
         }
       },
       "composesWith": [
@@ -18631,23 +18692,8 @@
           "required": true
         },
         {
-          "name": "children",
-          "type": "React.ReactNode",
-          "required": true
-        },
-        {
-          "name": "tone",
-          "type": "neutral | destructive",
-          "required": false
-        },
-        {
-          "name": "icon",
-          "type": "React.ReactNode",
-          "required": false
-        },
-        {
-          "name": "meta",
-          "type": "React.ReactNode",
+          "name": "style",
+          "type": "React.CSSProperties",
           "required": false
         }
       ],
@@ -18655,51 +18701,17 @@
         "posInSet": {
           "optional": false,
           "type": "number",
-          "description": "1-based position within the full collection (aria-posinset)."
+          "description": "1-based position within the full collection (`aria-posinset`)."
         },
         "setSize": {
           "optional": false,
           "type": "number",
-          "description": "Total item count in the full collection (aria-setsize)."
-        },
-        "children": {
-          "optional": false,
-          "type": "React.ReactNode",
-          "description": "Primary label (delegated to ListItem; truncates)."
-        },
-        "icon": {
-          "optional": true,
-          "type": "React.ReactNode",
-          "description": "Leading icon node."
-        },
-        "meta": {
-          "optional": true,
-          "type": "React.ReactNode",
-          "description": "End-aligned secondary content (Badge, Kbd, StatusDot, value)."
-        },
-        "trailingIcon": {
-          "optional": true,
-          "type": "React.ReactNode",
-          "description": "Trailing icon after meta."
-        },
-        "selected": {
-          "optional": true,
-          "type": "boolean",
-          "description": "Renders the trailing check. Visual only."
-        },
-        "tone": {
-          "optional": true,
-          "type": "union",
-          "values": [
-            "neutral",
-            "destructive"
-          ],
-          "description": "Destructive rows use the error treatment."
+          "description": "Total item count in the full collection (`aria-setsize`)."
         },
         "style": {
           "optional": true,
           "type": "React.CSSProperties",
-          "description": "Windowing position style injected by VirtualList (absolute + transform + block-size)."
+          "description": "Positioning style supplied by VirtualList (transform + block-size)."
         }
       },
       "composesWith": [

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -4976,7 +4976,7 @@
       "name": "DataTable",
       "group": "data-display",
       "tier": 1,
-      "status": "alpha",
+      "status": "beta",
       "description": "Accessible data table with typed columns, three-state sortable headings, optional row selection and pagination, and density variants. Composes the Table primitives and the useTable* hooks.",
       "dense": "typed native data table; sortable columns, optional row selection, accessible caption, empty state, sm/md/lg density",
       "keywords": [
@@ -5178,7 +5178,7 @@
         {
           "story": "Example",
           "description": null,
-          "source": "export const Example: Story = {\n  tags: [\"example\"],\n  args: { striped: true },\n  play: async ({ canvasElement }) => {\n    const canvas = within(canvasElement);\n    await userEvent.click(canvas.getByRole(\"button\", { name: \"Name\" }));\n    await expect(\n      canvas.getByRole(\"columnheader\", { name: /Name/ }),\n    ).toHaveAttribute(\"aria-sort\", \"ascending\");\n  },\n};"
+          "source": "export const Example: Story = {\n  tags: [\"beta-matrix\", \"example\"],\n  args: { striped: true },\n  play: async ({ canvasElement }) => {\n    const canvas = within(canvasElement);\n    await userEvent.click(canvas.getByRole(\"button\", { name: \"Name\" }));\n    await expect(\n      canvas.getByRole(\"columnheader\", { name: /Name/ }),\n    ).toHaveAttribute(\"aria-sort\", \"ascending\");\n  },\n};"
         },
         {
           "story": "Paginated",
@@ -12744,7 +12744,7 @@
       "name": "ResizablePanelGroup",
       "group": "layout",
       "tier": 1,
-      "status": "alpha",
+      "status": "beta",
       "description": "Two-or-more-panel layout with pointer and keyboard-accessible resize separators.",
       "dense": "horizontal or vertical resizable panel layout; pointer drag, arrow/Home/End keyboard resize, separator value semantics",
       "keywords": [
@@ -12871,7 +12871,7 @@
         {
           "story": "Example",
           "description": null,
-          "source": "export const Example: Story = {\n  tags: [\"example\"],\n  play: async ({ canvasElement }) => {\n    const canvas = within(canvasElement);\n    const separator = canvas.getByRole(\"separator\");\n    separator.focus();\n    await userEvent.keyboard(\"{ArrowRight}\");\n    await expect(separator).toHaveAttribute(\"aria-valuenow\", \"37\");\n  },\n};"
+          "source": "export const Example: Story = {\n  tags: [\"beta-matrix\", \"example\"],\n  play: async ({ canvasElement }) => {\n    const canvas = within(canvasElement);\n    const separator = canvas.getByRole(\"separator\");\n    separator.focus();\n    await userEvent.keyboard(\"{ArrowRight}\");\n    await expect(separator).toHaveAttribute(\"aria-valuenow\", \"37\");\n  },\n};"
         },
         {
           "story": "KeyboardResize",
@@ -15798,7 +15798,7 @@
       "name": "Table",
       "group": "data-display",
       "tier": 2,
-      "status": "alpha",
+      "status": "beta",
       "description": "The composable table root: a scroll wrapper around a semantic table with density, striping, and a sticky header. Compose with the sibling TableRow, TableHeaderCell, and TableCell components. The presentational layer beneath DataTable; pair with the useTable* hooks for behavior.",
       "dense": "composable native table primitives; density, striping, sticky header, three-state DS-Icon sort caret; pairs with useTable* hooks",
       "keywords": [
@@ -15933,7 +15933,7 @@
         {
           "story": "Example",
           "description": null,
-          "source": "export const Example: Story = {\n  tags: [\"example\"],\n  args: { striped: true },\n  render: (args) => (\n    <Table {...args} caption=\"Contributors (striped)\">\n      <Body />\n    </Table>\n  ),\n};\n\nfunction KeyboardSortTable(args: React.ComponentProps<typeof Table>) {\n  const [direction, setDirection] =\n    React.useState<TableSortDirection>(\"none\");\n  const cycle = () =>\n    setDirection((current) =>\n      current === \"none\"\n        ? \"ascending\"\n        : current === \"ascending\"\n          ? \"descending\"\n          : \"none\",\n    );\n  return (\n    <Table {...args} caption=\"Keyboard sort\">\n      <thead>\n        <TableRow>\n          <TableHeaderCell sortable sortDirection={direction} onSort={cycle}>\n            Name\n          </TableHeaderCell>\n          <TableHeaderCell>Role</TableHeaderCell>\n        </TableRow>\n      </thead>\n      <tbody>\n        {people.map((person) => (\n          <TableRow key={person.id}>\n            <TableCell>{person.name}</TableCell>\n            <TableCell>{person.role}</TableCell>\n          </TableRow>\n        ))}\n      </tbody>\n    </Table>\n  );\n}\n\n/**\n * The family keyboard contract with real key events: Tab reaches the native\n * sort button, Enter and Space cycle the three sort states, and aria-sort\n * tracks each transition on the columnheader.\n */"
+          "source": "export const Example: Story = {\n  tags: [\"beta-matrix\", \"example\"],\n  args: { striped: true },\n  render: (args) => (\n    <Table {...args} caption=\"Contributors (striped)\">\n      <Body />\n    </Table>\n  ),\n};\n\nfunction KeyboardSortTable(args: React.ComponentProps<typeof Table>) {\n  const [direction, setDirection] =\n    React.useState<TableSortDirection>(\"none\");\n  const cycle = () =>\n    setDirection((current) =>\n      current === \"none\"\n        ? \"ascending\"\n        : current === \"ascending\"\n          ? \"descending\"\n          : \"none\",\n    );\n  return (\n    <Table {...args} caption=\"Keyboard sort\">\n      <thead>\n        <TableRow>\n          <TableHeaderCell sortable sortDirection={direction} onSort={cycle}>\n            Name\n          </TableHeaderCell>\n          <TableHeaderCell>Role</TableHeaderCell>\n        </TableRow>\n      </thead>\n      <tbody>\n        {people.map((person) => (\n          <TableRow key={person.id}>\n            <TableCell>{person.name}</TableCell>\n            <TableCell>{person.role}</TableCell>\n          </TableRow>\n        ))}\n      </tbody>\n    </Table>\n  );\n}\n\n/**\n * The family keyboard contract with real key events: Tab reaches the native\n * sort button, Enter and Space cycle the three sort states, and aria-sort\n * tracks each transition on the columnheader.\n */"
         },
         {
           "story": "KeyboardInteraction",
@@ -15946,7 +15946,7 @@
       "name": "TableCell",
       "group": "data-display",
       "tier": 2,
-      "status": "alpha",
+      "status": "beta",
       "description": "A table data cell (<td>) for the Table family. align controls text alignment; numeric right-aligns with tabular figures so columns line up on the decimal.",
       "dense": "table td; align start/center/end, numeric = tabular figures right-aligned",
       "keywords": [
@@ -16013,7 +16013,7 @@
         {
           "story": "Example",
           "description": "numeric cells right-align with tabular figures so columns line up on the decimal.",
-          "source": "export const Example: Story = {\n  tags: [\"example\"],\n  parameters: {\n    docs: {\n      description: {\n        story: \"numeric cells right-align with tabular figures so columns line up on the decimal.\",\n      },\n    },\n  },\n  render: () => (\n    <Table caption=\"Numbers\">\n      <thead>\n        <TableRow>\n          <TableHeaderCell>Metric</TableHeaderCell>\n          <TableHeaderCell align=\"end\">Value</TableHeaderCell>\n        </TableRow>\n      </thead>\n      <tbody>\n        <TableRow>\n          <TableCell>Requests</TableCell>\n          <TableCell numeric>1,204</TableCell>\n        </TableRow>\n        <TableRow>\n          <TableCell>Errors</TableCell>\n          <TableCell numeric>12</TableCell>\n        </TableRow>\n        <TableRow>\n          <TableCell>Latency</TableCell>\n          <TableCell numeric>98</TableCell>\n        </TableRow>\n      </tbody>\n    </Table>\n  ),\n};"
+          "source": "export const Example: Story = {\n  tags: [\"beta-matrix\", \"example\"],\n  parameters: {\n    docs: {\n      description: {\n        story: \"numeric cells right-align with tabular figures so columns line up on the decimal.\",\n      },\n    },\n  },\n  render: () => (\n    <Table caption=\"Numbers\">\n      <thead>\n        <TableRow>\n          <TableHeaderCell>Metric</TableHeaderCell>\n          <TableHeaderCell align=\"end\">Value</TableHeaderCell>\n        </TableRow>\n      </thead>\n      <tbody>\n        <TableRow>\n          <TableCell>Requests</TableCell>\n          <TableCell numeric>1,204</TableCell>\n        </TableRow>\n        <TableRow>\n          <TableCell>Errors</TableCell>\n          <TableCell numeric>12</TableCell>\n        </TableRow>\n        <TableRow>\n          <TableCell>Latency</TableCell>\n          <TableCell numeric>98</TableCell>\n        </TableRow>\n      </tbody>\n    </Table>\n  ),\n};"
         }
       ]
     },
@@ -16021,7 +16021,7 @@
       "name": "TableHeaderCell",
       "group": "data-display",
       "tier": 2,
-      "status": "alpha",
+      "status": "beta",
       "description": "A table header cell (<th>). scope=col (default) carries an optional three-state DS-Icon sort control and aria-sort; scope=row marks the identifying cell of a body row so screen readers announce the row context with every other cell.",
       "dense": "th with scope col/row; col carries the three-state sort caret + aria-sort, row names its data row",
       "keywords": [
@@ -16135,7 +16135,7 @@
         {
           "story": "Example",
           "description": "The three-state sort control: caret-up-down (unsorted, muted), caret-up (ascending), caret-down (descending).",
-          "source": "export const Example: Story = {\n  tags: [\"example\"],\n  parameters: {\n    docs: {\n      description: {\n        story:\n          \"The three-state sort control: caret-up-down (unsorted, muted), caret-up (ascending), caret-down (descending).\",\n      },\n    },\n  },\n  render: () => (\n    <Table caption=\"Sort states\">\n      <thead>\n        <TableRow>\n          <TableHeaderCell sortable sortDirection=\"ascending\">\n            Name\n          </TableHeaderCell>\n          <TableHeaderCell sortable sortDirection=\"none\">\n            Role\n          </TableHeaderCell>\n          <TableHeaderCell sortable sortDirection=\"descending\" align=\"end\">\n            Projects\n          </TableHeaderCell>\n        </TableRow>\n      </thead>\n      <tbody>\n        <TableRow>\n          <TableCell>Ada</TableCell>\n          <TableCell>Engineer</TableCell>\n          <TableCell numeric>8</TableCell>\n        </TableRow>\n      </tbody>\n    </Table>\n  ),\n};"
+          "source": "export const Example: Story = {\n  tags: [\"beta-matrix\", \"example\"],\n  parameters: {\n    docs: {\n      description: {\n        story:\n          \"The three-state sort control: caret-up-down (unsorted, muted), caret-up (ascending), caret-down (descending).\",\n      },\n    },\n  },\n  render: () => (\n    <Table caption=\"Sort states\">\n      <thead>\n        <TableRow>\n          <TableHeaderCell sortable sortDirection=\"ascending\">\n            Name\n          </TableHeaderCell>\n          <TableHeaderCell sortable sortDirection=\"none\">\n            Role\n          </TableHeaderCell>\n          <TableHeaderCell sortable sortDirection=\"descending\" align=\"end\">\n            Projects\n          </TableHeaderCell>\n        </TableRow>\n      </thead>\n      <tbody>\n        <TableRow>\n          <TableCell>Ada</TableCell>\n          <TableCell>Engineer</TableCell>\n          <TableCell numeric>8</TableCell>\n        </TableRow>\n      </tbody>\n    </Table>\n  ),\n};"
         },
         {
           "story": "SortCycle",
@@ -16231,7 +16231,7 @@
       "name": "TableRow",
       "group": "data-display",
       "tier": 2,
-      "status": "alpha",
+      "status": "beta",
       "description": "A table row (<tr>) for the Table family. Works in <thead> and <tbody>; selected renders the selection surface. Presentational — semantics belong to the surrounding table.",
       "dense": "table row; works in thead/tbody, selected surface, hover + zebra via the Table root",
       "keywords": [
@@ -16280,7 +16280,7 @@
         {
           "story": "Example",
           "description": "Rows in context: the middle row is selected; the hover, zebra, and selection surfaces come from the Table root.",
-          "source": "export const Example: Story = {\n  tags: [\"example\"],\n  parameters: {\n    docs: {\n      description: {\n        story:\n          \"Rows in context: the middle row is selected; the hover, zebra, and selection surfaces come from the Table root.\",\n      },\n    },\n  },\n  render: () => (\n    <Table caption=\"Contributors\" striped>\n      <thead>\n        <TableRow>\n          <TableHeaderCell>Name</TableHeaderCell>\n          <TableHeaderCell>Role</TableHeaderCell>\n        </TableRow>\n      </thead>\n      <tbody>\n        {people.map((person, index) => (\n          <TableRow key={person.name} selected={index === 1}>\n            <TableCell>{person.name}</TableCell>\n            <TableCell>{person.role}</TableCell>\n          </TableRow>\n        ))}\n      </tbody>\n    </Table>\n  ),\n};"
+          "source": "export const Example: Story = {\n  tags: [\"beta-matrix\", \"example\"],\n  parameters: {\n    docs: {\n      description: {\n        story:\n          \"Rows in context: the middle row is selected; the hover, zebra, and selection surfaces come from the Table root.\",\n      },\n    },\n  },\n  render: () => (\n    <Table caption=\"Contributors\" striped>\n      <thead>\n        <TableRow>\n          <TableHeaderCell>Name</TableHeaderCell>\n          <TableHeaderCell>Role</TableHeaderCell>\n        </TableRow>\n      </thead>\n      <tbody>\n        {people.map((person, index) => (\n          <TableRow key={person.name} selected={index === 1}>\n            <TableCell>{person.name}</TableCell>\n            <TableCell>{person.role}</TableCell>\n          </TableRow>\n        ))}\n      </tbody>\n    </Table>\n  ),\n};"
         }
       ]
     },
@@ -18149,7 +18149,7 @@
       "name": "TreeView",
       "group": "navigation",
       "tier": 1,
-      "status": "alpha",
+      "status": "beta",
       "description": "Application tree with hierarchical selection, expansion, roving focus, and arrow-key navigation.",
       "dense": "application tree; controlled selection and expansion, roving focus, full arrow/Home/End/Enter/Space keyboard model",
       "keywords": [
@@ -18306,7 +18306,7 @@
         {
           "story": "Example",
           "description": null,
-          "source": "export const Example: Story = {\n  tags: [\"example\"],\n  play: async ({ canvasElement }) => {\n    const canvas = within(canvasElement);\n    const components = canvas.getByRole(\"treeitem\", { name: \"Components\" });\n    components.focus();\n    await userEvent.keyboard(\"{ArrowRight}\");\n    await expect(\n      canvas.getByRole(\"treeitem\", { name: /Button/ }),\n    ).toHaveFocus();\n  },\n};\n/**\n * A node with `disabled` stays discoverable (focusable via the roving\n * tabindex, announced with aria-disabled) but cannot be selected.\n */"
+          "source": "export const Example: Story = {\n  tags: [\"beta-matrix\", \"example\"],\n  play: async ({ canvasElement }) => {\n    const canvas = within(canvasElement);\n    const components = canvas.getByRole(\"treeitem\", { name: \"Components\" });\n    components.focus();\n    await userEvent.keyboard(\"{ArrowRight}\");\n    await expect(\n      canvas.getByRole(\"treeitem\", { name: /Button/ }),\n    ).toHaveFocus();\n  },\n};\n/**\n * A node with `disabled` stays discoverable (focusable via the roving\n * tabindex, announced with aria-disabled) but cannot be selected.\n */"
         },
         {
           "story": "LargeTree",
@@ -18433,7 +18433,7 @@
       "name": "VirtualList",
       "group": "data-display",
       "tier": 1,
-      "status": "alpha",
+      "status": "beta",
       "description": "Fixed-height windowed list with overscan and explicit assistive-technology position metadata.",
       "dense": "fixed-height windowed collection; overscan, stable keys, rendered-range callback, aria position and set-size metadata",
       "keywords": [
@@ -18589,7 +18589,7 @@
         {
           "story": "Example",
           "description": "Rows use the full VirtualListItem chrome — leading icon, label, and end meta (Badge / StatusDot) — the same extras as menus and other lists, while staying virtualized.",
-          "source": "export const Example: Story = {\n  tags: [\"example\"],\n  parameters: {\n    docs: {\n      description: {\n        story:\n          \"Rows use the full VirtualListItem chrome — leading icon, label, and end meta (Badge / StatusDot) — the same extras as menus and other lists, while staying virtualized.\",\n      },\n    },\n  },\n  args: {\n    getItemProps: (item) => ({\n      children: item.label,\n      icon: <Icon name=\"cube\" ariaLabel=\"\" />,\n      meta: item.isNew ? (\n        <Badge size=\"sm\" tone=\"info\">\n          New\n        </Badge>\n      ) : (\n        <StatusDot tone={item.online ? \"success\" : \"neutral\"} label={item.online ? \"Online\" : \"Offline\"} />\n      ),\n    }),\n  },\n};\n\n/**\n * 10,000 rows behind a ~7-row window: the DOM stays at viewport + overscan\n * regardless of collection size, and every mounted row carries its true\n * aria-posinset/aria-setsize. Used as the scroll-stability performance case\n * (see spec Design notes).\n */"
+          "source": "export const Example: Story = {\n  tags: [\"beta-matrix\", \"example\"],\n  parameters: {\n    docs: {\n      description: {\n        story:\n          \"Rows use the full VirtualListItem chrome — leading icon, label, and end meta (Badge / StatusDot) — the same extras as menus and other lists, while staying virtualized.\",\n      },\n    },\n  },\n  args: {\n    getItemProps: (item) => ({\n      children: item.label,\n      icon: <Icon name=\"cube\" ariaLabel=\"\" />,\n      meta: item.isNew ? (\n        <Badge size=\"sm\" tone=\"info\">\n          New\n        </Badge>\n      ) : (\n        <StatusDot tone={item.online ? \"success\" : \"neutral\"} label={item.online ? \"Online\" : \"Offline\"} />\n      ),\n    }),\n  },\n};\n\n/**\n * 10,000 rows behind a ~7-row window: the DOM stays at viewport + overscan\n * regardless of collection size, and every mounted row carries its true\n * aria-posinset/aria-setsize. Used as the scroll-stability performance case\n * (see spec Design notes).\n */"
         },
         {
           "story": "TenThousandRows",
@@ -18607,7 +18607,7 @@
       "name": "VirtualListItem",
       "group": "data-display",
       "tier": 2,
-      "status": "alpha",
+      "status": "beta",
       "description": "A single windowed list row: owns the role=listitem semantics with aria-posinset/aria-setsize position metadata, and composes ListItem for its chrome (leading icon, truncating label, end meta, trailing icon, selected check, destructive tone). Rendered by VirtualList.",
       "dense": "windowed list row; role=listitem + aria-posinset/aria-setsize, composes ListItem chrome; positioning arrives from VirtualList via style",
       "keywords": [
@@ -18728,7 +18728,7 @@
         {
           "story": "Example",
           "description": null,
-          "source": "export const Example: Story = {\n  tags: [\"example\"],\n  args: {\n    icon: <Icon name=\"cube\" ariaLabel=\"\" />,\n    meta: (\n      <Badge size=\"sm\" tone=\"info\">\n        New\n      </Badge>\n    ),\n  },\n};"
+          "source": "export const Example: Story = {\n  tags: [\"beta-matrix\", \"example\"],\n  args: {\n    icon: <Icon name=\"cube\" ariaLabel=\"\" />,\n    meta: (\n      <Badge size=\"sm\" tone=\"info\">\n        New\n      </Badge>\n    ),\n  },\n};"
         }
       ]
     },

--- a/scripts/design-system/figma-component-index.json
+++ b/scripts/design-system/figma-component-index.json
@@ -766,6 +766,51 @@
       "name": "Designerman",
       "type": "COMPONENT",
       "page": "Atoms"
+    },
+    "1716-2986": {
+      "name": "Table",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1715-2833": {
+      "name": "TableRow",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1715-2794": {
+      "name": "TableHeaderCell",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1715-2814": {
+      "name": "TableCell",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1719-3254": {
+      "name": "DataTable",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1719-3321": {
+      "name": "VirtualList",
+      "type": "COMPONENT",
+      "page": "Atoms"
+    },
+    "1719-3278": {
+      "name": "VirtualListItem",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1721-5507": {
+      "name": "TreeView",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
+    },
+    "1722-2833": {
+      "name": "ResizablePanelGroup",
+      "type": "COMPONENT_SET",
+      "page": "Atoms"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Builds real Figma components in DT-Site-stuff for all nine Phase-1 data primitives: **Table (1716-2986), TableRow (1715-2833), TableHeaderCell (1715-2794), TableCell (1715-2814), DataTable (1719-3254), VirtualList (1719-3321), VirtualListItem (1719-3278), TreeView (1721-5507), ResizablePanelGroup (1722-2833)** — full contract variant sets, DT/Color + DT/Dimension bindings, wash-idiom tints (verified in forced Dark), composed from existing DS instances (Checkbox, IconButton, ListItem, Phosphor carets). New 'Data display' section on Atoms; three per-mode variables minted (color/light-bg, color/neutral-bg, color/body-bg) mirroring variables.css.
- Flips all nine contracts alpha→beta with the node URLs; adds the ids to figma-component-index.json (ratchet stays 0/0).
- Completes beta gates surfaced by validate:components: argTypes coverage + variant-axis defaults, slots trued to the extracted interfaces, beta-matrix tags, contract props sync.
- 3-mode AT recapture at the flip SHA — yaml delta is exactly the WipBadge line alpha→beta (165 files).
- Heals pre-existing main red: Combobox / ContactFormEditorial / FormFieldEditorial stale a11y evidence (invalidated by #1408–#1411, never recaptured).

## Verification
Local gate all exit 0: typecheck, lint (0 errors), lint:css, vitest 2863/2863, build. Plus build:tokens, check:contract-props, check:consumers, check:figma-links, validate:components (HONEST_BETA_DOC_DEBT=0).

Next: re-export DataTable/TreeView/ResizablePanelGroup/VirtualList from @digitaltableteur/react at beta + republish (greens the dt verify exit gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)