### PR TITLE
chore(deps): consume @digitaltableteur/web-components 0.10.1

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-import "./.next/types/root-params.d.ts";
+import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@digitaltableteur/react": "^0.1.24",
         "@digitaltableteur/tokens": "^0.1.4",
         "@digitaltableteur/tokens-css": "^0.1.5",
-        "@digitaltableteur/web-components": "^0.10.0",
+        "@digitaltableteur/web-components": "^0.10.1",
         "@emailjs/browser": "^4.4.1",
         "@eslint/eslintrc": "^3.3.6",
         "@eslint/js": "^10.0.1",
@@ -3460,9 +3460,9 @@
       "license": "UNLICENSED"
     },
     "node_modules/@digitaltableteur/web-components": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@digitaltableteur/web-components/-/web-components-0.10.0.tgz",
-      "integrity": "sha512-8TaZ6O7Hy0ofsStRWi246TnrwXGETSpKvC5gCB8Uy+c3jNmVio6OSWhXltyE21/p7FtKAaRV3urh0+05QotObw==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@digitaltableteur/web-components/-/web-components-0.10.1.tgz",
+      "integrity": "sha512-wrA1VqRrjF0FZN/0wNpgoZCPYy3bvUK/ljdTm2T7jMu97kjxtiqBIdXP6voA9+HNwsbbT++Lz9OaCEpAA13E3w==",
       "license": "UNLICENSED",
       "peerDependencies": {
         "@digitaltableteur/react": "^0.1.16",

--- a/package.json
+++ b/package.json
@@ -229,7 +229,7 @@
     "@digitaltableteur/react": "^0.1.24",
     "@digitaltableteur/tokens": "^0.1.4",
     "@digitaltableteur/tokens-css": "^0.1.5",
-    "@digitaltableteur/web-components": "^0.10.0",
+    "@digitaltableteur/web-components": "^0.10.1",
     "@emailjs/browser": "^4.4.1",
     "@eslint/eslintrc": "^3.3.6",
     "@eslint/js": "^10.0.1",

--- a/public/ds-health/compat-matrix.json
+++ b/public/ds-health/compat-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-07T18:31:26.083Z",
+  "generatedAt": "2026-08-08T08:34:36.330Z",
   "package": {
     "name": "@digitaltableteur/react",
     "version": "0.1.24"
@@ -232,9 +232,9 @@
     }
   ],
   "provenance": {
-    "sourceCommit": "ef4fcf87b3ba66090805c075330e9d03c48cce4f",
+    "sourceCommit": "12cabe9a72e3711110622ec69466086520244c72",
     "workingTreeClean": false,
-    "dirtyPathCount": 4,
+    "dirtyPathCount": 3,
     "generator": {
       "name": "measure-compat-matrix",
       "version": 1,

--- a/public/ds-health/compatibility-manifest.json
+++ b/public/ds-health/compatibility-manifest.json
@@ -1,12 +1,12 @@
 {
-  "generatedAt": "2026-08-07T16:33:11.970Z",
+  "generatedAt": "2026-08-08T08:50:13.422Z",
   "scope": "combinations actually exercised by the local gates at generation time. Absence from this manifest means untested, not incompatible.",
   "packages": {
     "@digitaltableteur/cli": "0.5.0",
     "@digitaltableteur/react": "0.1.24",
     "@digitaltableteur/tokens": "0.1.4",
     "@digitaltableteur/tokens-css": "0.1.5",
-    "@digitaltableteur/web-components": "0.10.0"
+    "@digitaltableteur/web-components": "0.10.1"
   },
   "runtime": {
     "node": "v22.22.3",
@@ -103,7 +103,7 @@
   ],
   "preflight": {
     "note": "most recent RECORDED preflight run at manifest generation time; when the manifest is regenerated inside a preflight run, this describes the previous run",
-    "generatedAt": "2026-08-07T12:44:07.858Z",
+    "generatedAt": "2026-08-07T16:33:56.013Z",
     "status": "passed-clearance-recorded",
     "checks": {
       "astryx-roadmap": true,
@@ -135,9 +135,9 @@
     }
   },
   "provenance": {
-    "sourceCommit": "f298a71c11e4d882402afeebbaee1256023dfced",
+    "sourceCommit": "12cabe9a72e3711110622ec69466086520244c72",
     "workingTreeClean": false,
-    "dirtyPathCount": 3,
+    "dirtyPathCount": 5,
     "generator": {
       "name": "generate-compatibility-manifest",
       "version": 1,

--- a/public/ds-health/interaction-evidence.json
+++ b/public/ds-health/interaction-evidence.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-07T17:02:56.272Z",
+  "generatedAt": "2026-08-08T08:34:27.206Z",
   "package": {
     "name": "@digitaltableteur/react",
     "version": "0.1.24"
@@ -631,7 +631,7 @@
   "informational": {
     "timings": {
       "Button": {
-        "mountMs": 0.2,
+        "mountMs": 0.3,
         "rerenderMs": 0.2
       },
       "ButtonGroup": {
@@ -647,32 +647,32 @@
         "rerenderMs": 0.4
       },
       "SlideButton": {
-        "mountMs": 0.4,
+        "mountMs": 0.5,
         "rerenderMs": 0.4
       },
       "SplitButton": {
-        "mountMs": 2.4,
-        "rerenderMs": 2
+        "mountMs": 2.7,
+        "rerenderMs": 2.1
       },
       "AuthorBio": {
-        "mountMs": 0,
+        "mountMs": 0.1,
         "rerenderMs": 0
       },
       "CodeBlockWindow": {
         "mountMs": 0.8,
-        "rerenderMs": 0.7
+        "rerenderMs": 0.8
       },
       "CodeSnippet": {
-        "mountMs": 4.1,
-        "rerenderMs": 2
+        "mountMs": 4.4,
+        "rerenderMs": 2.2
       },
       "DataTable": {
         "mountMs": 1.5,
-        "rerenderMs": 1.4,
-        "recipeMs": 16.4
+        "rerenderMs": 1.5,
+        "recipeMs": 18.4
       },
       "ExpandableSection": {
-        "mountMs": 0.1,
+        "mountMs": 0,
         "rerenderMs": 0
       },
       "Gallery": {
@@ -689,7 +689,7 @@
       },
       "Logo": {
         "mountMs": 0,
-        "rerenderMs": 0
+        "rerenderMs": 0.1
       },
       "ReadingProgress": {
         "mountMs": 0,
@@ -712,8 +712,8 @@
         "rerenderMs": 0
       },
       "Timestamp": {
-        "mountMs": 0,
-        "rerenderMs": 0.1
+        "mountMs": 0.1,
+        "rerenderMs": 0
       },
       "ValueCard": {
         "mountMs": 0.1,
@@ -721,20 +721,20 @@
       },
       "VirtualList": {
         "mountMs": 0.1,
-        "rerenderMs": 0,
-        "recipeMs": 17.3
+        "rerenderMs": 0.1,
+        "recipeMs": 16.3
       },
       "VirtualListItem": {
         "mountMs": 0,
         "rerenderMs": 0
       },
       "AlertBanner": {
-        "mountMs": 0,
+        "mountMs": 0.1,
         "rerenderMs": 0
       },
       "EmptyState": {
-        "mountMs": 0,
-        "rerenderMs": 0.1
+        "mountMs": 0.1,
+        "rerenderMs": 0
       },
       "Progress": {
         "mountMs": 0,
@@ -762,15 +762,15 @@
       },
       "CheckboxGroup": {
         "mountMs": 0.1,
-        "rerenderMs": 0
+        "rerenderMs": 0.1
       },
       "Combobox": {
         "mountMs": 0.1,
-        "rerenderMs": 0.1
+        "rerenderMs": 0
       },
       "FileUpload": {
         "mountMs": 0.1,
-        "rerenderMs": 0
+        "rerenderMs": 0.1
       },
       "FormField": {
         "mountMs": 0,
@@ -790,11 +790,11 @@
       },
       "MultiCombobox": {
         "mountMs": 0.1,
-        "rerenderMs": 0
+        "rerenderMs": 0.1
       },
       "PhoneInput": {
         "mountMs": 1.2,
-        "rerenderMs": 0.8
+        "rerenderMs": 0.9
       },
       "Radio": {
         "mountMs": 0,
@@ -806,7 +806,7 @@
       },
       "Select": {
         "mountMs": 0.1,
-        "rerenderMs": 0.1
+        "rerenderMs": 0
       },
       "SelectableCard": {
         "mountMs": 0,
@@ -821,7 +821,7 @@
         "rerenderMs": 0
       },
       "TextInput": {
-        "mountMs": 0,
+        "mountMs": 0.1,
         "rerenderMs": 0
       },
       "Author": {
@@ -833,12 +833,12 @@
         "rerenderMs": 0
       },
       "AvatarGroup": {
-        "mountMs": 0.1,
+        "mountMs": 0,
         "rerenderMs": 0
       },
       "Badge": {
-        "mountMs": 0,
-        "rerenderMs": 0.1
+        "mountMs": 0.1,
+        "rerenderMs": 0
       },
       "Icon": {
         "mountMs": 0,
@@ -850,7 +850,7 @@
       },
       "Accordion": {
         "mountMs": 0.1,
-        "rerenderMs": 0
+        "rerenderMs": 0.1
       },
       "AspectRatio": {
         "mountMs": 0,
@@ -881,8 +881,8 @@
         "rerenderMs": 0
       },
       "MacWindowFrame": {
-        "mountMs": 0,
-        "rerenderMs": 0.1
+        "mountMs": 0.1,
+        "rerenderMs": 0
       },
       "ResizablePanelGroup": {
         "mountMs": 0,
@@ -931,7 +931,7 @@
       },
       "Pagination": {
         "mountMs": 0.1,
-        "rerenderMs": 0
+        "rerenderMs": 0.1
       },
       "ScrollIndicator": {
         "mountMs": 0.1,
@@ -950,9 +950,9 @@
         "rerenderMs": 0
       },
       "TreeView": {
-        "mountMs": 0.2,
-        "rerenderMs": 0.1,
-        "recipeMs": 1.3
+        "mountMs": 0.1,
+        "rerenderMs": 0.2,
+        "recipeMs": 1.7
       },
       "CategoryFilter": {
         "mountMs": 0.1,
@@ -968,7 +968,7 @@
       },
       "ProcessBlock": {
         "mountMs": 0,
-        "rerenderMs": 0.1
+        "rerenderMs": 0
       },
       "ThemeProvider": {
         "mountMs": 0,
@@ -997,9 +997,9 @@
     }
   },
   "provenance": {
-    "sourceCommit": "da6b2272b7c7275510ad8d916669610a516d473f",
+    "sourceCommit": "12cabe9a72e3711110622ec69466086520244c72",
     "workingTreeClean": false,
-    "dirtyPathCount": 3,
+    "dirtyPathCount": 2,
     "generator": {
       "name": "measure-interaction-evidence",
       "version": 1,

--- a/public/ds-health/override-evidence.json
+++ b/public/ds-health/override-evidence.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-07T16:33:11.731Z",
+  "generatedAt": "2026-08-08T08:34:25.332Z",
   "package": {
     "name": "@digitaltableteur/react",
     "version": "0.1.24"
@@ -1543,9 +1543,9 @@
     }
   },
   "provenance": {
-    "sourceCommit": "f298a71c11e4d882402afeebbaee1256023dfced",
+    "sourceCommit": "12cabe9a72e3711110622ec69466086520244c72",
     "workingTreeClean": false,
-    "dirtyPathCount": 2,
+    "dirtyPathCount": 1,
     "generator": {
       "name": "measure-override-evidence",
       "version": 1,

--- a/public/ds-health/ssr-evidence.json
+++ b/public/ds-health/ssr-evidence.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-07T16:33:07.054Z",
+  "generatedAt": "2026-08-08T08:34:20.699Z",
   "package": {
     "name": "@digitaltableteur/react",
     "version": "0.1.24"
@@ -1224,199 +1224,199 @@
   "informational": {
     "timings": {
       "Button": {
-        "renderToStringMs": 0.448
+        "renderToStringMs": 0.354
       },
       "ButtonGroup": {
-        "renderToStringMs": 0.06
+        "renderToStringMs": 0.067
       },
       "FilterChip": {
-        "renderToStringMs": 0.037
+        "renderToStringMs": 0.026
       },
       "IconButton": {
-        "renderToStringMs": 0.258
+        "renderToStringMs": 0.169
       },
       "SlideButton": {
-        "renderToStringMs": 0.205
+        "renderToStringMs": 0.076
       },
       "SplitButton": {
-        "renderToStringMs": 0.973
+        "renderToStringMs": 0.336
       },
       "AuthorBio": {
-        "renderToStringMs": 0.01
-      },
-      "CodeBlockWindow": {
-        "renderToStringMs": 0.293
-      },
-      "CodeSnippet": {
-        "renderToStringMs": 1.428
-      },
-      "DataTable": {
-        "renderToStringMs": 0.589
-      },
-      "ExpandableSection": {
-        "renderToStringMs": 0.08
-      },
-      "Gallery": {
-        "renderToStringMs": 0.272
-      },
-      "List": {
-        "renderToStringMs": 0.075
-      },
-      "ListItem": {
-        "renderToStringMs": 0.033
-      },
-      "Logo": {
-        "renderToStringMs": 0.168
-      },
-      "ReadingProgress": {
         "renderToStringMs": 0.008
       },
-      "Table": {
-        "renderToStringMs": 0.059
+      "CodeBlockWindow": {
+        "renderToStringMs": 0.163
       },
-      "TableCell": {
-        "renderToStringMs": 0.024
+      "CodeSnippet": {
+        "renderToStringMs": 0.413
       },
-      "TableHeaderCell": {
-        "renderToStringMs": 0.033
+      "DataTable": {
+        "renderToStringMs": 0.193
       },
-      "TableRow": {
-        "renderToStringMs": 0.027
+      "ExpandableSection": {
+        "renderToStringMs": 0.035
       },
-      "Timestamp": {
-        "renderToStringMs": 0.073
+      "Gallery": {
+        "renderToStringMs": 0.134
       },
-      "ValueCard": {
-        "renderToStringMs": 0.171
-      },
-      "VirtualList": {
-        "renderToStringMs": 0.322
-      },
-      "VirtualListItem": {
-        "renderToStringMs": 0.08
-      },
-      "AlertBanner": {
-        "renderToStringMs": 0.195
-      },
-      "EmptyState": {
-        "renderToStringMs": 0.259
-      },
-      "Progress": {
-        "renderToStringMs": 0.042
-      },
-      "Skeleton": {
-        "renderToStringMs": 0.064
-      },
-      "Spinner": {
-        "renderToStringMs": 0.023
-      },
-      "Toast": {
-        "renderToStringMs": 0.135
-      },
-      "ToastStack": {
-        "renderToStringMs": 0.166
-      },
-      "Checkbox": {
-        "renderToStringMs": 0.167
-      },
-      "CheckboxGroup": {
-        "renderToStringMs": 0.479
-      },
-      "Combobox": {
-        "renderToStringMs": 0.283
-      },
-      "FileUpload": {
-        "renderToStringMs": 0.244
-      },
-      "FormField": {
-        "renderToStringMs": 0.062
-      },
-      "GroupLabel": {
-        "renderToStringMs": 0.025
-      },
-      "HelperText": {
+      "List": {
         "renderToStringMs": 0.029
       },
-      "Label": {
+      "ListItem": {
+        "renderToStringMs": 0.015
+      },
+      "Logo": {
+        "renderToStringMs": 0.059
+      },
+      "ReadingProgress": {
+        "renderToStringMs": 0.007
+      },
+      "Table": {
+        "renderToStringMs": 0.026
+      },
+      "TableCell": {
+        "renderToStringMs": 0.01
+      },
+      "TableHeaderCell": {
+        "renderToStringMs": 0.011
+      },
+      "TableRow": {
+        "renderToStringMs": 0.009
+      },
+      "Timestamp": {
+        "renderToStringMs": 0.055
+      },
+      "ValueCard": {
+        "renderToStringMs": 0.053
+      },
+      "VirtualList": {
+        "renderToStringMs": 0.1
+      },
+      "VirtualListItem": {
+        "renderToStringMs": 0.023
+      },
+      "AlertBanner": {
+        "renderToStringMs": 0.054
+      },
+      "EmptyState": {
+        "renderToStringMs": 0.061
+      },
+      "Progress": {
+        "renderToStringMs": 0.019
+      },
+      "Skeleton": {
+        "renderToStringMs": 0.027
+      },
+      "Spinner": {
+        "renderToStringMs": 0.01
+      },
+      "Toast": {
+        "renderToStringMs": 0.049
+      },
+      "ToastStack": {
+        "renderToStringMs": 0.055
+      },
+      "Checkbox": {
+        "renderToStringMs": 0.035
+      },
+      "CheckboxGroup": {
+        "renderToStringMs": 0.123
+      },
+      "Combobox": {
+        "renderToStringMs": 0.108
+      },
+      "FileUpload": {
         "renderToStringMs": 0.078
       },
+      "FormField": {
+        "renderToStringMs": 0.023
+      },
+      "GroupLabel": {
+        "renderToStringMs": 0.017
+      },
+      "HelperText": {
+        "renderToStringMs": 0.011
+      },
+      "Label": {
+        "renderToStringMs": 0.021
+      },
       "MultiCombobox": {
-        "renderToStringMs": 0.243
+        "renderToStringMs": 0.103
       },
       "PhoneInput": {
-        "renderToStringMs": 4.099
+        "renderToStringMs": 1.404
       },
       "Radio": {
-        "renderToStringMs": 0.082
+        "renderToStringMs": 0.025
       },
       "RadioGroup": {
-        "renderToStringMs": 0.315
+        "renderToStringMs": 0.077
       },
       "Select": {
-        "renderToStringMs": 0.309
+        "renderToStringMs": 0.317
       },
       "SelectableCard": {
-        "renderToStringMs": 0.073
+        "renderToStringMs": 0.069
       },
       "Switch": {
-        "renderToStringMs": 0.117
+        "renderToStringMs": 0.114
       },
       "TextArea": {
-        "renderToStringMs": 0.101
+        "renderToStringMs": 0.097
       },
       "TextInput": {
-        "renderToStringMs": 0.129
+        "renderToStringMs": 0.103
       },
       "Author": {
-        "renderToStringMs": 0.056
+        "renderToStringMs": 0.074
       },
       "Avatar": {
-        "renderToStringMs": 0.028
+        "renderToStringMs": 0.024
       },
       "AvatarGroup": {
-        "renderToStringMs": 0.034
+        "renderToStringMs": 0.032
       },
       "Badge": {
         "renderToStringMs": 0.11
       },
       "Icon": {
-        "renderToStringMs": 0.062
+        "renderToStringMs": 0.067
       },
       "StatusDot": {
-        "renderToStringMs": 0.04
+        "renderToStringMs": 0.041
       },
       "Accordion": {
-        "renderToStringMs": 0.268
+        "renderToStringMs": 0.271
       },
       "AspectRatio": {
-        "renderToStringMs": 0.03
+        "renderToStringMs": 0.029
       },
       "Card": {
-        "renderToStringMs": 0.099
+        "renderToStringMs": 0.093
       },
       "Center": {
-        "renderToStringMs": 0.02
+        "renderToStringMs": 0.018
       },
       "Container": {
-        "renderToStringMs": 0.019
+        "renderToStringMs": 0.018
       },
       "Divider": {
-        "renderToStringMs": 0.02
+        "renderToStringMs": 0.019
       },
       "FlexBox": {
-        "renderToStringMs": 0.022
+        "renderToStringMs": 0.021
       },
       "Grid": {
-        "renderToStringMs": 0.023
+        "renderToStringMs": 0.021
       },
       "MacWindowFrame": {
-        "renderToStringMs": 0.128
+        "renderToStringMs": 0.122
       },
       "ResizablePanelGroup": {
-        "renderToStringMs": 0.142
+        "renderToStringMs": 0.136
       },
       "Section": {
-        "renderToStringMs": 0.028
+        "renderToStringMs": 0.026
       },
       "Spacer": {
         "renderToStringMs": 0.021
@@ -1425,80 +1425,80 @@
         "renderToStringMs": 0.021
       },
       "Breadcrumb": {
-        "renderToStringMs": 0.206
+        "renderToStringMs": 0.174
       },
       "CommandPalette": {
-        "renderToStringMs": 0.011
+        "renderToStringMs": 0.014
       },
       "LanguageSwitcher": {
-        "renderToStringMs": 0.105
+        "renderToStringMs": 0.126
       },
       "Link": {
-        "renderToStringMs": 0.031
+        "renderToStringMs": 0.03
       },
       "Menu": {
-        "renderToStringMs": 0.197
+        "renderToStringMs": 0.217
       },
       "NavLink": {
-        "renderToStringMs": 0.049
+        "renderToStringMs": 0.045
       },
       "NavMenuList": {
-        "renderToStringMs": 0.124
+        "renderToStringMs": 0.112
       },
       "Pagination": {
-        "renderToStringMs": 0.347
+        "renderToStringMs": 0.311
       },
       "ScrollIndicator": {
-        "renderToStringMs": 0.128
+        "renderToStringMs": 0.122
       },
       "SegmentedControl": {
-        "renderToStringMs": 0.093
+        "renderToStringMs": 0.085
       },
       "SkipLink": {
         "renderToStringMs": 0.022
       },
       "Tabs": {
-        "renderToStringMs": 0.185
+        "renderToStringMs": 0.166
       },
       "TreeView": {
-        "renderToStringMs": 0.663
+        "renderToStringMs": 0.612
       },
       "CategoryFilter": {
-        "renderToStringMs": 0.116
+        "renderToStringMs": 0.111
       },
       "Modal": {
-        "renderToStringMs": 0.2
+        "renderToStringMs": 0.218
       },
       "PageLayout": {
         "renderToStringMs": 0.023
       },
       "ProcessBlock": {
-        "renderToStringMs": 0.289
+        "renderToStringMs": 0.265
       },
       "ThemeProvider": {
-        "renderToStringMs": 0.024
+        "renderToStringMs": 0.022
       },
       "Display": {
-        "renderToStringMs": 0.022
+        "renderToStringMs": 0.019
       },
       "Kbd": {
-        "renderToStringMs": 0.035
+        "renderToStringMs": 0.024
       },
       "Text": {
-        "renderToStringMs": 0.027
+        "renderToStringMs": 0.023
       },
       "Title": {
-        "renderToStringMs": 0.026
+        "renderToStringMs": 0.023
       },
       "VisuallyHidden": {
-        "renderToStringMs": 0.022
+        "renderToStringMs": 0.019
       }
     }
   },
   "provenance": {
-    "sourceCommit": "f298a71c11e4d882402afeebbaee1256023dfced",
-    "workingTreeClean": false,
-    "dirtyPathCount": 1,
+    "sourceCommit": "12cabe9a72e3711110622ec69466086520244c72",
+    "workingTreeClean": true,
+    "dirtyPathCount": 0,
     "generator": {
       "name": "measure-ssr-evidence",
       "version": 1,

--- a/public/ds-health/wc-parity.json
+++ b/public/ds-health/wc-parity.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-08-07T20:20:10.947Z",
+  "generatedAt": "2026-08-08T08:50:13.140Z",
   "package": {
     "name": "@digitaltableteur/web-components",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "reactPackageVersion": "0.1.24"
   },
   "coverage": {
@@ -1036,11 +1036,11 @@
         "Example (desktop-forced-colors)": 0
       },
       "Spinner": {
-        "Default (desktop-light)": 0.0201,
-        "Example (desktop-light)": 0.0756,
-        "Example (mobile-light)": 0.0841,
-        "Example (desktop-dark)": 0.3702,
-        "Example (desktop-forced-colors)": 0.0903
+        "Default (desktop-light)": 0.0394,
+        "Example (desktop-light)": 0.0522,
+        "Example (mobile-light)": 0.0787,
+        "Example (desktop-dark)": 0.3692,
+        "Example (desktop-forced-colors)": 0.0907
       },
       "Progress": {
         "Default (desktop-light)": 0.0655,
@@ -1418,10 +1418,10 @@
       },
       "CodeSnippet": {
         "Default (desktop-light)": 0.0237,
-        "Example (desktop-light)": 0.0237,
+        "Example (desktop-light)": 0.0182,
         "Example (mobile-light)": 0.0462,
         "Example (desktop-dark)": 0.1571,
-        "Example (desktop-forced-colors)": 0.0242
+        "Example (desktop-forced-colors)": 0.0187
       },
       "CodeBlockWindow": {
         "Default (desktop-light)": 0.0189,
@@ -1480,11 +1480,11 @@
         "Example (desktop-forced-colors)": 0.129
       },
       "Gallery": {
-        "Default (desktop-light)": 0.4688,
-        "Example (desktop-light)": 0.592,
-        "Example (mobile-light)": 0.7847,
-        "Example (desktop-dark)": 0.8087,
-        "Example (desktop-forced-colors)": 0.4415
+        "Default (desktop-light)": 0.5021,
+        "Example (desktop-light)": 0.4951,
+        "Example (mobile-light)": 0.8183,
+        "Example (desktop-dark)": 0.7844,
+        "Example (desktop-forced-colors)": 0.5478
       },
       "ReadingProgress": {
         "Default (desktop-light)": 0.0341,
@@ -1571,12 +1571,12 @@
         "Example (desktop-forced-colors)": 0.0347
       }
     },
-    "sweepGeneratedAt": "2026-08-07T20:20:10.644Z"
+    "sweepGeneratedAt": "2026-08-08T08:50:12.770Z"
   },
   "provenance": {
-    "sourceCommit": "e51b381c3ca92a98f51811b858c78e86a8b34608",
+    "sourceCommit": "12cabe9a72e3711110622ec69466086520244c72",
     "workingTreeClean": false,
-    "dirtyPathCount": 9,
+    "dirtyPathCount": 4,
     "generator": {
       "name": "generate-wc-parity-evidence",
       "version": 1,


### PR DESCRIPTION
Consumes wc 0.10.1 (run 31249289171): the #1443 parity drift repairs now published. Registry guards green, lockfile stable (504), About strip browser-verified at 0.10.1, wc-parity evidence stamped at the published version. react 0.1.25 evaluated and skipped: dist-identical to 0.1.24 (spec.md-only delta). Gates: typecheck 0, lint 0, test 2912/2912, build 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)