### PR TITLE
fix(work): VertaaUX thumbnail mark another 10% smaller

### DIFF
--- a/nextjs-app/shared/data/projects.ts
+++ b/nextjs-app/shared/data/projects.ts
@@ -205,7 +205,7 @@ export const projects: Project[] = [
     title: "VertaaUX",
     description:
       "UX and accessibility auditing platform for dev teams who treat accessibility as craft, not compliance.",
-    thumbnail: "/images/portfolio/vertaaux/logo-on-white-thumb.svg",
+    thumbnail: "/images/portfolio/vertaaux/logo-on-white-thumb.svg?v=2",
     category: "ux-design",
     tags: ["AI Product", "UX Intelligence", "Accessibility", "Startup"],
     featured: false,

--- a/public/images/portfolio/vertaaux/logo-on-white-thumb.svg
+++ b/public/images/portfolio/vertaaux/logo-on-white-thumb.svg
@@ -1,6 +1,6 @@
 <svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect width="512" height="512" fill="white"/>
-<g transform="translate(256 256) scale(0.85) translate(-256 -256)">
+<g transform="translate(256 256) scale(0.765) translate(-256 -256)">
 <path d="M214.646 384.383L90 229.284H214.647V127.617H421L214.646 384.383Z" fill="black"/>
 </g>
 </svg>


### PR DESCRIPTION
scale(0.85) -> scale(0.765) on the dedicated thumb asset; thumbnail URL
versioned (?v=2) so cached browsers refetch. Verified live: ink width
48% of the card (0.765 x the original 64.6%).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
