### PR TITLE
feat(ds): override gate increment B - hostile-ancestor encapsulation matrix (informational)

### DIFF
--- a/docs/OVERRIDE_EVIDENCE_SPEC.md
+++ b/docs/OVERRIDE_EVIDENCE_SPEC.md
@@ -1,9 +1,21 @@
 # Override-precedence evidence (Phase 4, next increment)
 
-Status: **increment A implemented** (`npm run audit:override-evidence`).
+Status: **increments A and B implemented** (`npm run audit:override-evidence`).
 Owner decisions recorded: className-override-wins IS the contract (2026-08-07,
 open question 1 resolved); root-only probing for A; probe set v1 as specced.
-Increments B/C (hostile-ancestor matrix) remain open.
+
+Increment B ships INV-3 informationally: the formalized universal-selector
+scan (3 package exports today: Menu composes children; ProcessBlock and
+ToastStack are watchlist-only) and the container × child matrix with a
+pinned-property discriminator — a child participates only for properties
+whose standalone computed value differs from a neutral div in the same
+context, so inherited-by-design values never register as interference.
+Current artifact: Menu × 23 children, 0 affected. A `--containers` debug
+flag exercises the machinery against any renderable export.
+
+Increment C remains open: graduate INV-3 to the baseline gate, compose
+children inside semantic sub-slots (e.g. Menu items) rather than only as
+direct children, and extend the probe set.
 
 ## Why
 

--- a/public/ds-health/override-evidence.json
+++ b/public/ds-health/override-evidence.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-07T12:43:26.903Z",
+  "generatedAt": "2026-08-07T14:46:15.416Z",
   "package": {
     "name": "@digitaltableteur/react",
     "version": "0.1.23"
@@ -1208,10 +1208,71 @@
       "reason": "no component contract (not a renderable component export)"
     }
   },
