### PR TITLE
fix(work): coming-soon card rests like its siblings; VertaaUX gets a dedicated scaled thumbnail

### DIFF
--- a/nextjs-app/shared/components/EnhancedProjectCard/EnhancedProjectCard.module.css
+++ b/nextjs-app/shared/components/EnhancedProjectCard/EnhancedProjectCard.module.css
@@ -133,16 +133,12 @@
 }
 
 /* Coming-soon teaser: same chrome, no interactivity. The root is a div, so
-   the :hover/:focus-visible rules keyed to link affordances are neutralised
-   and the hover-gated tags become statically visible. */
+   the :hover/:focus-visible link affordances (lift, zoom, accent color) are
+   neutralised. Tags keep the sibling resting behavior: hidden until hover,
+   statically visible only under (hover: none). */
 
 .comingSoon {
   cursor: default;
-}
-
-.comingSoon .tags {
-  transform: none;
-  opacity: 1;
 }
 
 .comingSoon:hover .media {

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-coming-soon.dark.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-coming-soon.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-coming-soon",
   "mode": "dark",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:42.340Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:25:05.520Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-coming-soon.forced-colors.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-coming-soon.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-coming-soon",
   "mode": "forced-colors",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:46.176Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:25:09.430Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-coming-soon.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-coming-soon.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-coming-soon",
   "mode": "light",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:32.393Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:24:55.530Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-coming-soon.light.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-coming-soon.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-coming-soon",
   "mode": "light",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:37.295Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:25:00.607Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-default.dark.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-default.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-default",
   "mode": "dark",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:41.491Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:25:04.671Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-default.forced-colors.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-default.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-default",
   "mode": "forced-colors",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:46.050Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:25:09.320Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-default.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-default.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-default",
   "mode": "light",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:31.533Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:24:54.683Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-default.light.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-default.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-default",
   "mode": "light",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:36.436Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:24:59.753Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-example.dark.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-example.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-example",
   "mode": "dark",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:41.923Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:25:05.113Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-example.forced-colors.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-example.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-example",
   "mode": "forced-colors",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:46.127Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:25:09.383Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-example.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-example.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-example",
   "mode": "light",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:31.987Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:24:55.127Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-example.light.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-example.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-example",
   "mode": "light",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:36.891Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:25:00.192Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-forced-colors.dark.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-forced-colors.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-forced-colors",
   "mode": "dark",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:42.125Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:25:05.315Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-forced-colors.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:46.152Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:25:09.407Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-forced-colors.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-forced-colors",
   "mode": "light",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:32.190Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:24:55.331Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-forced-colors.light.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-forced-colors.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-forced-colors",
   "mode": "light",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:37.089Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:25:00.399Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-playground.dark.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-playground.dark.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-playground",
   "mode": "dark",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:41.719Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:25:04.902Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-playground.forced-colors.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-playground.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-playground",
   "mode": "forced-colors",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:46.104Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:25:09.353Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-playground.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-playground.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-playground",
   "mode": "light",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:31.788Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:24:54.917Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-playground.light.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-playground.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-playground",
   "mode": "light",
-  "sourceSHA": "72ed5b59cffe0596bc887b5d1c9cdcad400c2fd6",
-  "capturedAt": "2026-08-05T11:22:36.669Z",
-  "runner": "precedent-teaser",
+  "sourceSHA": "ebe76542ad5a9ce0cb63730006ccb2f17595ac1f",
+  "capturedAt": "2026-08-06T07:24:59.985Z",
+  "runner": "teaser-rest-state",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/data/projects.ts
+++ b/nextjs-app/shared/data/projects.ts
@@ -205,7 +205,7 @@ export const projects: Project[] = [
     title: "VertaaUX",
     description:
       "UX and accessibility auditing platform for dev teams who treat accessibility as craft, not compliance.",
-    thumbnail: "/images/portfolio/vertaaux/logo-on-white.svg",
+    thumbnail: "/images/portfolio/vertaaux/logo-on-white-thumb.svg",
     category: "ux-design",
     tags: ["AI Product", "UX Intelligence", "Accessibility", "Startup"],
     featured: false,

--- a/public/images/portfolio/vertaaux/logo-on-white-thumb.svg
+++ b/public/images/portfolio/vertaaux/logo-on-white-thumb.svg
@@ -1,4 +1,6 @@
 <svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect width="512" height="512" fill="white"/>
+<g transform="translate(256 256) scale(0.85) translate(-256 -256)">
 <path d="M214.646 384.383L90 229.284H214.647V127.617H421L214.646 384.383Z" fill="black"/>
+</g>
 </svg>


### PR DESCRIPTION
Two follow-ups from owner review of #1416/#1417:

- **Teaser rest state:** the static tags-visible override made the Precedent card read as perpetually hovered. Removed; coming-soon tags now follow the sibling resting behavior (hidden until hover, visible under hover:none). Badge and non-interactive root unchanged. Verified live: computed tags opacity 0 at rest.
- **VertaaUX thumbnail:** the 15% shrink from #1417 was invisible to cached browsers (same URL) and also leaked into the case-study page which shares the file. Restored logo-on-white.svg to the original art and pointed the work index at a new dedicated logo-on-white-thumb.svg carrying the center-anchored scale(0.85) mark. New URL busts all cache layers. Verified live: rendered ink width 54% of the card (0.85 x the original 64%).

EnhancedProjectCard evidence recaptured at the change SHA (20 provenance-only diffs, zero snapshot drift). Local gate all exit 0: typecheck, lint (0 errors), lint:css, vitest 2865/2865, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Coming-soon project tags now follow consistent hover behavior and remain visible in environments without hover support.
  - Updated the VertaaUX project thumbnail for improved display consistency.

- **Accessibility**
  - Refreshed accessibility verification records across project card themes, color modes, and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->