### PR TITLE
chore(deps): consume @digitaltableteur/react 0.1.24

### DIFF
--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.dark.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.23
+  - definition: 0.1.24
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.forced-colors.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.23
+  - definition: 0.1.24
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.light.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.23
+  - definition: 0.1.24
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--default.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.23
+  - definition: 0.1.24
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.dark.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.23
+  - definition: 0.1.24
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.forced-colors.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.23
+  - definition: 0.1.24
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.light.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.23
+  - definition: 0.1.24
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--example.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.23
+  - definition: 0.1.24
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.dark.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.23
+  - definition: 0.1.24
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.forced-colors.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.23
+  - definition: 0.1.24
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.light.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.23
+  - definition: 0.1.24
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--forced-colors.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.23
+  - definition: 0.1.24
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.dark.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.23
+  - definition: 0.1.24
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.forced-colors.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.forced-colors.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.23
+  - definition: 0.1.24
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.light.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.23
+  - definition: 0.1.24
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
+++ b/nextjs-app/shared/patterns/AboutPageContent/__a11y-snapshots__/patterns-aboutpagecontent--playground.yaml
@@ -73,7 +73,7 @@
     - listitem "Storybook 10"
     - listitem "npm"
   - term: react
-  - definition: 0.1.23
+  - definition: 0.1.24
   - term: web-components
   - definition: 0.10.0
   - term: tokens

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ai-sdk/openai": "^4.0.26",
         "@ai-sdk/react": "^4.0.48",
         "@calcom/embed-react": "^1.5.3",
-        "@digitaltableteur/react": "^0.1.23",
+        "@digitaltableteur/react": "^0.1.24",
         "@digitaltableteur/tokens": "^0.1.4",
         "@digitaltableteur/tokens-css": "^0.1.5",
         "@digitaltableteur/web-components": "^0.10.0",