+  "encapsulation": {
+    "note": "informational (increment B): container × child interference on properties the child PINS itself (standalone computed differs from a neutral div), so inherited-by-design values never count. Not gated; graduation to the baseline gate is increment C.",
+    "scan": [
+      {
+        "name": "Menu",
+        "universalSelectors": [
+          ".item > *",
+          ".item[data-disabled] > *",
+          ".subTrigger[data-state=\"open\"] > *",
+          ":global(html.sb-forced-colors-active) .item[data-disabled] > *",
+          ":global(html.sb-forced-colors-active) .item[data-highlighted] > *"
+        ],
+        "composesChildren": true
+      },
+      {
+        "name": "ProcessBlock",
+        "universalSelectors": [
+          ".processBlock *"
+        ],
+        "composesChildren": false
+      },
+      {
+        "name": "ToastStack",
+        "universalSelectors": [
+          ".stack > *"
+        ],
+        "composesChildren": false
+      }
+    ],
+    "matrix": {
+      "pairsMeasured": 23,
+      "pairsAffected": 0,
+      "affected": {},
+      "skips": {
+        "Menu × AspectRatio": "child pins none of the probed properties",
+        "Menu × CategoryFilter": "child pins none of the probed properties",
+        "Menu × Center": "child pins none of the probed properties",
+        "Menu × Combobox": "child pins none of the probed properties",
+        "Menu × Container": "child pins none of the probed properties",
+        "Menu × DataTable": "child pins none of the probed properties",
+        "Menu × ExpandableSection": "child pins none of the probed properties",
+        "Menu × FormField": "child pins none of the probed properties",
+        "Menu × Grid": "child pins none of the probed properties",
+        "Menu × LanguageSwitcher": "child pins none of the probed properties",
+        "Menu × List": "child pins none of the probed properties",
+        "Menu × Logo": "child pins none of the probed properties",
+        "Menu × MultiCombobox": "child pins none of the probed properties",
+        "Menu × PageLayout": "child pins none of the probed properties",
+        "Menu × Pagination": "child pins none of the probed properties",
+        "Menu × RadioGroup": "child pins none of the probed properties",
+        "Menu × Section": "child pins none of the probed properties",
+        "Menu × Skeleton": "child pins none of the probed properties",
+        "Menu × Spacer": "child pins none of the probed properties",
+        "Menu × Spinner": "child pins none of the probed properties",
+        "Menu × SplitButton": "child pins none of the probed properties",
+        "Menu × Stack": "child pins none of the probed properties",
+        "Menu × ToastStack": "child pins none of the probed properties",
+        "Menu × ValueCard": "child pins none of the probed properties"
+      }
+    }
+  },
   "provenance": {
-    "sourceCommit": "03c781e9941dac3d5d24beace438e4fee32d3985",
+    "sourceCommit": "b860d3ae80379e78aa3d6e6b040aa8590de5caa5",
     "workingTreeClean": false,
-    "dirtyPathCount": 4,
+    "dirtyPathCount": 6,
     "generator": {
       "name": "measure-override-evidence",
       "version": 1,

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -158,7 +158,10 @@
   2026-08-07); also probes contract theming.vars for liveness. Exit 2 on
   failures not in `override-evidence-baseline.json` (dated entries, never
   blanket-updated). Requires a built dist; `-- --build` rebuilds first.
-  Output: `public/ds-health/override-evidence.json`.
+  Output: `public/ds-health/override-evidence.json`. Increment B adds the
+  informational encapsulation section: universal-selector container scan +
+  container × child interference matrix on child-pinned properties (never
+  gated; `-- --containers Name` exercises the machinery ad hoc).
 - All four run automatically inside `check:react-publish-preflight` (after
   `react-public-api` rebuilds the dist), so every publish regenerates its
   evidence; commit the regenerated artifacts with the publish PR.

--- a/scripts/design-system/measure-override-evidence.mjs
+++ b/scripts/design-system/measure-override-evidence.mjs
@@ -39,9 +39,11 @@ import { createRequire } from "node:module";
 import { build } from "esbuild";
 import { loadComponentContract } from "./ssr-evidence-lib.mjs";
 import {
+  assembleEncapsulation,
   assembleOverrideEvidence,
   compareToBaseline,
   componentOverrideRecord,
+  hostileContainerScan,
   probeStylesheet,
 } from "./override-evidence-lib.mjs";
 import { currentProvenance, runtimeStampFor } from "./evidence-stamp-lib.mjs";
@@ -58,6 +60,14 @@ const GENERATOR_VERSION = 1;
 const require = createRequire(import.meta.url);
 
 const shouldBuild = process.argv.includes("--build");
+// Debug affordance: --containers Name,Name overrides the scan-selected
+// matrix containers so the composition machinery can be exercised against
+// any renderable export. Never used by the committed artifact flow.
+const containersFlagIndex = process.argv.indexOf("--containers");
+const containersOverride =
+  containersFlagIndex !== -1
+    ? (process.argv[containersFlagIndex + 1] ?? "").split(",").filter(Boolean)
+    : null;
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
@@ -104,6 +114,37 @@ for (const [entry, exportNames] of Object.entries(exportsByEntry)) {
   }
 }
 
+// INV-3 container scan reads SOURCE module.css (the shipped CSS is
+// entry-aggregated and cannot be attributed per component); the scan only
+// SELECTS matrix candidates — every measurement still runs against the dist.
+const scanInput = components.map(({ exportName, contract }) => {
+  let cssText = "";
+  for (const base of [
+    "nextjs-app/shared/components",
+    "nextjs-app/shared/patterns",
+  ]) {
+    const cssPath = join(ROOT, base, exportName, `${exportName}.module.css`);
+    if (existsSync(cssPath)) {
+      cssText = readFileSync(cssPath, "utf8");
+      break;
+    }
+  }
+  return {
+    name: exportName,
+    cssText,
+    hasChildren: Boolean(contract.props?.children),
+  };
+});
+const scan = hostileContainerScan(scanInput);
+const matrixContainers =
+  containersOverride ??
+  scan.filter((entry) => entry.composesChildren).map((entry) => entry.name);
+if (containersOverride) {
+  console.log(
+    `note: --containers override active (${matrixContainers.join(", ")}); artifact must not be committed from this run`,
+  );
+}
+
 // --- Assemble the harness in a temp dir -----------------------------------
 const harnessDir = mkdtempSync(join(tmpdir(), "dt-override-evidence-"));
 const cssLinks = [];
