### PR TITLE
fix(work): shrink the VertaaUX thumbnail mark 15% inside the card

### DIFF
--- a/public/images/portfolio/vertaaux/logo-on-white.svg
+++ b/public/images/portfolio/vertaaux/logo-on-white.svg
@@ -1,4 +1,6 @@
 <svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect width="512" height="512" fill="white"/>
+<g transform="translate(256 256) scale(0.85) translate(-256 -256)">
 <path d="M214.646 384.383L90 229.284H214.647V127.617H421L214.646 384.383Z" fill="black"/>
+</g>
 </svg>


### PR DESCRIPTION
Wraps the mark path in a center-anchored scale(0.85) group; canvas and
white ground unchanged. Verified on /work: rendered ink width 64% -> 54%
of the card (exactly the 0.85 ratio).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
