### PR TITLE
feat(ds): override-precedence evidence gate (increment A) + ProcessBlock inline-style fix

### DIFF
--- a/docs/OVERRIDE_EVIDENCE_SPEC.md
+++ b/docs/OVERRIDE_EVIDENCE_SPEC.md
@@ -1,7 +1,9 @@
 # Override-precedence evidence (Phase 4, next increment)
 
-Status: **specced, not implemented**. Owner review welcome; open questions at
-the end.
+Status: **increment A implemented** (`npm run audit:override-evidence`).
+Owner decisions recorded: className-override-wins IS the contract (2026-08-07,
+open question 1 resolved); root-only probing for A; probe set v1 as specced.
+Increments B/C (hostile-ancestor matrix) remain open.
 
 ## Why
 

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-08-06T21:45:19.439Z",
+  "generatedAt": "2026-08-07T11:44:01.570Z",
   "summary": {
     "componentCount": 177,
     "statusCounts": {
@@ -13201,20 +13201,20 @@
           {
             "id": "axe-no-violations",
             "statement": "Required stories produce no axe violations at the configured severity.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:matrix:ci"
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
           },
           {
             "id": "accessibility-tree",
             "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:matrix:ci"
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
           },
           {
             "id": "forced-colors-real-browser",
             "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:hc"
+            "verificationMode": "manual",
+            "note": "Storybook forced-colors addon (simulated, not real browser HC)."
           },
           {
             "id": "keyboard-contract",
@@ -13225,8 +13225,8 @@
           {
             "id": "aria-requirements",
             "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:matrix:ci"
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
           },
           {
             "id": "human-a11y-review",
@@ -24103,8 +24103,8 @@
           {
             "id": "accessibility-tree",
             "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:matrix:ci"
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
           },
           {
             "id": "forced-colors-real-browser",
@@ -24115,8 +24115,8 @@
           {
             "id": "aria-requirements",
             "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-            "verificationMode": "automated",
-            "check": "npm run test:stories:matrix:ci"
+            "verificationMode": "unverified",
+            "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
           },
           {
             "id": "human-a11y-review",

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-06T18:46:18.873Z",
+  "generatedAt": "2026-08-07T11:44:01.263Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -6863,20 +6863,20 @@
         {
           "id": "axe-no-violations",
           "statement": "Required stories produce no axe violations at the configured severity.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:matrix:ci"
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'axe-no-violations'; run npm run test:stories:matrix:ci to capture."
         },
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:matrix:ci"
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
         },
         {
           "id": "forced-colors-real-browser",
           "statement": "The component remains legible and operable under a real browser forced-colors: active pass.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:hc"
+          "verificationMode": "manual",
+          "note": "Storybook forced-colors addon (simulated, not real browser HC)."
         },
         {
           "id": "keyboard-contract",
@@ -6887,8 +6887,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:matrix:ci"
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
         },
         {
           "id": "human-a11y-review",
@@ -12621,8 +12621,8 @@
         {
           "id": "accessibility-tree",
           "statement": "The accessibility tree (role, name, state) matches the committed snapshot for every required story.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:matrix:ci"
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
         },
         {
           "id": "forced-colors-real-browser",
@@ -12633,8 +12633,8 @@
         {
           "id": "aria-requirements",
           "statement": "Documented ARIA roles, states, and properties are present on the rendered output.",
-          "verificationMode": "automated",
-          "check": "npm run test:stories:matrix:ci"
+          "verificationMode": "unverified",
+          "note": "No fresh a11y evidence for 'accessibility-tree'; run npm run test:stories:matrix:ci to capture."
         },
         {
           "id": "human-a11y-review",

--- a/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.module.css
+++ b/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.module.css
@@ -1,6 +1,27 @@
 /* ProcessBlock - Reusable process phase display component */
 
-/* Container styles applied via inline style (background, padding) */
+/* Container */
+
+.processBlock {
+  /* The old inline style referenced phantom --space-xl and only worked via
+     its 3rem fallback; --space-layout-48 is the real 3rem token. */
+  padding-block: var(--space-layout-48);
+}
+
+/* Background variants (classes, not inline styles, so consumer className
+   overrides keep winning — see docs/OVERRIDE_EVIDENCE_SPEC.md) */
+
+.bgLight {
+  background-color: var(--color-light-bg);
+}
+
+.bgWhite {
+  background-color: var(--color-white);
+}
+
+.bgTransparent {
+  background-color: transparent;
+}
 
 .sectionTitle {
   display: flex;

--- a/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.test.tsx
+++ b/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import ProcessBlock from "./ProcessBlock";
+import styles from "./ProcessBlock.module.css";
 
 const mockPhases = [
   {
@@ -139,26 +140,29 @@ describe("ProcessBlock", () => {
       expect(container.firstChild?.nodeName).toBe("DIV");
     });
 
-    it("applies light background by default", () => {
+    // Backgrounds are variant classes, not inline styles, so consumer
+    // className overrides can win (docs/OVERRIDE_EVIDENCE_SPEC.md).
+    it("applies the light background class by default with no inline style", () => {
       const { container } = render(<ProcessBlock phases={mockPhases} />);
       const section = container.firstChild as HTMLElement;
-      expect(section.style.backgroundColor).toBe("var(--color-light-bg)");
+      expect(section.className).toContain(styles.bgLight);
+      expect(section.getAttribute("style")).toBeNull();
     });
 
-    it("applies white background when specified", () => {
+    it("applies the white background class when specified", () => {
       const { container } = render(
         <ProcessBlock phases={mockPhases} backgroundColor="white" />,
       );
       const section = container.firstChild as HTMLElement;
-      expect(section.style.backgroundColor).toBe("var(--color-white)");
+      expect(section.className).toContain(styles.bgWhite);
     });
 
-    it("applies transparent background when specified", () => {
+    it("applies the transparent background class when specified", () => {
       const { container } = render(
         <ProcessBlock phases={mockPhases} backgroundColor="transparent" />,
       );
       const section = container.firstChild as HTMLElement;
-      expect(section.style.backgroundColor).toBe("transparent");
+      expect(section.className).toContain(styles.bgTransparent);
     });
 
     it("applies 4-column grid class by default", () => {

--- a/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx
+++ b/nextjs-app/shared/patterns/ProcessBlock/ProcessBlock.tsx
@@ -76,10 +76,10 @@ const ProcessBlock: React.FC<ProcessBlockProps> = ({
   ariaLabel,
 }) => {
   const Wrapper = as;
-  const bgColors = {
-    light: "var(--color-light-bg)",
-    white: "var(--color-white)",
-    transparent: "transparent",
+  const bgClasses = {
+    light: styles.bgLight,
+    white: styles.bgWhite,
+    transparent: styles.bgTransparent,
   };
 
   const gridClass =
@@ -91,11 +91,9 @@ const ProcessBlock: React.FC<ProcessBlockProps> = ({
 
   return (
     <Wrapper
-      className={[styles.processBlock, className].filter(Boolean).join(" ")}
-      style={{
-        backgroundColor: bgColors[backgroundColor],
-        paddingBlock: "var(--space-xl, 3rem)",
-      }}
+      className={[styles.processBlock, bgClasses[backgroundColor], className]
+        .filter(Boolean)
+        .join(" ")}
       aria-label={ariaLabel || sectionTitle}
     >
       <PageLayout maxWidth={maxWidth} spacing={spacing} as="div">

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "audit:bundle-evidence": "node scripts/design-system/measure-bundle-evidence.mjs",
     "audit:compatibility": "node scripts/design-system/generate-compatibility-manifest.mjs",
     "audit:ssr-evidence": "node scripts/design-system/measure-ssr-evidence.mjs",
+    "audit:override-evidence": "node scripts/design-system/measure-override-evidence.mjs",
     "agentic-ds-audit": "node scripts/design-system/agentic-ds-audit.mjs",
     "release:gate": "node scripts/design-system/release-gate.mjs",
     "check:trusted-publisher": "node scripts/design-system/check-trusted-publisher-config.mjs",

--- a/public/ds-health/bundle-evidence.json
+++ b/public/ds-health/bundle-evidence.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-07T09:46:28.271Z",
+  "generatedAt": "2026-08-07T11:46:57.979Z",
   "package": {
     "name": "@digitaltableteur/react",
     "version": "0.1.22"
@@ -1220,17 +1220,17 @@
     "patterns": {
       "js": {
         "self": {
-          "minBytes": 120411,
+          "minBytes": 120426,
           "gzipBytes": 44347
         },
         "withDeps": {
-          "minBytes": 365023,
-          "gzipBytes": 103132
+          "minBytes": 365038,
+          "gzipBytes": 103131
         }
       },
       "css": {
-        "rawBytes": 22381,
-        "gzipBytes": 4359
+        "rawBytes": 22608,
+        "gzipBytes": 4404
       },
       "components": {
         "CategoryFilter": {
@@ -1256,21 +1256,21 @@
         "PageLayout": {
           "self": {
             "minBytes": 31055,
-            "gzipBytes": 10042
+            "gzipBytes": 10043
           },
           "withDeps": {
             "minBytes": 31985,
-            "gzipBytes": 10418
+            "gzipBytes": 10417
           }
         },
         "ProcessBlock": {
           "self": {
-            "minBytes": 35950,
-            "gzipBytes": 11487
+            "minBytes": 35962,
+            "gzipBytes": 11490
           },
           "withDeps": {
-            "minBytes": 36878,
-            "gzipBytes": 11855
+            "minBytes": 36890,
+            "gzipBytes": 11861
           }
         }
       }
@@ -1665,23 +1665,23 @@
   "totals": {
     "js": {
       "self": {
-        "minBytes": 2219335,
+        "minBytes": 2219350,
         "gzipBytes": 739827
       },
       "withDeps": {
-        "minBytes": 4630816,
-        "gzipBytes": 1320794
+        "minBytes": 4630831,
+        "gzipBytes": 1320793
       }
     },
     "css": {
-      "rawBytes": 254807,
-      "gzipBytes": 48011
+      "rawBytes": 255034,
+      "gzipBytes": 48056
     }
   },
   "provenance": {
-    "sourceCommit": "292c7c8d5fa0cd7f89b3c0857510aa835d3342ca",
+    "sourceCommit": "af1915a5b5391c6a05b73e8b40ce2ffc5de91987",
     "workingTreeClean": false,
-    "dirtyPathCount": 2,
+    "dirtyPathCount": 18,
     "generator": {
       "name": "measure-bundle-evidence",
       "version": 1,

--- a/public/ds-health/override-evidence.json
+++ b/public/ds-health/override-evidence.json
@@ -1,0 +1,1221 @@
+{
+  "generatedAt": "2026-08-07T11:47:01.591Z",
+  "package": {
+    "name": "@digitaltableteur/react",
+    "version": "0.1.22"
+  },
+  "contract": "OWNER DECISION 2026-08-07: className-override-wins. A consumer's single-class, no-!important selector applied via className wins over component base styles for the probed properties on the root element, under the documented consumer arrangement (design-system CSS before consumer CSS).",
+  "environment": {
+    "chromium": "151.0.7922.34",
+    "playwright": "1.62.1",
+    "reducedMotion": true
+  },
+  "methodology": {
+    "probe": "single class .dtProbeOverride with color, margin-block-start, background-color; sentinel values no token resolves to; probe stylesheet loads after design-system CSS, mirroring the documented consumer import order",
+    "rendering": "components render from the built dist with the SSR-evidence render plans (contract playground defaults, type-driven function/ref synthesis, descriptor resolution); computed styles read in real Chromium with reduced motion",
+    "themingVars": "each contract-declared theming var is probed for liveness: setting it on a wrapper must change some computed style in the component subtree; zero declared vars is reported honestly, not hidden",
+    "skips": "a skip is a harness limitation (no className prop, no in-flow root such as portals, or an unrenderable plan), recorded with its reason and never counted as component evidence"
+  },
+  "totals": {
+    "pass": 47,
+    "fail": 0,
+    "renderError": 2,
+    "skipped": 94,
+    "themingVarsDeclared": 0
+  },
+  "components": {
+    "Accordion": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "AlertBanner": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "AnimationRuntimeProvider": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "AspectRatio": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Author": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "AuthorBio": {
+      "status": "skipped",
+      "reason": "renders no in-flow root element (portal or null render)"
+    },
+    "Avatar": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "AvatarGroup": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "Badge": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Breadcrumb": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "Button": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "ButtonGroup": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "Card": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "CategoryFilter": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Center": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Checkbox": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "CheckboxGroup": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "CodeBlockWindow": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "CodeSnippet": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "Combobox": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "CommandPalette": {
+      "status": "skipped",
+      "reason": "renders no in-flow root element (portal or null render)"
+    },
+    "Container": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "CookieConsent": {
+      "status": "render-error",
+      "error": "useCookieConsent must be used within CookieConsentProvider"
+    },
+    "CookieConsentProvider": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "DEFAULT_CONSENTS": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "DataTable": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Display": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "Divider": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "EmptyState": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "ExpandableSection": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "FileUpload": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "FilterChip": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "FlexBox": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "FormField": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Gallery": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "Grid": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "GroupLabel": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "HelperText": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Icon": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "IconButton": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "Image": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "ImageProvider": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "Kbd": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "Label": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "LanguageSwitcher": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "LayerProvider": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "Link": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "LinkProvider": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "List": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "ListItem": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Logo": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "MacWindowFrame": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Menu": {
+      "status": "skipped",
+      "reason": "renders no in-flow root element (portal or null render)"
+    },
+    "MenuContent": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "MenuItem": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "MenuSeparator": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "MenuSub": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "MenuSubContent": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "MenuSubTrigger": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "MenuTrigger": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "Modal": {
+      "status": "skipped",
+      "reason": "renders no in-flow root element (portal or null render)"
+    },
+    "MultiCombobox": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "NavLink": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "NavMenuList": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "NavigationProvider": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "PageLayout": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Pagination": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "PhoneInput": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "ProcessBlock": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Progress": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Radio": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "RadioGroup": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "ReadingProgress": {
+      "status": "skipped",
+      "reason": "renders no in-flow root element (portal or null render)"
+    },
+    "ResizablePanelGroup": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "ScrollIndicator": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Section": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "SegmentedControl": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Select": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "SelectOption": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "SelectableCard": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "SelectableCardGroup": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "Skeleton": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "SkipLink": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "SlideButton": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "Spacer": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Spinner": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "SplitButton": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Stack": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "StatusDot": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "Switch": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "Table": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "TableCell": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "TableHeaderCell": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "TableRow": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "Tabs": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Text": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "TextArea": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "TextInput": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "ThemeProvider": {
+      "status": "skipped",
+      "reason": "renders no in-flow root element (portal or null render)"
+    },
+    "Timestamp": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Title": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Toast": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "ToastRuntimeProvider": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "ToastStack": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "Tooltip": {
+      "status": "render-error",
+      "error": "`Tooltip` must be used within `TooltipProvider`"
+    },
+    "TooltipContent": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "TooltipProvider": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "TooltipTrigger": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "TranslationProvider": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "TreeView": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "ValueCard": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "VirtualList": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "VirtualListItem": {
+      "status": "skipped",
+      "reason": "contract declares neither className nor theming.vars (out of scope)"
+    },
+    "VisuallyHidden": {
+      "overrideWins": {
+        "ok": true,
+        "props": {
+          "color": {
+            "pass": true
+          },
+          "margin-block-start": {
+            "pass": true
+          },
+          "background-color": {
+            "pass": true
+          }
+        }
+      },
+      "status": "pass"
+    },
+    "clearConsentState": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "cn": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "formatTimestamp": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "getTabPanelProps": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "hasGivenConsent": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "isSvgSrc": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "loadConsentState": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "optionsFromSelectChildren": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "resolveMotionPlan": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "saveConsentState": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "splitPlaceholderOption": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "stateToConsents": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "useAnimationContext": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "useCookieConsent": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "useFocusTrap": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "useLayer": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "useLocalization": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "useMediaQuery": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "useNavigationPathname": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "useNavigationRouter": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "useNavigationRuntime": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "useNavigationSearchParams": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "useOverflow": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "useScrollLock": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "useScrollOverflow": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "useStreamingText": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "useTheme": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "useToast": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    },
+    "useTranslate": {
+      "status": "skipped",
+      "reason": "no component contract (not a renderable component export)"
+    }
+  },
+  "provenance": {
+    "sourceCommit": "af1915a5b5391c6a05b73e8b40ce2ffc5de91987",
+    "workingTreeClean": false,
+    "dirtyPathCount": 18,
+    "generator": {
+      "name": "measure-override-evidence",
+      "version": 1,
+      "node": "v22.22.3"
+    }
+  }
+}

--- a/public/ds-health/ssr-evidence.json
+++ b/public/ds-health/ssr-evidence.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-07T09:46:10.028Z",
+  "generatedAt": "2026-08-07T11:46:46.179Z",
   "package": {
     "name": "@digitaltableteur/react",
     "version": "0.1.22"
@@ -1028,7 +1028,7 @@
           "status": "pass",
           "ssr": {
             "ok": true,
-            "htmlBytes": 1001
+            "htmlBytes": 937
           },
           "hydration": {
             "ok": true
@@ -1224,281 +1224,281 @@
   "informational": {
     "timings": {
       "Button": {
-        "renderToStringMs": 0.309
+        "renderToStringMs": 0.262
       },
       "ButtonGroup": {
-        "renderToStringMs": 0.052
+        "renderToStringMs": 0.037
       },
       "FilterChip": {
-        "renderToStringMs": 0.031
+        "renderToStringMs": 0.022
       },
       "IconButton": {
-        "renderToStringMs": 0.216
+        "renderToStringMs": 0.072
       },
       "SlideButton": {
-        "renderToStringMs": 0.191
+        "renderToStringMs": 0.066
       },
       "SplitButton": {
-        "renderToStringMs": 0.868
+        "renderToStringMs": 0.264
       },
       "AuthorBio": {
-        "renderToStringMs": 0.009
+        "renderToStringMs": 0.006
       },
       "CodeBlockWindow": {
-        "renderToStringMs": 0.25
+        "renderToStringMs": 0.084
       },
       "CodeSnippet": {
-        "renderToStringMs": 1.008
+        "renderToStringMs": 0.341
       },
       "DataTable": {
-        "renderToStringMs": 0.486
-      },
-      "ExpandableSection": {
-        "renderToStringMs": 0.068
-      },
-      "Gallery": {
-        "renderToStringMs": 0.207
-      },
-      "List": {
-        "renderToStringMs": 0.064
-      },
-      "ListItem": {
-        "renderToStringMs": 0.027
-      },
-      "Logo": {
-        "renderToStringMs": 0.13
-      },
-      "ReadingProgress": {
-        "renderToStringMs": 0.007
-      },
-      "Table": {
-        "renderToStringMs": 0.047
-      },
-      "TableCell": {
-        "renderToStringMs": 0.02
-      },
-      "TableHeaderCell": {
-        "renderToStringMs": 0.022
-      },
-      "TableRow": {
-        "renderToStringMs": 0.02
-      },
-      "Timestamp": {
-        "renderToStringMs": 0.055
-      },
-      "ValueCard": {
-        "renderToStringMs": 0.159
-      },
-      "VirtualList": {
-        "renderToStringMs": 0.238
-      },
-      "VirtualListItem": {
-        "renderToStringMs": 0.057
-      },
-      "AlertBanner": {
         "renderToStringMs": 0.158
       },
-      "EmptyState": {
-        "renderToStringMs": 0.185
+      "ExpandableSection": {
+        "renderToStringMs": 0.031
       },
-      "Progress": {
-        "renderToStringMs": 0.033
+      "Gallery": {
+        "renderToStringMs": 0.193
       },
-      "Skeleton": {
-        "renderToStringMs": 0.052
+      "List": {
+        "renderToStringMs": 0.024
       },
-      "Spinner": {
-        "renderToStringMs": 0.02
+      "ListItem": {
+        "renderToStringMs": 0.012
       },
-      "Toast": {
-        "renderToStringMs": 0.115
+      "Logo": {
+        "renderToStringMs": 0.045
       },
-      "ToastStack": {
-        "renderToStringMs": 0.139
+      "ReadingProgress": {
+        "renderToStringMs": 0.005
       },
-      "Checkbox": {
-        "renderToStringMs": 0.09
-      },
-      "CheckboxGroup": {
-        "renderToStringMs": 0.396
-      },
-      "Combobox": {
-        "renderToStringMs": 0.234
-      },
-      "FileUpload": {
-        "renderToStringMs": 0.209
-      },
-      "FormField": {
-        "renderToStringMs": 0.051
-      },
-      "GroupLabel": {
-        "renderToStringMs": 0.021
-      },
-      "HelperText": {
-        "renderToStringMs": 0.026
-      },
-      "Label": {
-        "renderToStringMs": 0.064
-      },
-      "MultiCombobox": {
-        "renderToStringMs": 0.201
-      },
-      "PhoneInput": {
-        "renderToStringMs": 3.5
-      },
-      "Radio": {
-        "renderToStringMs": 0.071
-      },
-      "RadioGroup": {
-        "renderToStringMs": 0.286
-      },
-      "Select": {
-        "renderToStringMs": 0.24
-      },
-      "SelectableCard": {
-        "renderToStringMs": 0.065
-      },
-      "Switch": {
-        "renderToStringMs": 0.104
-      },
-      "TextArea": {
-        "renderToStringMs": 0.077
-      },
-      "TextInput": {
-        "renderToStringMs": 0.076
-      },
-      "Author": {
-        "renderToStringMs": 0.05
-      },
-      "Avatar": {
-        "renderToStringMs": 0.021
-      },
-      "AvatarGroup": {
-        "renderToStringMs": 0.029
-      },
-      "Badge": {
-        "renderToStringMs": 0.096
-      },
-      "Icon": {
-        "renderToStringMs": 0.058
-      },
-      "StatusDot": {
-        "renderToStringMs": 0.039
-      },
-      "Accordion": {
-        "renderToStringMs": 0.231
-      },
-      "AspectRatio": {
-        "renderToStringMs": 0.022
-      },
-      "Card": {
-        "renderToStringMs": 0.085
-      },
-      "Center": {
-        "renderToStringMs": 0.016
-      },
-      "Container": {
-        "renderToStringMs": 0.016
-      },
-      "Divider": {
+      "Table": {
         "renderToStringMs": 0.017
       },
-      "FlexBox": {
-        "renderToStringMs": 0.018
+      "TableCell": {
+        "renderToStringMs": 0.008
       },
-      "Grid": {
-        "renderToStringMs": 0.019
-      },
-      "MacWindowFrame": {
-        "renderToStringMs": 0.114
-      },
-      "ResizablePanelGroup": {
-        "renderToStringMs": 0.127
-      },
-      "Section": {
-        "renderToStringMs": 0.023
-      },
-      "Spacer": {
-        "renderToStringMs": 0.018
-      },
-      "Stack": {
-        "renderToStringMs": 0.022
-      },
-      "Breadcrumb": {
-        "renderToStringMs": 0.159
-      },
-      "CommandPalette": {
+      "TableHeaderCell": {
         "renderToStringMs": 0.01
       },
-      "LanguageSwitcher": {
-        "renderToStringMs": 0.091
+      "TableRow": {
+        "renderToStringMs": 0.01
       },
-      "Link": {
+      "Timestamp": {
+        "renderToStringMs": 0.045
+      },
+      "ValueCard": {
+        "renderToStringMs": 0.046
+      },
+      "VirtualList": {
+        "renderToStringMs": 0.074
+      },
+      "VirtualListItem": {
+        "renderToStringMs": 0.018
+      },
+      "AlertBanner": {
+        "renderToStringMs": 0.049
+      },
+      "EmptyState": {
+        "renderToStringMs": 0.05
+      },
+      "Progress": {
+        "renderToStringMs": 0.016
+      },
+      "Skeleton": {
         "renderToStringMs": 0.026
       },
-      "Menu": {
-        "renderToStringMs": 0.154
+      "Spinner": {
+        "renderToStringMs": 0.009
       },
-      "NavLink": {
-        "renderToStringMs": 0.04
+      "Toast": {
+        "renderToStringMs": 0.044
       },
-      "NavMenuList": {
-        "renderToStringMs": 0.103
+      "ToastStack": {
+        "renderToStringMs": 0.044
       },
-      "Pagination": {
-        "renderToStringMs": 0.312
+      "Checkbox": {
+        "renderToStringMs": 0.029
       },
-      "ScrollIndicator": {
-        "renderToStringMs": 0.107
+      "CheckboxGroup": {
+        "renderToStringMs": 0.109
       },
-      "SegmentedControl": {
-        "renderToStringMs": 0.077
+      "Combobox": {
+        "renderToStringMs": 0.093
       },
-      "SkipLink": {
+      "FileUpload": {
+        "renderToStringMs": 0.07
+      },
+      "FormField": {
         "renderToStringMs": 0.018
       },
-      "Tabs": {
-        "renderToStringMs": 0.144
+      "GroupLabel": {
+        "renderToStringMs": 0.011
       },
-      "TreeView": {
-        "renderToStringMs": 0.541
+      "HelperText": {
+        "renderToStringMs": 0.01
       },
-      "CategoryFilter": {
-        "renderToStringMs": 0.111
+      "Label": {
+        "renderToStringMs": 0.016
       },
-      "Modal": {
-        "renderToStringMs": 0.168
+      "MultiCombobox": {
+        "renderToStringMs": 0.076
       },
-      "PageLayout": {
-        "renderToStringMs": 0.019
+      "PhoneInput": {
+        "renderToStringMs": 1.308
       },
-      "ProcessBlock": {
-        "renderToStringMs": 0.239
-      },
-      "ThemeProvider": {
+      "Radio": {
         "renderToStringMs": 0.021
       },
-      "Display": {
-        "renderToStringMs": 0.018
+      "RadioGroup": {
+        "renderToStringMs": 0.068
       },
-      "Kbd": {
+      "Select": {
+        "renderToStringMs": 0.059
+      },
+      "SelectableCard": {
+        "renderToStringMs": 0.023
+      },
+      "Switch": {
+        "renderToStringMs": 0.028
+      },
+      "TextArea": {
+        "renderToStringMs": 0.029
+      },
+      "TextInput": {
+        "renderToStringMs": 0.031
+      },
+      "Author": {
         "renderToStringMs": 0.022
       },
+      "Avatar": {
+        "renderToStringMs": 0.012
+      },
+      "AvatarGroup": {
+        "renderToStringMs": 0.014
+      },
+      "Badge": {
+        "renderToStringMs": 0.032
+      },
+      "Icon": {
+        "renderToStringMs": 0.019
+      },
+      "StatusDot": {
+        "renderToStringMs": 0.012
+      },
+      "Accordion": {
+        "renderToStringMs": 0.089
+      },
+      "AspectRatio": {
+        "renderToStringMs": 0.008
+      },
+      "Card": {
+        "renderToStringMs": 0.026
+      },
+      "Center": {
+        "renderToStringMs": 0.006
+      },
+      "Container": {
+        "renderToStringMs": 0.006
+      },
+      "Divider": {
+        "renderToStringMs": 0.008
+      },
+      "FlexBox": {
+        "renderToStringMs": 0.009
+      },
+      "Grid": {
+        "renderToStringMs": 0.011
+      },
+      "MacWindowFrame": {
+        "renderToStringMs": 0.034
+      },
+      "ResizablePanelGroup": {
+        "renderToStringMs": 0.043
+      },
+      "Section": {
+        "renderToStringMs": 0.008
+      },
+      "Spacer": {
+        "renderToStringMs": 0.007
+      },
+      "Stack": {
+        "renderToStringMs": 0.007
+      },
+      "Breadcrumb": {
+        "renderToStringMs": 0.05
+      },
+      "CommandPalette": {
+        "renderToStringMs": 0.006
+      },
+      "LanguageSwitcher": {
+        "renderToStringMs": 0.046
+      },
+      "Link": {
+        "renderToStringMs": 0.011
+      },
+      "Menu": {
+        "renderToStringMs": 0.026
+      },
+      "NavLink": {
+        "renderToStringMs": 0.011
+      },
+      "NavMenuList": {
+        "renderToStringMs": 0.028
+      },
+      "Pagination": {
+        "renderToStringMs": 0.114
+      },
+      "ScrollIndicator": {
+        "renderToStringMs": 0.036
+      },
+      "SegmentedControl": {
+        "renderToStringMs": 0.038
+      },
+      "SkipLink": {
+        "renderToStringMs": 0.008
+      },
+      "Tabs": {
+        "renderToStringMs": 0.058
+      },
+      "TreeView": {
+        "renderToStringMs": 0.158
+      },
+      "CategoryFilter": {
+        "renderToStringMs": 0.034
+      },
+      "Modal": {
+        "renderToStringMs": 0.044
+      },
+      "PageLayout": {
+        "renderToStringMs": 0.008
+      },
+      "ProcessBlock": {
+        "renderToStringMs": 0.062
+      },
+      "ThemeProvider": {
+        "renderToStringMs": 0.01
+      },
+      "Display": {
+        "renderToStringMs": 0.007
+      },
+      "Kbd": {
+        "renderToStringMs": 0.007
+      },
       "Text": {
-        "renderToStringMs": 0.021
+        "renderToStringMs": 0.006
       },
       "Title": {
-        "renderToStringMs": 0.021
+        "renderToStringMs": 0.006
       },
       "VisuallyHidden": {
-        "renderToStringMs": 0.017
+        "renderToStringMs": 0.007
       }
     }
   },
   "provenance": {
-    "sourceCommit": "292c7c8d5fa0cd7f89b3c0857510aa835d3342ca",
+    "sourceCommit": "af1915a5b5391c6a05b73e8b40ce2ffc5de91987",
     "workingTreeClean": false,
-    "dirtyPathCount": 1,
+    "dirtyPathCount": 18,
     "generator": {
       "name": "measure-ssr-evidence",
       "version": 1,

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -149,11 +149,19 @@
   (td/tr/li) hydrate inside a valid ancestor chain from their contract
   `element`. Requires a built dist; `-- --build` rebuilds first. Output:
   `public/ds-health/ssr-evidence.json`.
-- All three run automatically inside `check:react-publish-preflight` (after
+- `npm run audit:override-evidence` — override-precedence gate
+  (docs/OVERRIDE_EVIDENCE_SPEC.md, increment A): renders every contracted
+  export from the built dist in real Chromium (esbuild harness + Playwright,
+  reduced motion, tokens-css + entry CSS like a registry consumer) and
+  asserts a consumer's single-class className override wins for the probed
+  properties (className-override-wins is the contract, owner decision
+  2026-08-07); also probes contract theming.vars for liveness. Exit 2 on
+  failures not in `override-evidence-baseline.json` (dated entries, never
+  blanket-updated). Requires a built dist; `-- --build` rebuilds first.
+  Output: `public/ds-health/override-evidence.json`.
+- All four run automatically inside `check:react-publish-preflight` (after
   `react-public-api` rebuilds the dist), so every publish regenerates its
   evidence; commit the regenerated artifacts with the publish PR.
-- Next increment (specced, not implemented): override-precedence evidence —
-  see `docs/OVERRIDE_EVIDENCE_SPEC.md`.
 
 ---
 

--- a/scripts/design-system/check-react-publish-preflight.mjs
+++ b/scripts/design-system/check-react-publish-preflight.mjs
@@ -141,6 +141,11 @@ const automatedChecks = [
     reason: "every renderable export server-renders without DOM globals and hydrates cleanly in jsdom, recorded as publish evidence",
   },
   {
+    name: "override-evidence",
+    command: ["run", "audit:override-evidence"],
+    reason: "consumer className overrides win over component base styles in real Chromium (className-override-wins contract), gated against the dated baseline",
+  },
+  {
     name: "compatibility-manifest",
     command: ["run", "audit:compatibility"],
     reason: "the toolchain combinations actually exercised by the gates are recorded as the per-publish compatibility manifest",

--- a/scripts/design-system/measure-override-evidence.mjs
+++ b/scripts/design-system/measure-override-evidence.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+/**
+ * Override-precedence evidence for @digitaltableteur/react
+ * (docs/OVERRIDE_EVIDENCE_SPEC.md, increment A).
+ *
+ * Package-honest and browser-real: bundles the built dist plus the harness
+ * runtime with esbuild, serves a page that loads the shipped entry CSS and
+ * tokens-css exactly like a registry consumer, and drives it with Playwright
+ * Chromium (reduced motion) to read computed styles.
+ *
+ * INV-1: a consumer's single-class, no-!important selector via className
+ * wins over component base styles for the probed properties on the root
+ * element (owner decision 2026-08-07: this IS the contract).
+ * INV-2: every contract-declared theming var is a live override channel.
+ *
+ * Writes public/ds-health/override-evidence.json and gates against
+ * override-evidence-baseline.json: exit 2 on any failure not explicitly
+ * baselined with a dated note.
+ *
+ * Usage:
+ *   npm run audit:override-evidence            # requires an existing dist
+ *   npm run audit:override-evidence -- --build # rebuild dist first
+ */
+import { execFileSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, extname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+import { build } from "esbuild";
+import { loadComponentContract } from "./ssr-evidence-lib.mjs";
+import {
+  assembleOverrideEvidence,
+  compareToBaseline,
+  componentOverrideRecord,
+  probeStylesheet,
+} from "./override-evidence-lib.mjs";
+import { currentProvenance, runtimeStampFor } from "./evidence-stamp-lib.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const PKG_DIR = join(ROOT, "packages/react");
+const MANIFEST = join(PKG_DIR, "public-api.manifest.json");
+const OUT = join(ROOT, "public/ds-health/override-evidence.json");
+const BASELINE = join(
+  ROOT,
+  "scripts/design-system/override-evidence-baseline.json",
+);
+const GENERATOR_VERSION = 1;
+const require = createRequire(import.meta.url);
+
+const shouldBuild = process.argv.includes("--build");
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+if (shouldBuild) {
+  console.log("→ building packages/react dist…");
+  execFileSync("npm", ["--prefix", "packages/react", "run", "build"], {
+    cwd: ROOT,
+    stdio: "inherit",
+  });
+}
+
+if (!existsSync(MANIFEST)) {
+  console.error("FAIL: packages/react/public-api.manifest.json missing.");
+  process.exit(1);
+}
+const manifest = readJson(MANIFEST);
+const exportsByEntry = manifest.runtimeExportsByEntry ?? {};
+const entryNames = Object.keys(exportsByEntry);
+const packageJson = readJson(join(PKG_DIR, "package.json"));
+
+const missingDist = entryNames.filter(
+  (entry) => !existsSync(join(PKG_DIR, "dist", `${entry}.js`)),
+);
+if (missingDist.length) {
+  console.error(
+    `FAIL: built dist entries missing (${missingDist.join(", ")}). ` +
+      "Run `npm --prefix packages/react run build` or pass --build.",
+  );
+  process.exit(1);
+}
+
+// Components with a contract get measured; the rest (hooks, runtime
+// adapters) are recorded as out-of-scope skips by the runtime's plan check
+// or here when no contract exists at all.
+const components = [];
+const noContract = [];
+for (const [entry, exportNames] of Object.entries(exportsByEntry)) {
+  for (const exportName of exportNames) {
+    const contract = loadComponentContract(ROOT, exportName);
+    if (contract) components.push({ entry, exportName, contract });
+    else noContract.push(exportName);
+  }
+}
+
+// --- Assemble the harness in a temp dir -----------------------------------
+const harnessDir = mkdtempSync(join(tmpdir(), "dt-override-evidence-"));
+const cssLinks = [];
+
+const tokensCss = require.resolve("@digitaltableteur/tokens-css/tokens.css");
+copyFileSync(tokensCss, join(harnessDir, "tokens.css"));
+cssLinks.push("tokens.css");
+
+for (const entry of entryNames) {
+  const cssPath = join(PKG_DIR, "dist", `${entry}.css`);
+  if (existsSync(cssPath)) {
+    copyFileSync(cssPath, join(harnessDir, `${entry}.css`));
+    cssLinks.push(`${entry}.css`);
+  }
+}
+
+// Probe stylesheet loads LAST: the documented consumer arrangement is
+// design-system CSS before consumer CSS.
+writeFileSync(join(harnessDir, "probe.css"), probeStylesheet());
+cssLinks.push("probe.css");
+
+const entryImports = entryNames
+  .map(
+    (entry, index) =>
+      `import * as entry${index} from ${JSON.stringify(join(PKG_DIR, "dist", `${entry}.js`))};`,
+  )
+  .join("\n");
+const harnessEntrySource = `
+import * as React from "react";
+import * as ReactDOMClient from "react-dom/client";
+import { runOverrideEvidence } from ${JSON.stringify(join(ROOT, "scripts/design-system/override-evidence-harness-runtime.mjs"))};
+${entryImports}
+const modules = { ${entryNames.map((entry, index) => `${JSON.stringify(entry)}: entry${index}`).join(", ")} };
+runOverrideEvidence({
+  React,
+  ReactDOMClient,
+  modules,
+  components: window.__OVERRIDE_DATA__.components,
+})
+  .then((results) => {
+    window.__OVERRIDE_RESULTS__ = results;
+  })
+  .catch((error) => {
+    window.__OVERRIDE_ERROR__ = String(error?.stack ?? error);
+  });
+`;
+
+await build({
+  stdin: {
+    contents: harnessEntrySource,
+    resolveDir: ROOT,
+    sourcefile: "override-evidence-entry.js",
+    loader: "js",
+  },
+  bundle: true,
+  format: "iife",
+  platform: "browser",
+  outfile: join(harnessDir, "bundle.js"),
+  logLevel: "silent",
+  alias: {
+    "node:fs": join(ROOT, "scripts/design-system/override-evidence-node-stubs.mjs"),
+    "node:path": join(ROOT, "scripts/design-system/override-evidence-node-stubs.mjs"),
+  },
+});
+
+const html = `<!doctype html>
+<html><head><meta charset="utf-8">
+${cssLinks.map((href) => `<link rel="stylesheet" href="${href}">`).join("\n")}
+<script>window.__OVERRIDE_DATA__ = ${JSON.stringify({ components })};</script>
+</head><body><script src="bundle.js"></script></body></html>`;
+writeFileSync(join(harnessDir, "index.html"), html);
+
+// --- Serve and drive ------------------------------------------------------
+const MIME = { ".html": "text/html", ".css": "text/css", ".js": "text/javascript" };
+const server = createServer((request, response) => {
+  const path = request.url === "/" ? "/index.html" : request.url;
+  const file = join(harnessDir, path.slice(1));
+  if (!file.startsWith(harnessDir) || !existsSync(file)) {
+    response.writeHead(404).end();
+    return;
+  }
+  response.writeHead(200, {
+    "content-type": MIME[extname(file)] ?? "application/octet-stream",
+  });
+  response.end(readFileSync(file));
+});
+await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+const port = server.address().port;
+
+const { chromium } = await import("@playwright/test");
+const browser = await chromium.launch();
+const context = await browser.newContext({ reducedMotion: "reduce" });
+const page = await context.newPage();
+const pageErrors = [];
+page.on("pageerror", (error) => pageErrors.push(String(error).slice(0, 200)));
+
+console.log(
+  `→ measuring ${components.length} components in Chromium (${cssLinks.length} stylesheets)…`,
+);
+await page.goto(`http://127.0.0.1:${port}/`);
+await page.waitForFunction(
+  "window.__OVERRIDE_RESULTS__ !== undefined || window.__OVERRIDE_ERROR__ !== undefined",
+  undefined,
+  { timeout: 120_000 },
+);
+const harnessError = await page.evaluate("window.__OVERRIDE_ERROR__");
+const rawResults = await page.evaluate("window.__OVERRIDE_RESULTS__");
+const chromiumVersion = browser.version();
+await browser.close();
+server.close();
+rmSync(harnessDir, { recursive: true, force: true });
+
+if (harnessError) {
+  console.error("FAIL: harness crashed in the browser:\n", harnessError);
+  process.exit(1);
+}
+if (pageErrors.length) {
+  console.error(`note: ${pageErrors.length} uncaught page error(s):`, pageErrors[0]);
+}
+
+// --- Assemble artifact ----------------------------------------------------
+const records = {};
+for (const { exportName } of components) {
+  records[exportName] = componentOverrideRecord(rawResults[exportName] ?? {
+    skip: "no measurement returned by the harness",
+  });
+}
+for (const exportName of noContract) {
+  records[exportName] = componentOverrideRecord({
+    skip: "no component contract (not a renderable component export)",
+  });
+}
+
+const playwrightVersion = readJson(
+  join(ROOT, "node_modules/@playwright/test/package.json"),
+).version;
+const substance = assembleOverrideEvidence({
+  packageName: packageJson.name,
+  packageVersion: packageJson.version,
+  environment: {
+    chromium: chromiumVersion,
+    playwright: playwrightVersion,
+    reducedMotion: true,
+  },
+  components: records,
+});
+
+const provenance = currentProvenance(ROOT, {
+  name: "measure-override-evidence",
+  version: GENERATOR_VERSION,
+});
+const stamp = runtimeStampFor(OUT, substance, provenance);
+const report = {
+  generatedAt: stamp.generatedAt,
+  ...substance,
+  provenance: stamp.provenance,
+};
+mkdirSync(dirname(OUT), { recursive: true });
+writeFileSync(OUT, `${JSON.stringify(report, null, 2)}\n`);
+
+// --- Baseline gate --------------------------------------------------------
+const baseline = existsSync(BASELINE) ? readJson(BASELINE) : { entries: {} };
+const { newFailures, stale } = compareToBaseline(substance, baseline);
+const { totals } = substance;
+console.log(
+  `\n✓ override evidence written: ${totals.pass} pass, ${totals.fail} fail ` +
+    `(${Object.keys(baseline.entries ?? {}).length} baselined), ${totals.renderError} render errors, ` +
+    `${totals.skipped} skipped, ${totals.themingVarsDeclared} theming vars declared → public/ds-health/override-evidence.json`,
+);
+if (stale.length) {
+  console.log(
+    `note: baseline entries no longer failing (prune them): ${stale.join(", ")}`,
+  );
+}
+if (newFailures.length) {
+  console.error(
+    `\nFAIL: ${newFailures.length} override failure(s) not in the baseline:`,
+  );
+  for (const name of newFailures) {
+    console.error(`  x ${name}: ${JSON.stringify(records[name]).slice(0, 200)}`);
+  }
+  console.error(
+    "  Fix the component, or add a dated, explained entry to scripts/design-system/override-evidence-baseline.json.",
+  );
+  process.exit(2);
+}

--- a/scripts/design-system/override-evidence-baseline.json
+++ b/scripts/design-system/override-evidence-baseline.json
@@ -1,0 +1,4 @@
+{
+  "note": "Approved override-precedence failures (docs/OVERRIDE_EVIDENCE_SPEC.md). Each entry is { \"<Component>\": { \"note\": <why this is approved debt>, \"on\": <date> } }. Never blanket-update; every entry is an explained, dated decision and a burn-down candidate.",
+  "entries": {}
+}

--- a/scripts/design-system/override-evidence-harness-runtime.mjs
+++ b/scripts/design-system/override-evidence-harness-runtime.mjs
@@ -1,0 +1,195 @@
+/**
+ * Browser-side runtime for override-precedence evidence
+ * (docs/OVERRIDE_EVIDENCE_SPEC.md increment A). Bundled by
+ * measure-override-evidence.mjs together with the dist entries and executed
+ * in real Chromium; never imported in node.
+ *
+ * For each component: render the SSR-evidence plan from the built dist, then
+ * (INV-1) re-render with the probe class merged into className and assert
+ * each probed property computes to its sentinel on the root element, and
+ * (INV-2) probe each contract-declared theming var for liveness against a
+ * computed-style fingerprint of the base subtree.
+ */
+import {
+  hydrationContainerChainFor,
+  renderPlanFor,
+  resolveDescriptors,
+} from "./ssr-evidence-lib.mjs";
+import {
+  PROBE_CLASS,
+  PROBE_PROPERTIES,
+  overrideTargetsFor,
+} from "./override-evidence-lib.mjs";
+
+function nextPaint() {
+  return new Promise((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(resolve)),
+  );
+}
+
+function subtreeFingerprint(root) {
+  const parts = [];
+  const walk = (el) => {
+    const style = getComputedStyle(el);
+    let line = "";
+    for (let i = 0; i < style.length; i += 1) {
+      const prop = style[i];
+      line += `${prop}:${style.getPropertyValue(prop)};`;
+    }
+    parts.push(line);
+    for (const child of el.children) walk(child);
+  };
+  walk(root);
+  return parts.join("\n");
+}
+
+export async function runOverrideEvidence({
+  React,
+  ReactDOMClient,
+  modules,
+  components,
+}) {
+  const { createElement } = React;
+  const lookup = (name) => {
+    for (const mod of Object.values(modules)) {
+      if (name in mod) return mod[name];
+    }
+    return undefined;
+  };
+
+  const mountHost = document.createElement("div");
+  document.body.appendChild(mountHost);
+
+  async function renderInto(Component, props, containerChain) {
+    const wrapper = document.createElement("div");
+    let container = wrapper;
+    for (const tag of containerChain) {
+      const level = document.createElement(tag);
+      container.appendChild(level);
+      container = level;
+    }
+    mountHost.appendChild(wrapper);
+    // React 19 render errors surface via onUncaughtError, never a
+    // synchronous throw; capture them so a provider-required component is
+    // recorded as a render error instead of a mislabelled "no root" skip.
+    const renderErrors = [];
+    const root = ReactDOMClient.createRoot(container, {
+      onUncaughtError(error) {
+        renderErrors.push(String(error?.message ?? error).split("\n")[0].slice(0, 300));
+      },
+    });
+    root.render(createElement(Component, props));
+    await nextPaint();
+    return {
+      wrapper,
+      container,
+      rootElement: container.firstElementChild,
+      renderError: renderErrors[0] ?? null,
+      cleanup() {
+        root.unmount();
+        wrapper.remove();
+      },
+    };
+  }
+
+  const results = {};
+  for (const { entry, exportName, contract } of components) {
+    const measurement = {};
+    try {
+      const mod = modules[entry];
+      const Component = mod?.[exportName];
+      const plan = renderPlanFor(exportName, contract);
+      if (plan.skip) {
+        results[exportName] = { skip: plan.skip };
+        continue;
+      }
+      const props = resolveDescriptors(plan.props, createElement, lookup);
+      const containerChain = hydrationContainerChainFor(contract?.element);
+      const targets = overrideTargetsFor(contract);
+
+      const base = await renderInto(Component, props, containerChain);
+      if (base.renderError) {
+        base.cleanup();
+        results[exportName] = { renderError: base.renderError };
+        continue;
+      }
+      if (!base.rootElement) {
+        base.cleanup();
+        results[exportName] = {
+          skip: "renders no in-flow root element (portal or null render)",
+        };
+        continue;
+      }
+      const baseFingerprint = targets.vars.length
+        ? subtreeFingerprint(base.rootElement)
+        : null;
+      base.cleanup();
+
+      if (targets.hasClassName) {
+        const mergedClassName = [props.className, PROBE_CLASS]
+          .filter(Boolean)
+          .join(" ");
+        const probe = await renderInto(
+          Component,
+          { ...props, className: mergedClassName },
+          containerChain,
+        );
+        if (!probe.rootElement) {
+          measurement.skip =
+            "renders no in-flow root element with probe class applied";
+        } else if (!probe.rootElement.classList.contains(PROBE_CLASS)) {
+          measurement.classNameForwarded = false;
+          measurement.overrides = {};
+        } else {
+          measurement.classNameForwarded = true;
+          const style = getComputedStyle(probe.rootElement);
+          measurement.overrides = {};
+          for (const { prop, value } of PROBE_PROPERTIES) {
+            const computed = style.getPropertyValue(prop);
+            measurement.overrides[prop] = {
+              pass: computed === value,
+              computed,
+            };
+          }
+        }
+        probe.cleanup();
+      }
+
+      if (!measurement.skip && targets.vars.length) {
+        measurement.vars = {};
+        for (const varTarget of targets.vars) {
+          const themed = await renderInto(Component, props, containerChain);
+          themed.wrapper.style.setProperty(
+            varTarget.name,
+            varTarget.probe.value,
+          );
+          await nextPaint();
+          const changed = themed.rootElement
+            ? subtreeFingerprint(themed.rootElement) !== baseFingerprint
+            : false;
+          measurement.vars[varTarget.name] = {
+            changed,
+            probeValue: varTarget.probe.value,
+          };
+          themed.cleanup();
+        }
+      }
+
+      if (
+        !measurement.skip &&
+        !targets.hasClassName &&
+        !targets.vars.length
+      ) {
+        measurement.skip =
+          "contract declares neither className nor theming.vars (out of scope)";
+      }
+      results[exportName] = measurement;
+    } catch (error) {
+      results[exportName] = {
+        renderError: String(error?.message ?? error).split("\n")[0].slice(0, 300),
+      };
+    }
+  }
+
+  return results;
+}

--- a/scripts/design-system/override-evidence-lib.mjs
+++ b/scripts/design-system/override-evidence-lib.mjs
@@ -1,0 +1,185 @@
+/**
+ * Helpers for override-precedence evidence (Astryx-gap Phase 4,
+ * docs/OVERRIDE_EVIDENCE_SPEC.md, increment A).
+ *
+ * OWNER DECISION (2026-08-07): className-override-wins IS the contract. A
+ * consumer's single-class, no-!important selector applied via className must
+ * beat component base styles for the probed properties on the root element,
+ * given the documented consumer arrangement (design-system CSS imported
+ * before consumer CSS). A failure is a defect or an explicitly baselined,
+ * dated debt.
+ */
+
+/**
+ * Probe set v1, sourced from the two shipped bug classes (#1280
+ * Modal/Switch ink+surface, Title/Text spacing). Sentinels are valid,
+ * visually meaningless values no token resolves to, so computed === sentinel
+ * is unambiguous.
+ */
+export const PROBE_PROPERTIES = [
+  { prop: "color", value: "rgb(9, 8, 7)" },
+  { prop: "margin-block-start", value: "7px" },
+  { prop: "background-color", value: "rgb(7, 8, 9)" },
+];
+
+export const PROBE_CLASS = "dtProbeOverride";
+
+/** Single class, no !important: winning must come from honest precedence. */
+export function probeStylesheet() {
+  const declarations = PROBE_PROPERTIES.map(
+    ({ prop, value }) => `  ${prop}: ${value};`,
+  ).join("\n");
+  return `.${PROBE_CLASS} {\n${declarations}\n}\n`;
+}
+
+/**
+ * Derive a probe value for a theming var from its declared default. The goal
+ * is liveness detection (computed output changes), not semantic correctness:
+ * even an invalid value changes the computed result of any property the var
+ * feeds, so unparseable defaults still detect a dead channel.
+ */
+export function varProbeValue(defaultValue) {
+  const value = String(defaultValue ?? "").trim();
+  if (/^(#|rgb|hsl|oklch|color-mix|light-dark)/i.test(value)) {
+    return { value: "rgb(9, 8, 7)", rule: "color-like default → sentinel color" };
+  }
+  const length = value.match(/^(-?\d+(?:\.\d+)?)(px|rem|em|%|vh|vw|ch|s|ms)$/);
+  if (length) {
+    const bumped = Number(length[1]) + 3;
+    return {
+      value: `${bumped}${length[2]}`,
+      rule: "numeric default → bumped by 3, unit kept",
+    };
+  }
+  return { value: "7px", rule: "unparseable default → 7px (liveness only)" };
+}
+
+/**
+ * What the gate can check for a component, from its contract. className
+ * eligibility for INV-1; declared theming vars for INV-2. Both empty means
+ * the component is out of scope, recorded honestly.
+ */
+export function overrideTargetsFor(contract) {
+  const hasClassName = Boolean(contract?.props?.className);
+  const vars = (contract?.theming?.vars ?? []).map((entry) => ({
+    name: entry.name,
+    default: entry.default,
+    probe: varProbeValue(entry.default),
+  }));
+  return { hasClassName, vars };
+}
+
+/**
+ * Classify one component's in-browser measurement into the artifact record.
+ * measurement: {
+ *   skip?: string,
+ *   classNameForwarded?: boolean,
+ *   overrides?: { [prop]: { computed, pass } },
+ *   vars?: { [name]: { changed, probeValue } },
+ * }
+ */
+export function componentOverrideRecord(measurement) {
+  if (measurement.skip) return { status: "skipped", reason: measurement.skip };
+  if (measurement.renderError) {
+    // A browser render throw is not an override defect; it gets its own
+    // status so it can neither hide in skips nor inflate failures.
+    return { status: "render-error", error: measurement.renderError };
+  }
+  const record = {};
+  let failed = false;
+  if (measurement.overrides) {
+    if (measurement.classNameForwarded === false) {
+      record.overrideWins = {
+        ok: false,
+        error: "className is not forwarded to the rendered root element",
+      };
+      failed = true;
+    } else {
+      const props = {};
+      for (const [prop, result] of Object.entries(measurement.overrides)) {
+        props[prop] = result.pass
+          ? { pass: true }
+          : { pass: false, computed: result.computed };
+        if (!result.pass) failed = true;
+      }
+      record.overrideWins = { ok: !failed, props };
+    }
+  }
+  if (measurement.vars && Object.keys(measurement.vars).length) {
+    const vars = {};
+    let varsFailed = false;
+    for (const [name, result] of Object.entries(measurement.vars)) {
+      vars[name] = result.changed
+        ? { pass: true }
+        : { pass: false, probeValue: result.probeValue };
+      if (!result.changed) varsFailed = true;
+    }
+    record.themingVars = { ok: !varsFailed, vars };
+    if (varsFailed) failed = true;
+  }
+  record.status = failed ? "fail" : "pass";
+  return record;
+}
+
+/** Assemble the report substance with sorted keys and honest totals. */
+export function assembleOverrideEvidence({
+  packageName,
+  packageVersion,
+  environment,
+  components,
+}) {
+  const sorted = {};
+  const totals = {
+    pass: 0,
+    fail: 0,
+    renderError: 0,
+    skipped: 0,
+    themingVarsDeclared: 0,
+  };
+  for (const name of Object.keys(components).sort()) {
+    const record = components[name];
+    sorted[name] = record;
+    if (record.status === "skipped") totals.skipped += 1;
+    else if (record.status === "render-error") totals.renderError += 1;
+    else if (record.status === "fail") totals.fail += 1;
+    else totals.pass += 1;
+    if (record.themingVars) {
+      totals.themingVarsDeclared += Object.keys(record.themingVars.vars).length;
+    }
+  }
+  return {
+    package: { name: packageName, version: packageVersion },
+    contract:
+      "OWNER DECISION 2026-08-07: className-override-wins. A consumer's single-class, no-!important selector applied via className wins over component base styles for the probed properties on the root element, under the documented consumer arrangement (design-system CSS before consumer CSS).",
+    environment,
+    methodology: {
+      probe: `single class .${PROBE_CLASS} with ${PROBE_PROPERTIES.map((p) => p.prop).join(", ")}; sentinel values no token resolves to; probe stylesheet loads after design-system CSS, mirroring the documented consumer import order`,
+      rendering:
+        "components render from the built dist with the SSR-evidence render plans (contract playground defaults, type-driven function/ref synthesis, descriptor resolution); computed styles read in real Chromium with reduced motion",
+      themingVars:
+        "each contract-declared theming var is probed for liveness: setting it on a wrapper must change some computed style in the component subtree; zero declared vars is reported honestly, not hidden",
+      skips:
+        "a skip is a harness limitation (no className prop, no in-flow root such as portals, or an unrenderable plan), recorded with its reason and never counted as component evidence",
+    },
+    totals,
+    components: sorted,
+  };
+}
+
+/**
+ * Baseline comparison. The baseline lists APPROVED failures as
+ * { "<Component>": { note, on } } (agent-experience-baseline precedent:
+ * dated, explained, never blanket-updated). Returns failures not covered by
+ * the baseline plus baseline entries that no longer fail (to be pruned).
+ */
+export function compareToBaseline(report, baseline) {
+  const approved = baseline?.entries ?? {};
+  const newFailures = [];
+  for (const [name, record] of Object.entries(report.components)) {
+    if (record.status === "fail" && !approved[name]) newFailures.push(name);
+  }
+  const stale = Object.keys(approved).filter(
+    (name) => report.components[name]?.status !== "fail",
+  );
+  return { newFailures, stale };
+}

--- a/scripts/design-system/override-evidence-lib.test.mjs
+++ b/scripts/design-system/override-evidence-lib.test.mjs
@@ -1,0 +1,142 @@
+import { expect, test } from "vitest";
+
+import {
+  PROBE_CLASS,
+  PROBE_PROPERTIES,
+  assembleOverrideEvidence,
+  compareToBaseline,
+  componentOverrideRecord,
+  overrideTargetsFor,
+  probeStylesheet,
+  varProbeValue,
+} from "./override-evidence-lib.mjs";
+
+test("probe stylesheet is a single class with no !important", () => {
+  const css = probeStylesheet();
+  expect(css.startsWith(`.${PROBE_CLASS} {`)).toBe(true);
+  expect(css).not.toMatch(/!important/);
+  for (const { prop, value } of PROBE_PROPERTIES) {
+    expect(css).toContain(`${prop}: ${value};`);
+  }
+});
+
+test("varProbeValue derives sentinels by default shape", () => {
+  expect(varProbeValue("#aabbcc").value).toBe("rgb(9, 8, 7)");
+  expect(varProbeValue("rgb(0, 0, 0)").value).toBe("rgb(9, 8, 7)");
+  expect(varProbeValue("12px")).toEqual({
+    value: "15px",
+    rule: "numeric default → bumped by 3, unit kept",
+  });
+  expect(varProbeValue("0.5rem").value).toBe("3.5rem");
+  expect(varProbeValue("var(--something)").rule).toMatch(/liveness only/);
+});
+
+test("overrideTargetsFor reads className and theming vars from the contract", () => {
+  const targets = overrideTargetsFor({
+    props: { className: { optional: true, type: "string" } },
+    theming: { vars: [{ name: "--dt-badge-ink", default: "#111111" }] },
+  });
+  expect(targets.hasClassName).toBe(true);
+  expect(targets.vars).toHaveLength(1);
+  expect(targets.vars[0].probe.value).toBe("rgb(9, 8, 7)");
+  expect(overrideTargetsFor({ props: {} })).toEqual({
+    hasClassName: false,
+    vars: [],
+  });
+});
+
+test("componentOverrideRecord classifies skip, render error, fail, and pass", () => {
+  expect(componentOverrideRecord({ skip: "x" })).toEqual({
+    status: "skipped",
+    reason: "x",
+  });
+  expect(componentOverrideRecord({ renderError: "boom" })).toEqual({
+    status: "render-error",
+    error: "boom",
+  });
+  const notForwarded = componentOverrideRecord({
+    classNameForwarded: false,
+    overrides: {},
+  });
+  expect(notForwarded.status).toBe("fail");
+  expect(notForwarded.overrideWins.error).toMatch(/not forwarded/);
+  const mixed = componentOverrideRecord({
+    classNameForwarded: true,
+    overrides: {
+      color: { pass: true, computed: "rgb(9, 8, 7)" },
+      "margin-block-start": { pass: false, computed: "0px" },
+    },
+  });
+  expect(mixed.status).toBe("fail");
+  expect(mixed.overrideWins.props.color).toEqual({ pass: true });
+  expect(mixed.overrideWins.props["margin-block-start"].computed).toBe("0px");
+  const pass = componentOverrideRecord({
+    classNameForwarded: true,
+    overrides: { color: { pass: true, computed: "rgb(9, 8, 7)" } },
+    vars: { "--dt-x": { changed: true, probeValue: "rgb(9, 8, 7)" } },
+  });
+  expect(pass.status).toBe("pass");
+  expect(pass.themingVars.ok).toBe(true);
+});
+
+test("a dead theming var fails the component", () => {
+  const record = componentOverrideRecord({
+    classNameForwarded: true,
+    overrides: { color: { pass: true, computed: "rgb(9, 8, 7)" } },
+    vars: { "--dt-dead": { changed: false, probeValue: "7px" } },
+  });
+  expect(record.status).toBe("fail");
+  expect(record.themingVars.vars["--dt-dead"].pass).toBe(false);
+});
+
+test("assembleOverrideEvidence sorts, totals, and states the contract", () => {
+  const report = assembleOverrideEvidence({
+    packageName: "@digitaltableteur/react",
+    packageVersion: "0.1.22",
+    environment: { chromium: "140.0.0.0", playwright: "1.62.1", reducedMotion: true },
+    components: {
+      Text: componentOverrideRecord({
+        classNameForwarded: true,
+        overrides: { color: { pass: true, computed: "rgb(9, 8, 7)" } },
+      }),
+      Badge: componentOverrideRecord({ skip: "x" }),
+      Alert: componentOverrideRecord({ renderError: "boom" }),
+      Title: componentOverrideRecord({
+        classNameForwarded: true,
+        overrides: { color: { pass: false, computed: "rgb(0, 0, 0)" } },
+      }),
+    },
+  });
+  expect(Object.keys(report.components)).toEqual([
+    "Alert",
+    "Badge",
+    "Text",
+    "Title",
+  ]);
+  expect(report.totals).toEqual({
+    pass: 1,
+    fail: 1,
+    renderError: 1,
+    skipped: 1,
+    themingVarsDeclared: 0,
+  });
+  expect(report.contract).toMatch(/className-override-wins/);
+});
+
+test("compareToBaseline reports new failures and stale approvals", () => {
+  const substance = {
+    components: {
+      Title: { status: "fail" },
+      Text: { status: "pass" },
+      Card: { status: "fail" },
+    },
+  };
+  const { newFailures, stale } = compareToBaseline(substance, {
+    entries: {
+      Card: { note: "known compound selector debt", on: "2026-08-07" },
+      Text: { note: "was failing before the tokens fix", on: "2026-08-01" },
+    },
+  });
+  expect(newFailures).toEqual(["Title"]);
+  expect(stale).toEqual(["Text"]);
+});

--- a/scripts/design-system/override-evidence-node-stubs.mjs
+++ b/scripts/design-system/override-evidence-node-stubs.mjs
@@ -1,0 +1,19 @@
+/**
+ * Browser-bundle stubs for node:fs / node:path, aliased in by
+ * measure-override-evidence.mjs when bundling ssr-evidence-lib.mjs for the
+ * harness page. Only loadComponentContract touches these APIs and the
+ * harness never calls it (contracts arrive pre-embedded), so every stub
+ * throws to make an accidental call loud instead of silently wrong.
+ */
+function refuse(name) {
+  return () => {
+    throw new Error(
+      `${name} is not available in the override-evidence browser harness`,
+    );
+  };
+}
+
+export const existsSync = refuse("node:fs existsSync");
+export const readFileSync = refuse("node:fs readFileSync");
+export const join = refuse("node:path join");
+export default {};


### PR DESCRIPTION
## Override-precedence evidence gate: increment A, and it caught something on run one

Implements [docs/OVERRIDE_EVIDENCE_SPEC.md](../blob/main/docs/OVERRIDE_EVIDENCE_SPEC.md) increment A with the owner decision recorded in the artifact itself: **className-override-wins is the contract**.

### The gate (`npm run audit:override-evidence`)

Renders all 92 contracted exports from the built dist in real Chromium (esbuild harness, Playwright, reduced motion), loading `tokens-css` plus the shipped entry CSS exactly like a registry consumer, probe stylesheet last per the documented import order.

- **INV-1**: a single-class, no-`!important` consumer selector applied via `className` must compute to its sentinel for `color`, `margin-block-start`, and `background-color` on the root element. A className that never reaches the root is its own recorded failure mode.
- **INV-2**: every contract-declared theming var is probed for liveness against a computed-style subtree fingerprint. Zero vars are declared today; the artifact says so honestly (`themingVarsDeclared: 0`) rather than hiding the vacuum.
- Render plans are the SSR-evidence derivation reused verbatim (one source of truth for contract-driven rendering); React 19 render errors are captured via `onUncaughtError` so provider-required components record as `render-error`, not mislabelled skips.
- Gate semantics: exit 2 on any failure absent from `override-evidence-baseline.json` (dated, explained entries; ships empty). Wired into the publish preflight after `ssr-evidence`.

### First catch, fixed in this PR

ProcessBlock set `background-color` and `padding-block` via **inline style** — unbeatable by any consumer class, and a violation of the repo's own inline-style rule. Converted to variant classes. The move then surfaced a second latent defect: the inline padding referenced phantom `--space-xl`, which only ever worked through its `3rem` fallback (rhythmguard caught it the moment the declaration became visible CSS). Replaced with the real `--space-layout-48` token, identical rendered value. Tests updated to assert classes and the absence of inline style (30/30).

Consumers import ProcessBlock from the published package, so the visible fix lands with the next react publish. That's now **three fixes queued for 0.1.23**: TreeView `File` icon, CommandPalette SSR stability, ProcessBlock overridability.

### Results (0.1.22 dist)

47 pass, 0 fail, 2 render errors (CookieConsent/Tooltip provider-required), 94 recorded skips, substance byte-identical across reruns. All three sibling artifacts regenerated for the updated dist.

### Gates

typecheck 0, lint 0, lint:css 0, rhythmguard 0, test 2901/2901, build 0; contract add-ons (build:tokens, check:contract-props, check:consumers, validate:agent-docs) all 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
