### PR TITLE
chore(deps): consume @digitaltableteur/react 0.1.22 (beta data primitives)

### DIFF
--- a/app/design-system/agent/AgentBenchSection.tsx
+++ b/app/design-system/agent/AgentBenchSection.tsx
@@ -1,7 +1,9 @@
-import { Table } from "../../../nextjs-app/shared/components/Table/Table";
-import { TableRow } from "../../../nextjs-app/shared/components/TableRow/TableRow";
-import { TableHeaderCell } from "../../../nextjs-app/shared/components/TableHeaderCell/TableHeaderCell";
-import { TableCell } from "../../../nextjs-app/shared/components/TableCell/TableCell";
+import {
+  Table,
+  TableCell,
+  TableHeaderCell,
+  TableRow,
+} from "@digitaltableteur/react";
 
 type ArmSummary = {
   runs: number;

--- a/app/design-system/agent/ComponentTaxonomyTree.tsx
+++ b/app/design-system/agent/ComponentTaxonomyTree.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { TreeView, type TreeViewNode } from "../../../nextjs-app/shared/components/TreeView/TreeView";
-import { ResizablePanelGroup } from "../../../nextjs-app/shared/components/ResizablePanelGroup/ResizablePanelGroup";
+import { TreeView, type TreeViewNode } from "@digitaltableteur/react";
+import { ResizablePanelGroup } from "@digitaltableteur/react";
 
 export type TaxonomyEntry = {
   name: string;

--- a/app/design-system/agent/GoldenIntentsTable.tsx
+++ b/app/design-system/agent/GoldenIntentsTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { DataTable, type DataTableColumn } from "../../../nextjs-app/shared/components/DataTable/DataTable";
+import { DataTable, type DataTableColumn } from "@digitaltableteur/react";
 
 export type GoldenIntentCase = {
   id: string;

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-08-05T09:43:13.196Z",
+  "generatedAt": "2026-08-05T10:13:02.334Z",
   "summary": {
     "componentCount": 177,
     "statusCounts": {
@@ -82,8 +82,8 @@
     "withProductionUsage": 42,
     "uniqueImportedComponents": 165,
     "totalEvidenceRows": 832,
-    "aliasImportFiles": 435,
-    "relativeImportFiles": 430,
+    "aliasImportFiles": 428,
+    "relativeImportFiles": 437,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
   },
@@ -15599,8 +15599,8 @@
         "evidence": [
           {
             "path": "app/design-system/agent/GoldenIntentsTable.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/DataTable",
+            "importKind": "relative",
+            "importPath": "../../../nextjs-app/shared/components/DataTable/DataTable",
             "context": "production"
           },
           {
@@ -39392,8 +39392,8 @@
         "evidence": [
           {
             "path": "app/design-system/agent/ComponentTaxonomyTree.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/ResizablePanelGroup",
+            "importKind": "relative",
+            "importPath": "../../../nextjs-app/shared/components/ResizablePanelGroup/ResizablePanelGroup",
             "context": "production"
           },
           {
@@ -49082,8 +49082,8 @@
         "evidence": [
           {
             "path": "app/design-system/agent/AgentBenchSection.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/Table",
+            "importKind": "relative",
+            "importPath": "../../../nextjs-app/shared/components/Table/Table",
             "context": "production"
           },
           {
@@ -49515,8 +49515,8 @@
         "evidence": [
           {
             "path": "app/design-system/agent/AgentBenchSection.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/TableCell",
+            "importKind": "relative",
+            "importPath": "../../../nextjs-app/shared/components/TableCell/TableCell",
             "context": "production"
           },
           {
@@ -49927,8 +49927,8 @@
         "evidence": [
           {
             "path": "app/design-system/agent/AgentBenchSection.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/TableHeaderCell",
+            "importKind": "relative",
+            "importPath": "../../../nextjs-app/shared/components/TableHeaderCell/TableHeaderCell",
             "context": "production"
           },
           {
@@ -50660,8 +50660,8 @@
         "evidence": [
           {
             "path": "app/design-system/agent/AgentBenchSection.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/TableRow",
+            "importKind": "relative",
+            "importPath": "../../../nextjs-app/shared/components/TableRow/TableRow",
             "context": "production"
           },
           {
@@ -56962,8 +56962,8 @@
         "evidence": [
           {
             "path": "app/design-system/agent/ComponentTaxonomyTree.tsx",
-            "importKind": "alias",
-            "importPath": "@dt/TreeView",
+            "importKind": "relative",
+            "importPath": "../../../nextjs-app/shared/components/TreeView/TreeView",
             "context": "production"
           },
           {

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.21
+  - definition: 0.1.22
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.forced-colors.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.21
+  - definition: 0.1.22
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.21
+  - definition: 0.1.22
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.21
+  - definition: 0.1.22
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.21
+  - definition: 0.1.22
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.forced-colors.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.21
+  - definition: 0.1.22
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.21
+  - definition: 0.1.22
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.21
+  - definition: 0.1.22
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.21
+  - definition: 0.1.22
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.forced-colors.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.21
+  - definition: 0.1.22
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.21
+  - definition: 0.1.22
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.21
+  - definition: 0.1.22
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.21
+  - definition: 0.1.22
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.forced-colors.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.21
+  - definition: 0.1.22
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.21
+  - definition: 0.1.22
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.21
+  - definition: 0.1.22
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ai-sdk/openai": "^4.0.16",
         "@ai-sdk/react": "^4.0.35",
         "@calcom/embed-react": "^1.5.3",
-        "@digitaltableteur/react": "^0.1.21",
+        "@digitaltableteur/react": "^0.1.22",
         "@digitaltableteur/tokens": "^0.1.4",
         "@digitaltableteur/tokens-css": "^0.1.5",
         "@digitaltableteur/web-components": "^0.10.0",
@@ -3421,9 +3421,9 @@
       "license": "MIT"
     },
     "node_modules/@digitaltableteur/react": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.21.tgz",
-      "integrity": "sha512-3u+/otDDq5qH/rBiandfl8QsT1nrTJc1zv4PqGVmvg2tN23kZYxz6CKxuchMOZejIDd2Klv0UMCGdCwbo/yF4A==",
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.22.tgz",
+      "integrity": "sha512-akW7ynPMQ257GC84z4MIop01wndmvp01fMQnT8NNWLMNVaIEBr48bf63ZX7279G/33twWUlcvqPHRoqbT3FejA==",
       "license": "UNLICENSED",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "@ai-sdk/openai": "^4.0.16",
     "@ai-sdk/react": "^4.0.35",
     "@calcom/embed-react": "^1.5.3",
-    "@digitaltableteur/react": "^0.1.21",
+    "@digitaltableteur/react": "^0.1.22",
     "@digitaltableteur/tokens": "^0.1.4",
     "@digitaltableteur/tokens-css": "^0.1.5",
     "@digitaltableteur/web-components": "^0.10.0",

--- a/scripts/design-system/check-package-registry-resolution.mjs
+++ b/scripts/design-system/check-package-registry-resolution.mjs
@@ -64,34 +64,6 @@ const ALLOWED_APP_LOCAL_IMPORTS = new Map([
 // unclassified). Keyed `file :: importPath`, both exact.
 const ALLOWED_LOCAL_SHARED_IMPORTS = new Map([
   [
-    "app/design-system/agent/AgentBenchSection.tsx :: ../../../nextjs-app/shared/components/Table/Table",
-    "pre-publish window for react 0.1.22: flip to the barrel + drop this entry in the consume PR",
-  ],
-  [
-    "app/design-system/agent/AgentBenchSection.tsx :: ../../../nextjs-app/shared/components/TableRow/TableRow",
-    "pre-publish window for react 0.1.22: flip to the barrel + drop this entry in the consume PR",
-  ],
-  [
-    "app/design-system/agent/AgentBenchSection.tsx :: ../../../nextjs-app/shared/components/TableHeaderCell/TableHeaderCell",
-    "pre-publish window for react 0.1.22: flip to the barrel + drop this entry in the consume PR",
-  ],
-  [
-    "app/design-system/agent/AgentBenchSection.tsx :: ../../../nextjs-app/shared/components/TableCell/TableCell",
-    "pre-publish window for react 0.1.22: flip to the barrel + drop this entry in the consume PR",
-  ],
-  [
-    "app/design-system/agent/GoldenIntentsTable.tsx :: ../../../nextjs-app/shared/components/DataTable/DataTable",
-    "pre-publish window for react 0.1.22: flip to the barrel + drop this entry in the consume PR",
-  ],
-  [
-    "app/design-system/agent/ComponentTaxonomyTree.tsx :: ../../../nextjs-app/shared/components/TreeView/TreeView",
-    "pre-publish window for react 0.1.22: flip to the barrel + drop this entry in the consume PR",
-  ],
-  [
-    "app/design-system/agent/ComponentTaxonomyTree.tsx :: ../../../nextjs-app/shared/components/ResizablePanelGroup/ResizablePanelGroup",
-    "pre-publish window for react 0.1.22: flip to the barrel + drop this entry in the consume PR",
-  ],
-  [
     "providers/NextLinkProvider.tsx :: @/nextjs-app/shared/lib/linkComponent",
     "dual-provides the LOCAL LinkProvider instance alongside the package one (#1019)",
   ],


### PR DESCRIPTION
Agent page flips to registry imports for DataTable/Table family/TreeView/
ResizablePanelGroup; pre-publish classifications dropped; AboutPageContent
yamls true the react definition line to 0.1.22 (16 files, anchored perl).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
