### PR TITLE
feat(ds): ProjectCard coming-soon teaser mode + home work sections passthrough

### DIFF
--- a/nextjs-app/shared/components/Badge/Badge.contract.json
+++ b/nextjs-app/shared/components/Badge/Badge.contract.json
@@ -129,7 +129,7 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
             "since": "2026-06-04"
         }
     ],

--- a/nextjs-app/shared/components/FlexBox/FlexBox.contract.json
+++ b/nextjs-app/shared/components/FlexBox/FlexBox.contract.json
@@ -3,7 +3,7 @@
     "name": "FlexBox",
     "tier": "atom",
     "group": "layout",
-    "status": "stable",
+    "status": "beta",
     "description": "Flexbox layout primitive for stacks and rows.",
     "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1176-1698",
     "radixPrimitive": null,
@@ -45,18 +45,7 @@
         "spacing": []
     },
     "lightDarkVerified": true,
-    "consumers": [
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
-            "since": "2026-06-04"
-        },
-        {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/Illustrations/index.ts",
-            "since": "2026-06-04"
-        }
-    ],
+    "consumers": [],
     "schemaVersion": 2,
     "props": {
         "direction": {

--- a/nextjs-app/shared/components/FlexBox/FlexBox.stories.tsx
+++ b/nextjs-app/shared/components/FlexBox/FlexBox.stories.tsx
@@ -25,7 +25,7 @@ const defaultArgs = {
 const meta = {
   title: "Layout/FlexBox",
   component: FlexBox,
-  tags: ["stable", "autodocs"],
+  tags: ["beta", "autodocs"],
   parameters: {
     design: {
       type: "figma",

--- a/nextjs-app/shared/components/Grid/Grid.contract.json
+++ b/nextjs-app/shared/components/Grid/Grid.contract.json
@@ -80,6 +80,16 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/Illustrations/index.ts",
+            "since": "2026-06-04"
+        },
+        {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Work/WorkIndex/index.ts",
             "since": "2026-06-04"
         },

--- a/nextjs-app/shared/components/ProjectCard/ProjectCard.contract.json
+++ b/nextjs-app/shared/components/ProjectCard/ProjectCard.contract.json
@@ -39,7 +39,8 @@
     "a11y": {
         "keyboard": [],
         "ariaRequirements": [
-            "Whole card is a single link to the project detail page; the thumbnail carries the project title as alt text"
+            "Whole card is a single link to the project detail page; the thumbnail carries the project title as alt text",
+            "With comingSoon the root is a non-interactive div (no link role); the badge label is plain visible text"
         ],
         "motion": true,
         "reducedMotion": true,
@@ -100,6 +101,16 @@
                 "below"
             ],
             "description": "Title overlay position"
+        },
+        "comingSoon": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Render as a non-interactive teaser with a \"coming soon\" badge over the media"
+        },
+        "comingSoonLabel": {
+            "optional": true,
+            "type": "string",
+            "description": "Visible badge label for the coming-soon overlay (pass a translated string)"
         },
         "className": {
             "optional": true,

--- a/nextjs-app/shared/components/ProjectCard/ProjectCard.spec.md
+++ b/nextjs-app/shared/components/ProjectCard/ProjectCard.spec.md
@@ -8,10 +8,12 @@ Basic portfolio project card for the work grid: a clickable thumbnail with title
 - Pointer: click anywhere on the card to open the project; hover scales the thumbnail
 - Screen readers: one link; the thumbnail carries the project title as alt text
 - Reduced motion: hover scale/translate/opacity transitions are gated behind `motion-reduce:` utilities
+- Coming soon: with `comingSoon` the root is a non-interactive `div` (nothing focusable, no hover affordances) and a badge with `comingSoonLabel` overlays the media; matches EnhancedProjectCard's teaser mode
 
 ## Do / don't
 - Do: pass `title`, `slug` and `thumbnail`; add `category`/`tags` for richer cards
 - Do: choose `titlePosition` (overlay | below) and `aspectRatio` per surface
+- Do: set `comingSoon` for projects without a case-study route, passing a translated `comingSoonLabel` (`t("workComingSoon")`)
 - Don't: invent parallel primitives inside this folder
 - Don't: reach for this when EnhancedProjectCard's richer surface is needed — pick one per surface
 

--- a/nextjs-app/shared/components/ProjectCard/ProjectCard.stories.tsx
+++ b/nextjs-app/shared/components/ProjectCard/ProjectCard.stories.tsx
@@ -64,6 +64,18 @@ const meta: Meta<typeof ProjectCard> = {
       description: "Whether the title sits over the image or beneath it.",
       table: { category: "Appearance", defaultValue: { summary: "overlay" } },
     },
+    comingSoon: {
+      control: "boolean",
+      description:
+        "Render as a non-interactive teaser with a badge over the media instead of a link.",
+      table: { category: "Behavior", defaultValue: { summary: "false" } },
+    },
+    comingSoonLabel: {
+      control: "text",
+      description:
+        "Visible badge label for the coming-soon overlay (pass a translated string).",
+      table: { category: "Content", defaultValue: { summary: "Coming soon" } },
+    },
     className: {
       control: "text",
       description: "Extra class names merged onto the card link.",
@@ -78,6 +90,8 @@ const meta: Meta<typeof ProjectCard> = {
     tags: tagPresets.Few as unknown as string[],
     aspectRatio: "video",
     titlePosition: "overlay",
+    comingSoon: false,
+    comingSoonLabel: "Coming soon",
     className: "",
   },
   decorators: [
@@ -116,6 +130,23 @@ export const TitleBelow: Story = {
 /** Square thumbnail frame. */
 export const SquareRatio: Story = {
   args: { aspectRatio: "square" },
+};
+
+/** Non-interactive teaser: no link wrapper, badge overlaid on the media. */
+export const ComingSoon: Story = {
+  args: {
+    title: "Precedent",
+    slug: "precedent",
+    category: "Tools",
+    tags: tagPresets.Few as unknown as string[],
+    comingSoon: true,
+    comingSoonLabel: "Coming soon",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.queryByRole("link")).not.toBeInTheDocument();
+    expect(canvas.getByText("Coming soon")).toBeInTheDocument();
+  },
 };
 
 export const Playground: Story = Default;

--- a/nextjs-app/shared/components/ProjectCard/ProjectCard.test.tsx
+++ b/nextjs-app/shared/components/ProjectCard/ProjectCard.test.tsx
@@ -52,6 +52,24 @@ describe("ProjectCard", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders comingSoon as a non-interactive card with the badge", () => {
+    render(
+      <ProjectCard {...baseProps} comingSoon comingSoonLabel="Coming soon" />,
+    );
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByText("Coming soon")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: baseProps.title, level: 3 }),
+    ).toBeInTheDocument();
+  });
+
+  it("comingSoon card has no axe violations", async () => {
+    const { container } = render(
+      <ProjectCard {...baseProps} comingSoon category="Tools" tags={["Figma"]} />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
   it("has no axe violations (overlay)", async () => {
     const { container } = render(
       <ProjectCard {...baseProps} category="Design systems" tags={["Figma"]} />,

--- a/nextjs-app/shared/components/ProjectCard/ProjectCard.tsx
+++ b/nextjs-app/shared/components/ProjectCard/ProjectCard.tsx
@@ -19,6 +19,10 @@ export interface ProjectCardProps {
   aspectRatio?: "square" | "video" | "portrait" | "landscape";
   /** Title overlay position */
   titlePosition?: "overlay" | "below";
+  /** Render as a non-interactive teaser with a "coming soon" badge over the media */
+  comingSoon?: boolean;
+  /** Visible badge label for the coming-soon overlay (pass a translated string) */
+  comingSoonLabel?: string;
   /** Custom className */
   className?: string;
 }
@@ -34,8 +38,9 @@ const aspectRatioClasses: Record<NonNullable<ProjectCardProps["aspectRatio"]>, s
  * Basic portfolio project card for the work grid: a clickable thumbnail with
  * the project title, optional category eyebrow and up to three tags. The title
  * can sit over the image (`overlay`) or beneath it (`below`), and the thumbnail
- * frame follows the chosen `aspectRatio`. EnhancedProjectCard is the richer
- * variant — pick one per surface.
+ * frame follows the chosen `aspectRatio`. With `comingSoon` the card renders as
+ * a non-interactive teaser with a badge over the media instead of a link.
+ * EnhancedProjectCard is the richer variant — pick one per surface.
  */
 export function ProjectCard({
   title,
@@ -45,18 +50,12 @@ export function ProjectCard({
   tags,
   aspectRatio = "video",
   titlePosition = "overlay",
+  comingSoon = false,
+  comingSoonLabel = "Coming soon",
   className,
 }: ProjectCardProps) {
-  return (
-    <Link
-      href={`/work/${slug}`}
-      className={cn(
-        "group relative block overflow-hidden rounded-lg",
-        "bg-muted",
-        className
-      )}
-      data-donny-interest="portfolio-project"
-    >
+  const content = (
+    <>
       {/* Image Container */}
       <div
         className={cn(
@@ -76,6 +75,22 @@ export function ProjectCard({
           )}
           sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
         />
+
+        {/* Coming-soon overlay badge */}
+        {comingSoon && (
+          <span
+            className={cn(
+              "absolute inset-0 z-10 m-auto h-fit w-fit",
+              "inline-flex items-center rounded-full border border-white/40 px-4 py-2",
+              "bg-black/60 backdrop-blur-sm",
+              "text-sm font-body font-medium text-white",
+              "forced-colors:border-[CanvasText] forced-colors:bg-[Canvas] forced-colors:text-[CanvasText]"
+            )}
+            data-project-card-coming-soon=""
+          >
+            {comingSoonLabel}
+          </span>
+        )}
 
         {/* Overlay (for overlay title position) */}
         {titlePosition === "overlay" && (
@@ -150,6 +165,37 @@ export function ProjectCard({
           )}
         </div>
       )}
+    </>
+  );
+
+  // Non-interactive teaser: no link, no hover affordances (the `group` class
+  // is omitted so group-hover: utilities stay at rest).
+  if (comingSoon) {
+    return (
+      <div
+        className={cn(
+          "relative block overflow-hidden rounded-lg",
+          "bg-muted",
+          className
+        )}
+        data-project-card-coming-soon-root=""
+      >
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <Link
+      href={`/work/${slug}`}
+      className={cn(
+        "group relative block overflow-hidden rounded-lg",
+        "bg-muted",
+        className
+      )}
+      data-donny-interest="portfolio-project"
+    >
+      {content}
     </Link>
   );
 }

--- a/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-coming-soon.json
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-coming-soon.json
@@ -1,8 +1,8 @@
 {
   "storyId": "site-projectcard-coming-soon",
   "mode": "light",
-  "sourceSHA": "f1ed492bbdba6b1deecf96669c65f4d0acb486b6",
-  "capturedAt": "2026-08-14T08:34:34.116Z",
+  "sourceSHA": "e97246dda02211701bf2dc9aa874bafb424b14bc",
+  "capturedAt": "2026-08-14T08:35:52.701Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-coming-soon.json
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-coming-soon.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-projectcard-coming-soon",
+  "mode": "light",
+  "sourceSHA": "f1ed492bbdba6b1deecf96669c65f4d0acb486b6",
+  "capturedAt": "2026-08-14T08:34:34.116Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-default.json
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-default.json
@@ -1,8 +1,8 @@
 {
   "storyId": "site-projectcard-default",
   "mode": "light",
-  "sourceSHA": "f1ed492bbdba6b1deecf96669c65f4d0acb486b6",
-  "capturedAt": "2026-08-14T08:34:33.451Z",
+  "sourceSHA": "e97246dda02211701bf2dc9aa874bafb424b14bc",
+  "capturedAt": "2026-08-14T08:35:52.081Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-default.json
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-default.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-projectcard-default",
+  "mode": "light",
+  "sourceSHA": "f1ed492bbdba6b1deecf96669c65f4d0acb486b6",
+  "capturedAt": "2026-08-14T08:34:33.451Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-example.json
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-example.json
@@ -1,8 +1,8 @@
 {
   "storyId": "site-projectcard-example",
   "mode": "light",
-  "sourceSHA": "f1ed492bbdba6b1deecf96669c65f4d0acb486b6",
-  "capturedAt": "2026-08-14T08:34:34.502Z",
+  "sourceSHA": "e97246dda02211701bf2dc9aa874bafb424b14bc",
+  "capturedAt": "2026-08-14T08:35:53.107Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-example.json
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-example.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-projectcard-example",
+  "mode": "light",
+  "sourceSHA": "f1ed492bbdba6b1deecf96669c65f4d0acb486b6",
+  "capturedAt": "2026-08-14T08:34:34.502Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-forced-colors.json
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-forced-colors.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-projectcard-forced-colors",
+  "mode": "light",
+  "sourceSHA": "f1ed492bbdba6b1deecf96669c65f4d0acb486b6",
+  "capturedAt": "2026-08-14T08:34:34.701Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-forced-colors.json
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-forced-colors.json
@@ -1,8 +1,8 @@
 {
   "storyId": "site-projectcard-forced-colors",
   "mode": "light",
-  "sourceSHA": "f1ed492bbdba6b1deecf96669c65f4d0acb486b6",
-  "capturedAt": "2026-08-14T08:34:34.701Z",
+  "sourceSHA": "e97246dda02211701bf2dc9aa874bafb424b14bc",
+  "capturedAt": "2026-08-14T08:35:53.299Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-playground.json
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-playground.json
@@ -1,8 +1,8 @@
 {
   "storyId": "site-projectcard-playground",
   "mode": "light",
-  "sourceSHA": "f1ed492bbdba6b1deecf96669c65f4d0acb486b6",
-  "capturedAt": "2026-08-14T08:34:34.308Z",
+  "sourceSHA": "e97246dda02211701bf2dc9aa874bafb424b14bc",
+  "capturedAt": "2026-08-14T08:35:52.913Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-playground.json
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-playground.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-projectcard-playground",
+  "mode": "light",
+  "sourceSHA": "f1ed492bbdba6b1deecf96669c65f4d0acb486b6",
+  "capturedAt": "2026-08-14T08:34:34.308Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-square-ratio.json
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-square-ratio.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-projectcard-square-ratio",
+  "mode": "light",
+  "sourceSHA": "f1ed492bbdba6b1deecf96669c65f4d0acb486b6",
+  "capturedAt": "2026-08-14T08:34:33.908Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-square-ratio.json
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-square-ratio.json
@@ -1,8 +1,8 @@
 {
   "storyId": "site-projectcard-square-ratio",
   "mode": "light",
-  "sourceSHA": "f1ed492bbdba6b1deecf96669c65f4d0acb486b6",
-  "capturedAt": "2026-08-14T08:34:33.908Z",
+  "sourceSHA": "e97246dda02211701bf2dc9aa874bafb424b14bc",
+  "capturedAt": "2026-08-14T08:35:52.504Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-title-below.json
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-title-below.json
@@ -1,8 +1,8 @@
 {
   "storyId": "site-projectcard-title-below",
   "mode": "light",
-  "sourceSHA": "f1ed492bbdba6b1deecf96669c65f4d0acb486b6",
-  "capturedAt": "2026-08-14T08:34:33.692Z",
+  "sourceSHA": "e97246dda02211701bf2dc9aa874bafb424b14bc",
+  "capturedAt": "2026-08-14T08:35:52.307Z",
   "runner": null,
   "checks": {
     "accessibility-tree": {

--- a/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-title-below.json
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-evidence__/site-projectcard-title-below.json
@@ -1,0 +1,16 @@
+{
+  "storyId": "site-projectcard-title-below",
+  "mode": "light",
+  "sourceSHA": "f1ed492bbdba6b1deecf96669c65f4d0acb486b6",
+  "capturedAt": "2026-08-14T08:34:33.692Z",
+  "runner": null,
+  "checks": {
+    "accessibility-tree": {
+      "passed": true
+    },
+    "axe-no-violations": {
+      "passed": true,
+      "axeViolations": 0
+    }
+  }
+}

--- a/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--coming-soon.yaml
+++ b/nextjs-app/shared/components/ProjectCard/__a11y-snapshots__/site-projectcard--coming-soon.yaml
@@ -1,0 +1,3 @@
+- text: Coming soon Tools
+- heading "Precedent" [level=3]
+- text: Figma React

--- a/nextjs-app/shared/components/StatusDot/StatusDot.contract.json
+++ b/nextjs-app/shared/components/StatusDot/StatusDot.contract.json
@@ -234,7 +234,7 @@
         },
         {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
             "since": "2026-06-04"
         }
     ]

--- a/nextjs-app/shared/foundations/dist/agent-manifest.json
+++ b/nextjs-app/shared/foundations/dist/agent-manifest.json
@@ -1,11 +1,11 @@
 {
   "schemaVersion": "1.5",
-  "generatedAt": "2026-08-07T18:31:56.074Z",
+  "generatedAt": "2026-08-14T08:34:06.552Z",
   "summary": {
     "componentCount": 177,
     "statusCounts": {
-      "beta": 49,
-      "stable": 104,
+      "beta": 50,
+      "stable": 103,
       "alpha": 23,
       "deprecated": 1
     },
@@ -13,14 +13,14 @@
     "catalogCompletenessPercent": 90.8,
     "codebaseComponentCount": 195,
     "usageCoveragePercent": 93.2,
-    "componentsWithProductionUsage": 35,
+    "componentsWithProductionUsage": 36,
     "notReadyForStablePromotion": false
   },
   "exportPolicy": {
     "importSurface": "@dt/<ComponentName>",
     "npmPackage": null,
     "semverDoc": "docs/PUBLIC_API.md",
-    "stableCount": 104,
+    "stableCount": 103,
     "releaseGate": "npm run release:gate"
   },
   "tokens": {
@@ -63,7 +63,7 @@
     "catalogCompletenessPercent": 90.8,
     "artifactCoverage": {
       "stories": 161,
-      "tests": 162,
+      "tests": 163,
       "mdx": 4,
       "spec": 177
     },
@@ -79,19 +79,19 @@
     "description": "Auto-detected import evidence from app/** and nextjs-app/**. Separate from contract.consumers[], which remains the stable-promotion gate for shipping-product proof.",
     "catalogedComponents": 177,
     "withAnyUsage": 165,
-    "withProductionUsage": 35,
+    "withProductionUsage": 36,
     "uniqueImportedComponents": 165,
-    "totalEvidenceRows": 825,
-    "aliasImportFiles": 428,
+    "totalEvidenceRows": 826,
+    "aliasImportFiles": 429,
     "relativeImportFiles": 430,
     "regenerate": "npm run audit:usage (--json) or npm run build:tokens",
     "findComponent": "npm run find-component -- \"your intent\""
   },
   "relationshipGraph": {
     "description": "Merged static composesWith policy + co-import evidence (see generate-relationship-graph.mjs).",
-    "generatedAt": "2026-08-05T08:09:22.131Z",
+    "generatedAt": "2026-08-14T08:28:00.623Z",
     "coImportMinFiles": 3,
-    "nodesWithComposesWith": 91,
+    "nodesWithComposesWith": 92,
     "regenerate": "npm run build:relationship-graph or npm run build:tokens",
     "path": "nextjs-app/shared/foundations/dist/relationship-graph.json"
   },
@@ -107,8 +107,8 @@
     },
     "statusMix": {
       "digitaltableteur": {
-        "beta": 49,
-        "stable": 104,
+        "beta": 50,
+        "stable": 103,
         "alpha": 23,
         "deprecated": 1
       },
@@ -4444,7 +4444,7 @@
           },
           {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
             "since": "2026-06-04"
           }
         ],
@@ -20360,7 +20360,7 @@
         "name": "FlexBox",
         "tier": "atom",
         "group": "layout",
-        "status": "stable",
+        "status": "beta",
         "description": "Flexbox layout primitive for stacks and rows.",
         "figma": "https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1176-1698",
         "radixPrimitive": null,
@@ -20402,18 +20402,7 @@
           "spacing": []
         },
         "lightDarkVerified": true,
-        "consumers": [
-          {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
-            "since": "2026-06-04"
-          },
-          {
-            "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/Illustrations/index.ts",
-            "since": "2026-06-04"
-          }
-        ],
+        "consumers": [],
         "schemaVersion": 2,
         "props": {
           "direction": {
@@ -22067,6 +22056,16 @@
           },
           {
             "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
+            "path": "nextjs-app/shared/components/pages/Work/Illustrations/index.ts",
+            "since": "2026-06-04"
+          },
+          {
+            "repo": "digitaltableteur/digitaltableteur",
             "path": "nextjs-app/shared/components/pages/Work/WorkIndex/index.ts",
             "since": "2026-06-04"
           },
@@ -22305,11 +22304,17 @@
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/Grid",
-        "importCount": 3,
-        "productionImportCount": 0,
+        "importCount": 4,
+        "productionImportCount": 1,
         "patternImportCount": 0,
         "componentImportCount": 1,
         "evidence": [
+          {
+            "path": "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+            "importKind": "alias",
+            "importPath": "@dt/Grid",
+            "context": "production"
+          },
           {
             "path": "nextjs-app/shared/components/index.ts",
             "importKind": "relative",
@@ -23652,12 +23657,12 @@
           },
           {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/design-system/agent/GoldenIntentsTable.tsx",
+            "path": "app/design-system/agent/EvidencePerPublishSection.tsx",
             "since": "2026-06-04"
           },
           {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "app/design-system/agent/page.tsx",
+            "path": "app/design-system/agent/GoldenIntentsTable.tsx",
             "since": "2026-06-04"
           }
         ],
@@ -36906,7 +36911,8 @@
         "a11y": {
           "keyboard": [],
           "ariaRequirements": [
-            "Whole card is a single link to the project detail page; the thumbnail carries the project title as alt text"
+            "Whole card is a single link to the project detail page; the thumbnail carries the project title as alt text",
+            "With comingSoon the root is a non-interactive div (no link role); the badge label is plain visible text"
           ],
           "motion": true,
           "reducedMotion": true,
@@ -36968,6 +36974,16 @@
             ],
             "description": "Title overlay position"
           },
+          "comingSoon": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Render as a non-interactive teaser with a \"coming soon\" badge over the media"
+          },
+          "comingSoonLabel": {
+            "optional": true,
+            "type": "string",
+            "description": "Visible badge label for the coming-soon overlay (pass a translated string)"
+          },
           "className": {
             "optional": true,
             "type": "string",
@@ -37022,7 +37038,7 @@
           }
         ]
       },
-      "spec": "# ProjectCard\n\n## Intent\nBasic portfolio project card for the work grid: a clickable thumbnail with title, optional category eyebrow and up to three tags.\n\n## Interaction contract\n- Keyboard: the whole card is a single focusable link to the project detail page\n- Pointer: click anywhere on the card to open the project; hover scales the thumbnail\n- Screen readers: one link; the thumbnail carries the project title as alt text\n- Reduced motion: hover scale/translate/opacity transitions are gated behind `motion-reduce:` utilities\n\n## Do / don't\n- Do: pass `title`, `slug` and `thumbnail`; add `category`/`tags` for richer cards\n- Do: choose `titlePosition` (overlay | below) and `aspectRatio` per surface\n- Don't: invent parallel primitives inside this folder\n- Don't: reach for this when EnhancedProjectCard's richer surface is needed — pick one per surface\n\n## Design notes\n- Tokens: Tailwind utility classes mapped to theme tokens; thumbnail radius uses rounded-lg\n- Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1031-109\n",
+      "spec": "# ProjectCard\n\n## Intent\nBasic portfolio project card for the work grid: a clickable thumbnail with title, optional category eyebrow and up to three tags.\n\n## Interaction contract\n- Keyboard: the whole card is a single focusable link to the project detail page\n- Pointer: click anywhere on the card to open the project; hover scales the thumbnail\n- Screen readers: one link; the thumbnail carries the project title as alt text\n- Reduced motion: hover scale/translate/opacity transitions are gated behind `motion-reduce:` utilities\n- Coming soon: with `comingSoon` the root is a non-interactive `div` (nothing focusable, no hover affordances) and a badge with `comingSoonLabel` overlays the media; matches EnhancedProjectCard's teaser mode\n\n## Do / don't\n- Do: pass `title`, `slug` and `thumbnail`; add `category`/`tags` for richer cards\n- Do: choose `titlePosition` (overlay | below) and `aspectRatio` per surface\n- Do: set `comingSoon` for projects without a case-study route, passing a translated `comingSoonLabel` (`t(\"workComingSoon\")`)\n- Don't: invent parallel primitives inside this folder\n- Don't: reach for this when EnhancedProjectCard's richer surface is needed — pick one per surface\n\n## Design notes\n- Tokens: Tailwind utility classes mapped to theme tokens; thumbnail radius uses rounded-lg\n- Figma: https://www.figma.com/design/PC2UPdYwm8qGt6ZTg0AakF/DT-Site-stuff?node-id=1031-109\n",
       "documentationDebt": false,
       "usage": {
         "publicImport": "@dt/ProjectCard",
@@ -37088,6 +37104,16 @@
             ],
             "description": "Title overlay position"
           },
+          "comingSoon": {
+            "optional": true,
+            "type": "boolean",
+            "description": "Render as a non-interactive teaser with a \"coming soon\" badge over the media"
+          },
+          "comingSoonLabel": {
+            "optional": true,
+            "type": "string",
+            "description": "Visible badge label for the coming-soon overlay (pass a translated string)"
+          },
           "className": {
             "optional": true,
             "type": "string",
@@ -37100,14 +37126,16 @@
         "variantsFnName": null,
         "useWhen": [
           "pass `title`, `slug` and `thumbnail`; add `category`/`tags` for richer cards",
-          "choose `titlePosition` (overlay | below) and `aspectRatio` per surface"
+          "choose `titlePosition` (overlay | below) and `aspectRatio` per surface",
+          "set `comingSoon` for projects without a case-study route, passing a translated `comingSoonLabel` (`t(\"workComingSoon\")`)"
         ],
         "avoidWhen": [
           "invent parallel primitives inside this folder",
           "reach for this when EnhancedProjectCard's richer surface is needed — pick one per surface"
         ],
         "requiredA11y": [
-          "Whole card is a single link to the project detail page; the thumbnail carries the project title as alt text"
+          "Whole card is a single link to the project detail page; the thumbnail carries the project title as alt text",
+          "With comingSoon the root is a non-interactive div (no link role); the badge label is plain visible text"
         ],
         "keyboard": [],
         "compositionRules": [
@@ -37126,7 +37154,7 @@
         ],
         "composesWith": [],
         "prefersOver": [],
-        "declaredPropCount": 8,
+        "declaredPropCount": 10,
         "guidelines": [
           {
             "level": "should",
@@ -37138,6 +37166,13 @@
           {
             "level": "should",
             "guidance": "choose `titlePosition` (overlay | below) and `aspectRatio` per surface",
+            "rationale": null,
+            "rationaleSource": null,
+            "source": "spec.md#do-dont"
+          },
+          {
+            "level": "should",
+            "guidance": "set `comingSoon` for projects without a case-study route, passing a translated `comingSoonLabel` (`t(\"workComingSoon\")`)",
             "rationale": null,
             "rationaleSource": null,
             "source": "spec.md#do-dont"
@@ -48305,7 +48340,7 @@
           },
           {
             "repo": "digitaltableteur/digitaltableteur",
-            "path": "nextjs-app/shared/components/pages/Work/Illustrations/IllustrationsPage.tsx",
+            "path": "nextjs-app/shared/patterns/ContactPageContentEditorial/ContactPageContentEditorial.tsx",
             "since": "2026-06-04"
           }
         ]
@@ -59483,7 +59518,10 @@
           "invent parallel primitives inside this folder",
           "use this for site-wide navigation (that is SiteHeader)"
         ],
-        "composesWith": [],
+        "composesWith": [
+          "Grid",
+          "ProjectDetailLayout"
+        ],
         "prefersOver": [],
         "declaredPropCount": 4,
         "guidelines": [

--- a/nextjs-app/shared/foundations/dist/component-agent-blocks.json
+++ b/nextjs-app/shared/foundations/dist/component-agent-blocks.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-07T16:16:44.124Z",
+  "generatedAt": "2026-08-14T08:28:09.691Z",
   "components": {
     "Accordion": {
       "preferredImport": "@dt/Accordion",
@@ -19619,6 +19619,16 @@
           ],
           "description": "Title overlay position"
         },
+        "comingSoon": {
+          "optional": true,
+          "type": "boolean",
+          "description": "Render as a non-interactive teaser with a \"coming soon\" badge over the media"
+        },
+        "comingSoonLabel": {
+          "optional": true,
+          "type": "string",
+          "description": "Visible badge label for the coming-soon overlay (pass a translated string)"
+        },
         "className": {
           "optional": true,
           "type": "string",
@@ -19631,14 +19641,16 @@
       "variantsFnName": null,
       "useWhen": [
         "pass `title`, `slug` and `thumbnail`; add `category`/`tags` for richer cards",
-        "choose `titlePosition` (overlay | below) and `aspectRatio` per surface"
+        "choose `titlePosition` (overlay | below) and `aspectRatio` per surface",
+        "set `comingSoon` for projects without a case-study route, passing a translated `comingSoonLabel` (`t(\"workComingSoon\")`)"
       ],
       "avoidWhen": [
         "invent parallel primitives inside this folder",
         "reach for this when EnhancedProjectCard's richer surface is needed — pick one per surface"
       ],
       "requiredA11y": [
-        "Whole card is a single link to the project detail page; the thumbnail carries the project title as alt text"
+        "Whole card is a single link to the project detail page; the thumbnail carries the project title as alt text",
+        "With comingSoon the root is a non-interactive div (no link role); the badge label is plain visible text"
       ],
       "keyboard": [],
       "compositionRules": [
@@ -19657,7 +19669,7 @@
       ],
       "composesWith": [],
       "prefersOver": [],
-      "declaredPropCount": 8,
+      "declaredPropCount": 10,
       "guidelines": [
         {
           "level": "should",
@@ -19669,6 +19681,13 @@
         {
           "level": "should",
           "guidance": "choose `titlePosition` (overlay | below) and `aspectRatio` per surface",
+          "rationale": null,
+          "rationaleSource": null,
+          "source": "spec.md#do-dont"
+        },
+        {
+          "level": "should",
+          "guidance": "set `comingSoon` for projects without a case-study route, passing a translated `comingSoonLabel` (`t(\"workComingSoon\")`)",
           "rationale": null,
           "rationaleSource": null,
           "source": "spec.md#do-dont"
@@ -32109,7 +32128,10 @@
         "invent parallel primitives inside this folder",
         "use this for site-wide navigation (that is SiteHeader)"
       ],
-      "composesWith": [],
+      "composesWith": [
+        "Grid",
+        "ProjectDetailLayout"
+      ],
       "prefersOver": [],
       "declaredPropCount": 4,
       "guidelines": [

--- a/nextjs-app/shared/foundations/dist/docs-registry.json
+++ b/nextjs-app/shared/foundations/dist/docs-registry.json
@@ -6704,7 +6704,7 @@
       "name": "FlexBox",
       "group": "layout",
       "tier": 1,
-      "status": "stable",
+      "status": "beta",
       "description": "Flexbox layout primitive for stacks and rows.",
       "dense": "Style-prop flexbox (css-less by design): direction/wrap/justify/align/alignContent + gap|rowGap|columnGap (number=px, string=token); passes through div attributes",
       "keywords": [
@@ -12174,6 +12174,16 @@
             "below"
           ],
           "description": "Title overlay position"
+        },
+        "comingSoon": {
+          "optional": true,
+          "type": "boolean",
+          "description": "Render as a non-interactive teaser with a \"coming soon\" badge over the media"
+        },
+        "comingSoonLabel": {
+          "optional": true,
+          "type": "string",
+          "description": "Visible badge label for the coming-soon overlay (pass a translated string)"
         },
         "className": {
           "optional": true,

--- a/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
+++ b/nextjs-app/shared/lib/design-system-mcp/__snapshots__/docs-registry.test.ts.snap
@@ -789,31 +789,6 @@ exports[`get > snapshot: get() shape per stable component (fields + example stor
     "group": "form",
     "import": "import { FilterChip } from "@dt/FilterChip";",
   },
-  "FlexBox": {
-    "exampleStories": [
-      "InlineCluster",
-      "SpaceBetween",
-      "ColumnWithTokenGap",
-    ],
-    "fields": [
-      "composesWith",
-      "dense",
-      "description",
-      "examples",
-      "forbiddenUse",
-      "group",
-      "import",
-      "keywords",
-      "name",
-      "prefersOver",
-      "props",
-      "status",
-      "tokens",
-      "usage",
-    ],
-    "group": "layout",
-    "import": "import FlexBox from "@dt/FlexBox";",
-  },
   "FormField": {
     "exampleStories": [
       "CheckboxCluster",

--- a/nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.tsx
+++ b/nextjs-app/shared/patterns/WorkMagneticField/WorkMagneticField.tsx
@@ -248,6 +248,8 @@ export function WorkMagneticField({
                   thumbnail={project.thumbnail}
                   category={project.category}
                   tags={project.tags}
+                  comingSoon={project.comingSoon}
+                  comingSoonLabel={t("workComingSoon", "Coming soon")}
                   aspectRatio="landscape"
                   showCategory={true}
                   showDescription={false}

--- a/nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.tsx
+++ b/nextjs-app/shared/patterns/WorkPreviewSection/WorkPreviewSection.tsx
@@ -21,6 +21,8 @@ export interface ProjectItem {
   category?: string;
   /** Project tags */
   tags?: string[];
+  /** Render as a non-interactive teaser (no case-study route yet) */
+  comingSoon?: boolean;
 }
 
 export interface WorkPreviewSectionProps {
@@ -61,6 +63,8 @@ export function WorkPreviewSection({
             thumbnail={project.thumbnail}
             category={project.category}
             tags={project.tags}
+            comingSoon={project.comingSoon}
+            comingSoonLabel={t("workComingSoon", "Coming soon")}
             aspectRatio="video"
           />
         </FadeIn>
@@ -81,6 +85,8 @@ export function WorkPreviewSection({
               thumbnail={first.thumbnail}
               category={first.category}
               tags={first.tags}
+              comingSoon={first.comingSoon}
+              comingSoonLabel={t("workComingSoon", "Coming soon")}
               aspectRatio="square"
               className="h-full"
             />
@@ -96,6 +102,8 @@ export function WorkPreviewSection({
                 thumbnail={project.thumbnail}
                 category={project.category}
                 tags={project.tags}
+                comingSoon={project.comingSoon}
+                comingSoonLabel={t("workComingSoon", "Coming soon")}
                 aspectRatio="video"
               />
             </FadeIn>
@@ -116,6 +124,8 @@ export function WorkPreviewSection({
               thumbnail={project.thumbnail}
               category={project.category}
               tags={project.tags}
+              comingSoon={project.comingSoon}
+              comingSoonLabel={t("workComingSoon", "Coming soon")}
               aspectRatio="landscape"
               showCategory={true}
               showDescription={false}


### PR DESCRIPTION
## Summary

Closes the last latent coming-soon 404 vector, following up on #1458 (which fixed the live ones).

- **ProjectCard** gains `comingSoon`/`comingSoonLabel` mirroring EnhancedProjectCard: the root becomes a non-interactive `div` (no link, `group` class omitted so hover affordances stay at rest) with a centered badge over the media, including `forced-colors:` treatment.
- **ProjectItem** carries `comingSoon`, and all five card call sites in WorkPreviewSection (grid, asymmetric x2, featured) and WorkMagneticField pass it through with the translated `workComingSoon` label.
- **Ceremony**: contract props + aria requirements updated, spec interaction contract extended, ComingSoon story with play assertions and deliberate Controls rows, unit tests (non-interactive + badge + axe), a11y snapshot `site-projectcard--coming-soon.yaml` bootstrapped and evidence recaptured at the change SHA.
- **Consumers audit reconciled** (Badge, Grid, StatusDot, ProjectCard had drifted since the Illustrations rebuild #1456).
- **FlexBox demoted stable -> beta** (owner call): #1456 removed its last production consumer, and the stable-consumers gate blocks all contract-touching pushes until resolved. Story lifecycle tag synced; docs-registry stable-set snapshot updated.

## Verification

- Storybook test-runner (real Chromium): all ProjectCard stories pass with a11y test:error, ComingSoon play asserts no link + badge text
- Local gate: typecheck, lint, test (2923), build, build:tokens, check:contract-props, check:consumers, check:story-lifecycle-tags all exit 0 (pre-push hook enforced the same)

🤖 Generated with [Claude Code](https://claude.com/claude-code)