### PR TITLE
chore(ds): pre-publish window for react 0.1.22 registry-resolution guard

### DIFF
--- a/app/design-system/agent/AgentBenchSection.tsx
+++ b/app/design-system/agent/AgentBenchSection.tsx
@@ -1,7 +1,7 @@
-import { Table } from "@dt/Table";
-import { TableRow } from "@dt/TableRow";
-import { TableHeaderCell } from "@dt/TableHeaderCell";
-import { TableCell } from "@dt/TableCell";
+import { Table } from "../../../nextjs-app/shared/components/Table/Table";
+import { TableRow } from "../../../nextjs-app/shared/components/TableRow/TableRow";
+import { TableHeaderCell } from "../../../nextjs-app/shared/components/TableHeaderCell/TableHeaderCell";
+import { TableCell } from "../../../nextjs-app/shared/components/TableCell/TableCell";
 
 type ArmSummary = {
   runs: number;

--- a/app/design-system/agent/ComponentTaxonomyTree.tsx
+++ b/app/design-system/agent/ComponentTaxonomyTree.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { TreeView, type TreeViewNode } from "@dt/TreeView";
-import { ResizablePanelGroup } from "@dt/ResizablePanelGroup";
+import { TreeView, type TreeViewNode } from "../../../nextjs-app/shared/components/TreeView/TreeView";
+import { ResizablePanelGroup } from "../../../nextjs-app/shared/components/ResizablePanelGroup/ResizablePanelGroup";
 
 export type TaxonomyEntry = {
   name: string;

--- a/app/design-system/agent/GoldenIntentsTable.tsx
+++ b/app/design-system/agent/GoldenIntentsTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { DataTable, type DataTableColumn } from "@dt/DataTable";
+import { DataTable, type DataTableColumn } from "../../../nextjs-app/shared/components/DataTable/DataTable";
 
 export type GoldenIntentCase = {
   id: string;

--- a/scripts/design-system/check-package-registry-resolution.mjs
+++ b/scripts/design-system/check-package-registry-resolution.mjs
@@ -64,6 +64,34 @@ const ALLOWED_APP_LOCAL_IMPORTS = new Map([
 // unclassified). Keyed `file :: importPath`, both exact.
 const ALLOWED_LOCAL_SHARED_IMPORTS = new Map([
   [
+    "app/design-system/agent/AgentBenchSection.tsx :: ../../../nextjs-app/shared/components/Table/Table",
+    "pre-publish window for react 0.1.22: flip to the barrel + drop this entry in the consume PR",
+  ],
+  [
+    "app/design-system/agent/AgentBenchSection.tsx :: ../../../nextjs-app/shared/components/TableRow/TableRow",
+    "pre-publish window for react 0.1.22: flip to the barrel + drop this entry in the consume PR",
+  ],
+  [
+    "app/design-system/agent/AgentBenchSection.tsx :: ../../../nextjs-app/shared/components/TableHeaderCell/TableHeaderCell",
+    "pre-publish window for react 0.1.22: flip to the barrel + drop this entry in the consume PR",
+  ],
+  [
+    "app/design-system/agent/AgentBenchSection.tsx :: ../../../nextjs-app/shared/components/TableCell/TableCell",
+    "pre-publish window for react 0.1.22: flip to the barrel + drop this entry in the consume PR",
+  ],
+  [
+    "app/design-system/agent/GoldenIntentsTable.tsx :: ../../../nextjs-app/shared/components/DataTable/DataTable",
+    "pre-publish window for react 0.1.22: flip to the barrel + drop this entry in the consume PR",
+  ],
+  [
+    "app/design-system/agent/ComponentTaxonomyTree.tsx :: ../../../nextjs-app/shared/components/TreeView/TreeView",
+    "pre-publish window for react 0.1.22: flip to the barrel + drop this entry in the consume PR",
+  ],
+  [
+    "app/design-system/agent/ComponentTaxonomyTree.tsx :: ../../../nextjs-app/shared/components/ResizablePanelGroup/ResizablePanelGroup",
+    "pre-publish window for react 0.1.22: flip to the barrel + drop this entry in the consume PR",
+  ],
+  [
     "providers/NextLinkProvider.tsx :: @/nextjs-app/shared/lib/linkComponent",
     "dual-provides the LOCAL LinkProvider instance alongside the package one (#1019)",
   ],


### PR DESCRIPTION
Agent-page imports of the nine about-to-publish symbols flip @dt -> relative
source with dated classifications (ToastStack #1128 precedent); the consume
PR flips them to the barrel and drops the entries.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
