### PR TITLE
chore(release): prepare @digitaltableteur/web-components 0.10.1

### DIFF
--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.10.1 - 2026-08-08
+
+- Rendered-parity drift repairs, porting the React source of truth to three
+  native twins (all three were enforced-roster regressions caught by the new
+  per-publish parity evidence):
+  - `dt-group-label` typography matches the unified field-label treatment
+    (`--font-text`, weight 400 — previously the pre-unification
+    `--font-body` / 500).
+  - `dt-testimonial` card chrome moves to the ramp tokens
+    (`--color-border-light`, `--radius-lg`, `--shadow-sm`/`--shadow-md`),
+    replacing a border that had silently vanished with the retired
+    `--color-gray-light` phantom and a hardcoded shadow. The forced-colors
+    border override is removed so the browser maps the author color exactly
+    as it does for the React card.
+  - `dt-menu` item shells declare `font: inherit` — shadow-DOM buttons keep
+    the UA font (13.33px Arial) by default, which leaked into every composed
+    `dt-list-item` row — and the panel shadow uses `--shadow-lg`.
+
 ## 0.10.0 - 2026-07-24
 
 - Adds two native custom elements (fleet 85 -> 87):

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digitaltableteur/web-components",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": false,
   "description": "Framework-neutral custom elements for the Digitaltableteur design system.",
   "type": "module",


### PR DESCRIPTION
Version bump + changelog for the #1443 rendered-parity drift repairs (dt-group-label typography, dt-testimonial ramp tokens, dt-menu font inheritance). Note: a react 0.1.25 was evaluated and skipped — the only react-package-input delta since 0.1.24 is two spec.md docs that never enter the dist, so the pending payload lives entirely in web-components. Gates: typecheck 0, lint 0, test 2912/2912, build 0, release-notes + tarballs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)