### PR TITLE
feat(ds): Phase 4 increment 2 - SSR + hydration evidence per component

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "audit:agent-experience": "node scripts/design-system/audit-agent-experience.mjs",
     "audit:bundle-evidence": "node scripts/design-system/measure-bundle-evidence.mjs",
     "audit:compatibility": "node scripts/design-system/generate-compatibility-manifest.mjs",
+    "audit:ssr-evidence": "node scripts/design-system/measure-ssr-evidence.mjs",
     "agentic-ds-audit": "node scripts/design-system/agentic-ds-audit.mjs",
     "release:gate": "node scripts/design-system/release-gate.mjs",
     "check:trusted-publisher": "node scripts/design-system/check-trusted-publisher-config.mjs",

--- a/public/ds-health/ssr-evidence.json
+++ b/public/ds-health/ssr-evidence.json
@@ -1,0 +1,1261 @@
+{
+  "generatedAt": "2026-08-06T21:05:31.796Z",
+  "package": {
+    "name": "@digitaltableteur/react",
+    "version": "0.1.22"
+  },
+  "environment": {
+    "react": "19.2.8",
+    "jsdom": "30.0.1",
+    "ssr": "node renderToString without DOM globals (the server condition Next runs the package in)",
+    "hydration": "hydrateRoot over the server HTML in jsdom with the unit suite's browser-API stubs (matchMedia, ResizeObserver, IntersectionObserver); recoverable hydration errors and hydration console errors fail the check"
+  },
+  "methodology": {
+    "props": "components render with their contract playground defaults; a required prop with no default skips the component (harness limitation, recorded, never counted as component evidence)",
+    "errors": "an ssr error means renderToString threw for this component standalone; the recorded message distinguishes browser-API access from missing host context — both are real facts about server-rendering the component outside the app shell",
+    "timings": "render timings are informational runtime data outside the substance stamp; they vary by machine and never gate anything"
+  },
+  "totals": {
+    "ssrPass": 66,
+    "ssrError": 2,
+    "hydrationClean": 66,
+    "hydrationError": 0,
+    "skipped": 75
+  },
+  "entries": {
+    "actions": {
+      "components": {
+        "Button": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 160
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "ButtonGroup": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 92
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "FilterChip": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: pressed"
+        },
+        "IconButton": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 828
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "SlideButton": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: label, href"
+        },
+        "SplitButton": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 944
+          },
+          "hydration": {
+            "ok": true
+          }
+        }
+      }
+    },
+    "consent": {
+      "components": {
+        "CookieConsent": {
+          "status": "ssr-error",
+          "ssr": {
+            "ok": false,
+            "error": "useCookieConsent must be used within CookieConsentProvider"
+          }
+        }
+      }
+    },
+    "content": {
+      "components": {
+        "AuthorBio": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 0
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "CodeBlockWindow": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 1002
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "CodeSnippet": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 1829
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "DataTable": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: data, columns, getRowId"
+        },
+        "ExpandableSection": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 194
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Gallery": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: images"
+        },
+        "List": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 129
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "ListItem": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 98
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Logo": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 978
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "ReadingProgress": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: targetRef"
+        },
+        "Table": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: caption"
+        },
+        "TableCell": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 51
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "TableHeaderCell": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 69
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "TableRow": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 32
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Timestamp": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 134
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "ValueCard": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: icon, title, description"
+        },
+        "VirtualList": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: items, getItemKey, getItemProps"
+        },
+        "VirtualListItem": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: posInSet, setSize"
+        },
+        "formatTimestamp": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        }
+      }
+    },
+    "feedback": {
+      "components": {
+        "AlertBanner": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 818
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "EmptyState": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 694
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Progress": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 230
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Skeleton": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 238
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Spinner": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 91
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Toast": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 594
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "ToastStack": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: toasts"
+        },
+        "Tooltip": {
+          "status": "ssr-error",
+          "ssr": {
+            "ok": false,
+            "error": "`Tooltip` must be used within `TooltipProvider`"
+          }
+        },
+        "TooltipContent": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "TooltipProvider": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "TooltipTrigger": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        }
+      }
+    },
+    "forms": {
+      "components": {
+        "Checkbox": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 225
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "CheckboxGroup": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 1123
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Combobox": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: onValueChange"
+        },
+        "FileUpload": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 648
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "FormField": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 220
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "GroupLabel": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 82
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "HelperText": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 63
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Label": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 163
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "MultiCombobox": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: onValueChange"
+        },
+        "PhoneInput": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 10117
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Radio": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 213
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "RadioGroup": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 896
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Select": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 832
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "SelectOption": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "SelectableCard": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: value"
+        },
+        "SelectableCardGroup": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "Switch": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 420
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "TextArea": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 315
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "TextInput": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 342
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "optionsFromSelectChildren": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "splitPlaceholderOption": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        }
+      }
+    },
+    "hooks": {
+      "components": {
+        "useFocusTrap": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "useMediaQuery": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "useOverflow": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "useScrollLock": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "useScrollOverflow": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "useStreamingText": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        }
+      }
+    },
+    "identity": {
+      "components": {
+        "Author": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: name"
+        },
+        "Avatar": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 70
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "AvatarGroup": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 132
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Badge": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 695
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Icon": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 575
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "StatusDot": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 167
+          },
+          "hydration": {
+            "ok": true
+          }
+        }
+      }
+    },
+    "layout": {
+      "components": {
+        "Accordion": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 1878
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "AspectRatio": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 108
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Card": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 360
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Center": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 69
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Container": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 91
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Divider": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 45
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "FlexBox": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 137
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Grid": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 132
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "MacWindowFrame": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 669
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "ResizablePanelGroup": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: panels"
+        },
+        "Section": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 86
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Spacer": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 42
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Stack": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 82
+          },
+          "hydration": {
+            "ok": true
+          }
+        }
+      }
+    },
+    "navigation": {
+      "components": {
+        "Breadcrumb": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 501
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "CommandPalette": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: open, onClose, items"
+        },
+        "LanguageSwitcher": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: onLanguageChange"
+        },
+        "Link": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 85
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Menu": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 8
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "MenuContent": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "MenuItem": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "MenuSeparator": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "MenuSub": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "MenuSubContent": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "MenuSubTrigger": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "MenuTrigger": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "NavLink": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 157
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "NavMenuList": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: items"
+        },
+        "Pagination": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: onPageChange"
+        },
+        "ScrollIndicator": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 621
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "SegmentedControl": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: items, value, onValueChange, ariaLabel"
+        },
+        "SkipLink": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 74
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Tabs": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 967
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "TreeView": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: nodes"
+        },
+        "getTabPanelProps": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        }
+      }
+    },
+    "patterns": {
+      "components": {
+        "CategoryFilter": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: categories, activeCategory, onCategoryChange"
+        },
+        "Modal": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: isOpen"
+        },
+        "PageLayout": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 115
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "ProcessBlock": {
+          "status": "skipped",
+          "reason": "required props without playground defaults: phases"
+        }
+      }
+    },
+    "runtime": {
+      "components": {
+        "AnimationRuntimeProvider": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "CookieConsentProvider": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "DEFAULT_CONSENTS": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "Image": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "ImageProvider": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "LayerProvider": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "LinkProvider": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "NavigationProvider": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "ThemeProvider": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 8
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "ToastRuntimeProvider": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "TranslationProvider": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "clearConsentState": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "cn": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "hasGivenConsent": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "isSvgSrc": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "loadConsentState": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "resolveMotionPlan": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "saveConsentState": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "stateToConsents": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "useAnimationContext": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "useCookieConsent": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "useLayer": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "useLocalization": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "useNavigationPathname": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "useNavigationRouter": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "useNavigationRuntime": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "useNavigationSearchParams": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "useTheme": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "useToast": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        },
+        "useTranslate": {
+          "status": "skipped",
+          "reason": "no component contract (not a renderable component export)"
+        }
+      }
+    },
+    "typography": {
+      "components": {
+        "Display": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 110
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Kbd": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 66
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Text": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 83
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "Title": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 67
+          },
+          "hydration": {
+            "ok": true
+          }
+        },
+        "VisuallyHidden": {
+          "status": "pass",
+          "ssr": {
+            "ok": true,
+            "htmlBytes": 43
+          },
+          "hydration": {
+            "ok": true
+          }
+        }
+      }
+    }
+  },
+  "informational": {
+    "timings": {
+      "Button": {
+        "renderToStringMs": 0.28
+      },
+      "ButtonGroup": {
+        "renderToStringMs": 0.049
+      },
+      "IconButton": {
+        "renderToStringMs": 0.076
+      },
+      "SplitButton": {
+        "renderToStringMs": 0.306
+      },
+      "AuthorBio": {
+        "renderToStringMs": 0.007
+      },
+      "CodeBlockWindow": {
+        "renderToStringMs": 0.09
+      },
+      "CodeSnippet": {
+        "renderToStringMs": 0.348
+      },
+      "ExpandableSection": {
+        "renderToStringMs": 0.034
+      },
+      "List": {
+        "renderToStringMs": 0.022
+      },
+      "ListItem": {
+        "renderToStringMs": 0.016
+      },
+      "Logo": {
+        "renderToStringMs": 0.053
+      },
+      "TableCell": {
+        "renderToStringMs": 0.009
+      },
+      "TableHeaderCell": {
+        "renderToStringMs": 0.01
+      },
+      "TableRow": {
+        "renderToStringMs": 0.008
+      },
+      "Timestamp": {
+        "renderToStringMs": 0.049
+      },
+      "AlertBanner": {
+        "renderToStringMs": 0.052
+      },
+      "EmptyState": {
+        "renderToStringMs": 0.052
+      },
+      "Progress": {
+        "renderToStringMs": 0.019
+      },
+      "Skeleton": {
+        "renderToStringMs": 0.024
+      },
+      "Spinner": {
+        "renderToStringMs": 0.01
+      },
+      "Toast": {
+        "renderToStringMs": 0.036
+      },
+      "Checkbox": {
+        "renderToStringMs": 0.03
+      },
+      "CheckboxGroup": {
+        "renderToStringMs": 0.138
+      },
+      "FileUpload": {
+        "renderToStringMs": 0.074
+      },
+      "FormField": {
+        "renderToStringMs": 0.019
+      },
+      "GroupLabel": {
+        "renderToStringMs": 0.016
+      },
+      "HelperText": {
+        "renderToStringMs": 0.011
+      },
+      "Label": {
+        "renderToStringMs": 0.018
+      },
+      "PhoneInput": {
+        "renderToStringMs": 1.217
+      },
+      "Radio": {
+        "renderToStringMs": 0.023
+      },
+      "RadioGroup": {
+        "renderToStringMs": 0.077
+      },
+      "Select": {
+        "renderToStringMs": 0.11
+      },
+      "Switch": {
+        "renderToStringMs": 0.033
+      },
+      "TextArea": {
+        "renderToStringMs": 0.036
+      },
+      "TextInput": {
+        "renderToStringMs": 0.036
+      },
+      "Avatar": {
+        "renderToStringMs": 0.014
+      },
+      "AvatarGroup": {
+        "renderToStringMs": 0.015
+      },
+      "Badge": {
+        "renderToStringMs": 0.047
+      },
+      "Icon": {
+        "renderToStringMs": 0.027
+      },
+      "StatusDot": {
+        "renderToStringMs": 0.014
+      },
+      "Accordion": {
+        "renderToStringMs": 0.105
+      },
+      "AspectRatio": {
+        "renderToStringMs": 0.009
+      },
+      "Card": {
+        "renderToStringMs": 0.027
+      },
+      "Center": {
+        "renderToStringMs": 0.01
+      },
+      "Container": {
+        "renderToStringMs": 0.007
+      },
+      "Divider": {
+        "renderToStringMs": 0.007
+      },
+      "FlexBox": {
+        "renderToStringMs": 0.009
+      },
+      "Grid": {
+        "renderToStringMs": 0.009
+      },
+      "MacWindowFrame": {
+        "renderToStringMs": 0.035
+      },
+      "Section": {
+        "renderToStringMs": 0.009
+      },
+      "Spacer": {
+        "renderToStringMs": 0.007
+      },
+      "Stack": {
+        "renderToStringMs": 0.007
+      },
+      "Breadcrumb": {
+        "renderToStringMs": 0.066
+      },
+      "Link": {
+        "renderToStringMs": 0.011
+      },
+      "Menu": {
+        "renderToStringMs": 0.025
+      },
+      "NavLink": {
+        "renderToStringMs": 0.011
+      },
+      "ScrollIndicator": {
+        "renderToStringMs": 0.048
+      },
+      "SkipLink": {
+        "renderToStringMs": 0.008
+      },
+      "Tabs": {
+        "renderToStringMs": 0.062
+      },
+      "PageLayout": {
+        "renderToStringMs": 0.01
+      },
+      "ThemeProvider": {
+        "renderToStringMs": 0.01
+      },
+      "Display": {
+        "renderToStringMs": 0.008
+      },
+      "Kbd": {
+        "renderToStringMs": 0.007
+      },
+      "Text": {
+        "renderToStringMs": 0.006
+      },
+      "Title": {
+        "renderToStringMs": 0.007
+      },
+      "VisuallyHidden": {
+        "renderToStringMs": 0.007
+      }
+    }
+  },
+  "provenance": {
+    "sourceCommit": "69b2ae84c430c8450feb9920b8d04ea1a0a2f4e5",
+    "workingTreeClean": false,
+    "dirtyPathCount": 2,
+    "generator": {
+      "name": "measure-ssr-evidence",
+      "version": 1,
+      "node": "v22.22.3"
+    }
+  }
+}

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -141,7 +141,15 @@
   (resolved versions, never ranges), declared peer ranges vs the single
   exercised version, and a summary of the latest recorded publish
   preflight. Output: `public/ds-health/compatibility-manifest.json`.
