### PR TITLE
chore(deps): TS7 prep (baseUrl removal) + moderate-advisory overrides from the major-migration research

### DIFF
--- a/digitaltableteur-blog/package-lock.json
+++ b/digitaltableteur-blog/package-lock.json
@@ -7632,18 +7632,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/@vercel/frameworks/node_modules/smol-toml": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.5.2.tgz",
-      "integrity": "sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/cyyynthia"
-      }
-    },
     "node_modules/@vercel/stega": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@vercel/stega/-/stega-1.1.0.tgz",

--- a/digitaltableteur-blog/package.json
+++ b/digitaltableteur-blog/package.json
@@ -42,6 +42,7 @@
     "undici": "^7.29.0",
     "@vercel/frameworks": {
       "js-yaml": "^3.15.0"
-    }
+    },
+    "smol-toml": "^1.7.1"
   }
 }

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-coming-soon.forced-colors.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-coming-soon.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-coming-soon",
   "mode": "forced-colors",
-  "sourceSHA": "94806aa863799a717d9cd8928b0de9493c0cd13d",
-  "capturedAt": "2026-08-06T07:43:38.275Z",
-  "runner": "badge-translucency",
+  "sourceSHA": "90475ef1f843b1f6831acb2de3c7868a2ff775b4",
+  "capturedAt": "2026-08-06T15:39:16.908Z",
+  "runner": "hc-refresh",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-default.forced-colors.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-default.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-default",
   "mode": "forced-colors",
-  "sourceSHA": "94806aa863799a717d9cd8928b0de9493c0cd13d",
-  "capturedAt": "2026-08-06T07:43:38.093Z",
-  "runner": "badge-translucency",
+  "sourceSHA": "90475ef1f843b1f6831acb2de3c7868a2ff775b4",
+  "capturedAt": "2026-08-06T15:39:16.756Z",
+  "runner": "hc-refresh",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-example.forced-colors.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-example.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-example",
   "mode": "forced-colors",
-  "sourceSHA": "94806aa863799a717d9cd8928b0de9493c0cd13d",
-  "capturedAt": "2026-08-06T07:43:38.204Z",
-  "runner": "badge-translucency",
+  "sourceSHA": "90475ef1f843b1f6831acb2de3c7868a2ff775b4",
+  "capturedAt": "2026-08-06T15:39:16.820Z",
+  "runner": "hc-refresh",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-forced-colors.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "94806aa863799a717d9cd8928b0de9493c0cd13d",
-  "capturedAt": "2026-08-06T07:43:38.231Z",
-  "runner": "badge-translucency",
+  "sourceSHA": "90475ef1f843b1f6831acb2de3c7868a2ff775b4",
+  "capturedAt": "2026-08-06T15:39:16.872Z",
+  "runner": "hc-refresh",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-playground.forced-colors.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-playground.forced-colors.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-playground",
   "mode": "forced-colors",
-  "sourceSHA": "94806aa863799a717d9cd8928b0de9493c0cd13d",
-  "capturedAt": "2026-08-06T07:43:38.152Z",
-  "runner": "badge-translucency",
+  "sourceSHA": "90475ef1f843b1f6831acb2de3c7868a2ff775b4",
+  "capturedAt": "2026-08-06T15:39:16.794Z",
+  "runner": "hc-refresh",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-snapshots__/site-enhancedprojectcard--coming-soon.forced-colors.yaml
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-snapshots__/site-enhancedprojectcard--coming-soon.forced-colors.yaml
@@ -1,0 +1,4 @@
+- text: "Category: Tools. A local-first desktop workspace that turns saved interface references into traceable design decisions.. Tags: Product Design, macOS App, Local-first Coming soon Tools"
+- heading "Precedent" [level=3]
+- paragraph: A local-first desktop workspace that turns saved interface references into traceable design decisions.
+- text: Product Design macOS App Local-first

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-08-05T11:17:38.066Z",
+  "generatedAt": "2026-08-06T15:33:58.074Z",
   "summary": {
     "componentCount": 177,
     "statusCounts": {
@@ -18662,8 +18662,8 @@
           {
             "id": "forced-colors-real-browser",
             "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:hc"
+            "verificationMode": "manual",
+            "note": "Storybook forced-colors addon (simulated, not real browser HC)."
           },
           {
             "id": "keyboard-contract",

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-05T11:14:54.400Z",
+  "generatedAt": "2026-08-06T15:33:57.819Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -9839,8 +9839,8 @@
         {
           "id": "forced-colors-real-browser",
           "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:hc"
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
         },
         {
           "id": "keyboard-contract",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13851,18 +13851,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@sanity/cli/node_modules/smol-toml": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz",
-      "integrity": "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/cyyynthia"
-      }
-    },
     "node_modules/@sanity/cli/node_modules/strip-final-newline": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
@@ -15243,20 +15231,6 @@
       },
       "peerDependenciesMeta": {
         "@sanity/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@sanity/visual-editing-csm/node_modules/valibot": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
-      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
           "optional": true
         }
       }
@@ -39521,9 +39495,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.5.2.tgz",
-      "integrity": "sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz",
+      "integrity": "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -42599,10 +42573,9 @@
       }
     },
     "node_modules/valibot": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
-      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
-      "dev": true,
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5"

--- a/package.json
+++ b/package.json
@@ -340,7 +340,9 @@
     },
     "@vercel/frameworks": {
       "js-yaml": "^3.15.0"
-    }
+    },
+    "valibot": "^1.4.2",
+    "smol-toml": "^1.7.1"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,6 @@
     "jsx": "react-jsx",
     "incremental": true,
     "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
     "typeRoots": [
       "./node_modules/@types"
     ],


### PR DESCRIPTION
Executable fallout of the eslint 10 / TypeScript 7 / Sanity migration research (full verdicts in the PR discussion / session summary):

- **eslint 10: HOLD (upstream).** eslint-plugin-react 7.37.5 (latest) crashes on the removed `context.getFilename()` and caps its peer at eslint ^9.7; eslint-config-next depends on it. No fixed release exists.
- **TypeScript 7: HOLD (upstream), prep landed.** TS 7.0.2 GA ships without the stable programmatic API (due in 7.1); typescript-eslint pins `typescript <6.1.0` and closed TS7 support as not-planned until then. This PR lands the forward-compatible half: `baseUrl` removed from tsconfig (paths are tsconfig-relative since TS 4.1) - the exact break TS 7 would force - verified across tsc, eslint import resolvers, ts-morph (build:tokens), vitest (2865/2865), next build, storybook capture.
- **Sanity: NOTHING TO MIGRATE.** sanity 6.9.1 (installed, both trees) is the latest release; the "sanity 5" line item was stale memory. The residual advisories were leaf transitives, addressed here: valibot ^1.4.2 + smol-toml ^1.7.1 overrides (root 17→9 moderates, blog 7→5; the rest is the held uuid multi-major dev-tooling set).
- Side findings: playwright 1.62 needed its chromium binary reinstalled post-sweep; foundations dist refreshed with one honest criterion flip (EnhancedProjectCard forced-colors evidence staleness - separate harness-race task spawned).

Gate: typecheck, lint (0 errors), build:tokens, vitest 2865/2865, next build, blog sanity build, validate:components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)