### PR TITLE
feat(ds): override gate increment C - sub-slot composition, wider probes, matrix gating

### DIFF
--- a/docs/OVERRIDE_EVIDENCE_SPEC.md
+++ b/docs/OVERRIDE_EVIDENCE_SPEC.md
@@ -13,9 +13,17 @@ context, so inherited-by-design values never register as interference.
 Current artifact: Menu × 23 children, 0 affected. A `--containers` debug
 flag exercises the machinery against any renderable export.
 
-Increment C remains open: graduate INV-3 to the baseline gate, compose
-children inside semantic sub-slots (e.g. Menu items) rather than only as
-direct children, and extend the probe set.
+Increment C (implemented): INV-3 graduated to the baseline gate — NEW
+affected matrix pairs fail against dated `encapsulation` baseline entries
+keyed `"Container × Child (via)"`. Children now also compose inside
+semantic sub-slots through explicit runtime recipes (Menu:
+Trigger + Content > Item, open; recipes are added when a container's
+hostile rules are unreachable through direct children). Probe set extended
+with `font-size` and `gap` — the gap probe immediately caught Grid applying
+gap/columns as inline styles on its non-responsive path (fixed by routing
+both through the existing custom-property mechanism unconditionally).
+Current artifact: 47 pass / 0 fail, 64 matrix pairs (direct + subslot),
+0 affected, empty baseline.
 
 ## Why
 

--- a/nextjs-app/shared/components/Grid/Grid.test.tsx
+++ b/nextjs-app/shared/components/Grid/Grid.test.tsx
@@ -37,16 +37,23 @@ describe("Grid", () => {
     expect(container.firstChild).toHaveClass("custom-class");
   });
 
