### PR TITLE
fix(ds): deterministic forced-colors evidence emission (kills the detection race)

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -136,6 +136,18 @@ export type ForcedColorsGlobal = "none" | "active";
  */
 const isForcedColorsRuntime = (): boolean => {
   if (typeof window === "undefined") return false;
+  // Deterministic first: the test-runner and the AT capture script inject this
+  // flag via addInitScript, which runs before any module evaluates. matchMedia
+  // at module-eval time raced Playwright's emulateMedia on warm workers, so
+  // whole-run behaviors keyed off it (a11y addon state, evidence emission)
+  // flipped run-to-run (#1424). The media query stays as the fallback for
+  // manual browsing under a real OS forced-colors mode.
+  if (
+    (window as { __DT_FORCED_COLORS__?: string }).__DT_FORCED_COLORS__ ===
+    "active"
+  ) {
+    return true;
+  }
   try {
     return window.matchMedia("(forced-colors: active)").matches;
   } catch {
@@ -507,10 +519,16 @@ const preview: Preview = {
       },
     },
     a11y: (() => {
-      // Detect forced-colors at module evaluation in the iframe. By the time this
-      // module loads under test-runner, Playwright has already applied emulateMedia.
+      // Detect forced-colors at module evaluation in the iframe (deterministic:
+      // the test-runner injects __DT_FORCED_COLORS__ before module eval).
       const forced = isForcedColorsRuntime();
-      const disabled = forced || process.env.DT_DISABLE_A11Y === "1";
+      // Forced-colors no longer force-disables the a11y config. Doing so made
+      // the merged `disable`/`test: "off"` ambiguous between author opt-outs
+      // and the runtime toggle, so the runner's evidence pass could not tell
+      // them apart (#1424). Under fc the addon is instead quieted via the
+      // `a11y.manual` initial global, and color-contrast is rule-disabled
+      // below; author opt-outs keep their own disable/test keys.
+      const disabled = process.env.DT_DISABLE_A11Y === "1";
 
       // In forced-colors mode the user agent overrides author colors. axe-core's
       // color-contrast rule then evaluates author colors that are not what the user

--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -405,6 +405,8 @@ async function captureA11yEvidence(
   // story with `parameters.a11y.disable` or `test: "off"` is not axe-checked, so
   // recording an axe result for it would be a false failure the enforced gate
   // never produces. Evidence must match the gate, not a stricter parallel run.
+  // Since #1424 the preview no longer injects disable/test-off under forced
+  // colors, so under fc these merged keys are author intent again.
   const axeDisabled = a11yParams?.disable === true || a11yParams?.test === "off";
   if (!axeDisabled) {
     try {
@@ -423,8 +425,20 @@ async function captureA11yEvidence(
       if (disabledRules.length) axe = axe.disableRules(disabledRules);
       const results = await axe.analyze();
       const axeViolations = results.violations.length;
-      checks["axe-no-violations"] = { passed: axeViolations === 0, axeViolations };
-      if (forced) checks["forced-colors-real-browser"] = { passed: axeViolations === 0 };
+      if (forced) {
+        // Under forced-colors the a11y addon is quieted (a11y.manual initial
+        // global), so there is no addon gate to mirror: this axe pass IS the
+        // real-browser forced-colors evidence. axe-no-violations stays a
+        // light/dark mirror of the addon gate and is deliberately NOT written
+        // in fc mode, so fc-only findings never contaminate the stable
+        // axe-no-violations tally (#1424).
+        checks["forced-colors-real-browser"] = {
+          passed: axeViolations === 0,
+          axeViolations,
+        };
+      } else {
+        checks["axe-no-violations"] = { passed: axeViolations === 0, axeViolations };
+      }
     } catch (err) {
       console.warn(
         `[a11y-evidence] axe skipped ${storyId}${suffix}: ${(err as Error).message}`,
@@ -472,6 +486,13 @@ const config: TestRunnerConfig = {
     }
     if (FORCED_COLORS === "active") {
       await page.emulateMedia({ forcedColors: "active" });
+      // Deterministic forced-colors signal for the preview: addInitScript runs
+      // before any iframe module evaluates, so isForcedColorsRuntime() no
+      // longer races emulateMedia on warm workers (#1424).
+      await page.addInitScript(() => {
+        (window as { __DT_FORCED_COLORS__?: string }).__DT_FORCED_COLORS__ =
+          "active";
+      });
     }
     await page.goto(iframeURL, { waitUntil: "load" });
   },
@@ -489,6 +510,10 @@ const config: TestRunnerConfig = {
     // Re-assert forced-colors per story in case the page was reset.
     if (FORCED_COLORS === "active") {
       await page.emulateMedia({ forcedColors: "active" });
+      await page.addInitScript(() => {
+        (window as { __DT_FORCED_COLORS__?: string }).__DT_FORCED_COLORS__ =
+          "active";
+      });
     }
     // Force prefers-reduced-motion so JS-driven animations (GSAP/Framer) collapse
     // to no-op tweens. Without this, axe color-contrast misreports partial-opacity

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-coming-soon.forced-colors.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-coming-soon.forced-colors.json
@@ -1,12 +1,16 @@
 {
   "storyId": "site-enhancedprojectcard-coming-soon",
   "mode": "forced-colors",
-  "sourceSHA": "90475ef1f843b1f6831acb2de3c7868a2ff775b4",
-  "capturedAt": "2026-08-06T15:39:16.908Z",
-  "runner": "hc-refresh",
+  "sourceSHA": "c7838b9be6dcdc112b78b3841cbed6ccf8c61ac0",
+  "capturedAt": "2026-08-06T18:44:59.098Z",
+  "runner": "fc-race-fix2",
   "checks": {
     "accessibility-tree": {
       "passed": true
+    },
+    "forced-colors-real-browser": {
+      "passed": true,
+      "axeViolations": 0
     }
   }
 }

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-coming-soon.light.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-coming-soon.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-coming-soon",
   "mode": "light",
-  "sourceSHA": "94806aa863799a717d9cd8928b0de9493c0cd13d",
-  "capturedAt": "2026-08-06T07:43:27.447Z",
-  "runner": "badge-translucency",
+  "sourceSHA": "c7838b9be6dcdc112b78b3841cbed6ccf8c61ac0",
+  "capturedAt": "2026-08-06T18:45:17.806Z",
+  "runner": "fc-race-fix",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-default.forced-colors.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-default.forced-colors.json
@@ -1,12 +1,16 @@
 {
   "storyId": "site-enhancedprojectcard-default",
   "mode": "forced-colors",
-  "sourceSHA": "90475ef1f843b1f6831acb2de3c7868a2ff775b4",
-  "capturedAt": "2026-08-06T15:39:16.756Z",
-  "runner": "hc-refresh",
+  "sourceSHA": "c7838b9be6dcdc112b78b3841cbed6ccf8c61ac0",
+  "capturedAt": "2026-08-06T18:44:58.314Z",
+  "runner": "fc-race-fix2",
   "checks": {
     "accessibility-tree": {
       "passed": true
+    },
+    "forced-colors-real-browser": {
+      "passed": true,
+      "axeViolations": 0
     }
   }
 }

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-default.light.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-default.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-default",
   "mode": "light",
-  "sourceSHA": "94806aa863799a717d9cd8928b0de9493c0cd13d",
-  "capturedAt": "2026-08-06T07:43:26.541Z",
-  "runner": "badge-translucency",
+  "sourceSHA": "c7838b9be6dcdc112b78b3841cbed6ccf8c61ac0",
+  "capturedAt": "2026-08-06T18:45:16.971Z",
+  "runner": "fc-race-fix",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-example.forced-colors.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-example.forced-colors.json
@@ -1,12 +1,16 @@
 {
   "storyId": "site-enhancedprojectcard-example",
   "mode": "forced-colors",
-  "sourceSHA": "90475ef1f843b1f6831acb2de3c7868a2ff775b4",
-  "capturedAt": "2026-08-06T15:39:16.820Z",
-  "runner": "hc-refresh",
+  "sourceSHA": "c7838b9be6dcdc112b78b3841cbed6ccf8c61ac0",
+  "capturedAt": "2026-08-06T18:44:58.714Z",
+  "runner": "fc-race-fix2",
   "checks": {
     "accessibility-tree": {
       "passed": true
+    },
+    "forced-colors-real-browser": {
+      "passed": true,
+      "axeViolations": 0
     }
   }
 }

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-example.light.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-example.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-example",
   "mode": "light",
-  "sourceSHA": "94806aa863799a717d9cd8928b0de9493c0cd13d",
-  "capturedAt": "2026-08-06T07:43:27.009Z",
-  "runner": "badge-translucency",
+  "sourceSHA": "c7838b9be6dcdc112b78b3841cbed6ccf8c61ac0",
+  "capturedAt": "2026-08-06T18:45:17.411Z",
+  "runner": "fc-race-fix",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-forced-colors.forced-colors.json
@@ -1,12 +1,16 @@
 {
   "storyId": "site-enhancedprojectcard-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "90475ef1f843b1f6831acb2de3c7868a2ff775b4",
-  "capturedAt": "2026-08-06T15:39:16.872Z",
-  "runner": "hc-refresh",
+  "sourceSHA": "c7838b9be6dcdc112b78b3841cbed6ccf8c61ac0",
+  "capturedAt": "2026-08-06T18:44:58.906Z",
+  "runner": "fc-race-fix2",
   "checks": {
     "accessibility-tree": {
       "passed": true
+    },
+    "forced-colors-real-browser": {
+      "passed": true,
+      "axeViolations": 0
     }
   }
 }

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-forced-colors.light.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-forced-colors.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-forced-colors",
   "mode": "light",
-  "sourceSHA": "94806aa863799a717d9cd8928b0de9493c0cd13d",
-  "capturedAt": "2026-08-06T07:43:27.218Z",
-  "runner": "badge-translucency",
+  "sourceSHA": "c7838b9be6dcdc112b78b3841cbed6ccf8c61ac0",
+  "capturedAt": "2026-08-06T18:45:17.607Z",
+  "runner": "fc-race-fix",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-playground.forced-colors.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-playground.forced-colors.json
@@ -1,12 +1,16 @@
 {
   "storyId": "site-enhancedprojectcard-playground",
   "mode": "forced-colors",
-  "sourceSHA": "90475ef1f843b1f6831acb2de3c7868a2ff775b4",
-  "capturedAt": "2026-08-06T15:39:16.794Z",
-  "runner": "hc-refresh",
+  "sourceSHA": "c7838b9be6dcdc112b78b3841cbed6ccf8c61ac0",
+  "capturedAt": "2026-08-06T18:44:58.520Z",
+  "runner": "fc-race-fix2",
   "checks": {
     "accessibility-tree": {
       "passed": true
+    },
+    "forced-colors-real-browser": {
+      "passed": true,
+      "axeViolations": 0
     }
   }
 }

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-playground.light.json
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-evidence__/site-enhancedprojectcard-playground.light.json
@@ -1,9 +1,9 @@
 {
   "storyId": "site-enhancedprojectcard-playground",
   "mode": "light",
-  "sourceSHA": "94806aa863799a717d9cd8928b0de9493c0cd13d",
-  "capturedAt": "2026-08-06T07:43:26.792Z",
-  "runner": "badge-translucency",
+  "sourceSHA": "c7838b9be6dcdc112b78b3841cbed6ccf8c61ac0",
+  "capturedAt": "2026-08-06T18:45:17.209Z",
+  "runner": "fc-race-fix",
   "checks": {
     "accessibility-tree": {
       "passed": true

--- a/nextjs-app/shared/components/EnhancedProjectCard/__a11y-snapshots__/site-enhancedprojectcard--coming-soon.forced-colors.yaml
+++ b/nextjs-app/shared/components/EnhancedProjectCard/__a11y-snapshots__/site-enhancedprojectcard--coming-soon.forced-colors.yaml
@@ -1,4 +1,0 @@
-- text: "Category: Tools. A local-first desktop workspace that turns saved interface references into traceable design decisions.. Tags: Product Design, macOS App, Local-first Coming soon Tools"
-- heading "Precedent" [level=3]
-- paragraph: A local-first desktop workspace that turns saved interface references into traceable design decisions.
-- text: Product Design macOS App Local-first

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-08-06T15:33:58.074Z",
+  "generatedAt": "2026-08-06T18:46:19.120Z",
   "summary": {
     "componentCount": 177,
     "statusCounts": {
@@ -18662,8 +18662,8 @@
           {
             "id": "forced-colors-real-browser",
             "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
-            "verificationMode": "manual",
-            "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+            "verificationMode": "automated",
+            "check": "npm run test:stories:hc"
           },
           {
             "id": "keyboard-contract",
@@ -72761,8 +72761,8 @@
           {
             "id": "forced-colors-real-browser",
             "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:hc"
+            "verificationMode": "manual",
+            "note": "Storybook forced-colors addon (simulated, not real browser HC)."
           },
           {
             "id": "keyboard-contract",

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-06T15:33:57.819Z",
+  "generatedAt": "2026-08-06T18:46:18.873Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -9839,8 +9839,8 @@
         {
           "id": "forced-colors-real-browser",
           "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
-          "verificationMode": "manual",
-          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
+          "verificationMode": "automated",
+          "check": "npm run test:stories:hc"
         },
         {
           "id": "keyboard-contract",
@@ -40475,8 +40475,8 @@
         {
           "id": "forced-colors-real-browser",
           "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:hc"
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
         },
         {
           "id": "keyboard-contract",

--- a/nextjs-app/shared/patterns/SiteHeader/__a11y-evidence__/patterns-siteheader-default.forced-colors.json
+++ b/nextjs-app/shared/patterns/SiteHeader/__a11y-evidence__/patterns-siteheader-default.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "patterns-siteheader-default",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:44:00.333Z",
-  "runner": "backfill",
+  "sourceSHA": "c7838b9be6dcdc112b78b3841cbed6ccf8c61ac0",
+  "capturedAt": "2026-08-06T18:45:21.930Z",
+  "runner": "fc-race-fix",
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/patterns/SiteHeader/__a11y-evidence__/patterns-siteheader-example.forced-colors.json
+++ b/nextjs-app/shared/patterns/SiteHeader/__a11y-evidence__/patterns-siteheader-example.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "patterns-siteheader-example",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:44:00.833Z",
-  "runner": "backfill",
+  "sourceSHA": "c7838b9be6dcdc112b78b3841cbed6ccf8c61ac0",
+  "capturedAt": "2026-08-06T18:45:21.983Z",
+  "runner": "fc-race-fix",
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/patterns/SiteHeader/__a11y-evidence__/patterns-siteheader-forced-colors.forced-colors.json
+++ b/nextjs-app/shared/patterns/SiteHeader/__a11y-evidence__/patterns-siteheader-forced-colors.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "patterns-siteheader-forced-colors",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:44:01.060Z",
-  "runner": "backfill",
+  "sourceSHA": "c7838b9be6dcdc112b78b3841cbed6ccf8c61ac0",
+  "capturedAt": "2026-08-06T18:45:22.008Z",
+  "runner": "fc-race-fix",
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/nextjs-app/shared/patterns/SiteHeader/__a11y-evidence__/patterns-siteheader-playground.forced-colors.json
+++ b/nextjs-app/shared/patterns/SiteHeader/__a11y-evidence__/patterns-siteheader-playground.forced-colors.json
@@ -1,18 +1,11 @@
 {
   "storyId": "patterns-siteheader-playground",
   "mode": "forced-colors",
-  "sourceSHA": "82c942f0040bb4aa516328e3fff356d4aa75b3ae",
-  "capturedAt": "2026-07-26T13:44:00.596Z",
-  "runner": "backfill",
+  "sourceSHA": "c7838b9be6dcdc112b78b3841cbed6ccf8c61ac0",
+  "capturedAt": "2026-08-06T18:45:21.957Z",
+  "runner": "fc-race-fix",
   "checks": {
-    "axe-no-violations": {
-      "passed": true,
-      "axeViolations": 0
-    },
     "accessibility-tree": {
-      "passed": true
-    },
-    "forced-colors-real-browser": {
       "passed": true
     }
   }

--- a/scripts/design-system/capture-story-a11y-snapshots.mjs
+++ b/scripts/design-system/capture-story-a11y-snapshots.mjs
@@ -133,6 +133,12 @@ const page = await context.newPage();
 
 if (FORCED_COLORS === "active") {
   await page.emulateMedia({ forcedColors: "active" });
+  // Deterministic forced-colors signal, mirroring .storybook/test-runner.ts:
+  // the preview's isForcedColorsRuntime() reads this before falling back to
+  // matchMedia, so both capture paths agree run-to-run (#1424).
+  await page.addInitScript(() => {
+    window.__DT_FORCED_COLORS__ = "active";
+  });
 }
 
 if (THEME) {


### PR DESCRIPTION
Fixes the harness bug found during the #1423 dist refresh: the `forced-colors-real-browser` a11y evidence check was only emitted when the preview's `matchMedia`-at-module-eval forced-colors detection LOST the race against Playwright's `emulateMedia` on warm workers — so 'automated' claims for that criterion were race-derived, and scoped recaptures silently downgraded components (EnhancedProjectCard in #1416-#1420).

## Fix
- **Deterministic signal**: test-runner and the AT capture script inject `window.__DT_FORCED_COLORS__` via `addInitScript` (runs before any iframe module evaluates); `isForcedColorsRuntime()` reads it first, `matchMedia` remains the fallback for real OS forced-colors browsing.
- **Author intent restored**: the preview no longer injects `disable`/`test: "off"` under fc (the color-contrast rule-disable and the `a11y.manual` global remain), so the merged a11y keys under fc mean author opt-out again — all 104 existing story opt-outs work unannotated.
- **Check separation**: under fc the evidence axe pass records ONLY `forced-colors-real-browser` (now with `axeViolations`); `axe-no-violations` stays a pure light/dark mirror of the addon gate, so fc-only findings can never contaminate the stable axe tally.

## Verification
Two consecutive fc runs emit identical records (race gone); light-mode mirror unchanged; SiteHeader's author-opted stories correctly emit AT-only records. Honest dist outcomes: **EnhancedProjectCard flips back to automated**; **SiteHeader flips to manual** (its four required stories author-opt out of axe — the old automated claim was a race artifact carrying axe checks it should never have had). ComingSoon themed-yaml strays cleaned per the base+matrix convention. Full gate: typecheck, lint (0 errors), vitest 2865/2865, build, validate:components, check:contract-props.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved support for forced-colors display modes by reliably detecting the active setting.
  - Accessibility checks now continue running in forced-colors mode, with color-contrast checks handled appropriately.
  - Added real-browser validation for forced-colors accessibility, confirming zero violations for supported project card examples.
- **Quality Assurance**
  - Refreshed accessibility evidence and snapshots for project cards and site headers.
  - Improved consistency and reliability of accessibility results across light, dark, and forced-colors modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->