### PR TITLE
chore(release): prepare @digitaltableteur/react 0.1.24

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.1.24 - 2026-08-07
+
+- `Grid` columns and gap are consumer-overridable: the non-responsive path
+  applied `gap` and `grid-template-columns` as inline styles, which no
+  consumer `className` could beat (caught by the override-precedence gate's
+  new `gap` probe). Both values now always flow through the CSS
+  custom-property mechanism read by the stylesheet (`--dt-grid-columns`,
+  `--dt-grid-gap`); with no per-breakpoint props the var fallback chains
+  resolve to the base values at every breakpoint and the legacy
+  `repeat(n, 1fr)` template form is preserved, so rendered output is
+  unchanged. The `columns`/`gap` props behave exactly as before.
+
 ## 0.1.23 - 2026-08-07
 
 - Fixes `TreeView` leaf icons: leaf nodes request the `file` icon, whose

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/react",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "private": false,
   "description": "React components and host adapters for the Digitaltableteur design system.",
   "type": "module",


### PR DESCRIPTION
Version bump + changelog for the Grid overridability fix (override gate increment C catch). Gates: typecheck 0, lint 0, test 2905/2905, build 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `Grid` styling flexibility by allowing consumer class overrides for columns and gaps.
  * Preserved existing rendering behavior and prop compatibility.

* **Documentation**
  * Added changelog details for the `0.1.24` release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->