### PR TITLE
chore(release): prepare @digitaltableteur/react 0.1.23

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.1.23 - 2026-08-07
+
+- Fixes `TreeView` leaf icons: leaf nodes request the `file` icon, whose
+  Phosphor component was never in the bundled icon registry (the name lives
+  in a ternary the icon-codegen JSX scan cannot see), so leaves silently
+  rendered without an icon. `File` is now curated in the registry.
+- `CommandPalette` is SSR-stable: the portal is gated on a mounted flag so
+  the server and initial client render agree, eliminating the hydration
+  mismatch when `open` is true at server-render time. Focus trap and scroll
+  lock arm once the dialog node exists; opening from user interaction is
+  unchanged.
+- `ProcessBlock` background and padding move from inline styles to module
+  classes, so consumer `className` overrides can win (the first catch of the
+  new override-precedence evidence gate). The padding now references the
+  real `--space-layout-48` token instead of a phantom var that only worked
+  through its fallback; rendered values are unchanged.
+
 ## 0.1.22 - 2026-08-05
 
 - Ships the matured data primitives at beta: `DataTable` (managed sortable/

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/react",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "private": false,
   "description": "React components and host adapters for the Digitaltableteur design system.",
   "type": "module",


### PR DESCRIPTION
Version bump + CHANGELOG for the publish carrying three merged fixes: TreeView leaf File icon (#1428), CommandPalette SSR stability (#1429), ProcessBlock overridable background/padding classes (#1431). No export surface changes (manifest stays 143). Gates: typecheck 0, lint 0, test 2901/2901, build 0, check:package-release-notes 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)