@@ -3430,9 +3430,9 @@
       "license": "MIT"
     },
     "node_modules/@digitaltableteur/react": {
-      "version": "0.1.23",
-      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.23.tgz",
-      "integrity": "sha512-kpxpmArZc1wyYE7HZZ26k+njaAKD5JlSj/+RRzLm52c0B2v+/0Lj6XPcE4iuc2mZLR9+6eaou/PJnh9HAJGd5w==",
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/@digitaltableteur/react/-/react-0.1.24.tgz",
+      "integrity": "sha512-Qvb7qearRbcdwZRr0o3Z9Hwd0M2iLIgMCmxe+ZZWE8Bqj4IZw4Q9ypLYexrWlBpASCY+2X97fvnZEl25QUxn6Q==",
       "license": "UNLICENSED",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "@ai-sdk/openai": "^4.0.26",
     "@ai-sdk/react": "^4.0.48",
     "@calcom/embed-react": "^1.5.3",
-    "@digitaltableteur/react": "^0.1.23",
+    "@digitaltableteur/react": "^0.1.24",
     "@digitaltableteur/tokens": "^0.1.4",
     "@digitaltableteur/tokens-css": "^0.1.5",
     "@digitaltableteur/web-components": "^0.10.0",

--- a/public/ds-health/bundle-evidence.json
+++ b/public/ds-health/bundle-evidence.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-08-07T12:43:18.581Z",
+  "generatedAt": "2026-08-07T16:33:01.829Z",
   "package": {
     "name": "@digitaltableteur/react",
-    "version": "0.1.23"
+    "version": "0.1.24"
   },
   "toolchain": {
     "esbuild": "0.28.1",
@@ -844,12 +844,12 @@
     "layout": {
       "js": {
         "self": {
-          "minBytes": 141047,
-          "gzipBytes": 46633
+          "minBytes": 141028,
+          "gzipBytes": 46626
         },
         "withDeps": {
-          "minBytes": 385551,
-          "gzipBytes": 105408
+          "minBytes": 385532,
+          "gzipBytes": 105400
         }
       },
       "css": {
@@ -859,22 +859,22 @@
       "components": {
         "Accordion": {
           "self": {
-            "minBytes": 135943,
-            "gzipBytes": 44941
+            "minBytes": 135924,
+            "gzipBytes": 44924
           },
           "withDeps": {
-            "minBytes": 380434,
-            "gzipBytes": 103699
+            "minBytes": 380413,
+            "gzipBytes": 103686
           }
         },
         "AspectRatio": {
           "self": {
-            "minBytes": 134733,
-            "gzipBytes": 44523
+            "minBytes": 134714,
+            "gzipBytes": 44506
           },
           "withDeps": {
-            "minBytes": 379218,
-            "gzipBytes": 103286
+            "minBytes": 379197,
+            "gzipBytes": 103267
           }
         },
         "Card": {
@@ -889,102 +889,102 @@
         },
         "Center": {
           "self": {
-            "minBytes": 134534,
-            "gzipBytes": 44451
+            "minBytes": 134515,
+            "gzipBytes": 44435
           },
           "withDeps": {
-            "minBytes": 379018,
-            "gzipBytes": 103204
+            "minBytes": 378997,
+            "gzipBytes": 103183
           }
         },
         "Container": {
           "self": {
-            "minBytes": 134749,
-            "gzipBytes": 44522
+            "minBytes": 134730,
+            "gzipBytes": 44507
           },
           "withDeps": {
-            "minBytes": 379233,
-            "gzipBytes": 103283
+            "minBytes": 379212,
+            "gzipBytes": 103265
           }
         },
         "Divider": {
           "self": {
-            "minBytes": 134410,
-            "gzipBytes": 44407
+            "minBytes": 134391,
+            "gzipBytes": 44393
           },
           "withDeps": {
-            "minBytes": 378893,
-            "gzipBytes": 103150
+            "minBytes": 378872,
+            "gzipBytes": 103130
           }
         },
         "FlexBox": {
           "self": {
-            "minBytes": 134881,
-            "gzipBytes": 44569
+            "minBytes": 134862,
+            "gzipBytes": 44555
           },
           "withDeps": {
-            "minBytes": 379365,
-            "gzipBytes": 103337
+            "minBytes": 379344,
+            "gzipBytes": 103323
           }
         },
         "Grid": {
           "self": {
-            "minBytes": 134407,
-            "gzipBytes": 44407
+            "minBytes": 134388,
+            "gzipBytes": 44393
           },
           "withDeps": {
-            "minBytes": 378890,
-            "gzipBytes": 103150
+            "minBytes": 378869,
+            "gzipBytes": 103130
           }
         },
         "MacWindowFrame": {
           "self": {
-            "minBytes": 134417,
-            "gzipBytes": 44407
+            "minBytes": 134398,
+            "gzipBytes": 44392
           },
           "withDeps": {
-            "minBytes": 378900,
-            "gzipBytes": 103150
+            "minBytes": 378879,
+            "gzipBytes": 103133
           }
         },
         "ResizablePanelGroup": {
           "self": {
-            "minBytes": 134422,
-            "gzipBytes": 44406
+            "minBytes": 134403,
+            "gzipBytes": 44392
           },
           "withDeps": {
-            "minBytes": 378905,
-            "gzipBytes": 103148
+            "minBytes": 378884,
+            "gzipBytes": 103129
           }
         },
         "Section": {
           "self": {
-            "minBytes": 134410,
-            "gzipBytes": 44406
+            "minBytes": 134391,
+            "gzipBytes": 44392
           },
           "withDeps": {
-            "minBytes": 378893,
-            "gzipBytes": 103149
+            "minBytes": 378872,
+            "gzipBytes": 103129
           }
         },
         "Spacer": {
           "self": {
-            "minBytes": 134768,
-            "gzipBytes": 44509
+            "minBytes": 134749,
+            "gzipBytes": 44494
           },
           "withDeps": {
-            "minBytes": 379252,
-            "gzipBytes": 103254
+            "minBytes": 379231,
+            "gzipBytes": 103238
           }
         },
         "Stack": {
           "self": {
-            "minBytes": 134938,
-            "gzipBytes": 44609
+            "minBytes": 134919,
+            "gzipBytes": 44593
           },
           "withDeps": {
-            "minBytes": 379422,
-            "gzipBytes": 103352
+            "minBytes": 379401,
+            "gzipBytes": 103337
           }
         }
       }
@@ -1665,12 +1665,12 @@
   "totals": {
     "js": {
       "self": {
-        "minBytes": 2219350,
-        "gzipBytes": 739827
+        "minBytes": 2219331,
+        "gzipBytes": 739820
       },
       "withDeps": {
-        "minBytes": 4630831,
-        "gzipBytes": 1320793
+        "minBytes": 4630812,
+        "gzipBytes": 1320785
       }
     },
     "css": {
@@ -1679,9 +1679,9 @@
     }
   },
   "provenance": {
-    "sourceCommit": "03c781e9941dac3d5d24beace438e4fee32d3985",
-    "workingTreeClean": false,
-    "dirtyPathCount": 2,
+    "sourceCommit": "f298a71c11e4d882402afeebbaee1256023dfced",
+    "workingTreeClean": true,
+    "dirtyPathCount": 0,
     "generator": {
       "name": "measure-bundle-evidence",
       "version": 1,

--- a/public/ds-health/compatibility-manifest.json
+++ b/public/ds-health/compatibility-manifest.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2026-08-07T12:43:27.195Z",
+  "generatedAt": "2026-08-07T16:33:11.970Z",
   "scope": "combinations actually exercised by the local gates at generation time. Absence from this manifest means untested, not incompatible.",
   "packages": {
     "@digitaltableteur/cli": "0.5.0",
-    "@digitaltableteur/react": "0.1.23",
+    "@digitaltableteur/react": "0.1.24",
     "@digitaltableteur/tokens": "0.1.4",
     "@digitaltableteur/tokens-css": "0.1.5",
     "@digitaltableteur/web-components": "0.10.0"
@@ -103,19 +103,30 @@
   ],
   "preflight": {
     "note": "most recent RECORDED preflight run at manifest generation time; when the manifest is regenerated inside a preflight run, this describes the previous run",
-    "generatedAt": "2026-08-07T12:28:31.500Z",
-    "status": "failed",
+    "generatedAt": "2026-08-07T12:44:07.858Z",
+    "status": "passed-clearance-recorded",
     "checks": {
       "astryx-roadmap": true,
       "beta-promotion-readiness": true,
       "build": true,
+      "bundle-evidence": true,
+      "compatibility-manifest": true,
+      "i18n-visual-matrix": true,
       "lint": true,
-      "npm-consumer-install": false,
+      "npm-consumer-install": true,
+      "override-evidence": true,
+      "package-publish-dry-run": true,
       "package-registry-resolution": true,
       "package-registry-status": true,
       "package-release-notes": true,
+      "package-tarballs": true,
+      "react-public-api": true,
+      "react-public-surface": true,
+      "react-publish-review": true,
       "react-registry-install-waiting": true,
       "registry-token-install": true,
+      "site-package-dogfood": true,
+      "ssr-evidence": true,
       "storybook-build": true,
       "storybook-registry-package": true,
       "test": true,
@@ -124,9 +135,9 @@
     }
   },
   "provenance": {
-    "sourceCommit": "03c781e9941dac3d5d24beace438e4fee32d3985",
+    "sourceCommit": "f298a71c11e4d882402afeebbaee1256023dfced",
     "workingTreeClean": false,
-    "dirtyPathCount": 5,
+    "dirtyPathCount": 3,
     "generator": {
       "name": "generate-compatibility-manifest",
       "version": 1,

--- a/public/ds-health/override-evidence.json
+++ b/public/ds-health/override-evidence.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-08-07T15:04:48.393Z",
+  "generatedAt": "2026-08-07T16:33:11.731Z",
   "package": {
     "name": "@digitaltableteur/react",
-    "version": "0.1.23"
+    "version": "0.1.24"
   },
   "contract": "OWNER DECISION 2026-08-07: className-override-wins. A consumer's single-class, no-!important selector applied via className wins over component base styles for the probed properties on the root element, under the documented consumer arrangement (design-system CSS before consumer CSS).",
   "environment": {
@@ -1543,9 +1543,9 @@
     }
   },
   "provenance": {
-    "sourceCommit": "39eca237b4d2692ae74417706f0743b7cee6efd5",
+    "sourceCommit": "f298a71c11e4d882402afeebbaee1256023dfced",
     "workingTreeClean": false,
-    "dirtyPathCount": 8,
+    "dirtyPathCount": 2,
     "generator": {
       "name": "measure-override-evidence",
       "version": 1,

--- a/public/ds-health/ssr-evidence.json
+++ b/public/ds-health/ssr-evidence.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-08-07T12:43:23.286Z",
+  "generatedAt": "2026-08-07T16:33:07.054Z",
   "package": {
     "name": "@digitaltableteur/react",
-    "version": "0.1.23"
+    "version": "0.1.24"
   },
   "environment": {
     "react": "19.2.8",
@@ -753,7 +753,7 @@
           "status": "pass",
           "ssr": {
             "ok": true,
-            "htmlBytes": 132
+            "htmlBytes": 146
           },
           "hydration": {
             "ok": true
@@ -1224,281 +1224,281 @@
   "informational": {
     "timings": {
       "Button": {
-        "renderToStringMs": 0.281
+        "renderToStringMs": 0.448
       },
       "ButtonGroup": {
-        "renderToStringMs": 0.048
+        "renderToStringMs": 0.06
       },
       "FilterChip": {
-        "renderToStringMs": 0.04
+        "renderToStringMs": 0.037
       },
       "IconButton": {
-        "renderToStringMs": 0.075
+        "renderToStringMs": 0.258
       },
       "SlideButton": {
-        "renderToStringMs": 0.064
+        "renderToStringMs": 0.205
       },
       "SplitButton": {
-        "renderToStringMs": 0.288
+        "renderToStringMs": 0.973
       },
       "AuthorBio": {
-        "renderToStringMs": 0.007
+        "renderToStringMs": 0.01
       },
       "CodeBlockWindow": {
-        "renderToStringMs": 0.095
+        "renderToStringMs": 0.293
       },
       "CodeSnippet": {
-        "renderToStringMs": 0.543
+        "renderToStringMs": 1.428
       },
       "DataTable": {
-        "renderToStringMs": 0.176
+        "renderToStringMs": 0.589
       },
       "ExpandableSection": {
-        "renderToStringMs": 0.036
-      },
-      "Gallery": {
-        "renderToStringMs": 0.128
-      },
-      "List": {
-        "renderToStringMs": 0.022
-      },
-      "ListItem": {
-        "renderToStringMs": 0.013
-      },
-      "Logo": {
-        "renderToStringMs": 0.053
-      },
-      "ReadingProgress": {
-        "renderToStringMs": 0.005
-      },
-      "Table": {
-        "renderToStringMs": 0.017
-      },
-      "TableCell": {
-        "renderToStringMs": 0.009
-      },
-      "TableHeaderCell": {
-        "renderToStringMs": 0.011
-      },
-      "TableRow": {
-        "renderToStringMs": 0.01
-      },
-      "Timestamp": {
-        "renderToStringMs": 0.049
-      },
-      "ValueCard": {
-        "renderToStringMs": 0.045
-      },
-      "VirtualList": {
-        "renderToStringMs": 0.085
-      },
-      "VirtualListItem": {
-        "renderToStringMs": 0.018
-      },
-      "AlertBanner": {
-        "renderToStringMs": 0.049
-      },
-      "EmptyState": {
-        "renderToStringMs": 0.049
-      },
-      "Progress": {
-        "renderToStringMs": 0.015
-      },
-      "Skeleton": {
-        "renderToStringMs": 0.024
-      },
-      "Spinner": {
-        "renderToStringMs": 0.009
-      },
-      "Toast": {
-        "renderToStringMs": 0.047
-      },
-      "ToastStack": {
-        "renderToStringMs": 0.047
-      },
-      "Checkbox": {
-        "renderToStringMs": 0.03
-      },
-      "CheckboxGroup": {
-        "renderToStringMs": 0.11
-      },
-      "Combobox": {
-        "renderToStringMs": 0.084
-      },
-      "FileUpload": {
-        "renderToStringMs": 0.071
-      },
-      "FormField": {
-        "renderToStringMs": 0.021
-      },
-      "GroupLabel": {
-        "renderToStringMs": 0.016
-      },
-      "HelperText": {
-        "renderToStringMs": 0.011
-      },
-      "Label": {
-        "renderToStringMs": 0.017
-      },
-      "MultiCombobox": {
-        "renderToStringMs": 0.116
-      },
-      "PhoneInput": {
-        "renderToStringMs": 1.325
-      },
-      "Radio": {
-        "renderToStringMs": 0.018
-      },
-      "RadioGroup": {
         "renderToStringMs": 0.08
       },
-      "Select": {
-        "renderToStringMs": 0.055
+      "Gallery": {
+        "renderToStringMs": 0.272
       },
-      "SelectableCard": {
-        "renderToStringMs": 0.02
+      "List": {
+        "renderToStringMs": 0.075
       },
-      "Switch": {
-        "renderToStringMs": 0.028
-      },
-      "TextArea": {
-        "renderToStringMs": 0.035
-      },
-      "TextInput": {
-        "renderToStringMs": 0.032
-      },
-      "Author": {
-        "renderToStringMs": 0.023
-      },
-      "Avatar": {
-        "renderToStringMs": 0.015
-      },
-      "AvatarGroup": {
-        "renderToStringMs": 0.013
-      },
-      "Badge": {
+      "ListItem": {
         "renderToStringMs": 0.033
       },
-      "Icon": {
-        "renderToStringMs": 0.02
+      "Logo": {
+        "renderToStringMs": 0.168
       },
-      "StatusDot": {
-        "renderToStringMs": 0.012
+      "ReadingProgress": {
+        "renderToStringMs": 0.008
       },
-      "Accordion": {
-        "renderToStringMs": 0.09
+      "Table": {
+        "renderToStringMs": 0.059
       },
-      "AspectRatio": {
-        "renderToStringMs": 0.009
+      "TableCell": {
+        "renderToStringMs": 0.024
       },
-      "Card": {
+      "TableHeaderCell": {
+        "renderToStringMs": 0.033
+      },
+      "TableRow": {
         "renderToStringMs": 0.027
       },
-      "Center": {
-        "renderToStringMs": 0.007
+      "Timestamp": {
+        "renderToStringMs": 0.073
       },
-      "Container": {
-        "renderToStringMs": 0.007
+      "ValueCard": {
+        "renderToStringMs": 0.171
       },
-      "Divider": {
-        "renderToStringMs": 0.007
+      "VirtualList": {
+        "renderToStringMs": 0.322
       },
-      "FlexBox": {
-        "renderToStringMs": 0.01
+      "VirtualListItem": {
+        "renderToStringMs": 0.08
       },
-      "Grid": {
-        "renderToStringMs": 0.011
+      "AlertBanner": {
+        "renderToStringMs": 0.195
       },
-      "MacWindowFrame": {
-        "renderToStringMs": 0.032
+      "EmptyState": {
+        "renderToStringMs": 0.259
       },
-      "ResizablePanelGroup": {
-        "renderToStringMs": 0.043
+      "Progress": {
+        "renderToStringMs": 0.042
       },
-      "Section": {
-        "renderToStringMs": 0.008
+      "Skeleton": {
+        "renderToStringMs": 0.064
       },
-      "Spacer": {
-        "renderToStringMs": 0.007
+      "Spinner": {
+        "renderToStringMs": 0.023
       },
-      "Stack": {
-        "renderToStringMs": 0.01
+      "Toast": {
+        "renderToStringMs": 0.135
       },
-      "Breadcrumb": {
-        "renderToStringMs": 0.052
+      "ToastStack": {
+        "renderToStringMs": 0.166
       },
-      "CommandPalette": {
-        "renderToStringMs": 0.006
+      "Checkbox": {
+        "renderToStringMs": 0.167
       },
-      "LanguageSwitcher": {
-        "renderToStringMs": 0.04
+      "CheckboxGroup": {
+        "renderToStringMs": 0.479
       },
-      "Link": {
-        "renderToStringMs": 0.01
+      "Combobox": {
+        "renderToStringMs": 0.283
       },
-      "Menu": {
+      "FileUpload": {
+        "renderToStringMs": 0.244
+      },
+      "FormField": {
+        "renderToStringMs": 0.062
+      },
+      "GroupLabel": {
         "renderToStringMs": 0.025
       },
-      "NavLink": {
-        "renderToStringMs": 0.011
+      "HelperText": {
+        "renderToStringMs": 0.029
       },
-      "NavMenuList": {
+      "Label": {
+        "renderToStringMs": 0.078
+      },
+      "MultiCombobox": {
+        "renderToStringMs": 0.243
+      },
+      "PhoneInput": {
+        "renderToStringMs": 4.099
+      },
+      "Radio": {
+        "renderToStringMs": 0.082
+      },
+      "RadioGroup": {
+        "renderToStringMs": 0.315
+      },
+      "Select": {
+        "renderToStringMs": 0.309
+      },
+      "SelectableCard": {
+        "renderToStringMs": 0.073
+      },
+      "Switch": {
+        "renderToStringMs": 0.117
+      },
+      "TextArea": {
+        "renderToStringMs": 0.101
+      },
+      "TextInput": {
+        "renderToStringMs": 0.129
+      },
+      "Author": {
+        "renderToStringMs": 0.056
+      },
+      "Avatar": {
+        "renderToStringMs": 0.028
+      },
+      "AvatarGroup": {
         "renderToStringMs": 0.034
       },
+      "Badge": {
+        "renderToStringMs": 0.11
+      },
+      "Icon": {
+        "renderToStringMs": 0.062
+      },
+      "StatusDot": {
+        "renderToStringMs": 0.04
+      },
+      "Accordion": {
+        "renderToStringMs": 0.268
+      },
+      "AspectRatio": {
+        "renderToStringMs": 0.03
+      },
+      "Card": {
+        "renderToStringMs": 0.099
+      },
+      "Center": {
+        "renderToStringMs": 0.02
+      },
+      "Container": {
+        "renderToStringMs": 0.019
+      },
+      "Divider": {
+        "renderToStringMs": 0.02
+      },
+      "FlexBox": {
+        "renderToStringMs": 0.022
+      },
+      "Grid": {
+        "renderToStringMs": 0.023
+      },
+      "MacWindowFrame": {
+        "renderToStringMs": 0.128
+      },
+      "ResizablePanelGroup": {
+        "renderToStringMs": 0.142
+      },
+      "Section": {
+        "renderToStringMs": 0.028
+      },
+      "Spacer": {
+        "renderToStringMs": 0.021
+      },
+      "Stack": {
+        "renderToStringMs": 0.021
+      },
+      "Breadcrumb": {
+        "renderToStringMs": 0.206
+      },
+      "CommandPalette": {
+        "renderToStringMs": 0.011
+      },
+      "LanguageSwitcher": {
+        "renderToStringMs": 0.105
+      },
+      "Link": {
+        "renderToStringMs": 0.031
+      },
+      "Menu": {
+        "renderToStringMs": 0.197
+      },
+      "NavLink": {
+        "renderToStringMs": 0.049
+      },
+      "NavMenuList": {
+        "renderToStringMs": 0.124
+      },
       "Pagination": {
-        "renderToStringMs": 0.134
+        "renderToStringMs": 0.347
       },
       "ScrollIndicator": {
-        "renderToStringMs": 0.038
+        "renderToStringMs": 0.128
       },
       "SegmentedControl": {
-        "renderToStringMs": 0.035
+        "renderToStringMs": 0.093
       },
       "SkipLink": {
-        "renderToStringMs": 0.008
+        "renderToStringMs": 0.022
       },
       "Tabs": {
-        "renderToStringMs": 0.055
+        "renderToStringMs": 0.185
       },
       "TreeView": {
-        "renderToStringMs": 0.208
+        "renderToStringMs": 0.663
       },
       "CategoryFilter": {
-        "renderToStringMs": 0.032
+        "renderToStringMs": 0.116
       },
       "Modal": {
-        "renderToStringMs": 0.043
+        "renderToStringMs": 0.2
       },
       "PageLayout": {
-        "renderToStringMs": 0.008
+        "renderToStringMs": 0.023
       },
       "ProcessBlock": {
-        "renderToStringMs": 0.063
+        "renderToStringMs": 0.289
       },
       "ThemeProvider": {
-        "renderToStringMs": 0.009
+        "renderToStringMs": 0.024
       },
       "Display": {
-        "renderToStringMs": 0.007
+        "renderToStringMs": 0.022
       },
       "Kbd": {
-        "renderToStringMs": 0.007
+        "renderToStringMs": 0.035
       },
       "Text": {
-        "renderToStringMs": 0.006
+        "renderToStringMs": 0.027
       },
       "Title": {
-        "renderToStringMs": 0.006
+        "renderToStringMs": 0.026
       },
       "VisuallyHidden": {
-        "renderToStringMs": 0.006
+        "renderToStringMs": 0.022
       }
     }
   },
   "provenance": {
-    "sourceCommit": "03c781e9941dac3d5d24beace438e4fee32d3985",
+    "sourceCommit": "f298a71c11e4d882402afeebbaee1256023dfced",
     "workingTreeClean": false,
-    "dirtyPathCount": 3,
+    "dirtyPathCount": 1,
     "generator": {
       "name": "measure-ssr-evidence",
       "version": 1,


### PR DESCRIPTION
Consumes 0.1.24 (run 31198192575): registry install + guards green, lockfile stable (504), 16-yaml recapture exact, four evidence artifacts stamped at 0.1.24. Ships the Grid overridability fix live. Gates: typecheck 0, lint 0, test 2905/2905, build 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)