-  it("keeps the legacy inline path when no responsive props are set", () => {
+  it("routes columns/gap through custom properties even without responsive props", () => {
+    // Inline declarations of the real properties would beat any consumer
+    // className override (override-precedence gate catch); the values flow
+    // as custom properties read by the .responsive class instead, keeping
+    // the legacy repeat(n, 1fr) template form.
     const { container } = render(
       <Grid columns={3} gap="1rem">
         <div>Item</div>
       </Grid>,
     );
     const grid = container.firstChild as HTMLElement;
-    expect(grid.style.gridTemplateColumns).toBe("repeat(3, 1fr)");
-    expect(grid.style.gap).toBe("1rem");
-    expect(grid.style.getPropertyValue("--grid-cols")).toBe("");
+    expect(grid.style.gridTemplateColumns).toBe("");
+    expect(grid.style.gap).toBe("");
+    expect(grid.style.getPropertyValue("--dt-grid-columns")).toBe(
+      "repeat(3, 1fr)",
+    );
+    expect(grid.style.getPropertyValue("--dt-grid-gap")).toBe("1rem");
   });
 
   it("switches to custom-property resolution when responsive props are set", () => {

--- a/nextjs-app/shared/components/Grid/Grid.tsx
+++ b/nextjs-app/shared/components/Grid/Grid.tsx
@@ -113,11 +113,20 @@ function Grid({
     return child;
   });
 
-  // Per-breakpoint props switch the column/gap resolution from inline styles
-  // to CSS custom properties read by the .responsive media queries in
-  // Grid.module.css (inline styles cannot express media queries). Without
-  // them the legacy inline path below renders byte-identical to before.
-  const isResponsive =
+  // Columns and gap ALWAYS flow through CSS custom properties read by the
+  // .responsive class: inline declarations of the real properties would beat
+  // any consumer className override (the override-precedence gate caught gap
+  // exactly that way — docs/OVERRIDE_EVIDENCE_SPEC.md), while inline custom
+  // properties keep the declaration in the stylesheet where a later
+  // single-class consumer rule wins ties. With no per-breakpoint props the
+  // var fallback chains resolve to the base values at every breakpoint,
+  // rendering identical to the former inline path.
+  //
+  // Responsive tracks use minmax(0, 1fr) so cells can shrink below their
+  // content's intrinsic width (matches utility-grid column behavior). The
+  // single-value legacy form repeat(n, 1fr) is preserved for the base
+  // columns value to keep non-responsive grids byte-identical.
+  const hasBreakpointProps =
     tabletColumns != null ||
     desktopColumns != null ||
     wideColumns != null ||
@@ -127,39 +136,36 @@ function Grid({
     wideGap != null ||
     ultraGap != null;
 
-  // Responsive tracks use minmax(0, 1fr) so cells can shrink below their
-  // content's intrinsic width (matches utility-grid column behavior).
   const toTemplate = (value: number | string) =>
     typeof value === "number" ? `repeat(${value}, minmax(0, 1fr))` : value;
+  const toBaseTemplate = (value: number | string) =>
+    typeof value === "number"
+      ? hasBreakpointProps
+        ? `repeat(${value}, minmax(0, 1fr))`
+        : `repeat(${value}, 1fr)`
+      : value;
 
   const gridStyles: CSSProperties = {
-    display: "grid",
-    ...(isResponsive
-      ? ({
-          "--dt-grid-columns": toTemplate(columns),
-          ...(tabletColumns != null && {
-            "--dt-grid-columns-tablet": toTemplate(tabletColumns),
-          }),
-          ...(desktopColumns != null && {
-            "--dt-grid-columns-desktop": toTemplate(desktopColumns),
-          }),
-          ...(wideColumns != null && {
-            "--dt-grid-columns-wide": toTemplate(wideColumns),
-          }),
-          ...(ultraColumns != null && {
-            "--dt-grid-columns-ultra": toTemplate(ultraColumns),
-          }),
-          "--dt-grid-gap": gap,
-          ...(tabletGap != null && { "--dt-grid-gap-tablet": tabletGap }),
-          ...(desktopGap != null && { "--dt-grid-gap-desktop": desktopGap }),
-          ...(wideGap != null && { "--dt-grid-gap-wide": wideGap }),
-          ...(ultraGap != null && { "--dt-grid-gap-ultra": ultraGap }),
-        } as CSSProperties)
-      : {
-          gridTemplateColumns:
-            typeof columns === "number" ? `repeat(${columns}, 1fr)` : columns,
-          gap,
-        }),
+    ...({
+      "--dt-grid-columns": toBaseTemplate(columns),
+      ...(tabletColumns != null && {
+        "--dt-grid-columns-tablet": toTemplate(tabletColumns),
+      }),
+      ...(desktopColumns != null && {
+        "--dt-grid-columns-desktop": toTemplate(desktopColumns),
+      }),
+      ...(wideColumns != null && {
+        "--dt-grid-columns-wide": toTemplate(wideColumns),
+      }),
+      ...(ultraColumns != null && {
+        "--dt-grid-columns-ultra": toTemplate(ultraColumns),
+      }),
+      "--dt-grid-gap": gap,
+      ...(tabletGap != null && { "--dt-grid-gap-tablet": tabletGap }),
+      ...(desktopGap != null && { "--dt-grid-gap-desktop": desktopGap }),
+      ...(wideGap != null && { "--dt-grid-gap-wide": wideGap }),
+      ...(ultraGap != null && { "--dt-grid-gap-ultra": ultraGap }),
+    } as CSSProperties),
     ...(rows && {
       gridTemplateRows:
         typeof rows === "number" ? `repeat(${rows}, 1fr)` : rows,
@@ -171,11 +177,7 @@ function Grid({
     ...style,
   };
 
-  const gridClassName = [
-    styles.grid,
-    isResponsive ? styles.responsive : "",
-    className,
-  ]
+  const gridClassName = [styles.grid, styles.responsive, className]
     .filter(Boolean)
     .join(" ");
 

--- a/public/ds-health/override-evidence.json
+++ b/public/ds-health/override-evidence.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-07T14:46:15.416Z",
+  "generatedAt": "2026-08-07T15:04:48.393Z",
   "package": {
     "name": "@digitaltableteur/react",
     "version": "0.1.23"
@@ -11,7 +11,7 @@
     "reducedMotion": true
   },
   "methodology": {
-    "probe": "single class .dtProbeOverride with color, margin-block-start, background-color; sentinel values no token resolves to; probe stylesheet loads after design-system CSS, mirroring the documented consumer import order",
+    "probe": "single class .dtProbeOverride with color, margin-block-start, background-color, font-size, gap; sentinel values no token resolves to; probe stylesheet loads after design-system CSS, mirroring the documented consumer import order",
     "rendering": "components render from the built dist with the SSR-evidence render plans (contract playground defaults, type-driven function/ref synthesis, descriptor resolution); computed styles read in real Chromium with reduced motion",
     "themingVars": "each contract-declared theming var is probed for liveness: setting it on a wrapper must change some computed style in the component subtree; zero declared vars is reported honestly, not hidden",
     "skips": "a skip is a harness limitation (no className prop, no in-flow root such as portals, or an unrenderable plan), recorded with its reason and never counted as component evidence"
@@ -35,6 +35,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -60,6 +66,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -94,6 +106,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -127,6 +145,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -143,6 +167,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -165,6 +195,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -181,6 +217,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -203,6 +245,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -223,6 +271,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -253,6 +307,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -273,6 +333,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -295,6 +361,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -312,6 +384,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -328,6 +406,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -350,6 +434,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -371,6 +461,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -391,6 +487,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -433,6 +535,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -462,6 +570,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -478,6 +592,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -496,6 +616,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -512,6 +638,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -566,6 +698,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -582,6 +720,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -608,6 +752,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -624,6 +774,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -646,6 +802,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -662,6 +824,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -684,6 +852,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -705,6 +879,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -721,6 +901,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -739,6 +925,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -755,6 +947,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -789,6 +987,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -805,6 +1009,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -827,6 +1037,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -843,6 +1059,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -861,6 +1083,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -877,6 +1105,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -919,6 +1153,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -952,6 +1192,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -968,6 +1214,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -993,6 +1245,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -1031,6 +1289,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -1048,6 +1312,12 @@
           },
           "background-color": {
             "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
+            "pass": true
           }
         }
       },
@@ -1064,6 +1334,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -1085,6 +1361,12 @@
             "pass": true
           },
           "background-color": {
+            "pass": true
+          },
+          "font-size": {
+            "pass": true
+          },
+          "gap": {
             "pass": true
           }
         }
@@ -1209,7 +1491,7 @@
     }
   },
   "encapsulation": {
-    "note": "informational (increment B): container × child interference on properties the child PINS itself (standalone computed differs from a neutral div), so inherited-by-design values never count. Not gated; graduation to the baseline gate is increment C.",
+    "note": "container × child interference on properties the child PINS itself (standalone computed differs from a neutral div), so inherited-by-design values never count. Composition runs as direct children and, where a sub-slot recipe exists, inside the container's semantic slot (via: subslot). Since increment C, NEW affected pairs gate against the dated baseline.",
     "scan": [
       {
         "name": "Menu",
@@ -1238,41 +1520,32 @@
       }
     ],
     "matrix": {
-      "pairsMeasured": 23,
+      "pairsMeasured": 64,
       "pairsAffected": 0,
       "affected": {},
       "skips": {
-        "Menu × AspectRatio": "child pins none of the probed properties",
-        "Menu × CategoryFilter": "child pins none of the probed properties",
-        "Menu × Center": "child pins none of the probed properties",
-        "Menu × Combobox": "child pins none of the probed properties",
-        "Menu × Container": "child pins none of the probed properties",
-        "Menu × DataTable": "child pins none of the probed properties",
-        "Menu × ExpandableSection": "child pins none of the probed properties",
-        "Menu × FormField": "child pins none of the probed properties",
-        "Menu × Grid": "child pins none of the probed properties",
-        "Menu × LanguageSwitcher": "child pins none of the probed properties",
-        "Menu × List": "child pins none of the probed properties",
-        "Menu × Logo": "child pins none of the probed properties",
-        "Menu × MultiCombobox": "child pins none of the probed properties",
-        "Menu × PageLayout": "child pins none of the probed properties",
-        "Menu × Pagination": "child pins none of the probed properties",
-        "Menu × RadioGroup": "child pins none of the probed properties",
-        "Menu × Section": "child pins none of the probed properties",
-        "Menu × Skeleton": "child pins none of the probed properties",
-        "Menu × Spacer": "child pins none of the probed properties",
-        "Menu × Spinner": "child pins none of the probed properties",
-        "Menu × SplitButton": "child pins none of the probed properties",
-        "Menu × Stack": "child pins none of the probed properties",
-        "Menu × ToastStack": "child pins none of the probed properties",
-        "Menu × ValueCard": "child pins none of the probed properties"
+        "Menu × AspectRatio (direct)": "child pins none of the probed properties",
+        "Menu × CategoryFilter (direct)": "child pins none of the probed properties",
+        "Menu × Center (direct)": "child pins none of the probed properties",
+        "Menu × Container (direct)": "child pins none of the probed properties",
+        "Menu × ExpandableSection (direct)": "child pins none of the probed properties",
+        "Menu × LanguageSwitcher (direct)": "child pins none of the probed properties",
+        "Menu × Logo (direct)": "child pins none of the probed properties",
+        "Menu × PageLayout (direct)": "child pins none of the probed properties",
+        "Menu × Pagination (direct)": "child pins none of the probed properties",
+        "Menu × RadioGroup (direct)": "child pins none of the probed properties",
+        "Menu × Section (direct)": "child pins none of the probed properties",
+        "Menu × Spacer (direct)": "child pins none of the probed properties",
+        "Menu × Spinner (direct)": "child pins none of the probed properties",
+        "Menu × Stack (direct)": "child pins none of the probed properties",
+        "Menu × ValueCard (direct)": "child pins none of the probed properties"
       }
     }
   },
   "provenance": {
-    "sourceCommit": "b860d3ae80379e78aa3d6e6b040aa8590de5caa5",
+    "sourceCommit": "39eca237b4d2692ae74417706f0743b7cee6efd5",
     "workingTreeClean": false,
-    "dirtyPathCount": 6,
+    "dirtyPathCount": 8,
     "generator": {
       "name": "measure-override-evidence",
       "version": 1,

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -158,10 +158,12 @@
   2026-08-07); also probes contract theming.vars for liveness. Exit 2 on
   failures not in `override-evidence-baseline.json` (dated entries, never
   blanket-updated). Requires a built dist; `-- --build` rebuilds first.
-  Output: `public/ds-health/override-evidence.json`. Increment B adds the
-  informational encapsulation section: universal-selector container scan +
-  container × child interference matrix on child-pinned properties (never
-  gated; `-- --containers Name` exercises the machinery ad hoc).
+  Output: `public/ds-health/override-evidence.json`. The encapsulation
+  section holds the universal-selector container scan + container × child
+  interference matrix on child-pinned properties (direct children and
+  sub-slot recipes; `-- --containers Name` exercises the machinery ad hoc).
+  Since increment C, NEW affected matrix pairs gate against dated
+  `encapsulation` baseline entries alongside component failures.
 - All four run automatically inside `check:react-publish-preflight` (after
   `react-public-api` rebuilds the dist), so every publish regenerates its
   evidence; commit the regenerated artifacts with the publish PR.

--- a/scripts/design-system/measure-override-evidence.mjs
+++ b/scripts/design-system/measure-override-evidence.mjs
@@ -314,7 +314,8 @@ writeFileSync(OUT, `${JSON.stringify(report, null, 2)}\n`);
 
 // --- Baseline gate --------------------------------------------------------
 const baseline = existsSync(BASELINE) ? readJson(BASELINE) : { entries: {} };
-const { newFailures, stale } = compareToBaseline(substance, baseline);
+const comparison = compareToBaseline(substance, baseline);
+const { newFailures, stale } = comparison;
 const { totals } = substance;
 const encapsulation = substance.encapsulation;
 console.log(
@@ -332,12 +333,21 @@ if (stale.length) {
     `note: baseline entries no longer failing (prune them): ${stale.join(", ")}`,
   );
 }
-if (newFailures.length) {
+if (comparison.stalePairs?.length) {
+  console.log(
+    `note: baseline encapsulation entries no longer affected (prune them): ${comparison.stalePairs.join(", ")}`,
+  );
+}
+const newAffectedPairs = comparison.newAffectedPairs ?? [];
+if (newFailures.length || newAffectedPairs.length) {
   console.error(
-    `\nFAIL: ${newFailures.length} override failure(s) not in the baseline:`,
+    `\nFAIL: ${newFailures.length} override failure(s) and ${newAffectedPairs.length} encapsulation pair(s) not in the baseline:`,
   );
   for (const name of newFailures) {
     console.error(`  x ${name}: ${JSON.stringify(records[name]).slice(0, 200)}`);
+  }
+  for (const key of newAffectedPairs) {
+    console.error(`  x ${key}`);
   }
   console.error(
     "  Fix the component, or add a dated, explained entry to scripts/design-system/override-evidence-baseline.json.",

--- a/scripts/design-system/override-evidence-baseline.json
+++ b/scripts/design-system/override-evidence-baseline.json
@@ -1,4 +1,5 @@
 {
-  "note": "Approved override-precedence failures (docs/OVERRIDE_EVIDENCE_SPEC.md). Each entry is { \"<Component>\": { \"note\": <why this is approved debt>, \"on\": <date> } }. Never blanket-update; every entry is an explained, dated decision and a burn-down candidate.",
-  "entries": {}
+  "note": "Approved override-precedence failures (docs/OVERRIDE_EVIDENCE_SPEC.md). `entries` holds component failures as { \"<Component>\": { note, on } }; `encapsulation` (increment C) holds approved interference pairs as { \"<Container> × <Child> (<via>)\": { note, on } }. Never blanket-update; every entry is an explained, dated decision and a burn-down candidate.",
+  "entries": {},
+  "encapsulation": {}
 }

--- a/scripts/design-system/override-evidence-harness-runtime.mjs
+++ b/scripts/design-system/override-evidence-harness-runtime.mjs
@@ -45,6 +45,33 @@ function subtreeFingerprint(root) {
 
 const CHILD_MARKER = "dtProbeChildMarker";
 
+/**
+ * Sub-slot composition recipes (increment C): how to place a child inside a
+ * container's SEMANTIC slot, where the container's descendant rules actually
+ * reach (Menu's `.item > *` only applies inside MenuItem). Explicit and
+ * reviewable, like the gallery's PreviewSpec — a recipe is added when a
+ * hostile container's rules are unreachable through direct children.
+ */
+const SUBSLOT_RECIPES = {
+  Menu(createElement, lookup, child) {
+    const MenuTrigger = lookup("MenuTrigger");
+    const MenuContent = lookup("MenuContent");
+    const MenuItem = lookup("MenuItem");
+    if (!MenuTrigger || !MenuContent || !MenuItem) return null;
+    return {
+      props: { open: true },
+      children: [
+        createElement(MenuTrigger, { key: "t" }, "Open"),
+        createElement(
+          MenuContent,
+          { key: "c" },
+          createElement(MenuItem, null, child),
+        ),
+      ],
+    };
+  },
+};
+
 export async function runOverrideEvidence({
   React,
   ReactDOMClient,
@@ -252,47 +279,86 @@ export async function runOverrideEvidence({
         });
         continue;
       }
-      try {
-        const childElement = createElement(child.Component, {
+      const childElement = () =>
+        createElement(child.Component, {
           ...child.props,
           className: [child.props.className, CHILD_MARKER]
             .filter(Boolean)
             .join(" "),
         });
-        const composed = await renderInto(
-          container.Component,
-          { ...container.props, children: childElement },
-          container.containerChain,
-        );
-        // Portals may place the child outside the wrapper; search the page.
-        const marked = document.querySelector(`.${CHILD_MARKER}`);
-        if (!marked) {
+
+      const compositions = [
+        {
+          via: "direct",
+          props: { ...container.props, children: childElement() },
+        },
+      ];
+      const recipe = SUBSLOT_RECIPES[containerName];
+      if (recipe) {
+        const slotted = recipe(createElement, lookup, childElement());
+        if (slotted) {
+          compositions.push({
+            via: "subslot",
+            props: {
+              ...container.props,
+              ...slotted.props,
+              children: slotted.children,
+            },
+          });
+        } else {
           matrix.push({
             container: containerName,
             child: childName,
-            skip: "container did not render the marked child",
+            via: "subslot",
+            skip: "sub-slot recipe parts are not exported from the dist",
           });
-        } else {
-          const style = getComputedStyle(marked);
-          const diffs = {};
-          for (const prop of pinned) {
-            const inContainer = style.getPropertyValue(prop);
-            if (inContainer !== child.baseComputed[prop]) {
-              diffs[prop] = {
-                standalone: child.baseComputed[prop],
-                inContainer,
-              };
-            }
-          }
-          matrix.push({ container: containerName, child: childName, diffs });
         }
-        composed.cleanup();
-      } catch (error) {
-        matrix.push({
-          container: containerName,
-          child: childName,
-          skip: `composition render failed: ${String(error?.message ?? error).split("\n")[0].slice(0, 200)}`,
-        });
+      }
+
+      for (const composition of compositions) {
+        try {
+          const composed = await renderInto(
+            container.Component,
+            composition.props,
+            container.containerChain,
+          );
+          // Portals may place the child outside the wrapper; search the page.
+          const marked = document.querySelector(`.${CHILD_MARKER}`);
+          if (!marked) {
+            matrix.push({
+              container: containerName,
+              child: childName,
+              via: composition.via,
+              skip: "container did not render the marked child",
+            });
+          } else {
+            const style = getComputedStyle(marked);
+            const diffs = {};
+            for (const prop of pinned) {
+              const inContainer = style.getPropertyValue(prop);
+              if (inContainer !== child.baseComputed[prop]) {
+                diffs[prop] = {
+                  standalone: child.baseComputed[prop],
+                  inContainer,
+                };
+              }
+            }
+            matrix.push({
+              container: containerName,
+              child: childName,
+              via: composition.via,
+              diffs,
+            });
+          }
+          composed.cleanup();
+        } catch (error) {
+          matrix.push({
+            container: containerName,
+            child: childName,
+            via: composition.via,
+            skip: `composition render failed: ${String(error?.message ?? error).split("\n")[0].slice(0, 200)}`,
+          });
+        }
       }
     }
   }

--- a/scripts/design-system/override-evidence-lib.mjs
+++ b/scripts/design-system/override-evidence-lib.mjs
@@ -11,15 +11,18 @@
  */
 
 /**
- * Probe set v1, sourced from the two shipped bug classes (#1280
- * Modal/Switch ink+surface, Title/Text spacing). Sentinels are valid,
- * visually meaningless values no token resolves to, so computed === sentinel
- * is unambiguous.
+ * Probe set: v1 props sourced from the two shipped bug classes (#1280
+ * Modal/Switch ink+surface, Title/Text spacing); font-size and gap added in
+ * increment C (typography compound-selector class, layout rhythm class).
+ * Sentinels are valid, visually meaningless values no token resolves to, so
+ * computed === sentinel is unambiguous.
  */
 export const PROBE_PROPERTIES = [
   { prop: "color", value: "rgb(9, 8, 7)" },
   { prop: "margin-block-start", value: "7px" },
   { prop: "background-color", value: "rgb(7, 8, 9)" },
+  { prop: "font-size", value: "13px" },
+  { prop: "gap", value: "9px" },
 ];
 
 export const PROBE_CLASS = "dtProbeOverride";
@@ -212,8 +215,9 @@ export function assembleEncapsulation({ scan, matrix }) {
   let affectedCount = 0;
   const skips = {};
   for (const pair of matrix) {
+    const via = pair.via ?? "direct";
     if (pair.skip) {
-      skips[`${pair.container} × ${pair.child}`] = pair.skip;
+      skips[`${pair.container} × ${pair.child} (${via})`] = pair.skip;
       continue;
     }
     measured += 1;
@@ -224,11 +228,13 @@ export function assembleEncapsulation({ scan, matrix }) {
     if (Object.keys(diffs).length) {
       affectedCount += 1;
       affected[pair.container] = affected[pair.container] ?? {};
-      affected[pair.container][pair.child] = diffs;
+      affected[pair.container][pair.child] =
+        affected[pair.container][pair.child] ?? {};
+      affected[pair.container][pair.child][via] = diffs;
     }
   }
   return {
-    note: "informational (increment B): container × child interference on properties the child PINS itself (standalone computed differs from a neutral div), so inherited-by-design values never count. Not gated; graduation to the baseline gate is increment C.",
+    note: "container × child interference on properties the child PINS itself (standalone computed differs from a neutral div), so inherited-by-design values never count. Composition runs as direct children and, where a sub-slot recipe exists, inside the container's semantic slot (via: subslot). Since increment C, NEW affected pairs gate against the dated baseline.",
     scan,
     matrix: {
       pairsMeasured: measured,
@@ -259,7 +265,9 @@ function sortObjectDeep(object) {
 
 /**
  * Baseline comparison. The baseline lists APPROVED failures as
- * { "<Component>": { note, on } } (agent-experience-baseline precedent:
+ * { "<Component>": { note, on } } under `entries`, and (since increment C)
+ * approved encapsulation interference as { "<Container> × <Child> (<via>)":
+ * { note, on } } under `encapsulation` (agent-experience-baseline precedent:
  * dated, explained, never blanket-updated). Returns failures not covered by
  * the baseline plus baseline entries that no longer fail (to be pruned).
  */
@@ -272,5 +280,22 @@ export function compareToBaseline(report, baseline) {
   const stale = Object.keys(approved).filter(
     (name) => report.components[name]?.status !== "fail",
   );
-  return { newFailures, stale };
+
+  // Increment C: affected matrix pairs gate too. A pair key is
+  // "Container × Child (via)".
+  const approvedPairs = baseline?.encapsulation ?? {};
+  const affected = report.encapsulation?.matrix?.affected ?? {};
+  const affectedKeys = [];
+  for (const [container, children] of Object.entries(affected)) {
+    for (const [child, byVia] of Object.entries(children)) {
+      for (const via of Object.keys(byVia)) {
+        affectedKeys.push(`${container} × ${child} (${via})`);
+      }
+    }
+  }
+  const newAffectedPairs = affectedKeys.filter((key) => !approvedPairs[key]);
+  const stalePairs = Object.keys(approvedPairs).filter(
+    (key) => !affectedKeys.includes(key),
+  );
+  return { newFailures, stale, newAffectedPairs, stalePairs };
 }

--- a/scripts/design-system/override-evidence-lib.test.mjs
+++ b/scripts/design-system/override-evidence-lib.test.mjs
@@ -149,26 +149,61 @@ test("hostileContainerScan finds universal selectors and ignores comments", () =
   expect(scan[1].composesChildren).toBe(false);
 });
 
-test("assembleEncapsulation totals pairs and keeps only real diffs", () => {
+test("assembleEncapsulation totals pairs, keys by via, keeps only real diffs", () => {
   const section = assembleEncapsulation({
     scan: [{ name: "Menu", universalSelectors: [".item > *"], composesChildren: true }],
     matrix: [
       {
         container: "Menu",
         child: "Badge",
+        via: "subslot",
         diffs: {
           color: { standalone: "rgb(1, 2, 3)", inContainer: "rgb(9, 9, 9)" },
         },
       },
+      { container: "Menu", child: "Badge", via: "direct", diffs: {} },
       { container: "Menu", child: "Text", diffs: {} },
       { container: "Menu", child: "Spacer", skip: "child pins none of the probed properties" },
     ],
   });
-  expect(section.matrix.pairsMeasured).toBe(2);
+  expect(section.matrix.pairsMeasured).toBe(3);
   expect(section.matrix.pairsAffected).toBe(1);
-  expect(section.matrix.affected.Menu.Badge.color.inContainer).toBe("rgb(9, 9, 9)");
-  expect(section.matrix.skips["Menu × Spacer"]).toMatch(/pins none/);
-  expect(section.note).toMatch(/informational/);
+  expect(section.matrix.affected.Menu.Badge.subslot.color.inContainer).toBe(
+    "rgb(9, 9, 9)",
+  );
+  expect(section.matrix.skips["Menu × Spacer (direct)"]).toMatch(/pins none/);
+  expect(section.note).toMatch(/gate against the dated baseline/);
+});
+
+test("new affected matrix pairs gate; baselined and stale pairs are reported", () => {
+  const substance = {
+    components: { Text: { status: "pass" } },
+    encapsulation: {
+      matrix: {
+        affected: {
+          Menu: {
+            Badge: { subslot: { color: {} } },
+            Kbd: { direct: { "font-size": {} } },
+          },
+        },
+      },
+    },
+  };
+  const { newAffectedPairs, stalePairs } = compareToBaseline(substance, {
+    entries: {},
+    encapsulation: {
+      "Menu × Kbd (direct)": { note: "approved", on: "2026-08-07" },
+      "Menu × Gone (direct)": { note: "old", on: "2026-08-01" },
+    },
+  });
+  expect(newAffectedPairs).toEqual(["Menu × Badge (subslot)"]);
+  expect(stalePairs).toEqual(["Menu × Gone (direct)"]);
+});
+
+test("probe set carries the increment C additions", () => {
+  const props = PROBE_PROPERTIES.map((p) => p.prop);
+  expect(props).toContain("font-size");
+  expect(props).toContain("gap");
 });
 
 test("compareToBaseline reports new failures and stale approvals", () => {


### PR DESCRIPTION
Completes the spec's increment ladder: sub-slot recipes (Menu items), font-size + gap probes, and matrix graduation to the dated baseline gate. First run of the gap probe caught Grid applying gap/columns as inline styles on its non-responsive path; fixed via the unconditional custom-property mechanism, byte-identical rendering, 9/9 tests. Artifact: 47 pass / 0 fail, 64 matrix pairs, 0 affected, empty baseline. Gates: typecheck 0, lint 0, test 2905/2905, build 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)