@@ -142,6 +183,7 @@ runOverrideEvidence({
   ReactDOMClient,
   modules,
   components: window.__OVERRIDE_DATA__.components,
+  matrixContainers: window.__OVERRIDE_DATA__.matrixContainers,
 })
   .then((results) => {
     window.__OVERRIDE_RESULTS__ = results;
@@ -172,7 +214,7 @@ await build({
 const html = `<!doctype html>
 <html><head><meta charset="utf-8">
 ${cssLinks.map((href) => `<link rel="stylesheet" href="${href}">`).join("\n")}
-<script>window.__OVERRIDE_DATA__ = ${JSON.stringify({ components })};</script>
+<script>window.__OVERRIDE_DATA__ = ${JSON.stringify({ components, matrixContainers })};</script>
 </head><body><script src="bundle.js"></script></body></html>`;
 writeFileSync(join(harnessDir, "index.html"), html);
 
@@ -225,9 +267,11 @@ if (pageErrors.length) {
 }
 
 // --- Assemble artifact ----------------------------------------------------
+const componentResults = rawResults.results ?? {};
+const matrixResults = rawResults.matrix ?? [];
 const records = {};
 for (const { exportName } of components) {
-  records[exportName] = componentOverrideRecord(rawResults[exportName] ?? {
+  records[exportName] = componentOverrideRecord(componentResults[exportName] ?? {
     skip: "no measurement returned by the harness",
   });
 }
@@ -250,6 +294,10 @@ const substance = assembleOverrideEvidence({
   },
   components: records,
 });
+substance.encapsulation = assembleEncapsulation({
+  scan,
+  matrix: matrixResults,
+});
 
 const provenance = currentProvenance(ROOT, {
   name: "measure-override-evidence",
@@ -268,10 +316,16 @@ writeFileSync(OUT, `${JSON.stringify(report, null, 2)}\n`);
 const baseline = existsSync(BASELINE) ? readJson(BASELINE) : { entries: {} };
 const { newFailures, stale } = compareToBaseline(substance, baseline);
 const { totals } = substance;
+const encapsulation = substance.encapsulation;
 console.log(
   `\n✓ override evidence written: ${totals.pass} pass, ${totals.fail} fail ` +
     `(${Object.keys(baseline.entries ?? {}).length} baselined), ${totals.renderError} render errors, ` +
     `${totals.skipped} skipped, ${totals.themingVarsDeclared} theming vars declared → public/ds-health/override-evidence.json`,
+);
+console.log(
+  `  encapsulation (informational): ${encapsulation.scan.length} hostile containers scanned ` +
+    `(${matrixContainers.length} compose children), ${encapsulation.matrix.pairsMeasured} pairs measured, ` +
+    `${encapsulation.matrix.pairsAffected} affected`,
 );
 if (stale.length) {
   console.log(

--- a/scripts/design-system/override-evidence-harness-runtime.mjs
+++ b/scripts/design-system/override-evidence-harness-runtime.mjs
@@ -43,11 +43,14 @@ function subtreeFingerprint(root) {
   return parts.join("\n");
 }
 
+const CHILD_MARKER = "dtProbeChildMarker";
+
 export async function runOverrideEvidence({
   React,
   ReactDOMClient,
   modules,
   components,
+  matrixContainers = [],
 }) {
   const { createElement } = React;
   const lookup = (name) => {
@@ -92,6 +95,21 @@ export async function runOverrideEvidence({
     };
   }
 
+  // Neutral reference for the pinned-property discriminator (INV-3): a
+  // child only participates in matrix comparisons for properties whose
+  // standalone computed value differs from a plain div in the same context,
+  // so inherited-by-design values never register as interference.
+  const neutralDiv = document.createElement("div");
+  mountHost.appendChild(neutralDiv);
+  await nextPaint();
+  const neutralStyle = getComputedStyle(neutralDiv);
+  const neutralComputed = {};
+  for (const { prop } of PROBE_PROPERTIES) {
+    neutralComputed[prop] = neutralStyle.getPropertyValue(prop);
+  }
+  neutralDiv.remove();
+
+  const componentCache = new Map();
   const results = {};
   for (const { entry, exportName, contract } of components) {
     const measurement = {};
@@ -107,9 +125,15 @@ export async function runOverrideEvidence({
       const containerChain = hydrationContainerChainFor(contract?.element);
       const targets = overrideTargetsFor(contract);
 
+      // Containers in the INV-3 matrix only need a working render plan (their
+      // child is located document-wide, so portal containers qualify); cache
+      // before the in-flow-root check. Children additionally need
+      // baseComputed + forwarded, added below.
+      componentCache.set(exportName, { Component, props, containerChain });
       const base = await renderInto(Component, props, containerChain);
       if (base.renderError) {
         base.cleanup();
+        componentCache.delete(exportName);
         results[exportName] = { renderError: base.renderError };
         continue;
       }
@@ -123,6 +147,12 @@ export async function runOverrideEvidence({
       const baseFingerprint = targets.vars.length
         ? subtreeFingerprint(base.rootElement)
         : null;
+      const baseStyle = getComputedStyle(base.rootElement);
+      const baseComputed = {};
+      for (const { prop } of PROBE_PROPERTIES) {
+        baseComputed[prop] = baseStyle.getPropertyValue(prop);
+      }
+      componentCache.get(exportName).baseComputed = baseComputed;
       base.cleanup();
 
       if (targets.hasClassName) {
@@ -183,6 +213,10 @@ export async function runOverrideEvidence({
         measurement.skip =
           "contract declares neither className nor theming.vars (out of scope)";
       }
+      if (componentCache.has(exportName)) {
+        componentCache.get(exportName).forwarded =
+          measurement.classNameForwarded === true;
+      }
       results[exportName] = measurement;
     } catch (error) {
       results[exportName] = {
@@ -191,5 +225,77 @@ export async function runOverrideEvidence({
     }
   }
 
-  return results;
+  // --- INV-3 matrix (informational): container × child interference ------
+  const matrix = [];
+  for (const containerName of matrixContainers) {
+    const container = componentCache.get(containerName);
+    if (!container) {
+      matrix.push({
+        container: containerName,
+        child: "*",
+        skip: "container is not renderable in the harness",
+      });
+      continue;
+    }
+    for (const [childName, child] of componentCache) {
+      if (childName === containerName) continue;
+      if (!child.baseComputed || !child.forwarded) continue; // marker travels via className
+      if (child.containerChain.length) continue; // fragments need table ancestry
+      const pinned = PROBE_PROPERTIES.map((p) => p.prop).filter(
+        (prop) => child.baseComputed[prop] !== neutralComputed[prop],
+      );
+      if (!pinned.length) {
+        matrix.push({
+          container: containerName,
+          child: childName,
+          skip: "child pins none of the probed properties",
+        });
+        continue;
+      }
+      try {
+        const childElement = createElement(child.Component, {
+          ...child.props,
+          className: [child.props.className, CHILD_MARKER]
+            .filter(Boolean)
+            .join(" "),
+        });
+        const composed = await renderInto(
+          container.Component,
+          { ...container.props, children: childElement },
+          container.containerChain,
+        );
+        // Portals may place the child outside the wrapper; search the page.
+        const marked = document.querySelector(`.${CHILD_MARKER}`);
+        if (!marked) {
+          matrix.push({
+            container: containerName,
+            child: childName,
+            skip: "container did not render the marked child",
+          });
+        } else {
+          const style = getComputedStyle(marked);
+          const diffs = {};
+          for (const prop of pinned) {
+            const inContainer = style.getPropertyValue(prop);
+            if (inContainer !== child.baseComputed[prop]) {
+              diffs[prop] = {
+                standalone: child.baseComputed[prop],
+                inContainer,
+              };
+            }
+          }
+          matrix.push({ container: containerName, child: childName, diffs });
+        }
+        composed.cleanup();
+      } catch (error) {
+        matrix.push({
+          container: containerName,
+          child: childName,
+          skip: `composition render failed: ${String(error?.message ?? error).split("\n")[0].slice(0, 200)}`,
+        });
+      }
+    }
+  }
+
+  return { results, matrix };
 }

--- a/scripts/design-system/override-evidence-lib.mjs
+++ b/scripts/design-system/override-evidence-lib.mjs
@@ -167,6 +167,97 @@ export function assembleOverrideEvidence({
 }
 
 /**
+ * INV-3 (increment B, informational): formalized hostile-container scan.
+ * A hostile container is a component whose stylesheet contains a universal
+ * selector (`*` as a compound in any combinator position) — the selector
+ * shape behind the #1280 Modal/Switch bug. Containers that also compose
+ * consumer children (contract declares `children`) enter the encapsulation
+ * matrix; the rest are inventoried as a watchlist.
+ *
+ * Input: [{ name, cssText, hasChildren }]. CSS comments are stripped before
+ * matching so asterisks inside comment blocks never false-positive.
+ */
+export function hostileContainerScan(components) {
+  const results = [];
+  for (const { name, cssText, hasChildren } of components) {
+    const css = String(cssText ?? "").replace(/\/\*[\s\S]*?\*\//g, "");
+    const selectors = [...css.matchAll(/([^{}]+)\{/g)]
+      .map((match) => match[1].trim())
+      .filter(
+        (selector) =>
+          !selector.startsWith("@") &&
+          /(^|[\s>+~(])\*/.test(selector),
+      );
+    if (selectors.length) {
+      results.push({
+        name,
+        universalSelectors: [...new Set(selectors)].sort(),
+        composesChildren: Boolean(hasChildren),
+      });
+    }
+  }
+  return results.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Assemble the informational encapsulation section from the scan and the
+ * in-browser matrix measurements. Deterministic substance, but NEVER gated:
+ * a difference on a pinned property is a fact to interpret (a container may
+ * style children by design), not an automatic defect — that judgment is
+ * increment C's.
+ */
+export function assembleEncapsulation({ scan, matrix }) {
+  const affected = {};
+  let measured = 0;
+  let affectedCount = 0;
+  const skips = {};
+  for (const pair of matrix) {
+    if (pair.skip) {
+      skips[`${pair.container} × ${pair.child}`] = pair.skip;
+      continue;
+    }
+    measured += 1;
+    const diffs = {};
+    for (const [prop, diff] of Object.entries(pair.diffs ?? {})) {
+      diffs[prop] = diff;
+    }
+    if (Object.keys(diffs).length) {
+      affectedCount += 1;
+      affected[pair.container] = affected[pair.container] ?? {};
+      affected[pair.container][pair.child] = diffs;
+    }
+  }
+  return {
+    note: "informational (increment B): container × child interference on properties the child PINS itself (standalone computed differs from a neutral div), so inherited-by-design values never count. Not gated; graduation to the baseline gate is increment C.",
+    scan,
+    matrix: {
+      pairsMeasured: measured,
+      pairsAffected: affectedCount,
+      affected: sortObjectDeep(affected),
+      skips: sortObject(skips),
+    },
+  };
+}
+
+function sortObject(object) {
+  const sorted = {};
+  for (const key of Object.keys(object).sort()) sorted[key] = object[key];
+  return sorted;
+}
+
+function sortObjectDeep(object) {
+  const sorted = {};
+  for (const key of Object.keys(object).sort()) {
+    const value = object[key];
+    sorted[key] =
+      value && typeof value === "object" && !Array.isArray(value)
+        ? sortObjectDeep(value)
+        : value;
+  }
+  return sorted;
+}
+
+/**
  * Baseline comparison. The baseline lists APPROVED failures as
  * { "<Component>": { note, on } } (agent-experience-baseline precedent:
  * dated, explained, never blanket-updated). Returns failures not covered by

--- a/scripts/design-system/override-evidence-lib.test.mjs
+++ b/scripts/design-system/override-evidence-lib.test.mjs
@@ -3,9 +3,11 @@ import { expect, test } from "vitest";
 import {
   PROBE_CLASS,
   PROBE_PROPERTIES,
+  assembleEncapsulation,
   assembleOverrideEvidence,
   compareToBaseline,
   componentOverrideRecord,
+  hostileContainerScan,
   overrideTargetsFor,
   probeStylesheet,
   varProbeValue,
@@ -121,6 +123,52 @@ test("assembleOverrideEvidence sorts, totals, and states the contract", () => {
     themingVarsDeclared: 0,
   });
   expect(report.contract).toMatch(/className-override-wins/);
+});
+
+test("hostileContainerScan finds universal selectors and ignores comments", () => {
+  const scan = hostileContainerScan([
+    {
+      name: "Menu",
+      cssText: ".item > * { color: red; }\n.plain { color: blue; }",
+      hasChildren: true,
+    },
+    {
+      name: "ProcessBlock",
+      cssText: "@media (prefers-reduced-motion: reduce) { .processBlock * { transition: none; } }",
+      hasChildren: false,
+    },
+    {
+      name: "Card",
+      cssText: "/* a * in a comment */ .card { padding: 0; }",
+      hasChildren: true,
+    },
+  ]);
+  expect(scan.map((s) => s.name)).toEqual(["Menu", "ProcessBlock"]);
+  expect(scan[0].composesChildren).toBe(true);
+  expect(scan[0].universalSelectors).toEqual([".item > *"]);
+  expect(scan[1].composesChildren).toBe(false);
+});
+
+test("assembleEncapsulation totals pairs and keeps only real diffs", () => {
+  const section = assembleEncapsulation({
+    scan: [{ name: "Menu", universalSelectors: [".item > *"], composesChildren: true }],
+    matrix: [
+      {
+        container: "Menu",
+        child: "Badge",
+        diffs: {
+          color: { standalone: "rgb(1, 2, 3)", inContainer: "rgb(9, 9, 9)" },
+        },
+      },
+      { container: "Menu", child: "Text", diffs: {} },
+      { container: "Menu", child: "Spacer", skip: "child pins none of the probed properties" },
+    ],
+  });
+  expect(section.matrix.pairsMeasured).toBe(2);
+  expect(section.matrix.pairsAffected).toBe(1);
+  expect(section.matrix.affected.Menu.Badge.color.inContainer).toBe("rgb(9, 9, 9)");
+  expect(section.matrix.skips["Menu × Spacer"]).toMatch(/pins none/);
+  expect(section.note).toMatch(/informational/);
 });
 
 test("compareToBaseline reports new failures and stale approvals", () => {


### PR DESCRIPTION
INV-3 shipped informationally: formalized universal-selector container scan (Menu + 2 watchlist), container x child matrix with a pinned-property discriminator that excludes inheritance noise, portal-container support, --containers debug flag. Artifact: Menu x 23 children measured, 0 affected; deterministic substance; never gated. Gates: typecheck 0, lint 0, test 2903/2903, build 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added informational scans for broad CSS selectors that may affect nested components.
  * Added container-and-child compatibility checks with property-difference reporting.
  * Added optional selection of containers for targeted analysis.
  * Enhanced evidence reports with encapsulation findings, skipped cases, and measurement totals.

* **Documentation**
  * Documented the new scans, compatibility matrix, and container-selection option.

* **Tests**
  * Added coverage for selector detection, composition analysis, measurement results, skips, and reported differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->