-- Both run automatically inside `check:react-publish-preflight` (after
+- `npm run audit:ssr-evidence` — server-renders every renderable export in
+  plain Node (no DOM globals, the real server condition) and hydrates the
+  captured HTML in a jsdom worker with the unit suite's browser stubs;
+  records ssr pass/error, hydration clean/mismatch, and HTML bytes as
+  deterministic substance (timings informational). Fragment elements
+  (td/tr/li) hydrate inside a valid ancestor chain from their contract
+  `element`. Requires a built dist; `-- --build` rebuilds first. Output:
+  `public/ds-health/ssr-evidence.json`.
+- All three run automatically inside `check:react-publish-preflight` (after
   `react-public-api` rebuilds the dist), so every publish regenerates its
   evidence; commit the regenerated artifacts with the publish PR.
 

--- a/scripts/design-system/check-react-publish-preflight.mjs
+++ b/scripts/design-system/check-react-publish-preflight.mjs
@@ -136,6 +136,11 @@ const automatedChecks = [
     reason: "per-component minified+gzip cost of the built dist is measured and stamped as publish evidence",
   },
   {
+    name: "ssr-evidence",
+    command: ["run", "audit:ssr-evidence"],
+    reason: "every renderable export server-renders without DOM globals and hydrates cleanly in jsdom, recorded as publish evidence",
+  },
+  {
     name: "compatibility-manifest",
     command: ["run", "audit:compatibility"],
     reason: "the toolchain combinations actually exercised by the gates are recorded as the per-publish compatibility manifest",

--- a/scripts/design-system/measure-ssr-evidence.mjs
+++ b/scripts/design-system/measure-ssr-evidence.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+/**
+ * SSR + hydration evidence for @digitaltableteur/react
+ * (Astryx-gap Phase 4, increment 2).
+ *
+ * Phase A (this process, NO DOM globals): import each dist entry and
+ * renderToString every renderable component export — the honest server
+ * condition. Phase B (child process with jsdom globals installed BEFORE any
+ * React import): hydrate the captured server HTML and record recoverable
+ * hydration errors and hydration console errors.
+ *
+ * Writes public/ds-health/ssr-evidence.json. Deterministic substance
+ * (statuses, error messages, HTML bytes); render timings are informational
+ * runtime data outside the stamp. Per-publish evidence: requires a built
+ * dist (pass --build to rebuild first).
+ *
+ * Usage:
+ *   npm run audit:ssr-evidence
+ *   npm run audit:ssr-evidence -- --build
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { performance } from "node:perf_hooks";
+import {
+  assembleSsrEvidence,
+  componentRecord,
+  hydrationContainerChainFor,
+  renderPlanFor,
+  stableErrorMessage,
+} from "./ssr-evidence-lib.mjs";
+import { currentProvenance, runtimeStampFor } from "./evidence-stamp-lib.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const PKG_DIR = join(ROOT, "packages/react");
+const MANIFEST = join(PKG_DIR, "public-api.manifest.json");
+const OUT = join(ROOT, "public/ds-health/ssr-evidence.json");
+const HYDRATE_WORKER = join(
+  ROOT,
+  "scripts/design-system/ssr-evidence-hydrate-worker.mjs",
+);
+const GENERATOR_VERSION = 1;
+
+const shouldBuild = process.argv.includes("--build");
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+if (shouldBuild) {
+  console.log("→ building packages/react dist…");
+  execFileSync("npm", ["--prefix", "packages/react", "run", "build"], {
+    cwd: ROOT,
+    stdio: "inherit",
+  });
+}
+
+if (typeof globalThis.window !== "undefined") {
+  console.error(
+    "FAIL: DOM globals present before SSR measurement; run in plain Node.",
+  );
+  process.exit(1);
+}
+
+const manifest = readJson(MANIFEST);
+const exportsByEntry = manifest.runtimeExportsByEntry ?? {};
+const packageJson = readJson(join(PKG_DIR, "package.json"));
+
+const missingDist = Object.keys(exportsByEntry).filter(
+  (entry) => !existsSync(join(PKG_DIR, "dist", `${entry}.js`)),
+);
+if (missingDist.length) {
+  console.error(
+    `FAIL: built dist entries missing (${missingDist.join(", ")}). ` +
+      "Run `npm --prefix packages/react run build` or pass --build.",
+  );
+  process.exit(1);
+}
+
+function contractFor(name) {
+  for (const base of [
+    "nextjs-app/shared/components",
+    "nextjs-app/shared/patterns",
+  ]) {
+    const path = join(ROOT, base, name, `${name}.contract.json`);
+    if (existsSync(path)) return readJson(path);
+  }
+  return null;
+}
+
+const { createElement } = await import("react");
+const { renderToString } = await import("react-dom/server");
+const reactVersion = (await import("react")).version;
+const jsdomVersion = readJson(join(ROOT, "node_modules/jsdom/package.json")).version;
+
+const entries = {};
+const informationalTimings = {};
+const hydrationJobs = [];
+
+for (const [entryName, exportNames] of Object.entries(exportsByEntry)) {
+  const components = {};
+  let entryModule = null;
+  let importError = null;
+  try {
+    entryModule = await import(
+      pathToFileURL(join(PKG_DIR, "dist", `${entryName}.js`)).href
+    );
+  } catch (error) {
+    importError = stableErrorMessage(error);
+  }
+  for (const exportName of exportNames) {
+    if (importError) {
+      components[exportName] = componentRecord({
+        ssrError: `entry import failed: ${importError}`,
+      });
+      continue;
+    }
+    const contract = contractFor(exportName);
+    const plan = renderPlanFor(exportName, contract);
+    if (plan.skip) {
+      components[exportName] = componentRecord({ skip: plan.skip });
+      continue;
+    }
+    const Component = entryModule[exportName];
+    let html = null;
+    try {
+      const element = createElement(Component, plan.props);
+      // Warmup render, then timed median of 5 (informational only).
+      html = renderToString(element);
+      const runs = [];
+      for (let i = 0; i < 5; i += 1) {
+        const start = performance.now();
+        renderToString(createElement(Component, plan.props));
+        runs.push(performance.now() - start);
+      }
+      runs.sort((a, b) => a - b);
+      informationalTimings[exportName] = {
+        renderToStringMs: Number(runs[2].toFixed(3)),
+      };
+    } catch (error) {
+      components[exportName] = componentRecord({
+        ssrError: stableErrorMessage(error),
+      });
+      continue;
+    }
+    components[exportName] = componentRecord({
+      htmlBytes: Buffer.byteLength(html),
+      hydrationErrors: null, // filled by the hydration phase
+    });
+    hydrationJobs.push({
+      entry: entryName,
+      exportName,
+      props: plan.props,
+      html,
+      containerChain: hydrationContainerChainFor(contract?.element),
+    });
+  }
+  entries[entryName] = { importError, components };
+  const measured = Object.values(components).filter((c) => c.ssr?.ok).length;
+  console.log(`✓ ssr ${entryName}: ${measured}/${exportNames.length} exports rendered`);
+}
+
+// Phase B: hydration in a child process so DOM globals exist BEFORE React
+// loads (React reads the environment at module scope; polluting this process
+// after renderToString would test neither condition honestly).
+console.log(`→ hydrating ${hydrationJobs.length} components in jsdom worker…`);
+const workerInput = JSON.stringify(hydrationJobs);
+let hydrationResults;
+try {
+  const stdout = execFileSync("node", [HYDRATE_WORKER], {
+    cwd: ROOT,
+    input: workerInput,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  hydrationResults = JSON.parse(stdout);
+} catch (error) {
+  console.error("FAIL: hydration worker crashed:", stableErrorMessage(error));
+  process.exit(1);
+}
+
+for (const result of hydrationResults) {
+  const record = entries[result.entry].components[result.exportName];
+  const hydration = result.errors.length
+    ? { ok: false, errors: result.errors }
+    : { ok: true };
+  record.hydration = hydration;
+  record.status = hydration.ok ? "pass" : "hydration-error";
+}
+
+const substance = assembleSsrEvidence({
+  packageName: packageJson.name,
+  packageVersion: packageJson.version,
+  reactVersion,
+  jsdomVersion,
+  entries,
+});
+
+const provenance = currentProvenance(ROOT, {
+  name: "measure-ssr-evidence",
+  version: GENERATOR_VERSION,
+});
+const stamp = runtimeStampFor(OUT, substance, provenance, ["informational"]);
+const report = {
+  generatedAt: stamp.generatedAt,
+  ...substance,
+  informational: { timings: informationalTimings },
+  provenance: stamp.provenance,
+};
+
+mkdirSync(dirname(OUT), { recursive: true });
+writeFileSync(OUT, `${JSON.stringify(report, null, 2)}\n`);
+const { totals } = substance;
+console.log(
+  `\n✓ ssr evidence written: ${totals.ssrPass} ssr pass, ${totals.hydrationClean} hydration clean, ` +
+    `${totals.ssrError} ssr errors, ${totals.hydrationError} hydration errors, ${totals.skipped} skipped → public/ds-health/ssr-evidence.json`,
+);
+process.exit(totals.ssrPass === 0 ? 1 : 0);

--- a/scripts/design-system/ssr-evidence-hydrate-worker.mjs
+++ b/scripts/design-system/ssr-evidence-hydrate-worker.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Hydration worker for measure-ssr-evidence.mjs.
+ *
+ * Reads hydration jobs (entry, exportName, props, server html) as JSON on
+ * stdin, installs jsdom globals BEFORE importing React or the dist (so
+ * module-scope environment checks see a browser, matching how a bundler
+ * loads the package client-side), hydrates each component over its server
+ * HTML, and reports recoverable hydration errors + hydration console errors
+ * as JSON on stdout.
+ *
+ * Browser-API stubs mirror the unit suite's vitest.setup.ts (matchMedia,
+ * ResizeObserver, IntersectionObserver) so hydration evidence describes the
+ * same environment the tests already prove rendering in.
+ */
+import { readFileSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+const { JSDOM } = await import("jsdom");
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "https://evidence.local/",
+  pretendToBeVisual: true,
+});
+
+const { window } = dom;
+globalThis.window = window;
+globalThis.document = window.document;
+globalThis.HTMLElement = window.HTMLElement;
+globalThis.HTMLInputElement = window.HTMLInputElement;
+globalThis.HTMLIFrameElement = window.HTMLIFrameElement;
+globalThis.Element = window.Element;
+globalThis.Node = window.Node;
+globalThis.SVGElement = window.SVGElement;
+globalThis.CustomEvent = window.CustomEvent;
+globalThis.Event = window.Event;
+globalThis.KeyboardEvent = window.KeyboardEvent;
+globalThis.MouseEvent = window.MouseEvent;
+globalThis.getComputedStyle = window.getComputedStyle;
+globalThis.requestAnimationFrame = window.requestAnimationFrame.bind(window);
+globalThis.cancelAnimationFrame = window.cancelAnimationFrame.bind(window);
+globalThis.localStorage = window.localStorage;
+globalThis.sessionStorage = window.sessionStorage;
+if (!globalThis.navigator?.userAgent) {
+  Object.defineProperty(globalThis, "navigator", {
+    value: window.navigator,
+    configurable: true,
+  });
+}
+
+// Stubs mirroring vitest.setup.ts
+window.matchMedia =
+  window.matchMedia ??
+  ((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
+globalThis.matchMedia = window.matchMedia;
+class ObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+globalThis.ResizeObserver = window.ResizeObserver = ObserverStub;
+globalThis.IntersectionObserver = window.IntersectionObserver = ObserverStub;
+
+const jobs = JSON.parse(readFileSync(0, "utf8"));
+
+const { createElement } = await import("react");
+const { hydrateRoot } = await import("react-dom/client");
+
+const moduleCache = new Map();
+async function entryModule(entry) {
+  if (!moduleCache.has(entry)) {
+    moduleCache.set(
+      entry,
+      await import(
+        pathToFileURL(join(ROOT, "packages/react/dist", `${entry}.js`)).href
+      ),
+    );
+  }
+  return moduleCache.get(entry);
+}
+
+function stableMessage(value) {
+  return String(value?.message ?? value ?? "unknown error")
+    .split("\n")[0]
+    .slice(0, 300);
+}
+
+const results = [];
+for (const job of jobs) {
+  const errors = [];
+  const originalConsoleError = console.error;
+  console.error = (...args) => {
+    const first = String(args[0] ?? "");
+    // React hydration diagnostics arrive via console.error; anything else a
+    // component logs during hydration is noise for this check.
+    if (/hydrat/i.test(first)) errors.push(first.split("\n")[0].slice(0, 300));
+  };
+  try {
+    const mod = await entryModule(job.entry);
+    const Component = mod[job.exportName];
+    // Fragment elements (td/tr/li/…) need a valid ancestor chain so the
+    // parser context matches what the component renders; the chain comes
+    // from the component's contract element.
+    const outermost = window.document.createElement("div");
+    let container = outermost;
+    for (const tag of job.containerChain ?? []) {
+      const level = window.document.createElement(tag);
+      container.appendChild(level);
+      container = level;
+    }
+    window.document.body.appendChild(outermost);
+    container.innerHTML = job.html;
+    const root = hydrateRoot(
+      container,
+      createElement(Component, job.props),
+      {
+        onRecoverableError: (error) => {
+          errors.push(stableMessage(error));
+        },
+      },
+    );
+    // Let the hydration pass and first effects flush.
+    await new Promise((resolveTick) => setTimeout(resolveTick, 25));
+    root.unmount();
+    outermost.remove();
+  } catch (error) {
+    errors.push(stableMessage(error));
+  } finally {
+    console.error = originalConsoleError;
+  }
+  results.push({
+    entry: job.entry,
+    exportName: job.exportName,
+    errors: [...new Set(errors)].sort(),
+  });
+}
+
+process.stdout.write(JSON.stringify(results));
+// Leaked component timers (a known Tabs rAF leak) must not keep the worker
+// alive after results are written.
+process.exit(0);

--- a/scripts/design-system/ssr-evidence-lib.mjs
+++ b/scripts/design-system/ssr-evidence-lib.mjs
@@ -1,0 +1,161 @@
+/**
+ * Pure helpers for SSR + hydration evidence (Astryx-gap Phase 4).
+ *
+ * The evidence answers two deterministic questions per exported component of
+ * @digitaltableteur/react, measured against the built dist:
+ *
+ * - ssr: does renderToString succeed in a Node process WITHOUT DOM globals
+ *   (the real server condition Next puts the package in)?
+ * - hydration: does hydrateRoot over that server HTML complete in jsdom
+ *   without recoverable hydration errors or hydration-mismatch console
+ *   errors (the same stubbed browser environment the unit suite tests in)?
+ *
+ * Render timings are informational runtime data, never substance: they vary
+ * by machine and run, so they live outside the stamp comparison.
+ */
+
+/**
+ * Decide how (and whether) a component can be rendered from contract data
+ * alone. Returns { props } when renderable, { skip } with an honest reason
+ * when not. A skip is a harness limitation, never component evidence.
+ */
+export function renderPlanFor(exportName, contract) {
+  if (!contract) {
+    // Hooks, adapters, and runtime helpers have no component contract; they
+    // are not renderable components and are out of scope by design.
+    return { skip: "no component contract (not a renderable component export)" };
+  }
+  const defaults = contract.playground?.defaults ?? {};
+  const props = { ...defaults };
+  const propEntries = Object.entries(contract.props ?? {});
+  const missingRequired = propEntries
+    .filter(
+      ([name, spec]) =>
+        spec?.optional !== true && name !== "children" && !(name in props),
+    )
+    .map(([name]) => name);
+  if (missingRequired.length) {
+    return {
+      skip: `required props without playground defaults: ${missingRequired.join(", ")}`,
+    };
+  }
+  const childrenSpec = contract.props?.children;
+  if (childrenSpec && childrenSpec.optional !== true && !("children" in props)) {
+    props.children = "Evidence";
+  }
+  return { props };
+}
+
+/**
+ * Assemble the report substance. Only deterministic facts participate:
+ * statuses, error messages, and server HTML byte counts. Sorted keys keep
+ * reruns byte-stable when nothing changed.
+ */
+export function assembleSsrEvidence({
+  packageName,
+  packageVersion,
+  reactVersion,
+  jsdomVersion,
+  entries,
+}) {
+  const sortedEntries = {};
+  const totals = { ssrPass: 0, ssrError: 0, hydrationClean: 0, hydrationError: 0, skipped: 0 };
+  for (const entryName of Object.keys(entries).sort()) {
+    const entry = entries[entryName];
+    const components = {};
+    for (const name of Object.keys(entry.components).sort()) {
+      const result = entry.components[name];
+      components[name] = result;
+      if (result.status === "skipped") totals.skipped += 1;
+      else if (result.ssr?.ok === false) totals.ssrError += 1;
+      else {
+        totals.ssrPass += 1;
+        if (result.hydration?.ok === true) totals.hydrationClean += 1;
+        else if (result.hydration?.ok === false) totals.hydrationError += 1;
+      }
+    }
+    sortedEntries[entryName] = {
+      ...(entry.importError ? { importError: entry.importError } : {}),
+      components,
+    };
+  }
+  return {
+    package: { name: packageName, version: packageVersion },
+    environment: {
+      react: reactVersion,
+      jsdom: jsdomVersion,
+      ssr: "node renderToString without DOM globals (the server condition Next runs the package in)",
+      hydration:
+        "hydrateRoot over the server HTML in jsdom with the unit suite's browser-API stubs (matchMedia, ResizeObserver, IntersectionObserver); recoverable hydration errors and hydration console errors fail the check",
+    },
+    methodology: {
+      props:
+        "components render with their contract playground defaults; a required prop with no default skips the component (harness limitation, recorded, never counted as component evidence)",
+      errors:
+        "an ssr error means renderToString threw for this component standalone; the recorded message distinguishes browser-API access from missing host context — both are real facts about server-rendering the component outside the app shell",
+      timings:
+        "render timings are informational runtime data outside the substance stamp; they vary by machine and never gate anything",
+    },
+    totals,
+    entries: sortedEntries,
+  };
+}
+
+/**
+ * Classify one component measurement into the record the artifact stores.
+ */
+export function componentRecord({ skip, ssrError, htmlBytes, hydrationErrors }) {
+  if (skip) return { status: "skipped", reason: skip };
+  if (ssrError) {
+    return { status: "ssr-error", ssr: { ok: false, error: ssrError } };
+  }
+  const hydration =
+    hydrationErrors == null
+      ? undefined
+      : hydrationErrors.length
+        ? { ok: false, errors: hydrationErrors }
+        : { ok: true };
+  return {
+    status: hydration?.ok === false ? "hydration-error" : "pass",
+    ssr: { ok: true, htmlBytes },
+    ...(hydration ? { hydration } : {}),
+  };
+}
+
+/**
+ * Table/list fragment elements cannot parse or hydrate inside a generic
+ * <div> container; give them the minimal valid ancestor chain so a
+ * hydration mismatch means the COMPONENT drifted, not the harness.
+ * Returns the nested tag names, outermost first, or [] for a plain div.
+ */
+export function hydrationContainerChainFor(contractElement) {
+  switch (contractElement) {
+    case "tr":
+      return ["table", "tbody"];
+    case "td":
+    case "th":
+      return ["table", "tbody", "tr"];
+    case "tbody":
+    case "thead":
+    case "tfoot":
+    case "caption":
+    case "colgroup":
+      return ["table"];
+    case "li":
+      return ["ul"];
+    case "option":
+    case "optgroup":
+      return ["select"];
+    case "dt":
+    case "dd":
+      return ["dl"];
+    default:
+      return [];
+  }
+}
+
+/** Normalize an error into a stable, machine-diffable one-line message. */
+export function stableErrorMessage(error) {
+  const message = String(error?.message ?? error ?? "unknown error");
+  return message.split("\n")[0].slice(0, 300);
+}

--- a/scripts/design-system/ssr-evidence-lib.test.mjs
+++ b/scripts/design-system/ssr-evidence-lib.test.mjs
@@ -1,0 +1,108 @@
+import { expect, test } from "vitest";
+
+import {
+  assembleSsrEvidence,
+  componentRecord,
+  hydrationContainerChainFor,
+  renderPlanFor,
+  stableErrorMessage,
+} from "./ssr-evidence-lib.mjs";
+
+test("no contract means an honest non-component skip", () => {
+  const plan = renderPlanFor("useThing", null);
+  expect(plan.skip).toMatch(/not a renderable component export/);
+});
+
+test("playground defaults become render props", () => {
+  const plan = renderPlanFor("Button", {
+    props: { variant: { optional: true, type: "string" } },
+    playground: { defaults: { variant: "primary", children: "Save" } },
+  });
+  expect(plan.props).toEqual({ variant: "primary", children: "Save" });
+});
+
+test("a required prop with no default skips with the prop named", () => {
+  const plan = renderPlanFor("Chart", {
+    props: {
+      data: { type: "Point[]" },
+      title: { optional: true, type: "string" },
+    },
+    playground: { defaults: {} },
+  });
+  expect(plan.skip).toMatch(/required props without playground defaults: data/);
+});
+
+test("required children are satisfied with a placeholder string", () => {
+  const plan = renderPlanFor("Card", {
+    props: { children: { type: "ReactNode" } },
+  });
+  expect(plan.props.children).toBe("Evidence");
+});
+
+test("componentRecord classifies skip, ssr error, hydration error, and pass", () => {
+  expect(componentRecord({ skip: "x" })).toEqual({
+    status: "skipped",
+    reason: "x",
+  });
+  expect(componentRecord({ ssrError: "window is not defined" })).toEqual({
+    status: "ssr-error",
+    ssr: { ok: false, error: "window is not defined" },
+  });
+  expect(
+    componentRecord({ htmlBytes: 10, hydrationErrors: ["mismatch"] }).status,
+  ).toBe("hydration-error");
+  const pass = componentRecord({ htmlBytes: 10, hydrationErrors: [] });
+  expect(pass.status).toBe("pass");
+  expect(pass.ssr).toEqual({ ok: true, htmlBytes: 10 });
+  expect(pass.hydration).toEqual({ ok: true });
+});
+
+test("assembleSsrEvidence sorts and totals honestly", () => {
+  const report = assembleSsrEvidence({
+    packageName: "@digitaltableteur/react",
+    packageVersion: "0.1.22",
+    reactVersion: "19.2.8",
+    jsdomVersion: "30.0.1",
+    entries: {
+      layout: {
+        importError: null,
+        components: {
+          Grid: componentRecord({ htmlBytes: 5, hydrationErrors: [] }),
+          Card: componentRecord({ ssrError: "boom" }),
+        },
+      },
+      actions: {
+        importError: null,
+        components: {
+          Button: componentRecord({ htmlBytes: 9, hydrationErrors: ["m"] }),
+          useX: componentRecord({ skip: "no component contract" }),
+        },
+      },
+    },
+  });
+  expect(Object.keys(report.entries)).toEqual(["actions", "layout"]);
+  expect(report.totals).toEqual({
+    ssrPass: 2,
+    ssrError: 1,
+    hydrationClean: 1,
+    hydrationError: 1,
+    skipped: 1,
+  });
+  expect(report.environment.react).toBe("19.2.8");
+});
+
+test("fragment elements get a valid hydration ancestor chain", () => {
+  expect(hydrationContainerChainFor("tr")).toEqual(["table", "tbody"]);
+  expect(hydrationContainerChainFor("td")).toEqual(["table", "tbody", "tr"]);
+  expect(hydrationContainerChainFor("th")).toEqual(["table", "tbody", "tr"]);
+  expect(hydrationContainerChainFor("li")).toEqual(["ul"]);
+  expect(hydrationContainerChainFor("div")).toEqual([]);
+  expect(hydrationContainerChainFor(undefined)).toEqual([]);
+});
+
+test("stableErrorMessage flattens to one bounded line", () => {
+  const long = new Error(`first line\nsecond line`);
+  expect(stableErrorMessage(long)).toBe("first line");
+  expect(stableErrorMessage("x".repeat(500)).length).toBe(300);
+  expect(stableErrorMessage(null)).toBe("unknown error");
+});


### PR DESCRIPTION
## Astryx-gap Phase 4, increment 2: SSR + hydration evidence

Follows #1426. Covers the "hydration" item of the Phase 4 list with deterministic, per-component evidence.

### What it proves (`npm run audit:ssr-evidence`)

Two facts per renderable export of `@digitaltableteur/react`, measured from the built dist:

- **ssr**: `renderToString` succeeds in plain Node **without DOM globals**, the actual server condition Next puts the package in. The script refuses to run if DOM globals are present.
- **hydration**: `hydrateRoot` over that exact server HTML completes in a jsdom worker with **zero recoverable hydration errors**. The worker installs jsdom globals *before* React loads (module-scope environment checks see a browser, matching a real client bundle), and uses the unit suite's browser stubs (matchMedia, ResizeObserver, IntersectionObserver) so the hydration environment is the one the tests already run in.

### Results on 0.1.22

- 66 renderable exports: **66/66 SSR pass, 66/66 hydration clean**
- 2 honest standalone-SSR errors recorded with their messages: `CookieConsent` and `Tooltip` throw without their providers, a real fact about server-rendering them outside the app shell
- 75 skips, each with a recorded reason: 51 hook/runtime exports (no component contract, not renderable by design), 24 components whose required props have no playground defaults (harness limitation, never counted as component evidence)

### Honesty mechanics

- Fragment elements (`td`/`tr`/`th`/`li`) hydrate inside a valid ancestor chain derived from their contract `element`. Without this, the parser mangles standalone fragments and reports false mismatches, which the first run demonstrated on the Table family; with it, a mismatch can only mean real drift.
- Substance is statuses + error messages + HTML bytes, verified byte-identical across reruns. Render timings are informational runtime data outside the stamp comparison (they vary by machine and gate nothing).
- Wired into `check:react-publish-preflight` between `bundle-evidence` and `compatibility-manifest`, so every publish regenerates it.

### Local gate

typecheck 0, lint 0, test 2890/2890 (7+1 new lib tests), build 0, validate:agent-docs pass.

### Follow-up candidates

Enriching the 24 missing playground defaults would raise renderable coverage; interaction cost in a real browser remains a later increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
